### PR TITLE
feat: surface backend agent availability in desktop settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,15 +251,18 @@ AGENT_PROTOCOL=opencode
 AGENT_PROTOCOL=qoder
 ```
 
-Kimi Code、Hermes、CodeBuddy、Codex 和 Claude Code 也可直接选择：
+后台 Agent 需要用户自行安装并完成原生配置；qwen-audio-agent 会复用其
+用户级模型、工具、MCP、Skill 和认证。
 
-```dotenv
-AGENT_PROTOCOL=kimi
-# 或 hermes、codebuddy、codex、claude
+其中部分 Agent 通过外部 ACP 适配器接入，除本体外，还需要全局安装对应的适配器。
+以 Codex 为例：
+
+```bash
+npm install -g @agentclientprotocol/codex-acp
 ```
 
-以上其他后台暂时需要用户自行安装并完成原生配置；qwen-audio-agent 会复用其
-用户级模型、工具、MCP、Skill 和认证。
+CLI 模式缺少适配器时会尝试通过 npx 按需启动；桌面版为保证启动可靠，仅使用已安装的
+组件，请提前安装。
 
 使用其他支持 ACP stdio 的 Agent：
 
@@ -321,6 +324,7 @@ npm run desktop   # macOS 桌面悬浮球
 ## 交流与分享
 
 你可以直接在 [GitHub Issues](https://github.com/QwenAudio/qwen-audio-agent/issues) 发起讨论。
+
 对中国用户，也可以扫描左侧二维码加入微信交流群；如果群二维码已满或过期，
 扫描右侧任一维护者的个人二维码，维护者会邀请你进群。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -283,17 +283,20 @@ Use Qoder:
 AGENT_PROTOCOL=qoder
 ```
 
-Kimi Code, Hermes, CodeBuddy, Codex, and Claude Code can also be selected
-directly:
+Backend Agents require the user to install and configure the native Agent
+first. qwen-audio-agent reuses its user-level model, tools, MCP servers,
+Skills, and authentication.
 
-```dotenv
-AGENT_PROTOCOL=kimi
-# Or hermes, codebuddy, codex, or claude
+Some Agents connect through external ACP adapters. Besides the Agent itself,
+install the matching adapter globally. For example, for Codex:
+
+```bash
+npm install -g @agentclientprotocol/codex-acp
 ```
 
-These other backends currently require the user to install and configure the
-native Agent first. qwen-audio-agent reuses its user-level model, tools, MCP
-servers, Skills, and authentication.
+The CLI falls back to starting a missing adapter on demand with npx; the
+desktop app only uses installed components for reliable startup, so install
+the adapter up front.
 
 Use another Agent that supports ACP over stdio:
 
@@ -369,6 +372,7 @@ releasing.
 
 You can start a discussion directly in
 [GitHub Issues](https://github.com/QwenAudio/qwen-audio-agent/issues).
+
 For users in China, you can also scan the QR code on the left to join our
 WeChat group. If the group code is full or expired, scan either maintainer's
 personal QR code on the right and they will invite you to the group.

--- a/cli/test/backend-setup.test.mjs
+++ b/cli/test/backend-setup.test.mjs
@@ -161,6 +161,63 @@ test('honors explicit package and binary runtime requirements', () => {
   assert.match(missingAdapter.issues[0], /codex-acp/)
 })
 
+test('desktop installed-only mode disables every npx fallback', () => {
+  const env = {
+    QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY: '1',
+    DASHSCOPE_API_KEY: 'test-key',
+    QWEN_AUDIO_AGENT_BACKEND_MODEL: 'qwen3.7-max',
+  }
+
+  // 未安装时不再走百炼自动部署，直接报告未安装
+  const missingOpenCode = inspector({
+    backend: 'opencode',
+    env,
+    commands: { npx: '/bin/npx' },
+  }).backends[0]
+  assert.equal(missingOpenCode.ready, false)
+  assert.match(missingOpenCode.issues[0], /未找到 OpenCode/)
+  assert.doesNotMatch(missingOpenCode.issues[0], /自动部署/)
+
+  // 版本过低时不再 npx 回退，报告版本不兼容
+  const legacyOpenCode = inspector({
+    backend: 'opencode',
+    env,
+    commands: { opencode: '/bin/opencode', npx: '/bin/npx' },
+    versions: { '/bin/opencode': '1.17.9' },
+  }).backends[0]
+  assert.equal(legacyOpenCode.ready, false)
+  assert.match(legacyOpenCode.issues[0], /低于最低版本/)
+
+  // 缺少 ACP Adapter 时不再 npx 回退，提示手动安装
+  const claude = inspector({
+    backend: 'claude',
+    env,
+    commands: { claude: '/bin/claude', npx: '/bin/npx' },
+  }).backends[0]
+  assert.equal(claude.ready, false)
+  assert.match(claude.issues[0], /桌面版需先手动安装/)
+
+  // package 模式同样被拒绝
+  const packageMode = inspector({
+    backend: 'claude',
+    env: { ...env, CLAUDE_CODE_ACP_RUNTIME: 'package' },
+    commands: { claude: '/bin/claude', npx: '/bin/npx' },
+  }).backends[0]
+  assert.equal(packageMode.ready, false)
+  assert.match(packageMode.issues[0], /桌面版需先安装 ACP Adapter/)
+
+  // 已安装的组件不受影响
+  const installed = inspector({
+    backend: 'claude',
+    env,
+    commands: {
+      claude: '/bin/claude',
+      'claude-code-acp': '/bin/claude-code-acp',
+    },
+  }).backends[0]
+  assert.equal(installed.ready, true)
+})
+
 test('formats a concise read-only setup report', () => {
   const report = inspector({
     backend: 'codex',

--- a/desktop/src/backend-options.mjs
+++ b/desktop/src/backend-options.mjs
@@ -1,0 +1,46 @@
+// 设置页"后台 Agent"下拉列表的展示状态计算。
+// 输入是 shared/backend-setup.mjs 的 inspectBackendSetups() 报告，
+// 保持纯函数，浏览器渲染层与 Node 测试共用同一份逻辑。
+
+export const NONE_OPTION_ID = 'none'
+
+export const NONE_OPTION_LABEL = '不使用后台 Agent'
+
+// 列表空间有限，把 issue 文案归并为短标签；完整原因放进 option 的 title。
+function shortReason(issues) {
+  const text = String(issues?.[0] || '').trim()
+  if (!text) return '当前不可用'
+  if (/未找到|PATH 中未找到/.test(text)) return '未安装'
+  if (/低于最低版本|不兼容|无法确认.*版本/.test(text)) return '版本不兼容'
+  if (/DASHSCOPE_API_KEY|QWEN_AUDIO_AGENT_BACKEND_MODEL/.test(text)) {
+    return '缺少百炼配置'
+  }
+  if (/ACP Adapter|缺少 \S+，并且 npx 不可用/.test(text)) return '需要 ACP 适配器'
+  if (/指定的命令不可用|指定的 ACP Adapter 不可用|请设置/.test(text)) {
+    return '需要配置'
+  }
+  return '当前不可用'
+}
+
+export function backendOptionStates(report) {
+  const states = [{
+    id: NONE_OPTION_ID,
+    label: NONE_OPTION_LABEL,
+    disabled: false,
+    title: '',
+  }]
+  for (const item of report?.backends || []) {
+    const ready = item.ready === true
+    states.push({
+      id: item.id,
+      label: ready
+        ? item.label || item.id
+        : `${item.label || item.id}（${shortReason(item.issues)}）`,
+      // 当前生效的配置项即使不可用也保持可选，否则下拉框无法显示
+      // 当前值，用户也无法通过它改回其他选项。
+      disabled: !ready && item.selected !== true,
+      title: ready ? '' : String(item.issues?.[0] || '').trim(),
+    })
+  }
+  return states
+}

--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -30,6 +30,9 @@ import {
   readGatewayHealth,
 } from '../../shared/gateway-client.mjs'
 import {
+  inspectBackendSetups,
+} from '../../shared/backend-setup.mjs'
+import {
   desktopGatewayEnvironment,
   EmbeddedGateway,
 } from './gateway-process.mjs'
@@ -40,6 +43,14 @@ import {
 import {
   startDesktopRendererServer,
 } from './renderer-server.mjs'
+import {
+  expandProcessPath,
+} from './process-path.mjs'
+
+// macOS / Linux 图形界面应用的 PATH 只包含系统目录。在启动最早阶段
+// 将其扩充为用户登录 shell 的 PATH，让 Gateway 子进程与后台可用性
+// 检测能找到通过 Homebrew、nvm 或官方脚本安装的 Agent 命令。
+expandProcessPath()
 
 const here = dirname(fileURLToPath(import.meta.url))
 const sourceRoot = resolve(here, '../..')
@@ -448,6 +459,37 @@ ipcMain.handle('qwen-audio-agent:settings-runtime-status', async event => {
     throw new Error('无权读取运行状态')
   }
   return runtimeStatus()
+})
+
+// 与 `qwenaudio setup --json` 同款的只读检测，供设置页标注各后台
+// Agent 在本机的可用状态。合并 config.env 是因为检测需要其中的
+// AGENT_PROTOCOL / DASHSCOPE_API_KEY / ACP_COMMAND 等配置。
+// INSTALLED_ONLY 与 gateway-process.mjs 保持一致：桌面版运行时禁止
+// npx 按需回退，检测口径必须与运行时一致，只认已安装的组件。
+ipcMain.handle('qwen-audio-agent:settings-detect-backends', async event => {
+  if (!settingsWindow || event.sender !== settingsWindow.webContents) {
+    throw new Error('无权检测后台 Agent')
+  }
+  const configured = existsSync(runtimeEnvironment.configPath)
+    ? parseEnv(readFileSync(runtimeEnvironment.configPath, 'utf8'))
+    : {}
+  const report = inspectBackendSetups({
+    env: {
+      ...process.env,
+      ...configured,
+      QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY: '1',
+    },
+  })
+  return {
+    selected: report.selected,
+    backends: report.backends.map(item => ({
+      id: item.id,
+      label: item.label,
+      ready: item.ready,
+      selected: item.selected,
+      issues: item.issues,
+    })),
+  }
 })
 
 ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {

--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -14,6 +14,9 @@ contextBridge.exposeInMainWorld('qwenAudioAgentDesktop', {
   loadRuntimeStatus: () => ipcRenderer.invoke(
     'qwen-audio-agent:settings-runtime-status',
   ),
+  detectBackends: () => ipcRenderer.invoke(
+    'qwen-audio-agent:settings-detect-backends',
+  ),
   saveSettings: settings => ipcRenderer.invoke(
     'qwen-audio-agent:settings-save',
     settings,

--- a/desktop/src/process-path.mjs
+++ b/desktop/src/process-path.mjs
@@ -1,0 +1,61 @@
+import { existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+
+// macOS / Linux 图形界面应用的 PATH 只包含系统目录，找不到通过 Homebrew、
+// nvm 或 Agent 官方安装脚本（如 ~/.kimi-code/bin）安装的命令。与终端保持
+// 一致的唯一可靠方式是读取用户登录 shell 解析后的 PATH；失败时回退到
+// 常见安装目录列表。
+
+const PATH_MARK = 'QWEN_AUDIO_AGENT_PATH'
+
+export function loginShellPath({
+  shell,
+  spawnImpl = spawnSync,
+  timeoutMs = 3000,
+} = {}) {
+  if (!shell) return ''
+  try {
+    // -l 读取 login 配置（如 homebrew），-i 读取 interactive 配置
+    // （nvm 等版本管理器通常在这里初始化）。用标记提取以容忍 shell
+    // 启动脚本里的其他输出。
+    const result = spawnImpl(
+      shell,
+      ['-l', '-i', '-c', `echo "${PATH_MARK}<<<$PATH>>>"`],
+      { encoding: 'utf8', timeout: timeoutMs, windowsHide: true },
+    )
+    const match = String(result?.stdout || '').match(
+      new RegExp(`${PATH_MARK}<<<([\\s\\S]*?)>>>`),
+    )
+    return match ? match[1].trim() : ''
+  } catch {
+    return ''
+  }
+}
+
+export function fallbackPathDirectories(home) {
+  return [
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    ...(home ? [`${home}/.local/bin`] : []),
+  ]
+}
+
+export function expandProcessPath({
+  env = process.env,
+  platform = process.platform,
+  spawnImpl = spawnSync,
+  existsImpl = existsSync,
+} = {}) {
+  if (platform === 'win32') return false
+  const current = (env.PATH || '').split(':').filter(Boolean)
+  const shellPath = loginShellPath({ shell: env.SHELL, spawnImpl })
+  const candidates = shellPath
+    ? shellPath.split(':').filter(Boolean)
+    : fallbackPathDirectories(env.HOME)
+  const missing = candidates.filter(
+    dir => !current.includes(dir) && existsImpl(dir),
+  )
+  if (missing.length === 0) return false
+  env.PATH = [...current, ...missing].join(':')
+  return true
+}

--- a/desktop/src/settings.css
+++ b/desktop/src/settings.css
@@ -238,6 +238,13 @@ button {
   transform: translateY(-1px);
 }
 
+.link-button:disabled {
+  opacity: .55;
+  box-shadow: none;
+  cursor: default;
+  transform: none;
+}
+
 footer {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/desktop/src/settings.html
+++ b/desktop/src/settings.html
@@ -70,18 +70,16 @@
 
           <div class="setting-row">
             <label for="agent-protocol">后台 Agent</label>
-            <select id="agent-protocol">
-              <option value="none">不使用后台 Agent</option>
-              <option value="opencode">OpenCode</option>
-              <option value="openclaw">OpenClaw</option>
-              <option value="qoder">Qoder</option>
-              <option value="kimi">Kimi Code</option>
-              <option value="hermes">Hermes</option>
-              <option value="codebuddy">CodeBuddy</option>
-              <option value="codex">Codex</option>
-              <option value="claude">Claude Code</option>
-              <option value="acp">通用 ACP Agent</option>
-            </select>
+            <div class="field-with-action">
+              <!-- 选项由 settings.js 按本机检测结果动态渲染 -->
+              <select id="agent-protocol"></select>
+              <button
+                id="refresh-backends"
+                class="link-button"
+                type="button"
+                title="重新检测本机已安装的后台 Agent"
+              >刷新</button>
+            </div>
           </div>
 
           <div class="setting-row">
@@ -115,6 +113,6 @@
         </footer>
       </form>
     </main>
-    <script src="./settings.js"></script>
+    <script src="./settings.js" type="module"></script>
   </body>
 </html>

--- a/desktop/src/settings.js
+++ b/desktop/src/settings.js
@@ -1,8 +1,11 @@
+import { backendOptionStates } from './backend-options.mjs'
+
 const form = document.querySelector('#settings-form')
 const gatewayUrl = document.querySelector('#gateway-url')
 const orbStyle = document.querySelector('#orb-style')
 const dashscopeApiKey = document.querySelector('#dashscope-api-key')
 const agentProtocol = document.querySelector('#agent-protocol')
+const refreshBackends = document.querySelector('#refresh-backends')
 const realtimeModel = document.querySelector('#realtime-model')
 const backendModel = document.querySelector('#backend-model')
 const getApiKey = document.querySelector('#get-api-key')
@@ -14,6 +17,7 @@ const submit = form.querySelector('button[type="submit"]')
 
 let settings
 let runtime
+let backendReport = null
 let appliedFingerprint = ''
 let applying = false
 let refreshingRuntime = false
@@ -28,6 +32,34 @@ function friendlyError(error, fallback) {
     /^Error invoking remote method '[^']+': Error:\s*/,
     '',
   )
+}
+
+function truncate(text, max = 80) {
+  const value = String(text || '').trim()
+  return value.length > max ? `${value.slice(0, max)}…` : value
+}
+
+// 按本机检测结果重建后台 Agent 下拉列表：可用的正常显示，不可用的
+// 置灰并标注原因；当前生效的值即使不可用也保留，避免下拉框丢值。
+function renderBackendOptions(currentValue) {
+  const states = backendOptionStates(backendReport)
+  if (currentValue && !states.some(state => state.id === currentValue)) {
+    states.push({
+      id: currentValue,
+      label: backendLabel(currentValue),
+      disabled: false,
+      title: '',
+    })
+  }
+  agentProtocol.replaceChildren(...states.map(state => {
+    const option = document.createElement('option')
+    option.value = state.id
+    option.textContent = state.label
+    option.disabled = state.disabled
+    if (state.title) option.title = state.title
+    return option
+  }))
+  agentProtocol.value = currentValue || 'none'
 }
 
 function backendLabel(value) {
@@ -97,6 +129,13 @@ function renderRuntime() {
   }
   const label = runtime.backend.label
     || backendLabel(runtime.backend.protocol)
+  if (!runtime.backend.connected && runtime.backend.error) {
+    const reason = String(runtime.backend.error).trim()
+    setBackendStatus(`${label} 未连接：${truncate(reason)}`, false)
+    currentBackend.title = reason
+    return
+  }
+  currentBackend.title = ''
   const details = runtime.backend.baseUrl
     ? `${label} · ${runtime.backend.baseUrl}`
     : label
@@ -124,11 +163,28 @@ async function refreshRuntime() {
   }
 }
 
+async function detectBackendOptions() {
+  refreshBackends.disabled = true
+  try {
+    backendReport = await window.qwenAudioAgentDesktop.detectBackends()
+    renderBackendOptions(agentProtocol.value || settings?.agentProtocol)
+    updateApplyState()
+  } catch (error) {
+    showMessage(friendlyError(error, '检测后台 Agent 失败'), 'error')
+  } finally {
+    refreshBackends.disabled = false
+  }
+}
+
+refreshBackends.addEventListener('click', () => {
+  void detectBackendOptions()
+})
+
 function render() {
   gatewayUrl.value = settings.gatewayUrl
   orbStyle.value = settings.orbStyle
   dashscopeApiKey.value = settings.dashscopeApiKey || ''
-  agentProtocol.value = settings.agentProtocol || 'none'
+  renderBackendOptions(settings.agentProtocol || 'none')
   realtimeModel.value = settings.realtimeModel
     || 'qwen-audio-3.0-realtime-plus'
   backendModel.value = settings.backendModel || ''
@@ -191,6 +247,7 @@ window.qwenAudioAgentDesktop.loadSettings().then(value => {
   settings = value.settings
   runtime = value.runtime
   render()
+  void detectBackendOptions()
   if (value.runtimeError) {
     showMessage(`当前配置启动失败：${value.runtimeError}`, 'error')
   } else if (value.setupRequired) {

--- a/desktop/test/backend-options.test.mjs
+++ b/desktop/test/backend-options.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { backendOptionStates } from '../src/backend-options.mjs'
+
+function report(backends) {
+  return { selected: '', readOnly: true, backends }
+}
+
+test('always offers the none option first, even without a report', () => {
+  const states = backendOptionStates(null)
+  assert.deepEqual(states, [{
+    id: 'none',
+    label: '不使用后台 Agent',
+    disabled: false,
+    title: '',
+  }])
+})
+
+test('ready backends are selectable with a plain label', () => {
+  const states = backendOptionStates(report([
+    {
+      id: 'opencode',
+      label: 'OpenCode',
+      ready: true,
+      selected: false,
+      issues: [],
+    },
+  ]))
+  assert.deepEqual(states[1], {
+    id: 'opencode',
+    label: 'OpenCode',
+    disabled: false,
+    title: '',
+  })
+})
+
+test('unavailable backends are disabled with a short reason and full title', () => {
+  const states = backendOptionStates(report([
+    {
+      id: 'claude',
+      label: 'Claude Code',
+      ready: false,
+      selected: false,
+      issues: ['未找到 Claude Code，请先安装并完成原生配置'],
+    },
+  ]))
+  assert.equal(states[1].disabled, true)
+  assert.equal(states[1].label, 'Claude Code（未安装）')
+  assert.equal(states[1].title, '未找到 Claude Code，请先安装并完成原生配置')
+})
+
+test('keeps the selected backend selectable even when unavailable', () => {
+  const states = backendOptionStates(report([
+    {
+      id: 'claude',
+      label: 'Claude Code',
+      ready: false,
+      selected: true,
+      issues: ['未找到 Claude Code，请先安装并完成原生配置'],
+    },
+  ]))
+  assert.equal(states[1].disabled, false)
+  assert.match(states[1].label, /（未安装）/)
+})
+
+test('classifies issue texts into short reasons', () => {
+  const cases = [
+    ['PATH 中未找到 OpenCode', '未安装'],
+    ['未找到 Kimi Code，请先安装并完成原生配置', '未安装'],
+    ['OpenCode 1.17.9 低于最低版本 1.18.0', '版本不兼容'],
+    ['Kimi Code 版本不兼容；自动部署需要 DASHSCOPE_API_KEY', '版本不兼容'],
+    ['无法确认 Kimi Code 版本', '版本不兼容'],
+    ['缺少 DASHSCOPE_API_KEY 和 QWEN_AUDIO_AGENT_BACKEND_MODEL', '缺少百炼配置'],
+    ['缺少 claude-code-acp，并且 npx 不可用', '需要 ACP 适配器'],
+    ['ACP_COMMAND 指定的命令不可用：missing-agent', '需要配置'],
+    ['', '当前不可用'],
+  ]
+  for (const [issue, reason] of cases) {
+    const states = backendOptionStates(report([
+      {
+        id: 'x',
+        label: 'X',
+        ready: false,
+        selected: false,
+        issues: [issue],
+      },
+    ]))
+    assert.equal(states[1].label, `X（${reason}）`, issue)
+  }
+})

--- a/desktop/test/process-path.test.mjs
+++ b/desktop/test/process-path.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  expandProcessPath,
+  fallbackPathDirectories,
+  loginShellPath,
+} from '../src/process-path.mjs'
+
+test('extracts PATH from login shell output with rc noise', () => {
+  const path = loginShellPath({
+    shell: '/bin/zsh',
+    spawnImpl: () => ({
+      stdout: 'some rc banner\nQWEN_AUDIO_AGENT_PATH<<</Users/x/.nvm/bin:/usr/bin>>>\n',
+    }),
+  })
+  assert.equal(path, '/Users/x/.nvm/bin:/usr/bin')
+})
+
+test('returns empty when the shell is missing or the mark is absent', () => {
+  assert.equal(loginShellPath({ shell: '' }), '')
+  assert.equal(
+    loginShellPath({
+      shell: '/bin/zsh',
+      spawnImpl: () => ({ stdout: 'no mark here' }),
+    }),
+    '',
+  )
+  assert.equal(
+    loginShellPath({
+      shell: '/bin/zsh',
+      spawnImpl: () => {
+        throw new Error('timeout')
+      },
+    }),
+    '',
+  )
+})
+
+test('expands process PATH with login shell directories', () => {
+  const env = {
+    PATH: '/usr/bin:/bin',
+    SHELL: '/bin/zsh',
+    HOME: '/Users/x',
+  }
+  const expanded = expandProcessPath({
+    env,
+    platform: 'darwin',
+    spawnImpl: () => ({
+      stdout: 'QWEN_AUDIO_AGENT_PATH<<</Users/x/.kimi-code/bin:/usr/bin:/Users/x/.nvm/bin>>>',
+    }),
+    existsImpl: () => true,
+  })
+  assert.equal(expanded, true)
+  assert.equal(
+    env.PATH,
+    '/usr/bin:/bin:/Users/x/.kimi-code/bin:/Users/x/.nvm/bin',
+  )
+})
+
+test('skips duplicates and directories that do not exist', () => {
+  const env = { PATH: '/usr/bin', SHELL: '/bin/zsh', HOME: '/Users/x' }
+  expandProcessPath({
+    env,
+    platform: 'darwin',
+    spawnImpl: () => ({
+      stdout: 'QWEN_AUDIO_AGENT_PATH<<</usr/bin:/missing:/tools/bin>>>',
+    }),
+    existsImpl: dir => dir !== '/missing',
+  })
+  assert.equal(env.PATH, '/usr/bin:/tools/bin')
+})
+
+test('falls back to well-known directories without a login shell', () => {
+  const env = { PATH: '/usr/bin', HOME: '/Users/x' }
+  const expanded = expandProcessPath({
+    env,
+    platform: 'linux',
+    spawnImpl: () => {
+      throw new Error('no shell')
+    },
+    existsImpl: dir => dir === '/opt/homebrew/bin',
+  })
+  assert.equal(expanded, true)
+  assert.equal(env.PATH, '/usr/bin:/opt/homebrew/bin')
+  assert.deepEqual(fallbackPathDirectories('/Users/x'), [
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/Users/x/.local/bin',
+  ])
+})
+
+test('does nothing on Windows or when PATH is already complete', () => {
+  const env = { PATH: 'C:\\Windows' }
+  assert.equal(expandProcessPath({ env, platform: 'win32' }), false)
+  assert.equal(env.PATH, 'C:\\Windows')
+
+  const complete = { PATH: '/usr/bin', SHELL: '/bin/zsh' }
+  assert.equal(
+    expandProcessPath({
+      env: complete,
+      platform: 'darwin',
+      spawnImpl: () => ({ stdout: 'QWEN_AUDIO_AGENT_PATH<<</usr/bin>>>' }),
+      existsImpl: () => true,
+    }),
+    false,
+  )
+})

--- a/desktop/test/settings-config.test.mjs
+++ b/desktop/test/settings-config.test.mjs
@@ -162,7 +162,11 @@ test('desktop settings expose the embedded voice service without editing backend
   assert.match(html, /id="agent-protocol"/)
   assert.match(html, /id="realtime-model"/)
   assert.match(html, /id="backend-model"/)
-  assert.match(html, /<option value="kimi">Kimi Code<\/option>/)
+  // 后台 Agent 选项按本机可用性检测结果动态渲染，HTML 里只保留空容器
+  assert.match(html, /<select id="agent-protocol"><\/select>/)
+  assert.match(html, /id="refresh-backends"/)
+  assert.match(html, /<script src="\.\/settings\.js" type="module"><\/script>/)
+  assert.doesNotMatch(html, /<option value="kimi">/)
   for (const id of [
     'api-key',
     'realtime-voice',

--- a/shared/backend-setup.mjs
+++ b/shared/backend-setup.mjs
@@ -256,6 +256,9 @@ function inspectAdapter(spec, env, find) {
   if (!spec.adapterCommand) {
     return { ready: true, source: spec.integration }
   }
+  // 桌面版（QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY）运行时禁止 npx
+  // 按需回退，检测口径必须与之一致，只认已安装的 Adapter。
+  const installedOnly = clean(env.QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY) === '1'
   const runtime = clean(
     env[spec.adapterRuntimeEnvironment] || 'auto',
   ).toLowerCase()
@@ -267,6 +270,12 @@ function inspectAdapter(spec, env, find) {
     }
   }
   if (runtime === 'package') {
+    if (installedOnly) {
+      return {
+        ready: false,
+        issue: `桌面版需先安装 ACP Adapter ${spec.adapterCommand}`,
+      }
+    }
     const npx = find('npx')
     return npx
       ? { ready: true, source: 'managed', path: npx }
@@ -291,11 +300,13 @@ function inspectAdapter(spec, env, find) {
       issue: `${spec.adapterCommand} 不可用`,
     }
   }
-  const npx = find('npx')
+  const npx = installedOnly ? '' : find('npx')
   if (npx) return { ready: true, source: 'managed', path: npx }
   return {
     ready: false,
-    issue: `缺少 ${spec.adapterCommand}，并且 npx 不可用`,
+    issue: installedOnly
+      ? `缺少 ACP Adapter ${spec.adapterCommand}，桌面版需先手动安装`
+      : `缺少 ${spec.adapterCommand}，并且 npx 不可用`,
   }
 }
 
@@ -324,6 +335,8 @@ function inspectBackend(id, {
     && Boolean(clean(env.QWEN_AUDIO_AGENT_BACKEND_MODEL))
     && clean(env.QWEN_AUDIO_AGENT_BACKEND_MODEL).toLowerCase() !== 'auto'
   )
+  // 桌面版运行时不做 npx 自动部署，检测同样关闭 managed 回退分支。
+  const installedOnly = clean(env.QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY) === '1'
   let backend = explicitRuntime(id, env, find)
   if (!backend) {
     const path = find(command)
@@ -343,6 +356,7 @@ function inspectBackend(id, {
         }
     if (
       !backend.ready
+      && !installedOnly
       && ['opencode', 'openclaw'].includes(id)
       && runtime === 'auto'
     ) {
@@ -368,7 +382,7 @@ function inspectBackend(id, {
     const version = readVersion(backend.path)
     backend.version = version
     if (!versionAtLeast(version, spec.minimumVersion)) {
-      const npx = runtime === 'auto' ? find('npx') : ''
+      const npx = !installedOnly && runtime === 'auto' ? find('npx') : ''
       if (npx && automaticBailian) {
         backend = {
           ready: true,


### PR DESCRIPTION
## 背景

桌面版用户反馈：后台 Agent 连接失败时界面无任何错误提示；设置页的后台列表全量显示所有 Agent（含本机未安装的），无法分辨哪些真正可用。

## 改动

**设置页可用性检测**
- 后台 Agent 列表改为按本机检测结果动态渲染（复用 `qwenaudio setup` 同款 `inspectBackendSetups`），不可用选项置灰并标注原因（未安装 / 版本不兼容 / 缺少百炼配置 / 需要 ACP 适配器 / 需要配置），悬浮显示完整引导文案
- 新增"刷新"按钮：打开设置页自动检测一次，新装 Agent 后可手动重新检测
- 当前已选中的项即使不可用也保持可选，避免下拉框丢值

**错误提示**
- 运行状态区显示后台连接失败的具体原因（`backend.error` 此前已透传到渲染层但未渲染），如 `Claude Code 未连接：缺少 claude-code-acp…`

**PATH 根因修复**
- macOS 打包应用的 PATH 只含系统目录，找不到 Homebrew（`/opt/homebrew/bin`）、nvm 版本化目录、Agent 官方脚本私有目录（如 `~/.kimi-code/bin`）安装的命令
- 启动时通过 `$SHELL -l -i -c` 读取登录 shell 解析后的真实 PATH（3s 超时回退静态目录列表），Gateway 子进程与检测共同继承

**检测口径与运行口径对齐**
- 桌面版运行时通过 `QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY=1` 禁止 npx 按需回退（4 个后台脚本统一遵守），但检测此前在 npx 存在时误判"可用（managed）"，导致"显示可选但连不上"
- `inspectBackendSetups` 现在尊重同一开关，关闭全部 4 处 npx 回退分支

**文档**
- README 双语补充 ACP 适配器安装说明（以 Codex 为例：`npm install -g @agentclientprotocol/codex-acp`）

## 测试

- 新增 11 个用例：backend-options 状态归类矩阵（5）、process-path PATH 提取/回退/去重（6）
- cli 侧新增 desktop installed-only 口径 5 分支矩阵
- 全量 462 个测试通过；release-check 通过
- macOS 模拟 GUI 受限环境（`env -i` 精简 PATH）端到端验证：PATH 扩充后 Kimi Code / Codex 检测恢复可用