### PR TITLE
refactor: decouple realtime provider protocols

### DIFF
--- a/server/src/voice/frontend-tools.mjs
+++ b/server/src/voice/frontend-tools.mjs
@@ -1,0 +1,184 @@
+import {
+  buildFrontendContext,
+  loadFrontendPrompt,
+} from '../conversation/frontend-agent-context.mjs'
+
+export const SPAWN_THINKING_TOOL_NAME = 'spawn_thinking'
+export const DELEGATE_TOOL_NAME = SPAWN_THINKING_TOOL_NAME
+export const CANCEL_AGENT_TASK_TOOL_NAME = 'cancel_agent_task'
+export const GET_AGENT_TASK_STATUS_TOOL_NAME = 'get_agent_task_status'
+export const GET_CURRENT_TIME_TOOL_NAME = 'get_current_time'
+export const USER_MEMORY_TOOL_NAME = 'user_memory'
+export const RESPOND_AGENT_PERMISSION_TOOL_NAME = 'respond_agent_permission'
+
+const delegateTool = {
+  type: 'function',
+  function: {
+    name: DELEGATE_TOOL_NAME,
+    description: '把明确的新执行或调查要求交给后台 Agent。需要当前信息、搜索、检查、工具、文件、屏幕、应用、代码、创作，或要求继续、修改已有工作时调用；询问此前工作的状态、进度、阶段产物或已经发现了什么统一改用 get_agent_task_status。缺少不可推断的核心目标时先问一个必要问题。可以按需先说一句具体行动预告，不要使用“好的、收到”等通用承接语。返回 accepted 只表示已受理；结合本轮已有发言判断是否还需回应，不重复确认或声称完成。',
+    parameters: {
+      type: 'object',
+      properties: {
+        objective: {
+          type: 'string',
+          description: '必须是已经可以执行的目标，忠实保留本轮用户要求并写明对象、动作、约束和期望结果，不得用“待用户说明主题”等占位内容启动空执行。仅在当前对话已经明确时消解“它、刚才那个”等指代；不要猜测或补造事实。后台 Agent 会同时收到近期对话和后台执行状态，因此这里是意图交接，不是对历史的替代。',
+        },
+      },
+      required: ['objective'],
+      additionalProperties: false,
+    },
+  },
+}
+
+const cancelAgentTaskTool = {
+  type: 'function',
+  function: {
+    name: CANCEL_AGENT_TASK_TOOL_NAME,
+    description: '取消用户此前交给后台、目前仍在排队或执行的工作。用户明确说取消、停止、别做了、不要继续，或要求取消“刚才那个任务”时必须调用，不要只口头说忽略结果。能够从运行上下文确定 work_id 时传入；用户泛指刚才的工作时可省略，系统会取消最近提交且仍活跃的工作。',
+    parameters: {
+      type: 'object',
+      properties: {
+        work_id: {
+          type: 'string',
+          description: '要取消的 work_id。仅在运行上下文已明确给出时填写；不得猜造。省略则取消当前语音会话最近提交且仍活跃的工作。',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+}
+
+const getAgentTaskStatusTool = {
+  type: 'function',
+  function: {
+    name: GET_AGENT_TASK_STATUS_TOOL_NAME,
+    description: '查询此前交给后台工作的状态、进度或阶段性结果。用户询问“刚才那个怎么样了、还在做吗、做到哪一步、已经发现了什么、是否完成”时统一调用，不要自行判断普通任务或第三层任务，也不要改用 spawn_thinking。系统会直接回答普通任务，并自动查询第三层任务。能够从运行上下文确定 work_id 时传入；省略时查询当前语音会话最近的工作。',
+    parameters: {
+      type: 'object',
+      properties: {
+        work_id: {
+          type: 'string',
+          description: '要查询的 work_id。仅在运行上下文已明确给出时填写，不得猜造；省略时查询当前语音会话最近的工作。',
+        },
+        question: {
+          type: 'string',
+          description: '用户本轮对任务状态、进度或阶段结果的原始问题。尽量忠实保留，不要自行改写成另一项任务；省略时系统会使用本轮语音转写。',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+}
+
+const getCurrentTimeTool = {
+  type: 'function',
+  function: {
+    name: GET_CURRENT_TIME_TOOL_NAME,
+    description: '获取用户本地时区中的准确当前日期、时间和星期。用户询问当前时间、今天日期、星期或相对日期判断时调用；不用于创建提醒。',
+    parameters: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+}
+
+const userMemoryTool = {
+  type: 'function',
+  function: {
+    name: USER_MEMORY_TOOL_NAME,
+    description: '管理千问Audio前台持有的用户记忆。profile 用于称呼、时区、语言和稳定交互偏好；long_term 用于用户明确希望跨会话保留的个人事实、喜好、目标和约定；不要保存项目执行历史或后台工作细节。使用 recall 回忆，remember 新增，replace 用新事实替换明确相关的旧记录，forget 遗忘。',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['recall', 'remember', 'replace', 'forget'],
+          description: '要执行的记忆操作。',
+        },
+        scope: {
+          type: 'string',
+          enum: ['profile', 'long_term', 'all'],
+          description: '记忆范围。remember 和 replace 必须使用 profile 或 long_term；recall 和 forget 可以使用 all。',
+        },
+        content: {
+          type: 'string',
+          description: 'remember 或 replace 时要保存的完整、简洁事实。',
+        },
+        query: {
+          type: 'string',
+          description: 'recall 或 forget 时用于匹配记忆的自然语言查询。',
+        },
+        memory_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          maxItems: 20,
+          description: 'replace 时要被新事实取代的旧记忆 ID；必须来自本轮 recall 结果，不得猜造。',
+        },
+        all: {
+          type: 'boolean',
+          description: '仅用于 forget；用户明确要求清空所选范围时设为 true。',
+        },
+      },
+      required: ['action', 'scope'],
+      additionalProperties: false,
+    },
+  },
+}
+
+const respondAgentPermissionTool = {
+  type: 'function',
+  function: {
+    name: RESPOND_AGENT_PERMISSION_TOOL_NAME,
+    description: '回复当前正在等待用户决定的后台权限请求。由你结合刚提出的具体权限问题和用户本轮自然表达，智能判断为本会话自动允许、拒绝或尚不明确；不要依赖固定关键词。用户回答“可以”“行”“好”“允许”“同意”“没问题”等自然肯定表达就是明确同意，应调用 always，不得要求复述固定口令。明确拒绝时调用 reject，不明确时不要调用并继续询问。',
+    parameters: {
+      type: 'object',
+      properties: {
+        authorization_id: {
+          type: 'string',
+          description: '待确认请求的 authorization_id，必须来自当前运行上下文，不得猜造。',
+        },
+        decision: {
+          type: 'string',
+          enum: ['always', 'reject'],
+          description: 'always 表示允许当前操作，并由 Gateway 在本次前台会话中自动允许后续权限请求；reject 表示拒绝当前操作，后续请求仍继续询问。',
+        },
+      },
+      required: ['authorization_id', 'decision'],
+      additionalProperties: false,
+    },
+  },
+}
+
+export const TOOLS = [
+  delegateTool,
+  cancelAgentTaskTool,
+  getAgentTaskStatusTool,
+  getCurrentTimeTool,
+  userMemoryTool,
+  respondAgentPermissionTool,
+]
+
+export const resultResponseInstructions = [
+  '这是先前提交工作的最终结果，不是用户的新请求。',
+  '把 result 当作事实材料，结合当前对话自然回应；可以按语境概括、合并、承接或询问必要信息，避免重复已经表达过的内容。',
+  '输入包含多个 event 时，必须覆盖每个 event 的实质结果；不得只说其中一个，也不得让过程性或状态性内容掩盖真正完成的工作。',
+  '开头直接说实际结果、关键发现、阻塞或必要问题，不用“好的、收到、任务完成了”等空泛承接语。',
+  '不要朗读协议前缀、字段、执行 ID、路径、URL 或不适合口语的长内容。',
+  '不要调用工具，不要添加事件中没有的事实，也不要把未完成说成完成。',
+].join(' ')
+
+export function speakResponseInstructions(content) {
+  return `请以自然口语传达下面的信息，保持事实一致，不调用工具：\n${content}`
+}
+
+export const permissionResponseInstructions = [
+  '这是后台 Agent 的权限请求。',
+  '自然、简短地说明操作，并询问用户是否同意授权。',
+  '不要规定具体回答方式，也不要提供或要求复述固定口令。',
+  '不要调用工具或朗读内部字段，等待用户回答。',
+].join(' ')
+
+export function buildFrontendInstructions(agentContext = {}) {
+  return `${loadFrontendPrompt()}\n\n${buildFrontendContext(agentContext)}`
+}

--- a/server/src/voice/providers/dashscope.mjs
+++ b/server/src/voice/providers/dashscope.mjs
@@ -1,0 +1,91 @@
+import { config, realtimeUrl } from '../../core/config.mjs'
+import {
+  TOOLS,
+  buildFrontendInstructions,
+  resultResponseInstructions,
+  speakResponseInstructions,
+  permissionResponseInstructions,
+} from '../frontend-tools.mjs'
+import { isRecoverableRealtimeInactivityError } from '../realtime-errors.mjs'
+import { openAiCompatibleProtocol } from './openai-compatible-protocol.mjs'
+
+function classifyError(message) {
+  if (isRecoverableRealtimeInactivityError(message)) return 'inactivity'
+  if (/user is speaking/i.test(message)) return 'input_busy'
+  if (/no active response/i.test(message)) return 'no_active_response'
+  return 'other'
+}
+
+export const dashscopeProvider = {
+  key: 'dashscope',
+  label: 'Qwen-Audio-Realtime',
+  inputSampleRate: 16000,
+  outputSampleRate: 24000,
+  protocol: openAiCompatibleProtocol,
+
+  model: () => config.audioModel,
+  voice: () => config.audioVoice,
+  apiKey: () => config.dashscopeApiKey,
+  missingKeyMessage: '请先配置 DASHSCOPE_API_KEY',
+  connectTimeoutMessage: '连接 Qwen Audio Realtime 超时',
+
+  url: () => realtimeUrl(config.audioRealtimeBaseUrl, config.audioModel),
+  headers: apiKey => ({ Authorization: `Bearer ${apiKey}` }),
+  classifyError,
+
+  buildSession: ({ configured, agentContext }) => {
+    const textOnly = agentContext?.textOnly === true
+    const session = {
+      instructions: buildFrontendInstructions(agentContext),
+      tools: TOOLS,
+    }
+    if (!configured) {
+      session.modalities = textOnly ? ['text'] : ['text', 'audio']
+      session.voice = config.audioVoice
+      session.input_audio_format = 'pcm'
+      session.output_audio_format = 'pcm'
+      session.turn_detection = textOnly ? null : { type: 'smart_turn' }
+    }
+    return session
+  },
+
+  buildSpeakResponse: (content, { textOnly = false } = {}) => ({
+    conversation: 'none',
+    modalities: textOnly ? ['text'] : ['text', 'audio'],
+    instructions: speakResponseInstructions(content),
+  }),
+
+  buildResultInjection: (content, { textOnly = false } = {}) => ({
+    item: {
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: content }],
+    },
+    response: {
+      modalities: textOnly ? ['text'] : ['text', 'audio'],
+      tool_choice: 'none',
+      instructions: resultResponseInstructions,
+    },
+  }),
+
+  buildPermissionInjection: (permission, { textOnly = false } = {}) => ({
+    item: {
+      type: 'message',
+      role: 'user',
+      content: [{
+        type: 'input_text',
+        text: [
+          '<backend_permission_request>',
+          `authorization_id=${permission.id}`,
+          `operation=${permission.summary}`,
+          '</backend_permission_request>',
+        ].join('\n'),
+      }],
+    },
+    response: {
+      modalities: textOnly ? ['text'] : ['text', 'audio'],
+      tool_choice: 'none',
+      instructions: permissionResponseInstructions,
+    },
+  }),
+}

--- a/server/src/voice/providers/openai-compatible-protocol.mjs
+++ b/server/src/voice/providers/openai-compatible-protocol.mjs
@@ -1,0 +1,56 @@
+import { randomUUID } from 'node:crypto'
+
+function eventId() {
+  return `event_${randomUUID().replaceAll('-', '')}`
+}
+
+/**
+ * Wire adapter for Realtime providers that use the OpenAI-compatible event
+ * envelope. Gateway code only consumes the normalized events returned by
+ * normalizeIncoming(), so a provider with a different protocol can implement
+ * the same adapter surface without leaking its wire format into the Gateway.
+ */
+export const openAiCompatibleProtocol = Object.freeze({
+  encodeOutgoing: payload => ({
+    event_id: eventId(),
+    ...payload,
+  }),
+
+  normalizeIncoming: event => event,
+
+  sessionUpdate: session => ({
+    type: 'session.update',
+    session,
+  }),
+
+  audioAppend: audio => ({
+    type: 'input_audio_buffer.append',
+    audio,
+  }),
+
+  conversationItemCreate: item => ({
+    type: 'conversation.item.create',
+    item,
+  }),
+
+  responseCreate: response => ({
+    type: 'response.create',
+    ...(response ? { response } : {}),
+  }),
+
+  responseCancel: () => ({
+    type: 'response.cancel',
+  }),
+
+  userTextItem: text => ({
+    type: 'message',
+    role: 'user',
+    content: [{ type: 'input_text', text }],
+  }),
+
+  functionOutputItem: (callId, output) => ({
+    type: 'function_call_output',
+    call_id: callId,
+    output: JSON.stringify(output),
+  }),
+})

--- a/server/src/voice/providers/registry.mjs
+++ b/server/src/voice/providers/registry.mjs
@@ -1,0 +1,87 @@
+import { config } from '../../core/config.mjs'
+import { dashscopeProvider } from './dashscope.mjs'
+
+const PROVIDER_METHODS = [
+  'model',
+  'voice',
+  'apiKey',
+  'url',
+  'headers',
+  'classifyError',
+  'buildSession',
+  'buildSpeakResponse',
+  'buildResultInjection',
+  'buildPermissionInjection',
+]
+
+const PROTOCOL_METHODS = [
+  'encodeOutgoing',
+  'normalizeIncoming',
+  'sessionUpdate',
+  'audioAppend',
+  'conversationItemCreate',
+  'responseCreate',
+  'responseCancel',
+  'userTextItem',
+  'functionOutputItem',
+]
+
+export function validateRealtimeProvider(provider) {
+  if (!provider?.key || !provider.label) {
+    throw new Error('Realtime Provider 必须定义 key 和 label')
+  }
+  for (const method of PROVIDER_METHODS) {
+    if (typeof provider[method] !== 'function') {
+      throw new Error(`Realtime Provider ${provider.key} 缺少 ${method}()`)
+    }
+  }
+  if (!Number.isFinite(provider.inputSampleRate)) {
+    throw new Error(`Realtime Provider ${provider.key} 缺少 inputSampleRate`)
+  }
+  if (!Number.isFinite(provider.outputSampleRate)) {
+    throw new Error(`Realtime Provider ${provider.key} 缺少 outputSampleRate`)
+  }
+  for (const method of PROTOCOL_METHODS) {
+    if (typeof provider.protocol?.[method] !== 'function') {
+      throw new Error(
+        `Realtime Provider ${provider.key} protocol 缺少 ${method}()`,
+      )
+    }
+  }
+  return provider
+}
+
+validateRealtimeProvider(dashscopeProvider)
+
+const providers = new Map([
+  ['dashscope', dashscopeProvider],
+  // Compatibility alias for internal callers while provider selection moves
+  // to stable external names.
+  ['qwen', dashscopeProvider],
+])
+
+export function resolveRealtimeProvider() {
+  const provider = providers.get(config.audioProvider)
+  if (!provider) {
+    throw new Error(`不支持的 Realtime 供应商：${config.audioProvider}`)
+  }
+  return provider
+}
+
+export function describeActiveRealtime() {
+  const provider = resolveRealtimeProvider()
+  return {
+    provider: provider.key,
+    label: provider.label,
+    model: provider.model(),
+    voice: provider.voice(),
+    inputSampleRate: provider.inputSampleRate,
+    configured: Boolean(provider.apiKey()),
+  }
+}
+
+/**
+ * Exposed for tests and callers that need direct provider access.
+ * New code should use resolveRealtimeProvider() instead.
+ */
+export const REALTIME_PROVIDERS = Object.fromEntries(providers)

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -25,7 +25,6 @@ import {
   ActiveVoiceClients,
   clientVoiceCapabilities,
 } from './active-voice-clients.mjs'
-import { isRecoverableRealtimeInactivityError } from './realtime-errors.mjs'
 import { ReconnectBackoff } from './reconnect-backoff.mjs'
 
 const MAX_PENDING_AUDIO_CHUNKS = 30
@@ -854,8 +853,8 @@ export function attachRealtimeGateway(server, {
               ?? (committedTurnId ? committedTurnGeneration : turnGeneration),
         })
         if (automaticTurn) {
-          // Qwen may begin inference and emit a function call before its final
-          // ASR event. response.created proves Smart Turn accepted this turn.
+          // A provider may begin inference and emit a function call before its
+          // final ASR event. response.created proves turn detection accepted it.
           commitTurn(automaticTurn)
           clearResponseCandidate()
         }
@@ -906,7 +905,8 @@ export function attachRealtimeGateway(server, {
         send(ws, {
           type: 'audio.delta',
           audio: event.delta,
-          sampleRate: 24000,
+          sampleRate: Number(event.sampleRate)
+            || frontend.provider.outputSampleRate,
           responseId: id,
           turnId: responseTurnId,
         })
@@ -1066,14 +1066,11 @@ export function attachRealtimeGateway(server, {
         const errorMessage = event.error?.message
           || event.message
           || '实时语音服务错误'
-        const recoverableInactivity = isRecoverableRealtimeInactivityError(
-          errorMessage,
-        )
+        const providerError = frontend.provider.classifyError(errorMessage)
+        const recoverableInactivity = providerError === 'inactivity'
         const permissionSpeechCollision = (
           event.__voiceOrigin === 'permission'
-          && /user is speaking/i.test(
-            errorMessage,
-          )
+          && providerError === 'input_busy'
         )
         if (permissionSpeechCollision) {
           schedulePermissionRetry()
@@ -1081,9 +1078,7 @@ export function attachRealtimeGateway(server, {
         }
         // 取消撞上已完成响应的良性竞态:提供方回"无进行中响应",对用户无意义,
         // 也不应触发失败簿记(此时本就没有响应在跑)。
-        const benignCancelRace = /no active response/i.test(
-          errorMessage,
-        )
+        const benignCancelRace = providerError === 'no_active_response'
         if (benignCancelRace) return
         const id = responseId(event)
         const context = responseContexts.get(id)
@@ -1120,10 +1115,10 @@ export function attachRealtimeGateway(server, {
           config.announcementQuietMs,
         )
         timer.unref?.()
-        // Qwen may close an inactive response scope after 180 seconds while a
-        // delegated backend task is still running. The task remains healthy,
-        // and any pending announcement has already been returned to the retry
-        // queue above, so this provider housekeeping event is not user-facing.
+        // A provider may close an inactive response scope while a delegated
+        // backend task is still running. The task remains healthy, and any
+        // pending announcement has already returned to the retry queue, so this
+        // provider housekeeping event is not user-facing.
         if (!recoverableInactivity) {
           send(ws, { type: 'error', message: errorMessage })
         }
@@ -1146,7 +1141,10 @@ export function attachRealtimeGateway(server, {
         },
         onEvent: handleEvent,
         onError: error => {
-          if (!isRecoverableRealtimeInactivityError(error.message)) {
+          if (
+            createdFrontend.provider.classifyError(error.message)
+            !== 'inactivity'
+          ) {
             send(ws, { type: 'error', message: error.message })
           }
         },

--- a/server/src/voice/realtime-provider.mjs
+++ b/server/src/voice/realtime-provider.mjs
@@ -1,291 +1,38 @@
 import WebSocket from 'ws'
 import { randomUUID } from 'crypto'
-import { config, realtimeUrl } from '../core/config.mjs'
 import {
-  buildFrontendContext,
-  loadFrontendPrompt,
-} from '../conversation/frontend-agent-context.mjs'
+  resolveRealtimeProvider,
+  validateRealtimeProvider,
+} from './providers/registry.mjs'
 
-export const SPAWN_THINKING_TOOL_NAME = 'spawn_thinking'
-export const DELEGATE_TOOL_NAME = SPAWN_THINKING_TOOL_NAME
-export const CANCEL_AGENT_TASK_TOOL_NAME = 'cancel_agent_task'
-export const GET_AGENT_TASK_STATUS_TOOL_NAME = 'get_agent_task_status'
-export const GET_CURRENT_TIME_TOOL_NAME = 'get_current_time'
-export const USER_MEMORY_TOOL_NAME = 'user_memory'
-export const RESPOND_AGENT_PERMISSION_TOOL_NAME = 'respond_agent_permission'
+// Re-export provider-agnostic tools and instructions so existing callers
+// (tests, tool-call-handler, bootstrap) continue to work without changes.
+export {
+  SPAWN_THINKING_TOOL_NAME,
+  DELEGATE_TOOL_NAME,
+  CANCEL_AGENT_TASK_TOOL_NAME,
+  GET_AGENT_TASK_STATUS_TOOL_NAME,
+  GET_CURRENT_TIME_TOOL_NAME,
+  USER_MEMORY_TOOL_NAME,
+  RESPOND_AGENT_PERMISSION_TOOL_NAME,
+  TOOLS,
+  buildFrontendInstructions,
+} from './frontend-tools.mjs'
 
-const delegateTool = {
-  type: 'function',
-  function: {
-    name: DELEGATE_TOOL_NAME,
-    description: '把明确的新执行或调查要求交给后台 Agent。需要当前信息、搜索、检查、工具、文件、屏幕、应用、代码、创作，或要求继续、修改已有工作时调用；询问此前工作的状态、进度、阶段产物或已经发现了什么统一改用 get_agent_task_status。缺少不可推断的核心目标时先问一个必要问题。可以按需先说一句具体行动预告，不要使用“好的、收到”等通用承接语。返回 accepted 只表示已受理；结合本轮已有发言判断是否还需回应，不重复确认或声称完成。',
-    parameters: {
-      type: 'object',
-      properties: {
-        objective: {
-          type: 'string',
-          description: '必须是已经可以执行的目标，忠实保留本轮用户要求并写明对象、动作、约束和期望结果，不得用“待用户说明主题”等占位内容启动空执行。仅在当前对话已经明确时消解“它、刚才那个”等指代；不要猜测或补造事实。后台 Agent 会同时收到近期对话和后台执行状态，因此这里是意图交接，不是对历史的替代。',
-        },
-      },
-      required: ['objective'],
-      additionalProperties: false,
-    },
-  },
-}
-
-const cancelAgentTaskTool = {
-  type: 'function',
-  function: {
-    name: CANCEL_AGENT_TASK_TOOL_NAME,
-    description: '取消用户此前交给后台、目前仍在排队或执行的工作。用户明确说取消、停止、别做了、不要继续，或要求取消“刚才那个任务”时必须调用，不要只口头说忽略结果。能够从运行上下文确定 work_id 时传入；用户泛指刚才的工作时可省略，系统会取消最近提交且仍活跃的工作。',
-    parameters: {
-      type: 'object',
-      properties: {
-        work_id: {
-          type: 'string',
-          description: '要取消的 work_id。仅在运行上下文已明确给出时填写；不得猜造。省略则取消当前语音会话最近提交且仍活跃的工作。',
-        },
-      },
-      additionalProperties: false,
-    },
-  },
-}
-
-const getAgentTaskStatusTool = {
-  type: 'function',
-  function: {
-    name: GET_AGENT_TASK_STATUS_TOOL_NAME,
-    description: '查询此前交给后台工作的状态、进度或阶段性结果。用户询问“刚才那个怎么样了、还在做吗、做到哪一步、已经发现了什么、是否完成”时统一调用，不要自行判断普通任务或第三层任务，也不要改用 spawn_thinking。系统会直接回答普通任务，并自动查询第三层任务。能够从运行上下文确定 work_id 时传入；省略时查询当前语音会话最近的工作。',
-    parameters: {
-      type: 'object',
-      properties: {
-        work_id: {
-          type: 'string',
-          description: '要查询的 work_id。仅在运行上下文已明确给出时填写，不得猜造；省略则查询当前语音会话最近的工作。',
-        },
-        question: {
-          type: 'string',
-          description: '用户本轮对任务状态、进度或阶段结果的原始问题。尽量忠实保留，不要自行改写成另一项任务；省略时系统会使用本轮语音转写。',
-        },
-      },
-      additionalProperties: false,
-    },
-  },
-}
-
-const getCurrentTimeTool = {
-  type: 'function',
-  function: {
-    name: GET_CURRENT_TIME_TOOL_NAME,
-    description: '获取用户本地时区中的准确当前日期、时间和星期。用户询问当前时间、今天日期、星期或相对日期判断时调用；不用于创建提醒。',
-    parameters: {
-      type: 'object',
-      properties: {},
-      additionalProperties: false,
-    },
-  },
-}
-
-const userMemoryTool = {
-  type: 'function',
-  function: {
-    name: USER_MEMORY_TOOL_NAME,
-    description: '管理千问Audio前台持有的用户记忆。profile 用于称呼、时区、语言和稳定交互偏好；long_term 用于用户明确希望跨会话保留的个人事实、喜好、目标和约定；不要保存项目执行历史或后台工作细节。使用 recall 回忆，remember 新增，replace 用新事实替换明确相关的旧记录，forget 遗忘。',
-    parameters: {
-      type: 'object',
-      properties: {
-        action: {
-          type: 'string',
-          enum: ['recall', 'remember', 'replace', 'forget'],
-          description: '要执行的记忆操作。',
-        },
-        scope: {
-          type: 'string',
-          enum: ['profile', 'long_term', 'all'],
-          description: '记忆范围。remember 和 replace 必须使用 profile 或 long_term；recall 和 forget 可以使用 all。',
-        },
-        content: {
-          type: 'string',
-          description: 'remember 或 replace 时要保存的完整、简洁事实。',
-        },
-        query: {
-          type: 'string',
-          description: 'recall 或 forget 时用于匹配记忆的自然语言查询。',
-        },
-        memory_ids: {
-          type: 'array',
-          items: { type: 'string' },
-          maxItems: 20,
-          description: 'replace 时要被新事实取代的旧记忆 ID；必须来自本轮 recall 结果，不得猜造。',
-        },
-        all: {
-          type: 'boolean',
-          description: '仅用于 forget；用户明确要求清空所选范围时设为 true。',
-        },
-      },
-      required: ['action', 'scope'],
-      additionalProperties: false,
-    },
-  },
-}
-
-const respondAgentPermissionTool = {
-  type: 'function',
-  function: {
-    name: RESPOND_AGENT_PERMISSION_TOOL_NAME,
-    description: '回复当前正在等待用户决定的后台权限请求。由你结合刚提出的具体权限问题和用户本轮自然表达，智能判断为本会话自动允许、拒绝或尚不明确；不要依赖固定关键词。用户回答“可以”“行”“好”“允许”“同意”“没问题”等自然肯定表达就是明确同意，应调用 always，不得要求复述固定口令。明确拒绝时调用 reject，不明确时不要调用并继续询问。',
-    parameters: {
-      type: 'object',
-      properties: {
-        authorization_id: {
-          type: 'string',
-          description: '待确认请求的 authorization_id，必须来自当前运行上下文，不得猜造。',
-        },
-        decision: {
-          type: 'string',
-          enum: ['always', 'reject'],
-          description: 'always 表示允许当前操作，并由 Gateway 在本次前台会话中自动允许后续权限请求；reject 表示拒绝当前操作，后续请求仍继续询问。',
-        },
-      },
-      required: ['authorization_id', 'decision'],
-      additionalProperties: false,
-    },
-  },
-}
-
-const TOOLS = [
-  delegateTool,
-  cancelAgentTaskTool,
-  getAgentTaskStatusTool,
-  getCurrentTimeTool,
-  userMemoryTool,
-  respondAgentPermissionTool,
-]
-
-const resultResponseInstructions = [
-  '这是先前提交工作的最终结果，不是用户的新请求。',
-  '把 result 当作事实材料，结合当前对话自然回应；可以按语境概括、合并、承接或询问必要信息，避免重复已经表达过的内容。',
-  '输入包含多个 event 时，必须覆盖每个 event 的实质结果；不得只说其中一个，也不得让过程性或状态性内容掩盖真正完成的工作。',
-  '开头直接说实际结果、关键发现、阻塞或必要问题，不用“好的、收到、任务完成了”等空泛承接语。',
-  '不要朗读协议前缀、字段、执行 ID、路径、URL 或不适合口语的长内容。',
-  '不要调用工具，不要添加事件中没有的事实，也不要把未完成说成完成。',
-].join(' ')
-
-function speakResponseInstructions(content) {
-  return `请以自然口语传达下面的信息，保持事实一致，不调用工具：\n${content}`
-}
-
-const permissionResponseInstructions = [
-  '这是后台 Agent 的权限请求。',
-  '自然、简短地说明操作，并询问用户是否同意授权。',
-  '不要规定具体回答方式，也不要提供或要求复述固定口令。',
-  '不要调用工具或朗读内部字段，等待用户回答。',
-].join(' ')
-
-export function buildFrontendInstructions(agentContext = {}) {
-  return `${loadFrontendPrompt()}\n\n${buildFrontendContext(agentContext)}`
-}
+// Re-export registry symbols for backward compatibility.
+export {
+  REALTIME_PROVIDERS,
+  resolveRealtimeProvider,
+  describeActiveRealtime,
+} from './providers/registry.mjs'
 
 function responseId(event) {
   return event.response_id || event.response?.id || ''
 }
 
-function eventId() {
-  return `event_${randomUUID().replaceAll('-', '')}`
-}
-
-const dashscopeRealtimeProvider = {
-    key: 'dashscope',
-    label: 'Qwen-Audio-Realtime',
-    model: () => config.audioModel,
-    voice: () => config.audioVoice,
-    inputSampleRate: 16000,
-    apiKey: () => config.dashscopeApiKey,
-    missingKeyMessage: '请先配置 DASHSCOPE_API_KEY',
-    connectTimeoutMessage: '连接 Qwen Audio Realtime 超时',
-    url: () => realtimeUrl(config.audioRealtimeBaseUrl, config.audioModel),
-    headers: apiKey => ({ Authorization: `Bearer ${apiKey}` }),
-    buildSession: ({ configured, agentContext }) => {
-      const textOnly = agentContext?.textOnly === true
-      const session = {
-        instructions: buildFrontendInstructions(agentContext),
-        tools: TOOLS,
-      }
-      if (!configured) {
-        session.modalities = textOnly ? ['text'] : ['text', 'audio']
-        session.voice = config.audioVoice
-        session.input_audio_format = 'pcm'
-        session.output_audio_format = 'pcm'
-        session.turn_detection = textOnly ? null : { type: 'smart_turn' }
-      }
-      return session
-    },
-    buildSpeakResponse: (content, { textOnly = false } = {}) => ({
-      conversation: 'none',
-      modalities: textOnly ? ['text'] : ['text', 'audio'],
-      instructions: speakResponseInstructions(content),
-    }),
-    buildResultInjection: (content, { textOnly = false } = {}) => ({
-      item: {
-        type: 'message',
-        role: 'user',
-        content: [{ type: 'input_text', text: content }],
-      },
-      response: {
-        modalities: textOnly ? ['text'] : ['text', 'audio'],
-        tool_choice: 'none',
-        instructions: resultResponseInstructions,
-      },
-    }),
-    buildPermissionInjection: (permission, { textOnly = false } = {}) => ({
-      item: {
-        type: 'message',
-        role: 'user',
-        content: [{
-          type: 'input_text',
-          text: [
-            '<backend_permission_request>',
-            `authorization_id=${permission.id}`,
-            `operation=${permission.summary}`,
-            '</backend_permission_request>',
-          ].join('\n'),
-        }],
-      },
-      response: {
-        modalities: textOnly ? ['text'] : ['text', 'audio'],
-        tool_choice: 'none',
-        instructions: permissionResponseInstructions,
-      },
-    }),
-}
-
-export const REALTIME_PROVIDERS = {
-  dashscope: dashscopeRealtimeProvider,
-  // Compatibility alias for internal callers while provider selection moves
-  // to stable external names.
-  qwen: dashscopeRealtimeProvider,
-}
-
-export function resolveRealtimeProvider() {
-  const provider = REALTIME_PROVIDERS[
-    config.audioProvider === 'qwen' ? 'dashscope' : config.audioProvider
-  ]
-  if (!provider) {
-    throw new Error(`不支持的 Realtime 供应商：${config.audioProvider}`)
-  }
-  return provider
-}
-
-export function describeActiveRealtime() {
-  const provider = resolveRealtimeProvider()
-  return {
-    provider: provider.key,
-    label: provider.label,
-    model: provider.model(),
-    voice: provider.voice(),
-    inputSampleRate: provider.inputSampleRate,
-    configured: Boolean(provider.apiKey()),
-  }
+function normalizedEvents(value) {
+  if (!value) return []
+  return Array.isArray(value) ? value.filter(Boolean) : [value]
 }
 
 export class RealtimeFrontend {
@@ -298,7 +45,11 @@ export class RealtimeFrontend {
     responseStartTimeoutMs = 30000,
     responseCompletionTimeoutMs = 120000,
   } = {}) {
-    this.provider = provider
+    this.provider = validateRealtimeProvider(provider)
+    this.protocol = provider.protocol
+    if (!this.protocol) {
+      throw new Error(`Realtime Provider ${provider.key || provider.label} 缺少 protocol`)
+    }
     this.onEvent = onEvent
     this.onError = onError
     this.onClose = onClose
@@ -350,22 +101,40 @@ export class RealtimeFrontend {
         this.onClose?.()
       })
       ws.on('message', raw => {
-        let event
+        let providerEvent
         try {
-          event = JSON.parse(raw.toString())
+          providerEvent = JSON.parse(raw.toString())
         } catch {
           return
         }
-        if (event.type === 'session.created') this.updateSession()
-        if (event.type === 'session.updated') {
-          this.ready = true
-          this.sessionConfigured = true
-          finish()
+        try {
+          this.handleProviderEvent(providerEvent, {
+            onSessionReady: () => finish(),
+          })
+        } catch (error) {
+          this.onError?.(error)
+          finish(error)
+          ws.terminate()
         }
-        this.handleLifecycle(event)
-        this.onEvent?.(event)
       })
     })
+  }
+
+  handleProviderEvent(providerEvent, { onSessionReady } = {}) {
+    const events = normalizedEvents(
+      this.protocol.normalizeIncoming(providerEvent),
+    )
+    for (const event of events) {
+      if (event.type === 'session.created') this.updateSession()
+      if (event.type === 'session.updated') {
+        this.ready = true
+        this.sessionConfigured = true
+        onSessionReady?.()
+      }
+      this.handleLifecycle(event)
+      this.onEvent?.(event)
+    }
+    return events
   }
 
   updateSession() {
@@ -373,7 +142,7 @@ export class RealtimeFrontend {
       configured: this.sessionConfigured,
       agentContext: this.agentContext,
     })
-    this.send({ type: 'session.update', session })
+    this.send(this.protocol.sessionUpdate(session))
   }
 
   updateAgentContext(patch = {}) {
@@ -387,29 +156,24 @@ export class RealtimeFrontend {
   }
 
   appendAudio(audio) {
-    this.send({ type: 'input_audio_buffer.append', audio })
+    this.send(this.protocol.audioAppend(audio))
   }
 
   sendUserText(text, context = {}, { modalities } = {}) {
     const content = String(text || '').trim()
     if (!content) return Promise.resolve()
     return this.enqueueResponse('model', context, async () => {
-      await this.createConversationItem({
-        type: 'message',
-        role: 'user',
-        content: [{ type: 'input_text', text: content }],
-      })
-      this.send({
-        type: 'response.create',
-        ...(modalities ? { response: { modalities } } : {}),
-      })
+      await this.createConversationItem(this.protocol.userTextItem(content))
+      this.send(this.protocol.responseCreate(
+        modalities ? { modalities } : undefined,
+      ))
     })
   }
 
   ensureResponse(context = {}, { shouldCreate } = {}) {
     return this.enqueueResponse('agent', context, () => {
       if (shouldCreate && !shouldCreate()) return false
-      this.send({ type: 'response.create' })
+      this.send(this.protocol.responseCreate())
     })
   }
 
@@ -417,18 +181,13 @@ export class RealtimeFrontend {
     createResponse = true,
     response,
   } = {}) {
-    const sendOutput = () => this.createConversationItem({
-      type: 'function_call_output',
-      call_id: callId,
-      output: JSON.stringify(output),
-    })
+    const sendOutput = () => this.createConversationItem(
+      this.protocol.functionOutputItem(callId, output),
+    )
     if (!createResponse) return this.enqueueAction(sendOutput)
     return this.enqueueResponse('agent', context, async () => {
       await sendOutput()
-      this.send({
-        type: 'response.create',
-        ...(response ? { response } : {}),
-      })
+      this.send(this.protocol.responseCreate(response))
     })
   }
 
@@ -442,14 +201,11 @@ export class RealtimeFrontend {
         timer: setTimeout(() => {
           if (this.conversationItemWaiters.get(id) !== waiter) return
           this.conversationItemWaiters.delete(id)
-          reject(new Error(`Qwen 未确认对话项 ${id}`))
+          reject(new Error(`${this.provider.label} 未确认对话项 ${id}`))
         }, this.responseStartTimeoutMs),
       }
       this.conversationItemWaiters.set(id, waiter)
-      this.send({
-        type: 'conversation.item.create',
-        item: { id, ...item },
-      })
+      this.send(this.protocol.conversationItemCreate({ id, ...item }))
     })
   }
 
@@ -460,12 +216,11 @@ export class RealtimeFrontend {
     if (!content) return Promise.resolve()
     return this.enqueueResponse(origin, context, () => {
       if (shouldSpeak && !shouldSpeak()) return false
-      this.send({
-        type: 'response.create',
-        response: this.provider.buildSpeakResponse(content, {
+      this.send(this.protocol.responseCreate(
+        this.provider.buildSpeakResponse(content, {
           textOnly: this.agentContext.textOnly === true,
         }),
-      })
+      ))
     })
   }
 
@@ -486,10 +241,7 @@ export class RealtimeFrontend {
         await this.createConversationItem(injection.item)
         contextInjected = true
       }
-      this.send({
-        type: 'response.create',
-        response: injection.response,
-      })
+      this.send(this.protocol.responseCreate(injection.response))
     })
     return {
       ...(outcome || {}),
@@ -510,10 +262,7 @@ export class RealtimeFrontend {
     await this.createConversationItem(injection.item)
     return this.enqueueResponse('permission', context, pending => {
       if (pending.settled || (shouldSpeak && !shouldSpeak())) return false
-      this.send({
-        type: 'response.create',
-        response: injection.response,
-      })
+      this.send(this.protocol.responseCreate(injection.response))
     })
   }
 
@@ -525,7 +274,7 @@ export class RealtimeFrontend {
     })
     this.pendingResponses = []
     this.rejectConversationItemWaiters(new Error('Realtime 请求已取消'))
-    if (hasResponse) this.send({ type: 'response.cancel' })
+    if (hasResponse) this.send(this.protocol.responseCancel())
   }
 
   cancelResponses(predicate) {
@@ -554,7 +303,7 @@ export class RealtimeFrontend {
         phase: 'completion',
       })
     }
-    if (cancelledActive) this.send({ type: 'response.cancel' })
+    if (cancelledActive) this.send(this.protocol.responseCancel())
     return cancelledActive
   }
 
@@ -647,7 +396,9 @@ export class RealtimeFrontend {
       const waiter = this.conversationItemWaiters.values().next().value
       clearTimeout(waiter.timer)
       this.conversationItemWaiters.delete(waiter.id)
-      const error = new Error(event.error?.message || 'Qwen 创建对话项失败')
+      const error = new Error(
+        event.error?.message || `${this.provider.label} 创建对话项失败`,
+      )
       error.realtimeEvent = true
       waiter.reject(error)
       return
@@ -663,7 +414,7 @@ export class RealtimeFrontend {
         if (pending) {
           pending.timer = setTimeout(() => {
             if (this.responseWaiters.get(id) !== pending) return
-            this.send({ type: 'response.cancel' })
+            this.send(this.protocol.responseCancel())
             this.settlePending(pending, {
               timedOut: true,
               phase: 'completion',
@@ -681,13 +432,22 @@ export class RealtimeFrontend {
         }
       }
     }
-    if (event.type === 'response.done' || event.type === 'error') {
+    if (
+      event.type === 'response.done'
+      || event.type === 'error'
+    ) {
       let id = responseId(event)
       let pending = this.responseWaiters.get(id)
-      if (event.type === 'error' && !pending && !id && this.pendingResponses.length) {
+      if (
+        event.type === 'error'
+        && !pending && !id && this.pendingResponses.length
+      ) {
         pending = this.pendingResponses.shift()
       }
-      if (event.type === 'error' && !pending && this.responseWaiters.size === 1) {
+      if (
+        event.type === 'error'
+        && !pending && this.responseWaiters.size === 1
+      ) {
         const first = this.responseWaiters.entries().next().value
         id = first[0]
         pending = first[1]
@@ -753,10 +513,7 @@ export class RealtimeFrontend {
 
   send(payload) {
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
-        event_id: eventId(),
-        ...payload,
-      }))
+      this.ws.send(JSON.stringify(this.protocol.encodeOutgoing(payload)))
     }
   }
 }

--- a/server/test/realtime-provider.test.mjs
+++ b/server/test/realtime-provider.test.mjs
@@ -240,6 +240,83 @@ test('adds an event id to realtime client events', () => {
   assert.equal(sent.audio, 'pcm')
 })
 
+test('isolates a provider with a different wire message shape', () => {
+  const events = []
+  let sent
+  const base = REALTIME_PROVIDERS.qwen
+  const provider = {
+    ...base,
+    key: 'custom',
+    label: 'Custom Realtime',
+    protocol: {
+      ...base.protocol,
+      encodeOutgoing: payload => ({ frame: payload }),
+      audioAppend: audio => ({ op: 'push-audio', chunk: audio }),
+      normalizeIncoming: event => {
+        if (event.kind === 'started') {
+          return {
+            type: 'response.created',
+            response: { id: event.responseId },
+          }
+        }
+        if (event.kind === 'finished') {
+          return {
+            type: 'response.done',
+            response: {
+              id: event.responseId,
+              status: event.outcome,
+            },
+          }
+        }
+        return null
+      },
+    },
+  }
+  const frontend = new RealtimeFrontend({
+    provider,
+    onEvent: event => events.push(event),
+  })
+  frontend.ws = {
+    readyState: 1,
+    send: value => {
+      sent = JSON.parse(value)
+    },
+  }
+  frontend.pendingResponses.push({
+    origin: 'agent',
+    context: { turnId: 'turn-custom' },
+    resolve: () => {},
+    settled: false,
+    timer: null,
+  })
+
+  frontend.appendAudio('custom-pcm')
+  assert.deepEqual(sent, {
+    frame: {
+      op: 'push-audio',
+      chunk: 'custom-pcm',
+    },
+  })
+
+  frontend.handleProviderEvent({
+    kind: 'started',
+    responseId: 'custom-response',
+  })
+  assert.equal(frontend.activeResponses.has('custom-response'), true)
+  assert.equal(events[0].type, 'response.created')
+  assert.deepEqual(events[0].__voiceContext, {
+    turnId: 'turn-custom',
+  })
+
+  frontend.handleProviderEvent({
+    kind: 'finished',
+    responseId: 'custom-response',
+    outcome: 'completed',
+  })
+  assert.equal(frontend.activeResponses.size, 0)
+  assert.equal(events[1].type, 'response.done')
+})
+
 test('builds frontend identity, time, memory and reconnect context', () => {
   const prompt = buildFrontendInstructions({
     client: { timeZone: 'Asia/Shanghai', locale: 'zh-CN' },


### PR DESCRIPTION
## Summary

- extract frontend tools/instructions from the Realtime transport
- introduce a validated Realtime provider registry and a dedicated DashScope provider
- isolate wire encoding, outgoing message construction, and incoming event normalization behind a provider protocol adapter
- move output sample rate and provider-specific error classification out of the Gateway
- preserve the existing DashScope/Qwen behavior and compatibility exports

## Review fixes

The initial local refactor split provider files but still allowed provider wire details to leak into `RealtimeFrontend` and `realtime-gateway`. This PR completes the boundary: a provider with different field names and event shapes can normalize into the Gateway lifecycle without changing Gateway or UI code.

## Validation

- `npm run release:check`
- custom non-OpenAI-compatible wire-format test
- npm artifact verification (138 files)