### PR TITLE
feat: add desktop orb task progress panel

### DIFF
--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -124,8 +124,14 @@ const DEFAULT_ORB_WIDTH = 172
 const DEFAULT_ORB_HEIGHT = 170
 const EXPANDED_ORB_HEIGHT = 380
 
+let orbResizeAnimation = null
+
 function animateWindowResize(window, targetWidth, targetHeight, duration = 200) {
   if (!window || window.isDestroyed()) return
+  if (orbResizeAnimation) {
+    clearTimeout(orbResizeAnimation.timer)
+    orbResizeAnimation = null
+  }
   const [currentWidth, currentHeight] = window.getSize()
   const [currentX, currentY] = window.getPosition()
   const startWidth = currentWidth
@@ -135,6 +141,10 @@ function animateWindowResize(window, targetWidth, targetHeight, duration = 200) 
   const startTime = performance.now()
 
   function frame() {
+    if (!window || window.isDestroyed()) {
+      orbResizeAnimation = null
+      return
+    }
     const now = performance.now()
     const elapsed = now - startTime
     const progress = Math.min(1, elapsed / duration)
@@ -143,12 +153,14 @@ function animateWindowResize(window, targetWidth, targetHeight, duration = 200) 
     const nextHeight = Math.round(startHeight + deltaHeight * ease)
     const nextX = Math.round(currentX - (deltaWidth * ease) / 2)
     const nextY = Math.round(currentY - (deltaHeight * ease) / 2)
-    if (!window.isDestroyed()) {
-      window.setBounds({ x: nextX, y: nextY, width: nextWidth, height: nextHeight })
-      if (progress < 1) setImmediate(frame)
+    window.setBounds({ x: nextX, y: nextY, width: nextWidth, height: nextHeight })
+    if (progress < 1) {
+      orbResizeAnimation = { timer: setTimeout(frame, 16) }
+    } else {
+      orbResizeAnimation = null
     }
   }
-  setImmediate(frame)
+  orbResizeAnimation = { timer: setTimeout(frame, 0) }
 }
 
 function ensureWindowWithinBounds(window) {

--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -120,6 +120,52 @@ let setupRequired = (
 )
 const preloadPath = resolve(here, 'preload.cjs')
 
+const DEFAULT_ORB_WIDTH = 172
+const DEFAULT_ORB_HEIGHT = 170
+const EXPANDED_ORB_HEIGHT = 380
+
+function animateWindowResize(window, targetWidth, targetHeight, duration = 200) {
+  if (!window || window.isDestroyed()) return
+  const [currentWidth, currentHeight] = window.getSize()
+  const startWidth = currentWidth
+  const startHeight = currentHeight
+  const startTime = performance.now()
+
+  function frame(now) {
+    const elapsed = now - startTime
+    const progress = Math.min(1, elapsed / duration)
+    const ease = progress * (2 - progress)
+    const nextWidth = Math.round(startWidth + (targetWidth - startWidth) * ease)
+    const nextHeight = Math.round(startHeight + (targetHeight - startHeight) * ease)
+    if (!window.isDestroyed()) {
+      window.setSize(nextWidth, nextHeight)
+      if (progress < 1) requestAnimationFrame(frame)
+    }
+  }
+  requestAnimationFrame(frame)
+}
+
+function ensureWindowWithinBounds(window) {
+  if (!window || window.isDestroyed()) return
+  const [x, y] = window.getPosition()
+  const [width, height] = window.getSize()
+  const display = screen.getDisplayNearestPoint({ x: x + width / 2, y: y + height / 2 })
+  const workArea = display.workArea
+  let nextX = x
+  let nextY = y
+  if (x + width > workArea.x + workArea.width) {
+    nextX = workArea.x + workArea.width - width - 8
+  }
+  if (y + height > workArea.y + workArea.height) {
+    nextY = workArea.y + workArea.height - height - 8
+  }
+  if (x < workArea.x) nextX = workArea.x + 8
+  if (y < workArea.y) nextY = workArea.y + 8
+  if (nextX !== x || nextY !== y) {
+    window.setPosition(nextX, nextY)
+  }
+}
+
 let mainWindow = null
 let settingsWindow = null
 let rendererServer = null
@@ -425,15 +471,15 @@ function createTray() {
 
 function createWindow() {
   const { workArea } = screen.getPrimaryDisplay()
-  const width = 172
-  const height = 170
+  const width = DEFAULT_ORB_WIDTH
+  const height = DEFAULT_ORB_HEIGHT
   const window = new BrowserWindow({
     width,
     height,
     minWidth: width,
     minHeight: height,
     maxWidth: width,
-    maxHeight: height,
+    maxHeight: EXPANDED_ORB_HEIGHT,
     x: workArea.x + workArea.width - width - 24,
     y: workArea.y + 24,
     frame: false,
@@ -561,6 +607,23 @@ ipcMain.on('qwen-audio-agent:drag-move', (event, point) => {
 
 ipcMain.on('qwen-audio-agent:drag-end', event => {
   if (mainWindow && event.sender === mainWindow.webContents) dragState = null
+})
+
+ipcMain.on('qwen-audio-agent:resize-orb', (event, { width, height, animate }) => {
+  if (!mainWindow || event.sender !== mainWindow.webContents) return
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return
+  if (animate) {
+    animateWindowResize(mainWindow, width, height, 200)
+  } else {
+    mainWindow.setSize(width, height)
+  }
+  ensureWindowWithinBounds(mainWindow)
+})
+
+ipcMain.on('qwen-audio-agent:open-webui', (event, url) => {
+  if (!mainWindow || event.sender !== mainWindow.webContents) return
+  if (typeof url !== 'string') return
+  void shell.openExternal(url)
 })
 
 ipcMain.on('qwen-audio-agent:open-settings', event => {

--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -127,8 +127,11 @@ const EXPANDED_ORB_HEIGHT = 380
 function animateWindowResize(window, targetWidth, targetHeight, duration = 200) {
   if (!window || window.isDestroyed()) return
   const [currentWidth, currentHeight] = window.getSize()
+  const [currentX, currentY] = window.getPosition()
   const startWidth = currentWidth
   const startHeight = currentHeight
+  const deltaWidth = targetWidth - startWidth
+  const deltaHeight = targetHeight - startHeight
   const startTime = performance.now()
 
   function frame() {
@@ -136,10 +139,12 @@ function animateWindowResize(window, targetWidth, targetHeight, duration = 200) 
     const elapsed = now - startTime
     const progress = Math.min(1, elapsed / duration)
     const ease = progress * (2 - progress)
-    const nextWidth = Math.round(startWidth + (targetWidth - startWidth) * ease)
-    const nextHeight = Math.round(startHeight + (targetHeight - startHeight) * ease)
+    const nextWidth = Math.round(startWidth + deltaWidth * ease)
+    const nextHeight = Math.round(startHeight + deltaHeight * ease)
+    const nextX = Math.round(currentX - (deltaWidth * ease) / 2)
+    const nextY = Math.round(currentY - (deltaHeight * ease) / 2)
     if (!window.isDestroyed()) {
-      window.setSize(nextWidth, nextHeight)
+      window.setBounds({ x: nextX, y: nextY, width: nextWidth, height: nextHeight })
       if (progress < 1) setImmediate(frame)
     }
   }
@@ -479,7 +484,7 @@ function createWindow() {
     height,
     minWidth: width,
     minHeight: height,
-    maxWidth: width,
+    maxWidth: 400,
     maxHeight: EXPANDED_ORB_HEIGHT,
     x: workArea.x + workArea.width - width - 24,
     y: workArea.y + 24,

--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -131,7 +131,8 @@ function animateWindowResize(window, targetWidth, targetHeight, duration = 200) 
   const startHeight = currentHeight
   const startTime = performance.now()
 
-  function frame(now) {
+  function frame() {
+    const now = performance.now()
     const elapsed = now - startTime
     const progress = Math.min(1, elapsed / duration)
     const ease = progress * (2 - progress)
@@ -139,10 +140,10 @@ function animateWindowResize(window, targetWidth, targetHeight, duration = 200) 
     const nextHeight = Math.round(startHeight + (targetHeight - startHeight) * ease)
     if (!window.isDestroyed()) {
       window.setSize(nextWidth, nextHeight)
-      if (progress < 1) requestAnimationFrame(frame)
+      if (progress < 1) setImmediate(frame)
     }
   }
-  requestAnimationFrame(frame)
+  setImmediate(frame)
 }
 
 function ensureWindowWithinBounds(window) {

--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -9,6 +9,14 @@ contextBridge.exposeInMainWorld('qwenAudioAgentDesktop', {
   dragStart: (x, y) => sendPoint('qwen-audio-agent:drag-start', x, y),
   dragMove: (x, y) => sendPoint('qwen-audio-agent:drag-move', x, y),
   dragEnd: () => ipcRenderer.send('qwen-audio-agent:drag-end'),
+  resizeOrb: ({ width, height, animate }) => {
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return
+    ipcRenderer.send('qwen-audio-agent:resize-orb', { width, height, animate })
+  },
+  openWebUI: url => {
+    if (typeof url !== 'string') return
+    ipcRenderer.send('qwen-audio-agent:open-webui', url)
+  },
   openSettings: () => ipcRenderer.send('qwen-audio-agent:open-settings'),
   enterHide: () => ipcRenderer.invoke('qwen-audio-agent:enter-hide'),
   wake: () => ipcRenderer.send('qwen-audio-agent:wake'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8635,23 +8635,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -15,6 +15,7 @@ import {
 } from './message-order.js'
 import MessageContent from './MessageContent.jsx'
 import DesktopFluidOrb from './DesktopFluidOrb.jsx'
+import DesktopTaskPanel from './DesktopTaskPanel.jsx'
 import { desktopOrbClassName } from './orb-presentation.js'
 import { resultLabel } from './presentation.js'
 import {
@@ -144,6 +145,45 @@ export default function App() {
 
   const noteInteraction = useCallback(() => {
     setLastInteractionAt(Date.now())
+  }, [])
+
+  const activePanelTask = useMemo(() => {
+    const active = agentTasks.filter(task => (
+      ['queued', 'running', 'delegated', 'finalizing', 'cancelling'].includes(task.phase)
+      || task.authorization?.status === 'pending'
+    ))
+    if (active.length === 0) return null
+    return active.reduce((latest, task) => (
+      (task.startedAt || task.createdAt || 0) > (latest.startedAt || latest.createdAt || 0)
+        ? task
+        : latest
+    ), active[0])
+  }, [agentTasks])
+
+  useEffect(() => {
+    if (!desktopOrbMode) return
+    const hasPanel = activePanelTask !== null
+    const targetHeight = hasPanel ? 380 : 170
+    window.qwenAudioAgentDesktop?.resizeOrb?.({
+      width: 172,
+      height: targetHeight,
+      animate: true,
+    })
+  }, [activePanelTask])
+
+  const cancelTask = useCallback(async taskId => {
+    try {
+      await fetch(`api/tasks/${encodeURIComponent(taskId)}`, { method: 'DELETE' })
+    } catch (error) {
+      console.error('Failed to cancel task:', error)
+    }
+  }, [])
+
+  const openTaskDetails = useCallback(() => {
+    const url = new URL(window.location.href)
+    url.searchParams.delete('desktop')
+    url.searchParams.delete('orbStyle')
+    window.qwenAudioAgentDesktop?.openWebUI?.(url.toString())
   }, [])
 
   const respondToPermission = useCallback(async (taskId, permission, decision) => {
@@ -893,6 +933,9 @@ export default function App() {
         onPointerUp={endOrbDrag}
         onPointerCancel={endOrbDrag}
       >
+        {activePanelTask && (
+          <div className="desktop-orb-running-ring" aria-hidden="true" />
+        )}
         <DesktopFluidOrb style={orbStyle} />
         <nav
           className="desktop-orb-controls"
@@ -945,6 +988,14 @@ export default function App() {
           </button>
         </nav>
       </section>
+      {activePanelTask && (
+        <DesktopTaskPanel
+          task={activePanelTask}
+          backendLabel={backend.label}
+          onCancel={cancelTask}
+          onOpenDetails={openTaskDetails}
+        />
+      )}
     </main>
   }
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -163,10 +163,9 @@ export default function App() {
   useEffect(() => {
     if (!desktopOrbMode) return
     const hasPanel = activePanelTask !== null
-    const targetHeight = hasPanel ? 380 : 170
     window.qwenAudioAgentDesktop?.resizeOrb?.({
-      width: 172,
-      height: targetHeight,
+      width: 280,
+      height: hasPanel ? 380 : 170,
       animate: true,
     })
   }, [activePanelTask])

--- a/web/src/DesktopTaskPanel.jsx
+++ b/web/src/DesktopTaskPanel.jsx
@@ -8,9 +8,8 @@ function formatElapsed(ms = 0) {
   return `${minutes}m ${remainder}s`
 }
 
-function truncateObjective(text = '', max = 40) {
-  if (text.length <= max) return text
-  return `${text.slice(0, max)}…`
+function normalizeText(text = '') {
+  return String(text).trim().replace(/[\s。，！？\.\,\!\?]+$/g, '')
 }
 
 export default function DesktopTaskPanel({
@@ -33,6 +32,10 @@ export default function DesktopTaskPanel({
   if (isFailed) statusClass = 'failed'
   if (task.authorization?.status === 'pending') statusClass = 'pending'
 
+  const detail = taskDetail(normalizedTask)
+  const objective = task.objective || ''
+  const showDetail = normalizeText(detail) !== normalizeText(objective)
+
   return (
     <aside
       className={`desktop-task-panel ${statusClass}`}
@@ -53,11 +56,13 @@ export default function DesktopTaskPanel({
           onOpenDetails?.()
         }}
       >
-        {truncateObjective(task.objective)}
+        {objective}
       </button>
-      <div className="desktop-task-panel-detail">
-        {taskDetail(normalizedTask)}
-      </div>
+      {showDetail && (
+        <div className="desktop-task-panel-detail">
+          {detail}
+        </div>
+      )}
       <div className="desktop-task-panel-footer">
         <div className="desktop-task-panel-progress">
           <div className="desktop-task-panel-progress-bar" />

--- a/web/src/DesktopTaskPanel.jsx
+++ b/web/src/DesktopTaskPanel.jsx
@@ -1,0 +1,71 @@
+import { taskDetail, taskLabel } from './task-view.js'
+
+function formatElapsed(ms = 0) {
+  const seconds = Math.max(0, Math.round(ms / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  return `${minutes}m ${remainder}s`
+}
+
+function truncateObjective(text = '', max = 40) {
+  if (text.length <= max) return text
+  return `${text.slice(0, max)}…`
+}
+
+export default function DesktopTaskPanel({
+  task,
+  backendLabel,
+  onCancel,
+  onOpenDetails,
+}) {
+  const phase = task.phase || task.status
+  const isRunning = ['queued', 'running', 'delegated', 'finalizing'].includes(phase)
+  const isFailed = phase === 'failed'
+  const isCompleted = phase === 'completed'
+
+  let statusClass = 'running'
+  if (isCompleted) statusClass = 'completed'
+  if (isFailed) statusClass = 'failed'
+  if (task.authorization?.status === 'pending') statusClass = 'pending'
+
+  return (
+    <aside
+      className={`desktop-task-panel ${statusClass}`}
+      onClick={onOpenDetails}
+      role="button"
+      tabIndex={0}
+      title="点击打开任务详情"
+    >
+      <div className="desktop-task-panel-header">
+        <span className="desktop-task-panel-agent">
+          {backendLabel || 'Agent'} {isRunning ? '正在执行' : taskLabel(task)}
+        </span>
+        <span className="desktop-task-panel-time">{formatElapsed(task.elapsedMs)}</span>
+      </div>
+      <div className="desktop-task-panel-title">
+        {truncateObjective(task.objective)}
+      </div>
+      <div className="desktop-task-panel-detail">
+        {taskDetail(task)}
+      </div>
+      <div className="desktop-task-panel-footer">
+        <div className="desktop-task-panel-progress">
+          <div className="desktop-task-panel-progress-bar" />
+        </div>
+        {isRunning && (
+          <button
+            className="desktop-task-panel-cancel"
+            onClick={event => {
+              event.stopPropagation()
+              onCancel?.(task.id)
+            }}
+            title="取消任务"
+          >
+            取消
+          </button>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/web/src/DesktopTaskPanel.jsx
+++ b/web/src/DesktopTaskPanel.jsx
@@ -19,21 +19,32 @@ export default function DesktopTaskPanel({
   onCancel,
   onOpenDetails,
 }) {
+  if (!task) return null
+
   const phase = task.phase || task.status
   const normalizedTask = { ...task, phase }
   const isRunning = ['queued', 'running', 'delegated', 'finalizing'].includes(phase)
   const isFailed = phase === 'failed'
   const isCompleted = phase === 'completed'
 
-  let statusClass = 'running'
+  let statusClass = ''
+  if (isRunning || phase === 'running') statusClass = 'running'
   if (isCompleted) statusClass = 'completed'
   if (isFailed) statusClass = 'failed'
   if (task.authorization?.status === 'pending') statusClass = 'pending'
+
+  const handleKeyDown = event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onOpenDetails?.()
+    }
+  }
 
   return (
     <aside
       className={`desktop-task-panel ${statusClass}`}
       onClick={onOpenDetails}
+      onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
       title="点击打开任务详情"

--- a/web/src/DesktopTaskPanel.jsx
+++ b/web/src/DesktopTaskPanel.jsx
@@ -33,20 +33,10 @@ export default function DesktopTaskPanel({
   if (isFailed) statusClass = 'failed'
   if (task.authorization?.status === 'pending') statusClass = 'pending'
 
-  const handleKeyDown = event => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      onOpenDetails?.()
-    }
-  }
-
   return (
     <aside
       className={`desktop-task-panel ${statusClass}`}
       onClick={onOpenDetails}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
       title="点击打开任务详情"
     >
       <div className="desktop-task-panel-header">
@@ -55,9 +45,14 @@ export default function DesktopTaskPanel({
         </span>
         <span className="desktop-task-panel-time">{formatElapsed(task.elapsedMs)}</span>
       </div>
-      <div className="desktop-task-panel-title">
+      <button
+        type="button"
+        className="desktop-task-panel-title-button"
+        onClick={onOpenDetails}
+        aria-label="打开任务详情"
+      >
         {truncateObjective(task.objective)}
-      </div>
+      </button>
       <div className="desktop-task-panel-detail">
         {taskDetail(normalizedTask)}
       </div>
@@ -67,6 +62,7 @@ export default function DesktopTaskPanel({
         </div>
         {isRunning && (
           <button
+            type="button"
             className="desktop-task-panel-cancel"
             onClick={event => {
               event.stopPropagation()

--- a/web/src/DesktopTaskPanel.jsx
+++ b/web/src/DesktopTaskPanel.jsx
@@ -20,6 +20,7 @@ export default function DesktopTaskPanel({
   onOpenDetails,
 }) {
   const phase = task.phase || task.status
+  const normalizedTask = { ...task, phase }
   const isRunning = ['queued', 'running', 'delegated', 'finalizing'].includes(phase)
   const isFailed = phase === 'failed'
   const isCompleted = phase === 'completed'
@@ -39,7 +40,7 @@ export default function DesktopTaskPanel({
     >
       <div className="desktop-task-panel-header">
         <span className="desktop-task-panel-agent">
-          {backendLabel || 'Agent'} {isRunning ? '正在执行' : taskLabel(task)}
+          {backendLabel || 'Agent'} {isRunning ? '正在执行' : taskLabel(normalizedTask)}
         </span>
         <span className="desktop-task-panel-time">{formatElapsed(task.elapsedMs)}</span>
       </div>
@@ -47,7 +48,7 @@ export default function DesktopTaskPanel({
         {truncateObjective(task.objective)}
       </div>
       <div className="desktop-task-panel-detail">
-        {taskDetail(task)}
+        {taskDetail(normalizedTask)}
       </div>
       <div className="desktop-task-panel-footer">
         <div className="desktop-task-panel-progress">

--- a/web/src/DesktopTaskPanel.jsx
+++ b/web/src/DesktopTaskPanel.jsx
@@ -48,8 +48,10 @@ export default function DesktopTaskPanel({
       <button
         type="button"
         className="desktop-task-panel-title-button"
-        onClick={onOpenDetails}
-        aria-label="打开任务详情"
+        onClick={event => {
+          event.stopPropagation()
+          onOpenDetails?.(event)
+        }}
       >
         {truncateObjective(task.objective)}
       </button>

--- a/web/src/DesktopTaskPanel.jsx
+++ b/web/src/DesktopTaskPanel.jsx
@@ -28,7 +28,7 @@ export default function DesktopTaskPanel({
   const isCompleted = phase === 'completed'
 
   let statusClass = ''
-  if (isRunning || phase === 'running') statusClass = 'running'
+  if (isRunning) statusClass = 'running'
   if (isCompleted) statusClass = 'completed'
   if (isFailed) statusClass = 'failed'
   if (task.authorization?.status === 'pending') statusClass = 'pending'
@@ -50,7 +50,7 @@ export default function DesktopTaskPanel({
         className="desktop-task-panel-title-button"
         onClick={event => {
           event.stopPropagation()
-          onOpenDetails?.(event)
+          onOpenDetails?.()
         }}
       >
         {truncateObjective(task.objective)}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -749,7 +749,7 @@ article.user .message-body .inline-code { background: #5e44c9; color: #f0eaff; }
   top: 166px;
   left: 50%;
   transform: translateX(-50%);
-  width: 220px;
+  width: 240px;
   background: rgba(30, 41, 59, 0.95);
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 12px;
@@ -783,9 +783,22 @@ article.user .message-body .inline-code { background: #5e44c9; color: #f0eaff; }
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 8px;
   margin-bottom: 6px;
   font-size: 11px;
   color: #94a3b8;
+}
+
+.desktop-task-panel-agent {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.desktop-task-panel-time {
+  flex-shrink: 0;
 }
 
 .desktop-task-panel-detail {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -102,6 +102,7 @@ header .voice.waiting { color: #ded5ff; border-color: #927cf480; }
 }
 
 .desktop-gallery-shell {
+  position: relative;
   width: 100%;
   height: 100%;
   display: grid;
@@ -742,75 +743,6 @@ article.user .message-body .inline-code { background: #5e44c9; color: #f0eaff; }
   from { opacity: 0; transform: translateY(4px) scale(.995); }
 }
 
-@media (max-width: 600px) {
-  header { padding: 0 14px; }
-  .brand small, header .ghost, .backend { display: none; }
-  .workspace { padding: 24px 0 14px; }
-  .orb:not(.desktop-orb) { width: 92px; height: 92px; }
-  .hero p { margin-top: 14px; }
-  .hero small { margin-top: 8px; }
-  .messages { margin-top: 16px; }
-  article { max-width: 90%; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .orb,
-  .orb::before,
-  .orb::after,
-  .fluid-orb::before,
-  .fluid-orb::after,
-  .fluid,
-  .fluid .blob,
-  .goo,
-  .goo .fill,
-  .conversation-turn,
-  .agent-task,
-  .task-spinner {
-    animation: none;
-    transition: none;
-  }
-}
-
-/* frontend provider selector */
-header select.frontend-provider {
-  background: transparent;
-  color: inherit;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: 999px;
-  padding: 6px 12px;
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
-}
-header select.frontend-provider option {
-  color: #111;
-}
-
-.desktop-task-panel-title-button {
-  display: block;
-  width: 100%;
-  padding: 0;
-  margin: 0 0 4px;
-  border: none;
-  background: none;
-  color: inherit;
-  font: inherit;
-  font-weight: 500;
-  line-height: 1.4;
-  text-align: left;
-  cursor: pointer;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.desktop-task-panel-title-button:focus-visible {
-  outline: 2px solid rgba(59, 130, 246, 0.6);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
 /* Desktop task progress panel */
 .desktop-task-panel {
   position: absolute;
@@ -825,7 +757,6 @@ header select.frontend-provider option {
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
   color: #f1f5f9;
   font-size: 13px;
-  cursor: pointer;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   transition: opacity 200ms ease, transform 200ms ease;
@@ -912,12 +843,85 @@ header select.frontend-provider option {
   flex-shrink: 0;
 }
 
-.desktop-task-panel-cancel:hover {
+.desktop-task-panel-cancel:hover,
+.desktop-task-panel-cancel:focus-visible {
   background: #475569;
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
 }
 
 @keyframes task-progress-pulse {
   0% { opacity: 1; }
   50% { opacity: 0.4; }
   100% { opacity: 1; }
+}
+
+.desktop-task-panel-title-button {
+  width: 100%;
+  padding: 0;
+  margin: 0 0 4px;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-weight: 500;
+  line-height: 1.4;
+  text-align: left;
+  cursor: pointer;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.desktop-task-panel-title-button:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+@media (max-width: 600px) {
+  header { padding: 0 14px; }
+  .brand small, header .ghost, .backend { display: none; }
+  .workspace { padding: 24px 0 14px; }
+  .orb:not(.desktop-orb) { width: 92px; height: 92px; }
+  .hero p { margin-top: 14px; }
+  .hero small { margin-top: 8px; }
+  .messages { margin-top: 16px; }
+  article { max-width: 90%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .orb,
+  .orb::before,
+  .orb::after,
+  .fluid-orb::before,
+  .fluid-orb::after,
+  .fluid,
+  .fluid .blob,
+  .goo,
+  .goo .fill,
+  .conversation-turn,
+  .agent-task,
+  .task-spinner,
+  .desktop-orb-running-ring,
+  .desktop-task-panel.running .desktop-task-panel-progress-bar {
+    animation: none;
+    transition: none;
+  }
+}
+
+/* frontend provider selector */
+header select.frontend-provider {
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+header select.frontend-provider option {
+  color: #111;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -771,3 +771,28 @@ header select.frontend-provider {
 header select.frontend-provider option {
   color: #111;
 }
+
+.desktop-task-panel-title-button {
+  display: block;
+  width: 100%;
+  padding: 0;
+  margin: 0 0 4px;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-weight: 500;
+  line-height: 1.4;
+  text-align: left;
+  cursor: pointer;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.desktop-task-panel-title-button:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
+  border-radius: 2px;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -314,6 +314,20 @@ header .voice.waiting { color: #ded5ff; border-color: #927cf480; }
   cursor: grabbing;
 }
 
+.desktop-orb-running-ring {
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 2px solid rgba(59, 130, 246, 0.4);
+  animation: orb-running-pulse 1.5s ease-out infinite;
+  pointer-events: none;
+}
+
+@keyframes orb-running-pulse {
+  0% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(1.25); opacity: 0; }
+}
+
 .desktop-orb-controls {
   position: absolute;
   left: 50%;
@@ -795,4 +809,115 @@ header select.frontend-provider option {
   outline: 2px solid rgba(59, 130, 246, 0.6);
   outline-offset: 2px;
   border-radius: 2px;
+}
+
+/* Desktop task progress panel */
+.desktop-task-panel {
+  position: absolute;
+  top: 166px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 220px;
+  background: rgba(30, 41, 59, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  color: #f1f5f9;
+  font-size: 13px;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: opacity 200ms ease, transform 200ms ease;
+  z-index: 10;
+}
+
+.desktop-task-panel.running {
+  border-color: rgba(59, 130, 246, 0.4);
+}
+
+.desktop-task-panel.completed {
+  border-color: rgba(34, 197, 94, 0.4);
+}
+
+.desktop-task-panel.failed {
+  border-color: rgba(239, 68, 68, 0.4);
+}
+
+.desktop-task-panel.pending {
+  border-color: rgba(245, 158, 11, 0.4);
+}
+
+.desktop-task-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  font-size: 11px;
+  color: #94a3b8;
+}
+
+.desktop-task-panel-detail {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-bottom: 10px;
+  line-height: 1.4;
+  min-height: 1.4em;
+}
+
+.desktop-task-panel-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.desktop-task-panel-progress {
+  flex: 1;
+  height: 3px;
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.desktop-task-panel.running .desktop-task-panel-progress-bar {
+  width: 60%;
+  height: 100%;
+  background: #3b82f6;
+  border-radius: 2px;
+  animation: task-progress-pulse 1.5s ease-in-out infinite;
+}
+
+.desktop-task-panel.completed .desktop-task-panel-progress-bar {
+  width: 100%;
+  height: 100%;
+  background: #22c55e;
+  border-radius: 2px;
+}
+
+.desktop-task-panel.failed .desktop-task-panel-progress-bar {
+  width: 100%;
+  height: 100%;
+  background: #ef4444;
+  border-radius: 2px;
+}
+
+.desktop-task-panel-cancel {
+  padding: 3px 8px;
+  font-size: 11px;
+  background: #334155;
+  border: none;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.desktop-task-panel-cancel:hover {
+  background: #475569;
+}
+
+@keyframes task-progress-pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
 }


### PR DESCRIPTION
## Summary
This PR adds a task progress panel to the desktop orb mode, making long-running agent work visible while keeping the floating-ball UI minimal.

- New `DesktopTaskPanel` component shows the active task title, current step, elapsed time, and a cancel button.
- Orb size animates to make room for the panel via new `resizeOrb` / `openWebUI` IPC calls.
- Status colors and a pulsing ring indicate running / success / failure states.
- Added reduced-motion support and kept styles in the existing CSS file.

## Test Plan
- `npm test` passes for all workspaces (root, server, web, tui, desktop, cli).
- Desktop DMG builds successfully (`npm run build:desktop`).
- Verified the panel renders and resizes the orb when an `agentTasks` event is active.