### PR TITLE
docs: add WeChat community badge to Chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![npm](https://img.shields.io/npm/v/qwen-audio-agent)](https://www.npmjs.com/package/qwen-audio-agent)
 [![node](https://img.shields.io/badge/node-%E2%89%A522.22.2-brightgreen)](https://nodejs.org/)
 [![license](https://img.shields.io/github/license/QwenAudio/qwen-audio-agent)](LICENSE)
+[![WeChat](https://img.shields.io/badge/WeChat-%E5%8A%A0%E5%85%A5%E8%AE%A8%E8%AE%BA-07C160?logo=wechat&logoColor=white)](#交流与分享)
 
 ## Agent，始终在场
 


### PR DESCRIPTION
## 改动\n\n中文版 README 徽章区新增微信公众号/社群徽章：\n\n- 徽章文字：WeChat · 加入讨论（微信品牌绿 07C160 + wechat logo）\n- 点击跳转至文末「交流与分享」小节（含微信群与联系人二维码）\n\n按需求不同步英文版。