### PR TITLE
Fix background Gateway service port

### DIFF
--- a/cli/src/launcher.mjs
+++ b/cli/src/launcher.mjs
@@ -9,6 +9,7 @@ import {
 import { helpText, parseArguments } from './arguments.mjs'
 import {
   ensureRuntime,
+  isLocalGateway,
   readGatewayHealth,
   waitForGateway,
 } from './runtime.mjs'
@@ -60,6 +61,17 @@ function gatewaySummary(health) {
     || '后台 Agent'
   const state = health?.backend?.ok ? '已连接' : '未连接'
   return `${label} ${state}`
+}
+
+function gatewayServiceEnvironment(url) {
+  const target = new URL(url)
+  if (target.protocol !== 'http:' || !isLocalGateway(url)) {
+    throw new Error('Gateway 后台服务只支持本机 HTTP 地址')
+  }
+  return {
+    HOST: target.hostname.replace(/^\[(.*)\]$/, '$1'),
+    PORT: target.port || '80',
+  }
 }
 
 async function waitForGatewayStop(url, {
@@ -124,9 +136,17 @@ export async function main(argv, {
     (options.command === 'gateway' && options.gatewayAction !== 'run')
     || options.command === 'status'
   ) {
+    const serviceEnvironment = [
+      'install',
+      'start',
+      'restart',
+    ].includes(options.gatewayAction)
+      ? gatewayServiceEnvironment(options.url)
+      : {}
     const serviceOptions = {
       configDirectory: environment.configDirectory,
       gatewayPath,
+      serviceEnvironment,
       serviceMetadata: {
         url: options.url,
       },

--- a/cli/test/launcher.test.mjs
+++ b/cli/test/launcher.test.mjs
@@ -239,6 +239,45 @@ test('installs, stops and reports the background Gateway service', async () => {
   ])
 })
 
+test('passes the configured local Gateway host and port to its service', async () => {
+  const target = harness()
+  target.dependencies.env.QWEN_AUDIO_AGENT_URL = 'http://127.0.0.1:3200'
+  target.dependencies.manageService = async (action, options) => {
+    target.calls.push(['service', action, options])
+    return {
+      installed: true,
+      running: true,
+      logPath: null,
+    }
+  }
+
+  assert.equal(
+    await main(['gateway', 'install'], target.dependencies),
+    0,
+  )
+  const install = target.calls.find(call => (
+    call[0] === 'service' && call[1] === 'install'
+  ))
+  assert.deepEqual(install[2].serviceEnvironment, {
+    HOST: '127.0.0.1',
+    PORT: '3200',
+  })
+})
+
+test('rejects a remote Gateway URL for the local background service', async () => {
+  const target = harness()
+  target.dependencies.env.QWEN_AUDIO_AGENT_URL = 'https://voice.example.com'
+
+  await assert.rejects(
+    main(['gateway', 'install'], target.dependencies),
+    /只支持本机 HTTP 地址/,
+  )
+  assert.equal(
+    target.calls.some(call => call[0] === 'service'),
+    false,
+  )
+})
+
 test('does not confuse a foreground Gateway with the background service', async () => {
   const restart = harness()
   restart.dependencies.manageService = async action => {


### PR DESCRIPTION
## Summary

Fixes background Gateway services ignoring the configured local Gateway port.

- Passes the configured `HOST` and `PORT` to launchd/systemd service environments.
- Keeps background service startup aligned with `QWEN_AUDIO_AGENT_URL`.
- Rejects remote or HTTPS URLs for local background-service start actions.

## Root cause

The service metadata stored the configured Gateway URL, but the generated service definition did not receive its host or port. As a result, a Gateway configured for `http://127.0.0.1:3200` could start on the default port (`3101`) while the CLI waited for health checks on `3200`.

## Impact

Users can now install, start, and restart a local Gateway service on a non-default port without the service binding to a different endpoint.

## Validation

```sh
npm run test --workspace @qwen-audio-agent/cli