### PR TITLE
release: qwen-audio-agent 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.0
 
 - 新增官方 Kimi Code CLI 后台，使用原生 `kimi acp` 接入共享 ACP Session、权限、
   模型覆盖和第三层任务链路；支持原生登录与 `KIMI_MODEL_*` 临时凭据配置，并将

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/cli",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bin": {
     "qwenaudio": "./bin/qwenaudio.mjs"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/desktop",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "src/main.mjs",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-audio-agent",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-audio-agent",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "workspaces": [
         "server",
@@ -36,14 +36,14 @@
     },
     "cli": {
       "name": "@qwen-audio-agent/cli",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "qwenaudio": "bin/qwenaudio.mjs"
       }
     },
     "desktop": {
       "name": "@qwen-audio-agent/desktop",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "ws": "8.21.1"
       },
@@ -7932,7 +7932,7 @@
     },
     "server": {
       "name": "@qwen-audio-agent/server",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.3.0",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -7943,14 +7943,14 @@
     },
     "tui": {
       "name": "@qwen-audio-agent/tui",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "ws": "^8.18.3"
       }
     },
     "web": {
       "name": "@qwen-audio-agent/web",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@vitejs/plugin-react": "^4.7.0",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-audio-agent",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A realtime voice frontend for mainstream AI agents.",
   "author": "qwen-audio-agent contributors",
   "license": "Apache-2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/server",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "node --watch src/index.mjs",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/tui",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "start": "node src/index.mjs",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/web",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",


### PR DESCRIPTION
Summary:
- release Kimi Code ACP backend support
- promote the Unreleased changelog entry to 1.1.0
- synchronize all workspace manifests and package-lock

Validation: npm run release:check