### PR TITLE
docs: fix pronoun agreement error in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,7 @@ Queue position is an internal scheduling detail and does not change the user's
 duplex conversation.
 
 Active Work cannot be safely resumed after a Gateway restart, so
-they become failed with an explicit restart reason. Completed results and
+it becomes failed with an explicit restart reason. Completed results and
 notification delivery state are persisted.
 
 ## 6. Progress animation


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/architecture.md` (line 152-153).

## Problem

Pronoun agreement error: "Active Work" is singular (used as a mass noun throughout the document — "only one Work", "A qwen-audio-agent Work record"), but the pronoun "they" and verb "become" are plural.

The problematic text:

```markdown
Active Work cannot be safely resumed after a Gateway restart, so
they become failed with an explicit restart reason.
```

## Fix

Replaced with:

```markdown
Active Work cannot be safely resumed after a Gateway restart, so
it becomes failed with an explicit restart reason.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text