### PR TITLE
ci: publish releases after release PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,18 +2,79 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+    paths:
+      - CHANGELOG.md
+      - package.json
+      - package-lock.json
+      - server/package.json
+      - web/package.json
+      - tui/package.json
+      - desktop/package.json
+      - cli/package.json
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing package version to publish or recover
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.plan.outputs.release }}
+      version: ${{ steps.plan.outputs.version }}
+      tag: ${{ steps.plan.outputs.tag }}
+      manual: ${{ steps.plan.outputs.manual }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect a release version change
+        id: plan
+        env:
+          RELEASE_BEFORE_SHA: ${{ github.event.before }}
+          RELEASE_REQUESTED_VERSION: ${{ inputs.version }}
+        run: node scripts/release-plan.mjs
+      - name: Verify the release PR branch
+        if: ${{ github.event_name == 'push' && steps.plan.outputs.release == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_VERSION: ${{ steps.plan.outputs.version }}
+        run: |
+          set -eu
+          RELEASE_HEAD=$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GH_REPO}/commits/${GITHUB_SHA}/pulls" \
+              --jq '[.[] | select(.merged_at != null and .base.ref == "main")][0].head.ref // ""'
+          )
+          case "$RELEASE_HEAD" in
+            release/"$RELEASE_VERSION"|release/v"$RELEASE_VERSION"|release-"$RELEASE_VERSION"|release-v"$RELEASE_VERSION"|*/release-"$RELEASE_VERSION"|*/release-v"$RELEASE_VERSION")
+              ;;
+            *)
+              echo "Version changes must be merged from a dedicated release branch; got '${RELEASE_HEAD}'." >&2
+              exit 1
+              ;;
+          esac
+
   verify:
+    needs: plan
+    if: ${{ needs.plan.outputs.release == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -25,12 +86,47 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - name: Verify tag and package version
-        run: node -e "const p=require('./package.json');if(process.env.GITHUB_REF_NAME!=='v'+p.version)throw new Error('tag/version mismatch')"
       - run: npm run release:check
 
+  tag:
+    needs: [plan, verify]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Create or verify the release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          set -eu
+          EXISTING=$(
+            gh api "repos/${GH_REPO}/git/ref/tags/${RELEASE_TAG}" \
+              --jq '.object.sha' 2>/dev/null || true
+          )
+          if [ -z "$EXISTING" ]; then
+            gh api \
+              --method POST \
+              "repos/${GH_REPO}/git/refs" \
+              -f "ref=refs/tags/${RELEASE_TAG}" \
+              -f "sha=${GITHUB_SHA}"
+          else
+            git fetch --force origin \
+              "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            RESOLVED=$(git rev-list -n 1 "$RELEASE_TAG")
+            if [ "$RESOLVED" != "$GITHUB_SHA" ]; then
+              echo "${RELEASE_TAG} already points to ${RESOLVED}, not ${GITHUB_SHA}." >&2
+              exit 1
+            fi
+          fi
+
   npm:
-    needs: verify
+    needs: [plan, tag]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,14 +140,26 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm publish --provenance --access public
+      - name: Check whether npm already has this version
+        id: npm
+        env:
+          RELEASE_VERSION: ${{ needs.plan.outputs.version }}
+        run: |
+          if npm view "qwen-audio-agent@${RELEASE_VERSION}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: ${{ steps.npm.outputs.published != 'true' }}
+        run: npm ci
+      - if: ${{ steps.npm.outputs.published != 'true' }}
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   macos:
-    needs: verify
-    if: ${{ vars.MACOS_RELEASE_ENABLED == 'true' }}
+    needs: [plan, tag]
+    if: ${{ needs.plan.outputs.release == 'true' && vars.MACOS_RELEASE_ENABLED == 'true' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -79,7 +187,7 @@ jobs:
           if-no-files-found: error
 
   github-release:
-    needs: [npm, macos]
+    needs: [plan, tag, npm, macos]
     if: ${{ always() && needs.npm.result == 'success' && (needs.macos.result == 'success' || needs.macos.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
@@ -94,10 +202,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 \
+            || gh release create "$RELEASE_TAG" --verify-tag --generate-notes
       - name: Upload macOS desktop artifacts
         if: ${{ needs.macos.result == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload "$GITHUB_REF_NAME" artifacts/*
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
+        run: gh release upload "$RELEASE_TAG" artifacts/* --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,13 @@ npm run version:major                 # 0.5.0 → 1.0.0，不兼容或稳定版
 npm run version:set -- 0.6.0-beta.1  # 指定预发布版本
 ```
 
-更新版本后必须同步维护 `CHANGELOG.md` 并运行 `npm run release:check`。版本标签必须
-与根 `package.json` 完全一致，例如 `v0.5.0`。标签触发发布工作流：
-先运行完整检查，再以 npm provenance 发布公共包，随后构建、签名、公证 macOS
-DMG 并创建 GitHub Release。仓库维护者需预先配置 `NPM_TOKEN`、Apple Developer
-签名证书和公证凭据。
+更新版本后必须同步维护 `CHANGELOG.md` 并运行 `npm run release:check`。发布改动
+应从专用分支提交，例如 `release/0.11.0` 或 `codex/release-0.11.0`。Release PR
+合并到 `main` 后，工作流会确认版本确实发生变化、版本对应的 Changelog 存在且
+完整检查通过，然后自动创建 `v0.11.0` 标签、以 npm provenance 发布公共包，
+并创建 GitHub Release。启用 macOS 正式发布时，还会构建、签名、公证并上传 DMG。
+
+普通 PR 合并或未改变版本号的 `main` 更新不会触发发布。若发布在创建标签、上传
+npm 或生成 Release 之间中断，可从 GitHub Actions 手动运行 Release 工作流，并
+输入当前 `package.json` 中的版本继续；已经完成的阶段会被安全复用。仓库维护者
+需预先配置 `NPM_TOKEN`，以及可选的 Apple Developer 签名证书和公证凭据。

--- a/scripts/release-plan.mjs
+++ b/scripts/release-plan.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { isValidVersion } from './set-version.mjs'
+
+const SCRIPT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function changelogHasVersion(changelog, version) {
+  return String(changelog)
+    .split(/\r?\n/)
+    .some(line => line.trim() === `## ${version}`)
+}
+
+export function createReleasePlan({
+  currentVersion,
+  previousVersion = '',
+  requestedVersion = '',
+  changelog = '',
+}) {
+  if (!isValidVersion(currentVersion)) {
+    throw new Error(`当前发布版本无效：${currentVersion}`)
+  }
+  if (requestedVersion && requestedVersion !== currentVersion) {
+    throw new Error(
+      `手动请求版本 ${requestedVersion} 与 package.json ${currentVersion} 不一致`,
+    )
+  }
+  if (previousVersion && !isValidVersion(previousVersion)) {
+    throw new Error(`合并前版本无效：${previousVersion}`)
+  }
+
+  const release = Boolean(requestedVersion)
+    || Boolean(previousVersion && previousVersion !== currentVersion)
+  if (release && !changelogHasVersion(changelog, currentVersion)) {
+    throw new Error(`CHANGELOG.md 缺少 ## ${currentVersion}`)
+  }
+
+  return {
+    release,
+    version: currentVersion,
+    tag: `v${currentVersion}`,
+    previousVersion,
+    manual: Boolean(requestedVersion),
+  }
+}
+
+function versionAtRevision(root, revision) {
+  if (!revision || /^0+$/.test(revision)) return ''
+  const content = execFileSync(
+    'git',
+    ['show', `${revision}:package.json`],
+    { cwd: root, encoding: 'utf8' },
+  )
+  return JSON.parse(content).version
+}
+
+function writeOutputs(path, plan) {
+  if (!path) return
+  appendFileSync(path, [
+    `release=${plan.release}`,
+    `version=${plan.version}`,
+    `tag=${plan.tag}`,
+    `previous_version=${plan.previousVersion}`,
+    `manual=${plan.manual}`,
+    '',
+  ].join('\n'))
+}
+
+const isMain = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMain) {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(resolve(SCRIPT_ROOT, 'package.json'), 'utf8'),
+    )
+    const requestedVersion = String(
+      process.env.RELEASE_REQUESTED_VERSION || '',
+    ).trim()
+    const previousVersion = requestedVersion
+      ? ''
+      : versionAtRevision(
+          SCRIPT_ROOT,
+          String(process.env.RELEASE_BEFORE_SHA || '').trim(),
+        )
+    const plan = createReleasePlan({
+      currentVersion: manifest.version,
+      previousVersion,
+      requestedVersion,
+      changelog: readFileSync(
+        resolve(SCRIPT_ROOT, 'CHANGELOG.md'),
+        'utf8',
+      ),
+    })
+    writeOutputs(process.env.GITHUB_OUTPUT, plan)
+    process.stdout.write(
+      plan.release
+        ? `准备发布 ${plan.tag}${plan.manual ? '（手动恢复）' : ''}\n`
+        : `版本仍为 ${plan.version}，本次 main 更新无需发布。\n`,
+    )
+  } catch (error) {
+    process.stderr.write(`发布计划检查失败：${error.message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/test/release-plan.test.mjs
+++ b/test/release-plan.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createReleasePlan } from '../scripts/release-plan.mjs'
+
+test('skips ordinary main updates when the package version is unchanged', () => {
+  assert.deepEqual(createReleasePlan({
+    currentVersion: '0.10.0',
+    previousVersion: '0.10.0',
+    changelog: '# Changelog\n\n## 0.10.0\n',
+  }), {
+    release: false,
+    version: '0.10.0',
+    tag: 'v0.10.0',
+    previousVersion: '0.10.0',
+    manual: false,
+  })
+})
+
+test('plans a release when a release PR changes the package version', () => {
+  assert.deepEqual(createReleasePlan({
+    currentVersion: '0.11.0',
+    previousVersion: '0.10.0',
+    changelog: '# Changelog\n\n## 0.11.0\n',
+  }), {
+    release: true,
+    version: '0.11.0',
+    tag: 'v0.11.0',
+    previousVersion: '0.10.0',
+    manual: false,
+  })
+})
+
+test('supports an explicit recovery run for the current version', () => {
+  const plan = createReleasePlan({
+    currentVersion: '0.10.0',
+    requestedVersion: '0.10.0',
+    changelog: '# Changelog\n\n## 0.10.0\n',
+  })
+  assert.equal(plan.release, true)
+  assert.equal(plan.manual, true)
+  assert.equal(plan.tag, 'v0.10.0')
+})
+
+test('rejects mismatched recovery versions and missing changelog entries', () => {
+  assert.throws(() => createReleasePlan({
+    currentVersion: '0.10.0',
+    requestedVersion: '0.9.1',
+    changelog: '# Changelog\n\n## 0.10.0\n',
+  }), /不一致/)
+  assert.throws(() => createReleasePlan({
+    currentVersion: '0.11.0',
+    previousVersion: '0.10.0',
+    changelog: '# Changelog\n\n## 0.10.0\n',
+  }), /CHANGELOG/)
+})


### PR DESCRIPTION
## Summary

- publish automatically after a dedicated Release PR changes the version on `main`
- validate the version and changelog before tagging
- make npm and GitHub Release stages safe to retry
- retain manual recovery for interrupted or previously missed releases

## Verification

- `npm run release:check`
- workflow YAML parse
- release planning unit tests