### PR TITLE
fix: reuse persisted secret with empty env

### DIFF
--- a/cli/test/runtime-environment.test.mjs
+++ b/cli/test/runtime-environment.test.mjs
@@ -130,6 +130,26 @@ test('generates and reuses a private stable local identity secret', () => {
   assertPrivateMode(result.userProfilePath)
 })
 
+test('reuses the persisted secret when the environment provides an empty value', () => {
+  const target = fixture()
+  const first = {}
+  loadRuntimeEnvironment({
+    root: target.root,
+    homeDirectory: target.homeDirectory,
+    env: first,
+  })
+
+  const second = { QWEN_AUDIO_AGENT_AUTH_SECRET: '' }
+  const result = loadRuntimeEnvironment({
+    root: target.root,
+    homeDirectory: target.homeDirectory,
+    env: second,
+  })
+
+  assert.equal(second.QWEN_AUDIO_AGENT_AUTH_SECRET, first.QWEN_AUDIO_AGENT_AUTH_SECRET)
+  assert.equal(result.generatedSecret, false)
+})
+
 test('does not overwrite an existing user profile', () => {
   const target = fixture()
   const configDirectory = resolve(target.homeDirectory, '.config/qwaudio')

--- a/shared/runtime-environment.mjs
+++ b/shared/runtime-environment.mjs
@@ -83,6 +83,8 @@ export function userConfigDirectory(
 function ensureGeneratedSecret(env, configDirectory) {
   if (env[SECRET_KEY]) return { generated: false, statePath: null }
   const statePath = resolve(configDirectory, 'state.env')
+  // An empty shell assignment must not mask the persisted local identity.
+  delete env[SECRET_KEY]
   loadFile(statePath, env)
   if (env[SECRET_KEY]) {
     try {


### PR DESCRIPTION
## Summary

- Reuse the persisted local identity secret when `QWEN_AUDIO_AGENT_AUTH_SECRET` is explicitly empty.
- Cover the regression with a runtime-environment test.

## Root cause

An empty environment value was defined, so the state-file loader preserved it instead of restoring the existing secret. The subsequent exclusive write then failed because the state file already existed.

## Security impact

An empty shell or service assignment can no longer prevent a valid, private persisted identity from being loaded. Existing non-empty secret overrides remain unchanged; no secrets are logged or rotated.

## Validation

- `npm test`
- `npm run build`
- `npm run release:check`
