### PR TITLE
ci: disable implicit desktop publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
             exit 1
           fi
       - name: Build, sign and notarize universal macOS DMG
-        run: npm run desktop:build -- --universal
+        run: npm run desktop:build -- --universal --publish never
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}


### PR DESCRIPTION
Electron Builder must only build, sign, and notarize the Universal DMG. The Release workflow uploads the artifact in its dedicated GitHub Release step.