### PR TITLE
test: stabilize announcement retry timing

### DIFF
--- a/server/test/announcement-manager.test.mjs
+++ b/server/test/announcement-manager.test.mjs
@@ -314,11 +314,12 @@ test('releases a poison batch after bounded retries so later results can proceed
     onRelease: taskIds => released.push(...taskIds),
   })
   manager.completed({ id: 'poison', objective: '坏任务', result: '坏结果' })
-  await new Promise(resolve => setTimeout(resolve, 2))
+  await waitFor(() => inputs.some(input => input.includes('坏结果')))
   manager.completed({ id: 'healthy', objective: '好任务', result: '好结果' })
-  await new Promise(resolve => setTimeout(resolve, 20))
-  assert.ok(released.includes('poison'))
-  assert.ok(inputs.some(input => input.includes('好结果')))
+  await waitFor(() => (
+    released.includes('poison')
+    && inputs.some(input => input.includes('好结果'))
+  ))
   manager.confirmMany(['healthy'])
   manager.close()
 })


### PR DESCRIPTION
Fix the intermittent Windows + Node 22 CI failure in the poison-batch recovery test.

The test now waits for observable state transitions instead of assuming Windows schedules zero/one-millisecond timers within a fixed wall-clock delay. Runtime behavior is unchanged.

Validation:
- target test repeated 30 times on Node 22.22.2
- full npm test