### PR TITLE
feat: add desktop auto-update and eliminate startup stalls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,7 @@ jobs:
           path: |
             dist/desktop/*.dmg
             dist/desktop/*.blockmap
+            dist/desktop/latest-mac.yml
           if-no-files-found: error
 
   github-release:

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -9,6 +9,13 @@ extraMetadata:
 directories:
   output: dist/desktop
 
+# 更新元数据（latest-mac.yml）指向 GitHub Releases，由 electron-updater
+# 在运行时发现新版本；CI 发布时随 dmg 与 blockmap 一并上传。
+publish:
+  - provider: github
+    owner: QwenAudio
+    repo: qwen-audio-agent
+
 files:
   - desktop/src/**/*
   - server/src/**/*

--- a/desktop/src/gateway-process.mjs
+++ b/desktop/src/gateway-process.mjs
@@ -1,5 +1,4 @@
 import { createConnection } from 'node:net'
-import { execFileSync } from 'node:child_process'
 import { dirname, posix, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { validateAppUrl } from './security.mjs'
@@ -13,39 +12,18 @@ function uniquePath(entries, separator = ':') {
   return [...new Set(entries.filter(Boolean))].join(separator)
 }
 
+// Gateway 子进程的 PATH 直接继承主进程：主进程入口的 expandProcessPath
+// 已把登录 shell 的 PATH（含磁盘缓存，零阻塞）合入 process.env，这里只
+// 叠加常见安装目录兜底。不要再在这里同步调用登录 shell——主进程事件
+// 循环会被阻塞数秒，直接拖慢桌面启动。
 export function desktopExecutablePath({
   env = process.env,
   platform = process.platform,
-  execFileSyncImpl = execFileSync,
 } = {}) {
   const separator = platform === 'win32' ? ';' : ':'
   const configured = String(env.PATH || '').split(separator)
   if (platform !== 'darwin') return uniquePath(configured, separator)
-  let loginPath = []
-  try {
-    const shell = env.SHELL || '/bin/zsh'
-    const output = execFileSyncImpl(
-      shell,
-      ['-ilc', 'printf "__QWAUDIO_PATH__%s" "$PATH"'],
-      {
-        encoding: 'utf8',
-        env,
-        timeout: 3000,
-        stdio: ['ignore', 'pipe', 'ignore'],
-      },
-    )
-    const marker = String(output).lastIndexOf('__QWAUDIO_PATH__')
-    if (marker >= 0) {
-      loginPath = String(output)
-        .slice(marker + '__QWAUDIO_PATH__'.length)
-        .trim()
-        .split(':')
-    }
-  } catch {
-    // Fall back to common macOS installation paths below.
-  }
   return uniquePath([
-    ...loginPath,
     env.HOME ? posix.join(env.HOME, '.local/bin') : '',
     env.HOME ? posix.join(env.HOME, '.npm-global/bin') : '',
     '/opt/homebrew/bin',
@@ -60,7 +38,6 @@ export function desktopGatewayEnvironment({
   runtimeRoot = '',
   sourceRoot = '',
   platform = process.platform,
-  execFileSyncImpl = execFileSync,
 } = {}) {
   const merged = {
     ...env,
@@ -74,7 +51,6 @@ export function desktopGatewayEnvironment({
     PATH: desktopExecutablePath({
       env: merged,
       platform,
-      execFileSyncImpl,
     }),
     QWEN_AUDIO_AGENT_DESKTOP: '1',
     QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY: '1',

--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -45,7 +45,11 @@ import {
 } from './renderer-server.mjs'
 import {
   expandProcessPath,
+  refreshProcessPath,
 } from './process-path.mjs'
+import {
+  createDesktopUpdater,
+} from './updater.mjs'
 
 // macOS / Linux 图形界面应用的 PATH 只包含系统目录。在启动最早阶段
 // 将其扩充为用户登录 shell 的 PATH，让 Gateway 子进程与后台可用性
@@ -94,6 +98,7 @@ let reconnectTimer = null
 let embeddedGateway = null
 let gatewayCrashCount = 0
 let lastRuntimeError = ''
+let desktopUpdater = null
 
 const MAX_GATEWAY_CRASH_RESTARTS = 3
 
@@ -466,10 +471,25 @@ ipcMain.handle('qwen-audio-agent:settings-runtime-status', async event => {
 // AGENT_PROTOCOL / DASHSCOPE_API_KEY / ACP_COMMAND 等配置。
 // INSTALLED_ONLY 与 gateway-process.mjs 保持一致：桌面版运行时禁止
 // npx 按需回退，检测口径必须与运行时一致，只认已安装的组件。
-ipcMain.handle('qwen-audio-agent:settings-detect-backends', async event => {
+// 检测结果按会话缓存：重复打开设置页直接复用；“刷新”按钮（force）
+// 或缓存过期才真正重跑。真正检测前同步刷新登录 shell PATH，
+// 保证刚安装的命令立即可见。
+const BACKEND_REPORT_TTL_MS = 10 * 60 * 1000
+let backendReportCache = null
+
+ipcMain.handle('qwen-audio-agent:settings-detect-backends', async (event, options) => {
   if (!settingsWindow || event.sender !== settingsWindow.webContents) {
     throw new Error('无权检测后台 Agent')
   }
+  const now = Date.now()
+  if (
+    options?.force !== true
+    && backendReportCache
+    && now - backendReportCache.time < BACKEND_REPORT_TTL_MS
+  ) {
+    return backendReportCache.report
+  }
+  refreshProcessPath()
   const configured = existsSync(runtimeEnvironment.configPath)
     ? parseEnv(readFileSync(runtimeEnvironment.configPath, 'utf8'))
     : {}
@@ -480,7 +500,7 @@ ipcMain.handle('qwen-audio-agent:settings-detect-backends', async event => {
       QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY: '1',
     },
   })
-  return {
+  const result = {
     selected: report.selected,
     backends: report.backends.map(item => ({
       id: item.id,
@@ -489,6 +509,32 @@ ipcMain.handle('qwen-audio-agent:settings-detect-backends', async event => {
       selected: item.selected,
       issues: item.issues,
     })),
+  }
+  backendReportCache = { report: result, time: now }
+  return result
+})
+
+ipcMain.handle('qwen-audio-agent:updater-status', event => {
+  if (!settingsWindow || event.sender !== settingsWindow.webContents) {
+    throw new Error('无权读取更新状态')
+  }
+  return desktopUpdater?.state() || null
+})
+
+ipcMain.handle('qwen-audio-agent:updater-check', async event => {
+  if (!settingsWindow || event.sender !== settingsWindow.webContents) {
+    throw new Error('无权检查更新')
+  }
+  return desktopUpdater ? desktopUpdater.check() : null
+})
+
+// 仅在安装包已下载完成时允许触发安装，避免误重启。
+ipcMain.handle('qwen-audio-agent:updater-install', event => {
+  if (!settingsWindow || event.sender !== settingsWindow.webContents) {
+    throw new Error('无权安装更新')
+  }
+  if (desktopUpdater?.state().phase === 'downloaded') {
+    desktopUpdater.install()
   }
 })
 
@@ -590,6 +636,18 @@ if (!app.requestSingleInstanceLock()) {
       app.setActivationPolicy('accessory')
       app.dock?.hide()
     }
+    desktopUpdater = createDesktopUpdater({
+      currentVersion: app.getVersion(),
+      enabled: app.isPackaged,
+      notify: status => {
+        if (settingsWindow && !settingsWindow.isDestroyed()) {
+          settingsWindow.webContents.send(
+            'qwen-audio-agent:updater-status',
+            status,
+          )
+        }
+      },
+    })
     if (setupRequired) {
       showSettings()
     } else {

--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -14,9 +14,24 @@ contextBridge.exposeInMainWorld('qwenAudioAgentDesktop', {
   loadRuntimeStatus: () => ipcRenderer.invoke(
     'qwen-audio-agent:settings-runtime-status',
   ),
-  detectBackends: () => ipcRenderer.invoke(
+  detectBackends: options => ipcRenderer.invoke(
     'qwen-audio-agent:settings-detect-backends',
+    { force: options?.force === true },
   ),
+  loadUpdaterStatus: () => ipcRenderer.invoke(
+    'qwen-audio-agent:updater-status',
+  ),
+  checkUpdates: () => ipcRenderer.invoke('qwen-audio-agent:updater-check'),
+  installUpdate: () => ipcRenderer.invoke('qwen-audio-agent:updater-install'),
+  onUpdaterStatus: callback => {
+    if (typeof callback !== 'function') return () => {}
+    const listener = (_event, status) => callback(status)
+    ipcRenderer.on('qwen-audio-agent:updater-status', listener)
+    return () => ipcRenderer.removeListener(
+      'qwen-audio-agent:updater-status',
+      listener,
+    )
+  },
   saveSettings: settings => ipcRenderer.invoke(
     'qwen-audio-agent:settings-save',
     settings,

--- a/desktop/src/process-path.mjs
+++ b/desktop/src/process-path.mjs
@@ -1,10 +1,13 @@
-import { existsSync } from 'node:fs'
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, resolve } from 'node:path'
 
-// macOS / Linux 图形界面应用的 PATH 只包含系统目录，找不到通过 Homebrew、
-// nvm 或 Agent 官方安装脚本（如 ~/.kimi-code/bin）安装的命令。与终端保持
-// 一致的唯一可靠方式是读取用户登录 shell 解析后的 PATH；失败时回退到
-// 常见安装目录列表。
+import { userConfigDirectory } from '../../shared/runtime-environment.mjs'
 
 const PATH_MARK = 'QWEN_AUDIO_AGENT_PATH'
 
@@ -40,22 +43,104 @@ export function fallbackPathDirectories(home) {
   ]
 }
 
+export function pathCacheFile(env = process.env) {
+  return resolve(userConfigDirectory(env), 'login-shell-path.json')
+}
+
+export function readPathCache(file) {
+  try {
+    const data = JSON.parse(readFileSync(file, 'utf8'))
+    if (typeof data?.path === 'string' && data.path) return data.path
+  } catch {
+    // 缓存损坏时按无缓存处理，下次启动会重建。
+  }
+  return ''
+}
+
+function writePathCache(file, pathValue) {
+  try {
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, JSON.stringify({ path: pathValue }), 'utf8')
+  } catch {
+    // 缓存写失败只影响下次启动速度，不影响本次 PATH 扩充。
+  }
+}
+
+function applyMissingPath(env, pathValue, existsImpl) {
+  const current = (env.PATH || '').split(':').filter(Boolean)
+  const missing = pathValue
+    .split(':')
+    .filter(Boolean)
+    .filter(dir => !current.includes(dir) && existsImpl(dir))
+  if (missing.length === 0) return false
+  env.PATH = [...current, ...missing].join(':')
+  return true
+}
+
+// 有缓存时后台异步重跑登录 shell 更新缓存，供下次启动使用；
+// 失败静默——缓存只是提速手段。
+function refreshPathCacheAsync({ shell, cacheFile, spawnImpl = spawn }) {
+  if (!shell || !cacheFile) return
+  try {
+    const child = spawnImpl(
+      shell,
+      ['-l', '-i', '-c', `echo "${PATH_MARK}<<<$PATH>>>"`],
+      { windowsHide: true },
+    )
+    let output = ''
+    child.stdout?.on('data', chunk => {
+      output += chunk
+    })
+    child.on('error', () => {})
+    child.on('close', () => {
+      const match = output.match(
+        new RegExp(`${PATH_MARK}<<<([\\s\\S]*?)>>>`),
+      )
+      if (match?.[1]?.trim()) writePathCache(cacheFile, match[1].trim())
+    })
+  } catch {
+    // ignore
+  }
+}
+
+// 启动路径：优先读磁盘缓存（毫秒级），同时后台异步刷新缓存；
+// 仅首次无缓存时同步执行登录 shell（一次性成本）。
+// 登录 shell 全失败时回退到常见安装目录。
 export function expandProcessPath({
   env = process.env,
   platform = process.platform,
   spawnImpl = spawnSync,
   existsImpl = existsSync,
+  cacheFile,
 } = {}) {
   if (platform === 'win32') return false
-  const current = (env.PATH || '').split(':').filter(Boolean)
+  const cache = cacheFile === undefined ? pathCacheFile(env) : cacheFile
+  const cached = cache ? readPathCache(cache) : ''
+  if (cached) {
+    refreshPathCacheAsync({ shell: env.SHELL, cacheFile: cache })
+    return applyMissingPath(env, cached, existsImpl)
+  }
   const shellPath = loginShellPath({ shell: env.SHELL, spawnImpl })
-  const candidates = shellPath
-    ? shellPath.split(':').filter(Boolean)
-    : fallbackPathDirectories(env.HOME)
-  const missing = candidates.filter(
-    dir => !current.includes(dir) && existsImpl(dir),
-  )
-  if (missing.length === 0) return false
-  env.PATH = [...current, ...missing].join(':')
-  return true
+  if (shellPath && cache) writePathCache(cache, shellPath)
+  const effective = shellPath || fallbackPathDirectories(env.HOME).join(':')
+  return applyMissingPath(env, effective, existsImpl)
+}
+
+// 主动刷新路径（设置页"刷新"检测前调用）：同步重读登录 shell，
+// 保证刚安装的命令立即可见；失败时沿用缓存，永不回退。
+export function refreshProcessPath({
+  env = process.env,
+  platform = process.platform,
+  spawnImpl = spawnSync,
+  existsImpl = existsSync,
+  cacheFile,
+} = {}) {
+  if (platform === 'win32') return false
+  const cache = cacheFile === undefined ? pathCacheFile(env) : cacheFile
+  const shellPath = loginShellPath({ shell: env.SHELL, spawnImpl })
+  if (shellPath && cache) writePathCache(cache, shellPath)
+  const effective = shellPath
+    || (cache ? readPathCache(cache) : '')
+    || fallbackPathDirectories(env.HOME).join(':')
+  return applyMissingPath(env, effective, existsImpl)
 }

--- a/desktop/src/settings.css
+++ b/desktop/src/settings.css
@@ -28,6 +28,24 @@ header {
   margin-bottom: 24px;
 }
 
+.app-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  /* 与下方卡片内容右缘对齐（卡片 padding 19px），避免文本油墨超出卡片边框的视觉突起 */
+  margin-right: 19px;
+  color: #9aa3a9;
+  font-size: 11px;
+}
+
+.app-meta span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .brand-mark {
   position: relative;
   width: 36px;
@@ -118,6 +136,26 @@ h2 {
   font-size: 12px;
   font-weight: 560;
   overflow-wrap: anywhere;
+}
+
+.text-button {
+  flex: none;
+  padding: 0;
+  border: 0;
+  color: #4a7f84;
+  background: none;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.text-button:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.text-button:disabled {
+  color: #b6bcc1;
+  cursor: default;
 }
 
 .connection-status {

--- a/desktop/src/settings.html
+++ b/desktop/src/settings.html
@@ -17,6 +17,10 @@
           <span></span>
         </div>
         <h1>设置</h1>
+        <div class="app-meta">
+          <span id="updater-status"></span>
+          <button id="check-updates" class="text-button" type="button">检查更新</button>
+        </div>
       </header>
 
       <section class="runtime-status" aria-labelledby="runtime-status-title">

--- a/desktop/src/settings.js
+++ b/desktop/src/settings.js
@@ -1,4 +1,5 @@
 import { backendOptionStates } from './backend-options.mjs'
+import { updaterButtonState, updaterStatusText } from './update-status.mjs'
 
 const form = document.querySelector('#settings-form')
 const gatewayUrl = document.querySelector('#gateway-url')
@@ -13,6 +14,8 @@ const message = document.querySelector('#message')
 const currentRealtime = document.querySelector('#current-realtime')
 const currentGateway = document.querySelector('#current-gateway')
 const currentBackend = document.querySelector('#current-backend')
+const updaterStatus = document.querySelector('#updater-status')
+const checkUpdates = document.querySelector('#check-updates')
 const submit = form.querySelector('button[type="submit"]')
 
 let settings
@@ -21,6 +24,38 @@ let backendReport = null
 let appliedFingerprint = ''
 let applying = false
 let refreshingRuntime = false
+let updaterState = null
+let startupError = null
+
+// 更新状态由主进程推送（onUpdaterStatus）与打开时拉取（loadUpdaterStatus）
+// 共同驱动；下载完成前按钮禁用，完成后变为“重启更新”。
+function renderUpdater(status) {
+  if (!status) return
+  updaterState = status
+  updaterStatus.textContent = updaterStatusText(status)
+  updaterStatus.title = status.phase === 'error' ? status.message : ''
+  const button = updaterButtonState(status)
+  checkUpdates.textContent = button.label
+  checkUpdates.disabled = button.disabled
+}
+
+checkUpdates.addEventListener('click', () => {
+  if (updaterState?.phase === 'downloaded') {
+    void window.qwenAudioAgentDesktop.installUpdate()
+    return
+  }
+  checkUpdates.disabled = true
+  window.qwenAudioAgentDesktop.checkUpdates()
+    .then(renderUpdater)
+    .catch(() => {
+      checkUpdates.disabled = false
+    })
+})
+
+window.qwenAudioAgentDesktop.onUpdaterStatus(renderUpdater)
+window.qwenAudioAgentDesktop.loadUpdaterStatus()
+  .then(renderUpdater)
+  .catch(() => {})
 
 function showMessage(text, kind = '') {
   message.textContent = text
@@ -149,6 +184,15 @@ async function refreshRuntime() {
     runtime = await window.qwenAudioAgentDesktop.loadRuntimeStatus()
     renderRuntime()
     if (
+      startupError
+      && runtime.gatewayConnected
+      && (!runtime.backend || runtime.backend.connected)
+    ) {
+      // 启动失败已被自动重启等机制恢复，清掉残留的错误提示，
+      // 避免“显示报错”与“实际已连接”并存。
+      startupError = null
+      showMessage('服务已自动恢复连接。', 'success')
+    } else if (
       runtime.gatewayConnected
       && (!runtime.backend || runtime.backend.connected)
       && message.className === 'notice'
@@ -163,10 +207,12 @@ async function refreshRuntime() {
   }
 }
 
-async function detectBackendOptions() {
+async function detectBackendOptions(force = false) {
   refreshBackends.disabled = true
   try {
-    backendReport = await window.qwenAudioAgentDesktop.detectBackends()
+    backendReport = await window.qwenAudioAgentDesktop.detectBackends(
+      force ? { force: true } : undefined,
+    )
     renderBackendOptions(agentProtocol.value || settings?.agentProtocol)
     updateApplyState()
   } catch (error) {
@@ -177,7 +223,7 @@ async function detectBackendOptions() {
 }
 
 refreshBackends.addEventListener('click', () => {
-  void detectBackendOptions()
+  void detectBackendOptions(true)
 })
 
 function render() {
@@ -249,6 +295,7 @@ window.qwenAudioAgentDesktop.loadSettings().then(value => {
   render()
   void detectBackendOptions()
   if (value.runtimeError) {
+    startupError = value.runtimeError
     showMessage(`当前配置启动失败：${value.runtimeError}`, 'error')
   } else if (value.setupRequired) {
     showMessage('首次使用，请填写 API Key 并选择后台 Agent。', 'notice')

--- a/desktop/src/update-status.mjs
+++ b/desktop/src/update-status.mjs
@@ -1,0 +1,58 @@
+// 桌面版自动更新的状态模型与展示文案。
+// 纯逻辑模块：主进程接线（updater.mjs）、设置页渲染（settings.js）
+// 与 Node 测试三方共用，不引入 electron 或 node 内置模块。
+
+export function initialUpdateState(currentVersion) {
+  return {
+    phase: 'idle',
+    currentVersion,
+    updateVersion: '',
+    percent: 0,
+    message: '',
+  }
+}
+
+export function friendlyUpdateError(error) {
+  const text = String(error?.message || error || '').trim()
+  const firstLine = text.split('\n')[0].trim()
+  if (/latest-mac\.yml|latest\.yml|404/.test(firstLine)) {
+    return '暂未发布可用于自动更新的版本'
+  }
+  if (/ENOTFOUND|ETIMEDOUT|ECONNREFUSED|ECONNRESET|network|net::/i.test(firstLine)) {
+    return '网络连接失败，请稍后重试'
+  }
+  if (/code sign|not signed|signature/i.test(firstLine)) {
+    return '当前安装包未签名，无法自动更新'
+  }
+  return firstLine.slice(0, 120) || '检查更新失败'
+}
+
+export function updaterStatusText(status) {
+  const version = status?.currentVersion || ''
+  switch (status?.phase) {
+    case 'checking':
+      return `${version} · 正在检查更新…`
+    case 'downloading': {
+      const percent = status.percent > 0 ? ` ${status.percent}%` : ''
+      return `发现新版本 ${status.updateVersion}，正在下载${percent}…`
+    }
+    case 'downloaded':
+      return `新版本 ${status.updateVersion} 已就绪`
+    case 'current':
+      return `${version} · 已是最新版本`
+    case 'error':
+      return `${version} · ${status.message || '检查更新失败'}`
+    default:
+      return version
+  }
+}
+
+export function updaterButtonState(status) {
+  if (status?.phase === 'downloaded') {
+    return { label: '重启更新', action: 'install', disabled: false }
+  }
+  if (status?.phase === 'checking' || status?.phase === 'downloading') {
+    return { label: '检查更新', action: 'check', disabled: true }
+  }
+  return { label: '检查更新', action: 'check', disabled: false }
+}

--- a/desktop/src/updater.mjs
+++ b/desktop/src/updater.mjs
@@ -1,0 +1,76 @@
+import electronUpdater from 'electron-updater'
+
+import { friendlyUpdateError, initialUpdateState } from './update-status.mjs'
+
+// 包装 electron-updater：事件归约为统一状态推送给设置页。
+// enabled=false（如开发环境）时检查直接失败并给出提示，
+// 避免 dev 环境缺少 app-update.yml 时抛出原始异常。
+// electron-updater 的 autoUpdater 是惰性 getter，访问即实例化并依赖
+// Electron 运行时，因此只能在 createDesktopUpdater 调用时取默认实现，
+// 不能在模块顶层解构（Node 测试环境无 Electron）。
+export function createDesktopUpdater({
+  currentVersion,
+  enabled = true,
+  notify = () => {},
+  impl,
+} = {}) {
+  const updaterImpl = impl || electronUpdater.autoUpdater
+  let state = initialUpdateState(currentVersion)
+  const transition = patch => {
+    state = { ...state, ...patch }
+    notify(state)
+  }
+
+  updaterImpl.autoDownload = true
+  updaterImpl.autoInstallOnAppQuit = true
+  updaterImpl.logger = null
+
+  updaterImpl.on('checking-for-update', () => {
+    transition({ phase: 'checking', message: '' })
+  })
+  updaterImpl.on('update-available', info => {
+    transition({
+      phase: 'downloading',
+      updateVersion: info?.version || '',
+      percent: 0,
+      message: '',
+    })
+  })
+  updaterImpl.on('update-not-available', () => {
+    transition({ phase: 'current', updateVersion: '', percent: 0 })
+  })
+  updaterImpl.on('download-progress', progress => {
+    transition({
+      phase: 'downloading',
+      percent: Math.round(progress?.percent || 0),
+    })
+  })
+  updaterImpl.on('update-downloaded', info => {
+    transition({
+      phase: 'downloaded',
+      updateVersion: info?.version || state.updateVersion,
+      percent: 100,
+    })
+  })
+  updaterImpl.on('error', error => {
+    transition({ phase: 'error', message: friendlyUpdateError(error) })
+  })
+
+  return {
+    state: () => state,
+    check: async () => {
+      if (!enabled) {
+        transition({ phase: 'error', message: '当前环境不支持自动更新' })
+        return state
+      }
+      transition({ phase: 'checking', message: '' })
+      try {
+        await updaterImpl.checkForUpdates()
+      } catch (error) {
+        transition({ phase: 'error', message: friendlyUpdateError(error) })
+      }
+      return state
+    },
+    install: () => updaterImpl.quitAndInstall(),
+  }
+}

--- a/desktop/test/gateway-process.test.mjs
+++ b/desktop/test/gateway-process.test.mjs
@@ -278,22 +278,23 @@ test('desktop gateway environment applies saved settings and packaged roots', ()
   )
 })
 
-test('macOS desktop PATH includes login-shell and common binary locations', () => {
+test('macOS desktop PATH inherits the expanded process PATH plus common locations', () => {
+  // 主进程入口的 expandProcessPath 已把登录 shell PATH 合入 process.env
+  // （此处用 /custom/bin 模拟），这里只叠加常见安装目录，不再调用 shell。
   const path = desktopExecutablePath({
     env: {
-      PATH: '/usr/bin',
+      PATH: '/custom/bin:/usr/bin',
       HOME: '/Users/tester',
       SHELL: '/bin/zsh',
     },
     platform: 'darwin',
-    execFileSyncImpl: () => 'noise\n__QWAUDIO_PATH__/custom/bin:/usr/bin',
   })
   assert.deepEqual(path.split(':'), [
-    '/custom/bin',
-    '/usr/bin',
     '/Users/tester/.local/bin',
     '/Users/tester/.npm-global/bin',
     '/opt/homebrew/bin',
     '/usr/local/bin',
+    '/custom/bin',
+    '/usr/bin',
   ])
 })

--- a/desktop/test/process-path.test.mjs
+++ b/desktop/test/process-path.test.mjs
@@ -1,10 +1,22 @@
 import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
+
 import {
   expandProcessPath,
   fallbackPathDirectories,
   loginShellPath,
+  readPathCache,
+  refreshProcessPath,
 } from '../src/process-path.mjs'
+
+function tempCacheFile() {
+  const dir = mkdtempSync(join(tmpdir(), 'qwen-audio-path-'))
+  const file = join(dir, 'login-shell-path.json')
+  return { dir, file, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
 
 test('extracts PATH from login shell output with rc noise', () => {
   const path = loginShellPath({
@@ -45,6 +57,7 @@ test('expands process PATH with login shell directories', () => {
   const expanded = expandProcessPath({
     env,
     platform: 'darwin',
+    cacheFile: '',
     spawnImpl: () => ({
       stdout: 'QWEN_AUDIO_AGENT_PATH<<</Users/x/.kimi-code/bin:/usr/bin:/Users/x/.nvm/bin>>>',
     }),
@@ -62,6 +75,7 @@ test('skips duplicates and directories that do not exist', () => {
   expandProcessPath({
     env,
     platform: 'darwin',
+    cacheFile: '',
     spawnImpl: () => ({
       stdout: 'QWEN_AUDIO_AGENT_PATH<<</usr/bin:/missing:/tools/bin>>>',
     }),
@@ -75,6 +89,7 @@ test('falls back to well-known directories without a login shell', () => {
   const expanded = expandProcessPath({
     env,
     platform: 'linux',
+    cacheFile: '',
     spawnImpl: () => {
       throw new Error('no shell')
     },
@@ -99,9 +114,111 @@ test('does nothing on Windows or when PATH is already complete', () => {
     expandProcessPath({
       env: complete,
       platform: 'darwin',
+      cacheFile: '',
       spawnImpl: () => ({ stdout: 'QWEN_AUDIO_AGENT_PATH<<</usr/bin>>>' }),
       existsImpl: () => true,
     }),
     false,
   )
+})
+
+test('applies the disk cache without running the login shell synchronously', () => {
+  const { dir, file, cleanup } = tempCacheFile()
+  try {
+    writeFileSync(file, JSON.stringify({ path: '/cached/bin:/usr/bin' }), 'utf8')
+    const env = { PATH: '/usr/bin', SHELL: '', HOME: '/Users/x' }
+    let syncCalls = 0
+    const expanded = expandProcessPath({
+      env,
+      platform: 'darwin',
+      cacheFile: file,
+      spawnImpl: () => {
+        syncCalls += 1
+        return { stdout: '' }
+      },
+      existsImpl: () => true,
+    })
+    assert.equal(expanded, true)
+    assert.equal(env.PATH, '/usr/bin:/cached/bin')
+    assert.equal(syncCalls, 0)
+  } finally {
+    cleanup()
+  }
+})
+
+test('writes the login shell result to the cache on first launch', () => {
+  const { file, cleanup } = tempCacheFile()
+  try {
+    const env = { PATH: '/usr/bin', SHELL: '/bin/zsh', HOME: '/Users/x' }
+    expandProcessPath({
+      env,
+      platform: 'darwin',
+      cacheFile: file,
+      spawnImpl: () => ({
+        stdout: 'QWEN_AUDIO_AGENT_PATH<<</fresh/bin:/usr/bin>>>',
+      }),
+      existsImpl: () => true,
+    })
+    assert.equal(
+      JSON.parse(readFileSync(file, 'utf8')).path,
+      '/fresh/bin:/usr/bin',
+    )
+  } finally {
+    cleanup()
+  }
+})
+
+test('refreshProcessPath re-reads the shell and updates the cache', () => {
+  const { dir, file, cleanup } = tempCacheFile()
+  try {
+    writeFileSync(file, JSON.stringify({ path: '/old/bin' }), 'utf8')
+    const env = { PATH: '/usr/bin', SHELL: '/bin/zsh', HOME: '/Users/x' }
+    refreshProcessPath({
+      env,
+      platform: 'darwin',
+      cacheFile: file,
+      spawnImpl: () => ({
+        stdout: 'QWEN_AUDIO_AGENT_PATH<<</new/bin:/usr/bin>>>',
+      }),
+      existsImpl: () => true,
+    })
+    assert.equal(env.PATH, '/usr/bin:/new/bin')
+    assert.equal(
+      JSON.parse(readFileSync(file, 'utf8')).path,
+      '/new/bin:/usr/bin',
+    )
+  } finally {
+    cleanup()
+  }
+})
+
+test('refreshProcessPath falls back to the cache when the shell fails', () => {
+  const { dir, file, cleanup } = tempCacheFile()
+  try {
+    writeFileSync(file, JSON.stringify({ path: '/cached/bin' }), 'utf8')
+    const env = { PATH: '/usr/bin', SHELL: '/bin/zsh', HOME: '/Users/x' }
+    refreshProcessPath({
+      env,
+      platform: 'darwin',
+      cacheFile: file,
+      spawnImpl: () => ({ stdout: 'no mark' }),
+      existsImpl: () => true,
+    })
+    assert.equal(env.PATH, '/usr/bin:/cached/bin')
+  } finally {
+    cleanup()
+  }
+})
+
+test('readPathCache tolerates a corrupted cache file', () => {
+  const { dir, file, cleanup } = tempCacheFile()
+  try {
+    assert.equal(readPathCache(join(dir, 'missing.json')), '')
+    writeFileSync(file, 'not json', 'utf8')
+    assert.equal(readPathCache(file), '')
+    writeFileSync(file, JSON.stringify({ path: 42 }), 'utf8')
+    assert.equal(readPathCache(file), '')
+  } finally {
+    cleanup()
+  }
 })

--- a/desktop/test/settings-config.test.mjs
+++ b/desktop/test/settings-config.test.mjs
@@ -165,6 +165,9 @@ test('desktop settings expose the embedded voice service without editing backend
   // 后台 Agent 选项按本机可用性检测结果动态渲染，HTML 里只保留空容器
   assert.match(html, /<select id="agent-protocol"><\/select>/)
   assert.match(html, /id="refresh-backends"/)
+  // 版本与自动更新状态由主进程推送渲染
+  assert.match(html, /id="updater-status"/)
+  assert.match(html, /id="check-updates"/)
   assert.match(html, /<script src="\.\/settings\.js" type="module"><\/script>/)
   assert.doesNotMatch(html, /<option value="kimi">/)
   for (const id of [

--- a/desktop/test/update-status.test.mjs
+++ b/desktop/test/update-status.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  friendlyUpdateError,
+  initialUpdateState,
+  updaterButtonState,
+  updaterStatusText,
+} from '../src/update-status.mjs'
+
+test('initial state carries the current version and idle phase', () => {
+  assert.deepEqual(initialUpdateState('1.2.0'), {
+    phase: 'idle',
+    currentVersion: '1.2.0',
+    updateVersion: '',
+    percent: 0,
+    message: '',
+  })
+})
+
+test('friendly errors map known failure modes to actionable text', () => {
+  assert.equal(
+    friendlyUpdateError(new Error('Cannot find latest-mac.yml in the release')),
+    '暂未发布可用于自动更新的版本',
+  )
+  assert.equal(
+    friendlyUpdateError(new Error('HttpError: 404 Not Found')),
+    '暂未发布可用于自动更新的版本',
+  )
+  assert.equal(
+    friendlyUpdateError(new Error('net::ERR_CONNECTION_REFUSED')),
+    '网络连接失败，请稍后重试',
+  )
+  assert.equal(
+    friendlyUpdateError(new Error('Could not get code signature for running application')),
+    '当前安装包未签名，无法自动更新',
+  )
+  assert.equal(friendlyUpdateError(null), '检查更新失败')
+})
+
+test('unknown errors keep the first line and stay bounded', () => {
+  const long = `x`.repeat(200)
+  assert.equal(friendlyUpdateError(new Error(`${long}\nsecond`)), long.slice(0, 120))
+})
+
+test('status text follows the update lifecycle', () => {
+  const base = initialUpdateState('1.1.1')
+  assert.equal(updaterStatusText(base), '1.1.1')
+  assert.equal(
+    updaterStatusText({ ...base, phase: 'checking' }),
+    '1.1.1 · 正在检查更新…',
+  )
+  assert.equal(
+    updaterStatusText({ ...base, phase: 'downloading', updateVersion: '1.2.0', percent: 45 }),
+    '发现新版本 1.2.0，正在下载 45%…',
+  )
+  assert.equal(
+    updaterStatusText({ ...base, phase: 'downloading', updateVersion: '1.2.0' }),
+    '发现新版本 1.2.0，正在下载…',
+  )
+  assert.equal(
+    updaterStatusText({ ...base, phase: 'downloaded', updateVersion: '1.2.0' }),
+    '新版本 1.2.0 已就绪',
+  )
+  assert.equal(
+    updaterStatusText({ ...base, phase: 'current' }),
+    '1.1.1 · 已是最新版本',
+  )
+  assert.equal(
+    updaterStatusText({ ...base, phase: 'error', message: '网络连接失败，请稍后重试' }),
+    '1.1.1 · 网络连接失败，请稍后重试',
+  )
+})
+
+test('button state gates checking and flips to install once downloaded', () => {
+  const base = initialUpdateState('1.1.1')
+  assert.deepEqual(updaterButtonState(base), {
+    label: '检查更新',
+    action: 'check',
+    disabled: false,
+  })
+  assert.deepEqual(updaterButtonState({ ...base, phase: 'checking' }), {
+    label: '检查更新',
+    action: 'check',
+    disabled: true,
+  })
+  assert.deepEqual(updaterButtonState({ ...base, phase: 'downloading' }), {
+    label: '检查更新',
+    action: 'check',
+    disabled: true,
+  })
+  assert.deepEqual(updaterButtonState({ ...base, phase: 'downloaded' }), {
+    label: '重启更新',
+    action: 'install',
+    disabled: false,
+  })
+})

--- a/desktop/test/updater.test.mjs
+++ b/desktop/test/updater.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createDesktopUpdater } from '../src/updater.mjs'
+
+function fakeImpl(overrides = {}) {
+  const handlers = new Map()
+  return {
+    autoDownload: undefined,
+    autoInstallOnAppQuit: undefined,
+    logger: undefined,
+    calls: [],
+    on(event, fn) {
+      handlers.set(event, fn)
+    },
+    emit(event, payload) {
+      handlers.get(event)?.(payload)
+    },
+    async checkForUpdates() {
+      this.calls.push('check')
+    },
+    quitAndInstall() {
+      this.calls.push('install')
+    },
+    ...overrides,
+  }
+}
+
+test('check configures differential-friendly defaults and runs', async () => {
+  const impl = fakeImpl()
+  const seen = []
+  const updater = createDesktopUpdater({
+    currentVersion: '1.1.1',
+    notify: status => seen.push(status.phase),
+    impl,
+  })
+  const state = await updater.check()
+  assert.equal(impl.autoDownload, true)
+  assert.equal(impl.autoInstallOnAppQuit, true)
+  assert.deepEqual(impl.calls, ['check'])
+  assert.equal(state.phase, 'checking')
+  assert.deepEqual(seen, ['checking'])
+})
+
+test('disabled environments fail with a friendly message', async () => {
+  const impl = fakeImpl()
+  const updater = createDesktopUpdater({
+    currentVersion: '1.1.1',
+    enabled: false,
+    impl,
+  })
+  const state = await updater.check()
+  assert.equal(state.phase, 'error')
+  assert.equal(state.message, '当前环境不支持自动更新')
+  assert.deepEqual(impl.calls, [])
+})
+
+test('event flow reduces to download progress and readiness', async () => {
+  const impl = fakeImpl()
+  const updater = createDesktopUpdater({ currentVersion: '1.1.1', impl })
+  await updater.check()
+  impl.emit('update-available', { version: '1.2.0' })
+  assert.deepEqual(updater.state(), {
+    phase: 'downloading',
+    currentVersion: '1.1.1',
+    updateVersion: '1.2.0',
+    percent: 0,
+    message: '',
+  })
+  impl.emit('download-progress', { percent: 45.4 })
+  assert.equal(updater.state().percent, 45)
+  impl.emit('update-downloaded', { version: '1.2.0' })
+  assert.equal(updater.state().phase, 'downloaded')
+  assert.equal(updater.state().percent, 100)
+  updater.install()
+  assert.deepEqual(impl.calls, ['check', 'install'])
+})
+
+test('update-not-available resolves to the current phase', async () => {
+  const impl = fakeImpl()
+  const updater = createDesktopUpdater({ currentVersion: '1.1.1', impl })
+  await updater.check()
+  impl.emit('update-not-available', { version: '1.1.1' })
+  assert.equal(updater.state().phase, 'current')
+})
+
+test('rejected checks and runtime errors surface friendly messages', async () => {
+  const impl = fakeImpl({
+    async checkForUpdates() {
+      throw new Error('net::ERR_INTERNET_DISCONNECTED')
+    },
+  })
+  const updater = createDesktopUpdater({ currentVersion: '1.1.1', impl })
+  const state = await updater.check()
+  assert.equal(state.phase, 'error')
+  assert.equal(state.message, '网络连接失败，请稍后重试')
+
+  impl.emit('error', new Error('Cannot find latest-mac.yml'))
+  assert.equal(updater.state().message, '暂未发布可用于自动更新的版本')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "1.3.0",
         "@modelcontextprotocol/sdk": "1.29.0",
+        "electron-updater": "6.8.9",
         "express": "^4.22.2",
         "ws": "^8.21.1",
         "zod": "^4.4.3"
@@ -2376,7 +2377,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -2632,7 +2632,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -3423,6 +3422,34 @@
       "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -3935,7 +3962,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4160,7 +4186,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4588,7 +4613,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4662,7 +4686,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -4685,7 +4708,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -4693,6 +4715,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -6829,7 +6864,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -7320,6 +7354,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7548,7 +7588,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "1.3.0",
     "@modelcontextprotocol/sdk": "1.29.0",
+    "electron-updater": "6.8.9",
     "express": "^4.22.2",
     "ws": "^8.21.1",
     "zod": "^4.4.3"


### PR DESCRIPTION
## 背景

桌面版缺少更新渠道，用户只能手动下载新 dmg；同时 1.1.x 的启动链路存在两处同步登录 shell 调用（主进程入口与 Gateway 环境准备），zsh `-i` 加载 nvm 等配置动辄 1-3 秒，直接卡住冷启动。

## 改动

**自动更新**
- 接入 electron-updater（GitHub Releases 源，blockmap 差量下载）：设置页右上角显示版本号与"检查更新"，发现新版本后台下载，完成后按钮变为"重启更新"
- 错误文案友好化（未发布更新元数据 / 网络失败 / 未签名包）
- electron-builder.yml 增加 `publish: github`；release.yml 随 dmg 上传 `latest-mac.yml`，1.2.0 起发版自动发布更新元数据

**启动提速**
- 登录 shell PATH 磁盘缓存（`login-shell-path.json`）：启动读缓存约 1ms 并后台异步刷新，替代启动时同步执行 `$SHELL -l -i`；仅首次启动付出一次性成本
- 删除 `desktopExecutablePath` 中第二处同步登录 shell 调用（Gateway 子进程直接继承主进程已扩充的 PATH）
- 设置页"刷新"检测前同步重读登录 shell PATH，保证新装命令立即可见；检测结果按会话缓存 10 分钟，重复打开设置页秒开

**错误提示自愈**
- Gateway 意外退出会自动重启恢复，但设置页错误提示此前不会随恢复清除（"报错"与"已连接"并存）；恢复后现在自动替换为"服务已自动恢复连接"

## 测试

- 新增 15 个用例：更新状态机与文案（10）、PATH 缓存读写/回退（5）
- desktop 58 个测试全过；release-check 通过
- 本地未签名包验证：检查更新链路（查询 → 已是最新）完整可用；重启安装仅对 CI 签名包生效