### PR TITLE
feat(voice): complete speech-to-speech frontend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ## News
 
+- **v1.3.0 · 测试中**
+  🧪 新增 [🤗 speech-to-speech](https://github.com/huggingface/speech-to-speech) 前台接入，支持本地部署 VAD、STT、LLM 与 TTS 全链路。当前可从源码体验，正式 Release 将在完成测试后发布。
 - **2026-07-30 · [v1.0.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.0.0)**
   🚀 正式版发布，推出内置 Gateway 的 macOS 桌面版。
 - **2026-07-28 · [v0.9.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v0.9.0)**
@@ -167,12 +169,13 @@ qwenaudio webui
 
 ### 使用 Hugging Face speech-to-speech 前台
 
+> [!NOTE]
+> 此功能计划随 v1.3.0 正式发布，目前仅在源码版本中提供，仍在测试中。
+
 qwen-audio-agent 也可以连接用户自行运行的
 [Hugging Face speech-to-speech](https://github.com/huggingface/speech-to-speech)。
 它将 VAD、STT、LLM 和 TTS 组合成 OpenAI Realtime 兼容服务，整条语音链路既可以
 完全运行在本地，也可以按需替换其中的模型或服务。
-Linux / Windows 可通过 `transformers` 在 CUDA 或 CPU 上运行本地 LLM，Apple Silicon
-则可以使用 `mlx-lm`。使用前需准备 Python 3.10 或更高版本。
 
 1. 安装 speech-to-speech：
 
@@ -212,8 +215,7 @@ SPEECH_TO_SPEECH_REALTIME_URL=ws://127.0.0.1:8765/v1/realtime
 ```
 
 然后正常启动 `qwenaudio`。在全本地模式下无需云端 API Key。Gateway 只连接 Realtime
-接口，不会修改 speech-to-speech 的 STT、LLM、TTS 或音色配置。你也可以自行将其中的
-LLM 换成 DashScope、OpenAI 等兼容服务；相关模型和认证仍由 speech-to-speech 管理。
+接口，不会修改 speech-to-speech 的 STT、LLM、TTS 或音色配置。
 如果 Realtime 接口位于需要 Bearer 认证的代理后方，可设置
 `SPEECH_TO_SPEECH_AUTH_TOKEN`。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,6 +25,8 @@ tells you:
 
 ## News
 
+- **v1.3.0 · In testing**
+  🧪 Adds a [🤗 speech-to-speech](https://github.com/huggingface/speech-to-speech) frontend for a locally deployed VAD–STT–LLM–TTS pipeline. Available from source; the formal Release will follow after testing.
 - **2026-07-30 · [v1.0.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.0.0)**
   🚀 First stable release with a macOS desktop app and integrated Gateway.
 - **2026-07-28 · [v0.9.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v0.9.0)**
@@ -188,27 +190,28 @@ qwenaudio webui
 
 ### Use a Hugging Face speech-to-speech frontend
 
+> [!NOTE]
+> This feature is planned for v1.3.0. It is currently available from source and remains under testing; it is not yet included in a stable Release.
+
 qwen-audio-agent can also connect to a user-managed
 [Hugging Face speech-to-speech](https://github.com/huggingface/speech-to-speech)
 server. It combines VAD, STT, LLM, and TTS behind an OpenAI Realtime-compatible
 API. The entire voice pipeline can run locally, or you can replace individual
-models and services as needed. Fully local operation is not limited to macOS:
-Linux and Windows can run a local LLM through `transformers` on CUDA or CPU,
-while Apple Silicon can use `mlx-lm`. Python 3.10 or later is required.
+models and services as needed.
 
 1. Install speech-to-speech:
 
 ```bash
-pip install speech-to-speech
+pip install "speech-to-speech[paraformer]"
 ```
 
-2. Start a fully local service. STT and TTS use local models by default; select
-   the LLM backend for your hardware:
+2. Start a fully local service:
 
 Linux / Windows with an NVIDIA GPU:
 
 ```bash
 speech-to-speech \
+  --stt paraformer \
   --llm_backend transformers \
   --device cuda
 ```
@@ -217,14 +220,13 @@ Apple Silicon:
 
 ```bash
 speech-to-speech \
+  --stt paraformer \
   --llm_backend mlx-lm \
   --device mps
 ```
 
-Both commands use Qwen3-4B by default. Specify `--model_name` only when you want
-to use another model or a quantized variant. Without an NVIDIA GPU, you can
-choose a smaller local model suitable for CPU inference, or point the LLM
-backend at a local vLLM / llama.cpp server. The service listens on
+Without an NVIDIA GPU, you can choose a smaller local model suitable for CPU
+inference, or point the LLM backend at a local vLLM / llama.cpp server. The service listens on
 `ws://127.0.0.1:8765/v1/realtime` by default.
 
 3. Add the following to the qwen-audio-agent `config.env` file:
@@ -236,10 +238,9 @@ SPEECH_TO_SPEECH_REALTIME_URL=ws://127.0.0.1:8765/v1/realtime
 
 Then start `qwenaudio` as usual. Fully local mode requires no cloud API Key. The
 Gateway only connects to the Realtime endpoint and does not alter the STT, LLM,
-TTS, or voice configured in speech-to-speech. You can still replace its LLM with
-DashScope, OpenAI, or another compatible service; speech-to-speech continues to
-own that model and its authentication. Set `SPEECH_TO_SPEECH_AUTH_TOKEN` only
-when the Realtime endpoint is behind a proxy that requires Bearer authentication.
+TTS, or voice configured in speech-to-speech. Set
+`SPEECH_TO_SPEECH_AUTH_TOKEN` only when the Realtime endpoint is behind a proxy
+that requires Bearer authentication.
 
 ### TUI Notes
 

--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -38,6 +38,7 @@ import {
 } from './gateway-process.mjs'
 import {
   parseSettings,
+  realtimeSettingsConfigured,
   updateSettingsContent,
 } from './settings-config.mjs'
 import {
@@ -85,7 +86,7 @@ let setupRequired = (
   !configExistedAtLaunch
   || (
     isLoopbackUrl(configuredGatewayOrigin)
-    && !initialSettings.dashscopeApiKey
+    && !realtimeSettingsConfigured(initialSettings)
   )
 )
 const preloadPath = resolve(here, 'preload.cjs')
@@ -197,8 +198,10 @@ async function runtimeStatus(target = appOrigin) {
   return {
     gatewayConnected: Boolean(health),
     realtimeProvider: health?.realtimeProvider || null,
+    realtimeLabel: health?.realtimeLabel || null,
     realtimeModel: health?.realtimeModel || null,
     voiceConfigured: health?.voiceConfigured === true,
+    realtimeConnection: health?.voiceClients?.realtime || null,
     backend: health?.backend
       ? {
           protocol: health.backend.kind || health.backend.protocol || null,
@@ -309,6 +312,9 @@ function createWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
+      // The floating window is normally unfocused. Keep its renderer timers
+      // aligned with Web Audio so playback receipts are not delayed and retried.
+      backgroundThrottling: false,
       preload: preloadPath,
     },
   })
@@ -344,7 +350,7 @@ function createWindow() {
 function createSettingsWindow() {
   const window = new BrowserWindow({
     width: 540,
-    height: 730,
+    height: 860,
     minWidth: 460,
     minHeight: 640,
     title: '设置',
@@ -448,8 +454,10 @@ ipcMain.handle('qwen-audio-agent:settings-load', async event => {
       ? {
           gatewayConnected: false,
           realtimeProvider: null,
+          realtimeLabel: null,
           realtimeModel: null,
           voiceConfigured: false,
+          realtimeConnection: null,
           backend: null,
         }
       : await runtimeStatus(),
@@ -548,8 +556,10 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
   const normalized = parseSettings(content)
   const nextOrigin = validateAppUrl(normalized.gatewayUrl)
   const remote = !isLoopbackUrl(nextOrigin)
-  if (!remote && !normalized.dashscopeApiKey) {
-    throw new Error('请先填写 DashScope API Key')
+  if (!remote && !realtimeSettingsConfigured(normalized)) {
+    throw new Error(normalized.realtimeProvider === 'dashscope'
+      ? '请先填写 DashScope API Key'
+      : '请先填写 Speech-to-Speech 服务地址')
   }
   if (remote) {
     const remoteRuntime = await runtimeStatus(nextOrigin)
@@ -564,8 +574,17 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
   chmodSync(runtimeEnvironment.configPath, 0o600)
   const gatewayChanged = nextOrigin !== configuredGatewayOrigin
   const apiKeyChanged = previous.dashscopeApiKey !== normalized.dashscopeApiKey
+  const realtimeProviderChanged = (
+    previous.realtimeProvider !== normalized.realtimeProvider
+  )
   const backendChanged = previous.agentProtocol !== normalized.agentProtocol
   const realtimeModelChanged = previous.realtimeModel !== normalized.realtimeModel
+  const speechToSpeechChanged = (
+    previous.speechToSpeechRealtimeUrl
+      !== normalized.speechToSpeechRealtimeUrl
+    || previous.speechToSpeechAuthToken
+      !== normalized.speechToSpeechAuthToken
+  )
   const backendModelChanged = previous.backendModel !== normalized.backendModel
   const orbStyleChanged = previous.orbStyle !== normalized.orbStyle
   let restarted = false
@@ -581,8 +600,10 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
     && (
       gatewayChanged
       || apiKeyChanged
+      || realtimeProviderChanged
       || backendChanged
       || realtimeModelChanged
+      || speechToSpeechChanged
       || backendModelChanged
     )
   ) {

--- a/desktop/src/realtime-status.mjs
+++ b/desktop/src/realtime-status.mjs
@@ -1,0 +1,12 @@
+export function realtimeStatusLabel(provider) {
+  return provider === 'speech-to-speech'
+    ? 'Speech-to-Speech'
+    : 'Qwen Audio'
+}
+
+export function realtimeModelStatusLabel(model) {
+  const value = String(model || '').trim()
+  if (value === 'qwen-audio-3.0-realtime-plus') return 'plus'
+  if (value === 'qwen-audio-3.0-realtime-flash') return 'flash'
+  return value
+}

--- a/desktop/src/settings-config.mjs
+++ b/desktop/src/settings-config.mjs
@@ -3,13 +3,22 @@ import {
   backendDefinition,
   normalizeBackendProtocol,
 } from '../../shared/backend-catalog.mjs'
+import {
+  DEFAULT_DASHSCOPE_REALTIME_MODEL,
+  DEFAULT_REALTIME_PROVIDER,
+  DEFAULT_SPEECH_TO_SPEECH_REALTIME_URL,
+  normalizeRealtimeProvider,
+} from '../../shared/realtime-provider-catalog.mjs'
 
 const DEFAULTS = {
   gatewayUrl: 'http://127.0.0.1:3101',
   orbStyle: 'fluid',
   dashscopeApiKey: '',
+  realtimeProvider: DEFAULT_REALTIME_PROVIDER,
   agentProtocol: 'none',
-  realtimeModel: 'qwen-audio-3.0-realtime-plus',
+  realtimeModel: DEFAULT_DASHSCOPE_REALTIME_MODEL,
+  speechToSpeechRealtimeUrl: '',
+  speechToSpeechAuthToken: '',
   backendModel: '',
 }
 
@@ -17,8 +26,11 @@ const SETTING_KEYS = {
   gatewayUrl: 'QWEN_AUDIO_AGENT_URL',
   orbStyle: 'QWEN_AUDIO_ORB_STYLE',
   dashscopeApiKey: 'DASHSCOPE_API_KEY',
+  realtimeProvider: 'QWEN_AUDIO_REALTIME_PROVIDER',
   agentProtocol: 'AGENT_PROTOCOL',
   realtimeModel: 'QWEN_AUDIO_REALTIME_MODEL',
+  speechToSpeechRealtimeUrl: 'SPEECH_TO_SPEECH_REALTIME_URL',
+  speechToSpeechAuthToken: 'SPEECH_TO_SPEECH_AUTH_TOKEN',
   backendModel: 'QWEN_AUDIO_AGENT_BACKEND_MODEL',
 }
 
@@ -33,6 +45,15 @@ function cleanUrl(value, fallback, label = '地址') {
     throw new Error(`${label}只支持 HTTP 或 HTTPS`)
   }
   return url.origin
+}
+
+function cleanRealtimeUrl(value, fallback) {
+  const text = String(value || fallback).trim()
+  const url = new URL(text)
+  if (!['ws:', 'wss:'].includes(url.protocol)) {
+    throw new Error('Speech-to-Speech 服务地址只支持 WS 或 WSS')
+  }
+  return text.replace(/\/+$/, '')
 }
 
 function cleanAgentProtocol(value) {
@@ -68,6 +89,28 @@ export function parseSettings(content = '', fallback = {}) {
     'QWEN_AUDIO_ORB_STYLE',
     fallback.QWEN_AUDIO_ORB_STYLE || '',
   )
+  const configuredS2sUrl = configured(
+    values,
+    'SPEECH_TO_SPEECH_REALTIME_URL',
+    configured(
+      values,
+      'S2S_REALTIME_URL',
+      fallback.SPEECH_TO_SPEECH_REALTIME_URL
+      || fallback.S2S_REALTIME_URL
+      || DEFAULTS.speechToSpeechRealtimeUrl,
+    ),
+  )
+  const configuredS2sToken = configured(
+    values,
+    'SPEECH_TO_SPEECH_AUTH_TOKEN',
+    configured(
+      values,
+      'S2S_API_KEY',
+      fallback.SPEECH_TO_SPEECH_AUTH_TOKEN
+      || fallback.S2S_API_KEY
+      || DEFAULTS.speechToSpeechAuthToken,
+    ),
+  )
   return {
     gatewayUrl: configured(
       values,
@@ -78,6 +121,11 @@ export function parseSettings(content = '', fallback = {}) {
       String(configuredOrbStyle).toLowerCase(),
     ) ? String(configuredOrbStyle).toLowerCase() : DEFAULTS.orbStyle,
     dashscopeApiKey: String(configuredApiKey || '').trim(),
+    realtimeProvider: normalizeRealtimeProvider(configured(
+      values,
+      'QWEN_AUDIO_REALTIME_PROVIDER',
+      fallback.QWEN_AUDIO_REALTIME_PROVIDER || DEFAULTS.realtimeProvider,
+    )),
     agentProtocol: cleanAgentProtocol(configured(
       values,
       'AGENT_PROTOCOL',
@@ -88,6 +136,10 @@ export function parseSettings(content = '', fallback = {}) {
       'QWEN_AUDIO_REALTIME_MODEL',
       fallback.QWEN_AUDIO_REALTIME_MODEL || DEFAULTS.realtimeModel,
     ) || DEFAULTS.realtimeModel).trim(),
+    speechToSpeechRealtimeUrl: String(
+      configuredS2sUrl || DEFAULTS.speechToSpeechRealtimeUrl,
+    ).trim(),
+    speechToSpeechAuthToken: String(configuredS2sToken || '').trim(),
     backendModel: String(configured(
       values,
       'QWEN_AUDIO_AGENT_BACKEND_MODEL',
@@ -97,6 +149,13 @@ export function parseSettings(content = '', fallback = {}) {
 }
 
 export function normalizeSettings(settings = {}) {
+  const realtimeProvider = normalizeRealtimeProvider(
+    settings.realtimeProvider ?? DEFAULTS.realtimeProvider,
+  )
+  const requestedS2sUrl = String(
+    settings.speechToSpeechRealtimeUrl
+    ?? DEFAULTS.speechToSpeechRealtimeUrl,
+  ).trim()
   return {
     gatewayUrl: cleanUrl(
       settings.gatewayUrl,
@@ -111,6 +170,7 @@ export function normalizeSettings(settings = {}) {
     dashscopeApiKey: String(
       settings.dashscopeApiKey ?? DEFAULTS.dashscopeApiKey,
     ).trim(),
+    realtimeProvider,
     agentProtocol: cleanAgentProtocol(
       settings.agentProtocol ?? DEFAULTS.agentProtocol,
     ),
@@ -120,9 +180,35 @@ export function normalizeSettings(settings = {}) {
     ].includes(String(settings.realtimeModel || '').trim())
       ? String(settings.realtimeModel).trim()
       : DEFAULTS.realtimeModel,
+    speechToSpeechRealtimeUrl: requestedS2sUrl
+      ? cleanRealtimeUrl(requestedS2sUrl, '')
+      : realtimeProvider === 'speech-to-speech'
+        ? DEFAULT_SPEECH_TO_SPEECH_REALTIME_URL
+        : '',
+    speechToSpeechAuthToken: String(
+      settings.speechToSpeechAuthToken
+      ?? DEFAULTS.speechToSpeechAuthToken,
+    ).trim(),
     backendModel: String(
       settings.backendModel ?? DEFAULTS.backendModel,
     ).trim(),
+  }
+}
+
+export function realtimeSettingsConfigured(settings = {}) {
+  const provider = normalizeRealtimeProvider(
+    settings.realtimeProvider ?? DEFAULTS.realtimeProvider,
+  )
+  if (provider === 'dashscope') {
+    return Boolean(String(settings.dashscopeApiKey || '').trim())
+  }
+  try {
+    return Boolean(cleanRealtimeUrl(
+      settings.speechToSpeechRealtimeUrl,
+      DEFAULTS.speechToSpeechRealtimeUrl,
+    ))
+  } catch {
+    return false
   }
 }
 

--- a/desktop/src/settings.css
+++ b/desktop/src/settings.css
@@ -99,7 +99,7 @@ section {
 
 .runtime-status {
   padding: 17px 19px 16px;
-  margin-bottom: 15px;
+  margin-bottom: 21px;
 }
 
 h2 {
@@ -185,8 +185,49 @@ h2 {
   box-shadow: 0 0 0 3px #d16d6d16;
 }
 
+.connection-status.unavailable::before {
+  background: #9ca5aa;
+  box-shadow: 0 0 0 3px #7d898f14;
+}
+
+.settings-groups {
+  display: grid;
+  gap: 19px;
+}
+
+.settings-group {
+  border: 0;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.settings-group-heading {
+  display: flex;
+  min-height: 39px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 0 4px 7px;
+}
+
+.settings-group-heading h2 {
+  margin: 0;
+  color: #354047;
+  font-size: 13.5px;
+  font-weight: 690;
+  letter-spacing: .005em;
+}
+
 .settings-card {
   padding: 0 19px;
+  overflow: hidden;
+  border: 1px solid #dce2e4;
+  border-radius: 15px;
+  background: #ffffffd9;
+  box-shadow: 0 8px 28px #26363e0b;
+  backdrop-filter: blur(14px);
 }
 
 .setting-row {
@@ -205,6 +246,98 @@ h2 {
   color: #3e484f;
   font-size: 13px;
   font-weight: 580;
+}
+
+.provider-panel {
+  display: contents;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.provider-segmented {
+  display: flex;
+  flex: none;
+  min-width: 0;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid #d9dfe1;
+  border-radius: 9px;
+  margin: 0;
+  background: #e9edef;
+  box-shadow: inset 0 1px 2px #384a5210;
+}
+
+.provider-segmented legend {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.provider-segment {
+  position: relative;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.provider-segment input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.provider-segment span {
+  display: flex;
+  height: 27px;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+  overflow: hidden;
+  border-radius: 6px;
+  color: #6f787e;
+  background: transparent;
+  font-size: 10.5px;
+  font-weight: 590;
+  letter-spacing: -.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition:
+    background .16s ease,
+    box-shadow .16s ease,
+    color .16s ease;
+}
+
+.provider-segment:hover span {
+  color: #38484e;
+}
+
+.provider-segment input:focus-visible + span {
+  outline: 2px solid #6d9fa5;
+  outline-offset: 1px;
+}
+
+.provider-segment input:checked + span {
+  color: #2e4f53;
+  background: #fff;
+  box-shadow: 0 1px 4px #273d461c, inset 0 0 0 1px #ffffff;
+}
+
+.provider-attribution {
+  margin: 0;
+  padding: 8px 0 10px 112px;
+  color: #98a1a6;
+  font-size: 9.5px;
+  line-height: 1.3;
+  letter-spacing: .01em;
 }
 
 input,
@@ -288,7 +421,7 @@ footer {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 16px;
-  min-height: 62px;
+  min-height: 68px;
 }
 
 #message {

--- a/desktop/src/settings.html
+++ b/desktop/src/settings.html
@@ -42,74 +42,153 @@
       </section>
 
       <form id="settings-form">
-        <section class="settings-card">
-          <div class="setting-row api-key-row">
-            <label for="dashscope-api-key">API Key</label>
-            <div class="field-with-action">
-              <input
-                id="dashscope-api-key"
-                type="password"
-                autocomplete="off"
-                spellcheck="false"
-                placeholder="sk-…"
-              />
-              <button id="get-api-key" class="link-button" type="button">
-                获取 API Key
-                <span aria-hidden="true">↗</span>
-              </button>
+        <div class="settings-groups">
+          <section class="settings-group" aria-labelledby="voice-settings-title">
+            <div class="settings-group-heading">
+              <h2 id="voice-settings-title">语音前台</h2>
+              <fieldset
+                id="realtime-provider"
+                class="provider-segmented"
+                aria-label="选择实时语音引擎"
+              >
+                <legend>选择实时语音引擎</legend>
+                <label class="provider-segment">
+                  <input
+                    type="radio"
+                    name="realtime-provider"
+                    value="dashscope"
+                    checked
+                  />
+                  <span>Qwen Audio</span>
+                </label>
+                <label class="provider-segment">
+                  <input
+                    type="radio"
+                    name="realtime-provider"
+                    value="speech-to-speech"
+                  />
+                  <span>Speech-to-Speech</span>
+                </label>
+              </fieldset>
             </div>
-          </div>
+            <div class="settings-card">
+              <div class="provider-panel" data-provider-panel="dashscope">
+                <div class="setting-row api-key-row">
+                  <label for="dashscope-api-key">API Key</label>
+                  <div class="field-with-action">
+                    <input
+                      id="dashscope-api-key"
+                      type="password"
+                      autocomplete="off"
+                      spellcheck="false"
+                      placeholder="sk-…"
+                    />
+                    <button id="get-api-key" class="link-button" type="button">
+                      获取 API Key
+                      <span aria-hidden="true">↗</span>
+                    </button>
+                  </div>
+                </div>
 
-          <div class="setting-row">
-            <label for="realtime-model">前台模型</label>
-            <select id="realtime-model">
-              <option value="qwen-audio-3.0-realtime-plus">
-                qwen-audio-3.0-realtime-plus
-              </option>
-              <option value="qwen-audio-3.0-realtime-flash">
-                qwen-audio-3.0-realtime-flash
-              </option>
-            </select>
-          </div>
+                <div class="setting-row">
+                  <label for="realtime-model">前台模型</label>
+                  <select id="realtime-model">
+                    <option value="qwen-audio-3.0-realtime-plus">
+                      qwen-audio-3.0-realtime-plus
+                    </option>
+                    <option value="qwen-audio-3.0-realtime-flash">
+                      qwen-audio-3.0-realtime-flash
+                    </option>
+                  </select>
+                </div>
+                <p class="provider-attribution">Qwen-Audio-Realtime · DashScope</p>
+              </div>
 
-          <div class="setting-row">
-            <label for="agent-protocol">后台 Agent</label>
-            <div class="field-with-action">
-              <!-- 选项由 settings.js 按本机检测结果动态渲染 -->
-              <select id="agent-protocol"></select>
-              <button
-                id="refresh-backends"
-                class="link-button"
-                type="button"
-                title="重新检测本机已安装的后台 Agent"
-              >刷新</button>
+              <div
+                class="provider-panel"
+                data-provider-panel="speech-to-speech"
+                hidden
+              >
+                <div class="setting-row service-url-row">
+                  <label for="speech-to-speech-url">服务地址</label>
+                  <input
+                    id="speech-to-speech-url"
+                    type="url"
+                    autocomplete="off"
+                    spellcheck="false"
+                    placeholder="ws://127.0.0.1:8765/v1/realtime"
+                  />
+                </div>
+
+                <div class="setting-row">
+                  <label for="speech-to-speech-token">访问令牌</label>
+                  <input
+                    id="speech-to-speech-token"
+                    type="password"
+                    autocomplete="off"
+                    spellcheck="false"
+                    placeholder="可选，用于 Bearer 认证"
+                  />
+                </div>
+                <p class="provider-attribution">
+                  Speech-to-Speech · Hugging Face · 需单独启动本地服务
+                </p>
+              </div>
             </div>
-          </div>
+          </section>
 
-          <div class="setting-row">
-            <label for="backend-model">后台模型</label>
-            <input
-              id="backend-model"
-              type="text"
-              autocomplete="off"
-              spellcheck="false"
-              placeholder="留空使用默认模型"
-            />
-          </div>
+          <section class="settings-group" aria-labelledby="backend-settings-title">
+            <div class="settings-group-heading">
+              <h2 id="backend-settings-title">后台 Agent</h2>
+            </div>
+            <div class="settings-card">
+              <div class="setting-row">
+                <label for="agent-protocol">后台 Agent</label>
+                <div class="field-with-action">
+                  <!-- 选项由 settings.js 按本机检测结果动态渲染 -->
+                  <select id="agent-protocol"></select>
+                  <button
+                    id="refresh-backends"
+                    class="link-button"
+                    type="button"
+                    title="重新检测本机已安装的后台 Agent"
+                  >刷新</button>
+                </div>
+              </div>
 
-          <div class="setting-row">
-            <label for="gateway-url">Gateway</label>
-            <input id="gateway-url" type="url" spellcheck="false" required />
-          </div>
+              <div class="setting-row">
+                <label for="backend-model">后台模型</label>
+                <input
+                  id="backend-model"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  placeholder="留空使用默认模型"
+                />
+              </div>
+            </div>
+          </section>
 
-          <div class="setting-row">
-            <label for="orb-style">外观</label>
-            <select id="orb-style">
-              <option value="fluid">流光声波球</option>
-              <option value="goo">液态渐变球</option>
-            </select>
-          </div>
-        </section>
+          <section class="settings-group" aria-labelledby="app-settings-title">
+            <div class="settings-group-heading">
+              <h2 id="app-settings-title">应用</h2>
+            </div>
+            <div class="settings-card">
+              <div class="setting-row">
+                <label for="gateway-url">Gateway</label>
+                <input id="gateway-url" type="url" spellcheck="false" required />
+              </div>
+
+              <div class="setting-row">
+                <label for="orb-style">外观</label>
+                <select id="orb-style">
+                  <option value="fluid">流光声波球</option>
+                  <option value="goo">液态渐变球</option>
+                </select>
+              </div>
+            </div>
+          </section>
+        </div>
 
         <footer>
           <p id="message" role="status"></p>

--- a/desktop/src/settings.js
+++ b/desktop/src/settings.js
@@ -1,10 +1,26 @@
 import { backendOptionStates } from './backend-options.mjs'
+import {
+  realtimeModelStatusLabel,
+  realtimeStatusLabel,
+} from './realtime-status.mjs'
 import { updaterButtonState, updaterStatusText } from './update-status.mjs'
 
 const form = document.querySelector('#settings-form')
 const gatewayUrl = document.querySelector('#gateway-url')
 const orbStyle = document.querySelector('#orb-style')
 const dashscopeApiKey = document.querySelector('#dashscope-api-key')
+const realtimeProviderInputs = [
+  ...document.querySelectorAll('input[name="realtime-provider"]'),
+]
+const providerPanels = [
+  ...document.querySelectorAll('[data-provider-panel]'),
+]
+const speechToSpeechRealtimeUrl = document.querySelector(
+  '#speech-to-speech-url',
+)
+const speechToSpeechAuthToken = document.querySelector(
+  '#speech-to-speech-token',
+)
 const agentProtocol = document.querySelector('#agent-protocol')
 const refreshBackends = document.querySelector('#refresh-backends')
 const realtimeModel = document.querySelector('#realtime-model')
@@ -111,6 +127,30 @@ function backendLabel(value) {
   return value
 }
 
+function selectedRealtimeProvider() {
+  return realtimeProviderInputs.find(input => input.checked)?.value
+    || 'dashscope'
+}
+
+function renderRealtimeProvider(value, { populateDefault = false } = {}) {
+  const provider = value === 'speech-to-speech'
+    ? 'speech-to-speech'
+    : 'dashscope'
+  for (const input of realtimeProviderInputs) {
+    input.checked = input.value === provider
+  }
+  for (const panel of providerPanels) {
+    panel.hidden = panel.dataset.providerPanel !== provider
+  }
+  if (
+    populateDefault
+    && provider === 'speech-to-speech'
+    && !speechToSpeechRealtimeUrl.value.trim()
+  ) {
+    speechToSpeechRealtimeUrl.value = 'ws://127.0.0.1:8765/v1/realtime'
+  }
+}
+
 const BAILIAN_API_KEY_URL = 'https://bailian.console.aliyun.com/?tab=model#/api-key'
 
 function formSettings() {
@@ -118,8 +158,11 @@ function formSettings() {
     gatewayUrl: gatewayUrl.value,
     orbStyle: orbStyle.value,
     dashscopeApiKey: dashscopeApiKey.value,
+    realtimeProvider: selectedRealtimeProvider(),
     agentProtocol: agentProtocol.value,
     realtimeModel: realtimeModel.value,
+    speechToSpeechRealtimeUrl: speechToSpeechRealtimeUrl.value,
+    speechToSpeechAuthToken: speechToSpeechAuthToken.value,
     backendModel: backendModel.value,
   }
 }
@@ -129,8 +172,11 @@ function fingerprint(value) {
     gatewayUrl: value.gatewayUrl,
     orbStyle: value.orbStyle,
     dashscopeApiKey: value.dashscopeApiKey,
+    realtimeProvider: value.realtimeProvider,
     agentProtocol: value.agentProtocol,
     realtimeModel: value.realtimeModel,
+    speechToSpeechRealtimeUrl: value.speechToSpeechRealtimeUrl,
+    speechToSpeechAuthToken: value.speechToSpeechAuthToken,
     backendModel: value.backendModel,
   })
 }
@@ -144,20 +190,51 @@ function setBackendStatus(text, connected) {
   currentBackend.className = `connection-status ${connected ? 'connected' : 'disconnected'}`
 }
 
+function realtimeConnectionState(provider) {
+  const status = runtime?.realtimeConnection?.byProvider?.[provider]
+  if (!status) return 'configured'
+  if (status.connected > 0) return 'connected'
+  if (status.connecting > 0) return 'connecting'
+  return 'disconnected'
+}
+
+function setRealtimeStatus(text, state) {
+  currentRealtime.textContent = text
+  currentRealtime.className = state === 'configured'
+    ? ''
+    : `connection-status ${state === 'connected' ? 'connected' : state === 'connecting' ? 'checking' : 'unavailable'}`
+}
+
 function renderRuntime() {
   if (!runtime?.gatewayConnected) {
     currentGateway.textContent = '未连接'
     currentGateway.className = 'connection-status disconnected'
-    currentRealtime.textContent = 'Gateway 未连接'
+    setRealtimeStatus('Gateway 未连接', 'disconnected')
     setBackendStatus('未连接', false)
     return
   }
 
   currentGateway.textContent = '已连接'
   currentGateway.className = 'connection-status connected'
-  currentRealtime.textContent = runtime.voiceConfigured
-    ? runtime.realtimeModel || '默认模型'
-    : '缺少凭据'
+  const realtimeLabel = realtimeStatusLabel(runtime.realtimeProvider)
+  const realtimeModelLabel = realtimeModelStatusLabel(runtime.realtimeModel)
+  if (!runtime.voiceConfigured) {
+    setRealtimeStatus(`${realtimeLabel} · 配置不完整`, 'disconnected')
+  } else {
+    const state = realtimeConnectionState(runtime.realtimeProvider)
+    const stateLabel = {
+      connected: '已连接',
+      connecting: '正在连接',
+      disconnected: '连接异常',
+      configured: '已配置',
+    }[state]
+    setRealtimeStatus(
+      [realtimeLabel, realtimeModelLabel, stateLabel]
+        .filter(Boolean)
+        .join(' · '),
+      state,
+    )
+  }
   if (!runtime.backend) {
     setBackendStatus('未配置', false)
     return
@@ -191,13 +268,13 @@ async function refreshRuntime() {
       // 启动失败已被自动重启等机制恢复，清掉残留的错误提示，
       // 避免“显示报错”与“实际已连接”并存。
       startupError = null
-      showMessage('服务已自动恢复连接。', 'success')
+      showMessage('Gateway 已自动恢复。', 'success')
     } else if (
       runtime.gatewayConnected
       && (!runtime.backend || runtime.backend.connected)
       && message.className === 'notice'
     ) {
-      showMessage('服务已连接，可以开始使用。', 'success')
+      showMessage('配置已应用，Gateway 已启动。', 'success')
     }
   } catch {
     // A Gateway restart can briefly invalidate one poll. The next poll
@@ -233,6 +310,9 @@ function render() {
   renderBackendOptions(settings.agentProtocol || 'none')
   realtimeModel.value = settings.realtimeModel
     || 'qwen-audio-3.0-realtime-plus'
+  speechToSpeechRealtimeUrl.value = settings.speechToSpeechRealtimeUrl || ''
+  speechToSpeechAuthToken.value = settings.speechToSpeechAuthToken || ''
+  renderRealtimeProvider(settings.realtimeProvider)
   backendModel.value = settings.backendModel || ''
   renderRuntime()
   appliedFingerprint = fingerprint(formSettings())
@@ -243,9 +323,12 @@ for (const control of [
   gatewayUrl,
   orbStyle,
   dashscopeApiKey,
+  speechToSpeechRealtimeUrl,
+  speechToSpeechAuthToken,
   agentProtocol,
   realtimeModel,
   backendModel,
+  ...realtimeProviderInputs,
 ]) {
   control.addEventListener('input', () => {
     showMessage('')
@@ -253,6 +336,9 @@ for (const control of [
   })
   control.addEventListener('change', () => {
     showMessage('')
+    if (realtimeProviderInputs.includes(control)) {
+      renderRealtimeProvider(control.value, { populateDefault: true })
+    }
     updateApplyState()
   })
 }
@@ -277,7 +363,7 @@ form.addEventListener('submit', async event => {
       showMessage('Gateway 已启动，后台 Agent 正在连接…', 'notice')
     } else {
       showMessage(
-        result.restarted ? '已应用，服务已连接。' : '已应用。',
+        result.restarted ? '已应用，Gateway 已启动。' : '已应用。',
         'success',
       )
     }
@@ -298,7 +384,7 @@ window.qwenAudioAgentDesktop.loadSettings().then(value => {
     startupError = value.runtimeError
     showMessage(`当前配置启动失败：${value.runtimeError}`, 'error')
   } else if (value.setupRequired) {
-    showMessage('首次使用，请填写 API Key 并选择后台 Agent。', 'notice')
+    showMessage('首次使用，请配置语音引擎并选择后台 Agent。', 'notice')
   }
 }).catch(error => {
   showMessage(friendlyError(error, '读取设置失败'), 'error')

--- a/desktop/test/realtime-status.test.mjs
+++ b/desktop/test/realtime-status.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  realtimeModelStatusLabel,
+  realtimeStatusLabel,
+} from '../src/realtime-status.mjs'
+
+test('uses compact realtime provider labels in the desktop status card', () => {
+  assert.equal(realtimeStatusLabel('dashscope'), 'Qwen Audio')
+  assert.equal(
+    realtimeStatusLabel('speech-to-speech'),
+    'Speech-to-Speech',
+  )
+})
+
+test('shortens known Qwen Audio realtime model names', () => {
+  assert.equal(
+    realtimeModelStatusLabel('qwen-audio-3.0-realtime-plus'),
+    'plus',
+  )
+  assert.equal(
+    realtimeModelStatusLabel('qwen-audio-3.0-realtime-flash'),
+    'flash',
+  )
+  assert.equal(realtimeModelStatusLabel('custom-model'), 'custom-model')
+})

--- a/desktop/test/settings-config.test.mjs
+++ b/desktop/test/settings-config.test.mjs
@@ -3,16 +3,24 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import {
   parseSettings,
+  realtimeSettingsConfigured,
   updateSettingsContent,
 } from '../src/settings-config.mjs'
+
+const REALTIME_DEFAULTS = {
+  realtimeProvider: 'dashscope',
+  realtimeModel: 'qwen-audio-3.0-realtime-plus',
+  speechToSpeechRealtimeUrl: '',
+  speechToSpeechAuthToken: '',
+}
 
 test('reads desktop-owned settings with friendly defaults', () => {
   assert.deepEqual(parseSettings(''), {
     gatewayUrl: 'http://127.0.0.1:3101',
     orbStyle: 'fluid',
     dashscopeApiKey: '',
+    ...REALTIME_DEFAULTS,
     agentProtocol: 'none',
-    realtimeModel: 'qwen-audio-3.0-realtime-plus',
     backendModel: '',
   })
 })
@@ -26,8 +34,8 @@ test('shows effective client settings when user config is empty', () => {
     gatewayUrl: 'http://127.0.0.1:3200',
     orbStyle: 'goo',
     dashscopeApiKey: 'sk-from-env',
+    ...REALTIME_DEFAULTS,
     agentProtocol: 'none',
-    realtimeModel: 'qwen-audio-3.0-realtime-plus',
     backendModel: '',
   })
 })
@@ -57,6 +65,7 @@ test('updates client settings without changing Gateway-owned configuration', () 
     gatewayUrl: 'http://127.0.0.1:3200',
     orbStyle: 'goo',
     dashscopeApiKey: 'secret',
+    ...REALTIME_DEFAULTS,
     agentProtocol: 'qoder',
     realtimeModel: 'realtime-model',
     backendModel: '',
@@ -107,8 +116,8 @@ test('an explicitly empty key and backend override stale process values', () => 
     gatewayUrl: 'http://127.0.0.1:3101',
     orbStyle: 'fluid',
     dashscopeApiKey: '',
+    ...REALTIME_DEFAULTS,
     agentProtocol: 'none',
-    realtimeModel: 'qwen-audio-3.0-realtime-plus',
     backendModel: '',
   })
 })
@@ -143,6 +152,84 @@ test('updates the realtime model and clears an explicit backend model', () => {
   assert.match(content, /QWEN_AUDIO_AGENT_BACKEND_MODEL=\n?/)
 })
 
+test('reads and updates the Speech-to-Speech desktop configuration', () => {
+  const settings = parseSettings([
+    'QWEN_AUDIO_REALTIME_PROVIDER=speech-to-speech',
+    'SPEECH_TO_SPEECH_REALTIME_URL=wss://voice.example.test/v1/realtime',
+    'SPEECH_TO_SPEECH_AUTH_TOKEN=private-token',
+    '',
+  ].join('\n'))
+
+  assert.equal(settings.realtimeProvider, 'speech-to-speech')
+  assert.equal(
+    settings.speechToSpeechRealtimeUrl,
+    'wss://voice.example.test/v1/realtime',
+  )
+  assert.equal(settings.speechToSpeechAuthToken, 'private-token')
+  assert.equal(realtimeSettingsConfigured(settings), true)
+
+  const content = updateSettingsContent('', settings)
+  assert.match(content, /QWEN_AUDIO_REALTIME_PROVIDER=speech-to-speech/)
+  assert.match(
+    content,
+    /SPEECH_TO_SPEECH_REALTIME_URL=wss:\/\/voice\.example\.test\/v1\/realtime/,
+  )
+  assert.match(content, /SPEECH_TO_SPEECH_AUTH_TOKEN=private-token/)
+})
+
+test('supports the compact S2S aliases when reading existing configuration', () => {
+  const settings = parseSettings([
+    'QWEN_AUDIO_REALTIME_PROVIDER=s2s',
+    'S2S_REALTIME_URL=ws://127.0.0.1:9000/realtime',
+    'S2S_API_KEY=alias-token',
+    '',
+  ].join('\n'))
+
+  assert.equal(settings.realtimeProvider, 'speech-to-speech')
+  assert.equal(
+    settings.speechToSpeechRealtimeUrl,
+    'ws://127.0.0.1:9000/realtime',
+  )
+  assert.equal(settings.speechToSpeechAuthToken, 'alias-token')
+})
+
+test('requires the selected realtime provider configuration', () => {
+  assert.equal(realtimeSettingsConfigured({
+    realtimeProvider: 'dashscope',
+    dashscopeApiKey: '',
+  }), false)
+  assert.equal(realtimeSettingsConfigured({
+    realtimeProvider: 'dashscope',
+    dashscopeApiKey: 'sk-valid',
+  }), true)
+  assert.equal(realtimeSettingsConfigured({
+    realtimeProvider: 'speech-to-speech',
+    speechToSpeechRealtimeUrl: 'not-a-websocket-url',
+  }), false)
+})
+
+test('does not configure Speech-to-Speech while DashScope is selected', () => {
+  const content = updateSettingsContent('', {
+    realtimeProvider: 'dashscope',
+    dashscopeApiKey: 'sk-valid',
+    speechToSpeechRealtimeUrl: '',
+  })
+
+  assert.match(content, /QWEN_AUDIO_REALTIME_PROVIDER=dashscope/)
+  assert.match(content, /SPEECH_TO_SPEECH_REALTIME_URL=\n?/)
+  assert.doesNotMatch(
+    content,
+    /SPEECH_TO_SPEECH_REALTIME_URL=ws:\/\/127\.0\.0\.1:8765/,
+  )
+})
+
+test('rejects invalid Speech-to-Speech service URLs', () => {
+  assert.throws(() => updateSettingsContent('', {
+    realtimeProvider: 'speech-to-speech',
+    speechToSpeechRealtimeUrl: 'https://voice.example.test/realtime',
+  }), /只支持 WS 或 WSS/)
+})
+
 test('rejects invalid Gateway URLs', () => {
   assert.throws(() => updateSettingsContent('', {
     gatewayUrl: 'file:///tmp/gateway',
@@ -158,6 +245,17 @@ test('desktop settings expose the embedded voice service without editing backend
   assert.match(html, /id="current-realtime"/)
   assert.match(html, /id="current-backend"/)
   assert.match(html, /id="dashscope-api-key"/)
+  assert.match(html, /id="realtime-provider"/)
+  assert.match(html, /value="speech-to-speech"/)
+  assert.match(html, /id="speech-to-speech-url"/)
+  assert.match(html, /id="speech-to-speech-token"/)
+  assert.match(html, />语音前台</)
+  assert.match(html, />后台 Agent</)
+  assert.match(html, />应用</)
+  assert.match(html, /Qwen-Audio-Realtime/)
+  assert.match(html, /DashScope/)
+  assert.match(html, /Speech-to-Speech/)
+  assert.match(html, /Hugging Face/)
   assert.match(html, /id="get-api-key"/)
   assert.match(html, /id="agent-protocol"/)
   assert.match(html, /id="realtime-model"/)

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -20,6 +20,7 @@ import { streamingInputTranscript } from './input-transcript.mjs'
 import {
   ensureResponseContext,
   mergeResponseContext,
+  responseActivityContextPatch,
 } from './response-context.mjs'
 import {
   ActiveVoiceClients,
@@ -262,6 +263,14 @@ export function attachRealtimeGateway(server, {
     const voiceClient = {
       ws,
       descriptor,
+      realtimeStatus: () => ({
+        provider: sessionProvider,
+        state: frontend?.ready
+          ? 'connected'
+          : connectPromise
+            ? 'connecting'
+            : 'disconnected',
+      }),
       // Lets the arbitration evict this owner once its socket has died without
       // a clean close, so a stale holder never blocks a new voice claim.
       isAlive: () => ws.readyState === WebSocket.OPEN,
@@ -611,14 +620,16 @@ export function attachRealtimeGateway(server, {
     const beginResponseLifecycle = event => {
       const id = realtimeResponseId(event)
       if (!id) return null
+      const existing = responseContexts.get(id)
       const automaticResponse = (
-        (event.__voiceOrigin || 'model') === 'model'
+        !existing
+        && (event.__voiceOrigin || 'model') === 'model'
         && !event.__voiceContext?.turnId
       )
       const automaticTurn = automaticResponse
         ? responseTurnCandidate
         : null
-      const context = mergeResponseContext(responseContexts, id, {
+      const fallback = {
         turnId: event.__voiceContext?.turnId
           || automaticTurn?.turnId
           || committedTurnId
@@ -630,22 +641,27 @@ export function attachRealtimeGateway(server, {
           ? event.__voiceContext.turnGeneration
           : automaticTurn?.turnGeneration
             ?? (committedTurnId ? committedTurnGeneration : turnGeneration),
-      })
+      }
+      const context = mergeResponseContext(
+        responseContexts,
+        id,
+        responseActivityContextPatch({ existing, event, fallback }),
+      )
+      // Compatible Realtime servers may omit response.created and reveal the
+      // correlation only on response.done. If audio already reached the
+      // client, confirm the newly identified task notification immediately.
+      if (
+        context.playbackStarted
+        && confirmsTaskNotificationOnPlaybackStart(context)
+      ) {
+        announcements.confirmMany(contextTaskIds(context))
+      }
       if (automaticTurn) {
         // Some OpenAI-compatible servers start an implicit server-VAD response
         // with transcript or audio output and omit response.created. Any valid
         // response output proves that turn detection accepted this turn.
         commitTurn(automaticTurn)
         clearResponseCandidate()
-      }
-      if (Array.isArray(event.__voiceContext?.taskIds)) {
-        context.taskIds = event.__voiceContext.taskIds
-      }
-      if (Array.isArray(event.__voiceContext?.turnIds)) {
-        context.turnIds = event.__voiceContext.turnIds
-      }
-      if (event.__voiceContext?.deliverySequence) {
-        context.deliverySequence = event.__voiceContext.deliverySequence
       }
       if (!context.responseStarted) {
         context.responseStarted = true
@@ -1205,6 +1221,11 @@ export function attachRealtimeGateway(server, {
     const connectFrontendNow = () => {
       if (frontend?.ready) return Promise.resolve()
       if (connectPromise) return connectPromise
+      send(ws, {
+        type: GatewayServerEvent.VOICE_CONNECTION,
+        state: 'connecting',
+        provider: sessionProvider,
+      })
       const activeTasks = activeTaskContext()
       lastActiveTaskSignature = activeTaskSignature(activeTasks)
       let createdFrontend
@@ -1231,6 +1252,11 @@ export function attachRealtimeGateway(server, {
           if (frontend !== createdFrontend) return
           frontend = null
           if (!inputEnabled && !outputEnabled) return
+          send(ws, {
+            type: GatewayServerEvent.VOICE_CONNECTION,
+            state: 'unavailable',
+            provider: sessionProvider,
+          })
           if (
             realtimeConnectedAt
             && Date.now() - realtimeConnectedAt >= REALTIME_STABLE_CONNECTION_MS
@@ -1252,6 +1278,11 @@ export function attachRealtimeGateway(server, {
         .then(() => {
           if (frontend !== createdFrontend) return
           realtimeConnectedAt = Date.now()
+          send(ws, {
+            type: GatewayServerEvent.VOICE_CONNECTION,
+            state: 'connected',
+            provider: createdFrontend.provider.key,
+          })
           refreshActiveTaskContext()
           announcePendingPermissions()
           pendingAudio.forEach(audio => createdFrontend.appendAudio(audio))
@@ -1263,6 +1294,17 @@ export function attachRealtimeGateway(server, {
             provider: createdFrontend.provider.key,
             providerLabel: createdFrontend.provider.label,
           })
+        })
+        .catch(error => {
+          if (frontend === createdFrontend) {
+            send(ws, {
+              type: GatewayServerEvent.VOICE_CONNECTION,
+              state: 'unavailable',
+              provider: createdFrontend.provider.key,
+              message: error.message,
+            })
+          }
+          throw error
         })
         .finally(() => {
           if (connectPromise === createdConnectPromise) connectPromise = null
@@ -1487,18 +1529,37 @@ export function attachRealtimeGateway(server, {
   return {
     status() {
       const byType = { desktop: 0, cli: 0, web: 0 }
+      const realtime = {
+        connected: 0,
+        connecting: 0,
+        disconnected: 0,
+        byProvider: {},
+      }
       let connected = 0
       for (const clients of voiceConnections.values()) {
         for (const client of clients) {
           connected += 1
           const type = client.descriptor?.type || 'web'
           byType[type] = (byType[type] || 0) + 1
+          const status = client.realtimeStatus?.()
+          if (!status) continue
+          realtime[status.state] = (realtime[status.state] || 0) + 1
+          if (!realtime.byProvider[status.provider]) {
+            realtime.byProvider[status.provider] = {
+              connected: 0,
+              connecting: 0,
+              disconnected: 0,
+            }
+          }
+          const provider = realtime.byProvider[status.provider]
+          provider[status.state] = (provider[status.state] || 0) + 1
         }
       }
       return {
         connected,
         activeOwners: activeVoiceClients.size,
         byType,
+        realtime,
       }
     },
   }

--- a/server/src/voice/response-context.mjs
+++ b/server/src/voice/response-context.mjs
@@ -2,6 +2,43 @@ function pendingTranscripts(value) {
   return Array.isArray(value) ? value : []
 }
 
+const CORRELATED_CONTEXT_FIELDS = [
+  'turnId',
+  'taskId',
+  'taskIds',
+  'turnIds',
+  'authorizationId',
+  'turnGeneration',
+  'deliverySequence',
+  'consumesTaskNotification',
+]
+
+/**
+ * Build the authoritative part of a response context from one provider event.
+ *
+ * Realtime providers commonly attach correlation metadata only to
+ * response.created/response.done, not to every audio or transcript delta.
+ * Missing metadata on a later delta must therefore preserve the context that
+ * was already correlated instead of resetting it to the ordinary model turn.
+ */
+export function responseActivityContextPatch({
+  existing,
+  event,
+  fallback,
+}) {
+  const patch = existing ? {} : { ...fallback }
+  const correlated = event?.__voiceContext
+  if (correlated && typeof correlated === 'object') {
+    for (const field of CORRELATED_CONTEXT_FIELDS) {
+      if (Object.hasOwn(correlated, field)) patch[field] = correlated[field]
+    }
+  }
+  if (typeof event?.__voiceOrigin === 'string' && event.__voiceOrigin) {
+    patch.origin = event.__voiceOrigin
+  }
+  return patch
+}
+
 export function ensureResponseContext(contexts, id, fallback = {}) {
   const existing = contexts.get(id)
   if (existing) {

--- a/server/test/announcement-manager.test.mjs
+++ b/server/test/announcement-manager.test.mjs
@@ -29,6 +29,25 @@ test('formats only final work results for realtime presentation', () => {
   assert.doesNotMatch(text, /permission|lifecycle|session/i)
 })
 
+test('passes backend-provided error content through for realtime interpretation', () => {
+  const backendResult = JSON.stringify({
+    code: 'Provider.InternalError',
+    message: 'backend supplied detail',
+  })
+  const text = formatWorkResults([{
+    event: 'task.completed',
+    taskId: 'work-provider-error',
+    objective: '执行后台任务',
+    status: 'completed',
+    result: backendResult,
+  }])
+
+  assert.match(text, /^\[COMPLETE\]/)
+  assert.match(text, /type: task\.completed/)
+  assert.match(text, /Provider\.InternalError/)
+  assert.match(text, /backend supplied detail/)
+})
+
 test('waits while duplex speech blocks delivery', async () => {
   let blocked = true
   let spoken = 0

--- a/server/test/response-context.test.mjs
+++ b/server/test/response-context.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   ensureResponseContext,
   mergeResponseContext,
+  responseActivityContextPatch,
 } from '../src/voice/response-context.mjs'
 
 test('creates a complete fallback context for out-of-order transcript events', () => {
@@ -77,4 +78,52 @@ test('preserves a cancelled response tombstone when metadata arrives late', () =
   assert.equal(merged.suppressed, true)
   assert.equal(merged.playbackEnded, true)
   assert.deepEqual(merged.taskIds, ['work-1'])
+})
+
+test('an uncorrelated audio delta preserves an announcement context', () => {
+  const existing = {
+    origin: 'announcement',
+    taskIds: ['work-1'],
+    turnId: 'turn-1',
+  }
+
+  assert.deepEqual(responseActivityContextPatch({
+    existing,
+    event: {
+      type: 'response.audio.delta',
+      // Some compatible implementations normalize absent correlation into
+      // explicit undefined/empty fields on later lifecycle events.
+      __voiceOrigin: undefined,
+      __voiceContext: {},
+    },
+    fallback: {
+      origin: 'model',
+      taskId: null,
+      turnId: 'fallback-turn',
+    },
+  }), {})
+})
+
+test('late provider correlation replaces only explicitly supplied fields', () => {
+  const existing = {
+    origin: 'model',
+    turnId: 'fallback-turn',
+  }
+
+  assert.deepEqual(responseActivityContextPatch({
+    existing,
+    event: {
+      type: 'response.done',
+      __voiceOrigin: 'announcement',
+      __voiceContext: {
+        taskIds: ['work-1'],
+        consumesTaskNotification: true,
+      },
+    },
+    fallback: { taskId: null },
+  }), {
+    origin: 'announcement',
+    taskIds: ['work-1'],
+    consumesTaskNotification: true,
+  })
 })

--- a/shared/realtime-events.mjs
+++ b/shared/realtime-events.mjs
@@ -15,6 +15,7 @@ export const GatewayClientEvent = Object.freeze({
 export const GatewayServerEvent = Object.freeze({
   GATEWAY_CONNECTED: 'gateway.connected',
   GATEWAY_DISCONNECTED: 'gateway.disconnected',
+  VOICE_CONNECTION: 'voice.connection',
   VOICE_READY: 'voice.ready',
   VOICE_STATE: 'voice.state',
   VOICE_OWNERSHIP: 'voice.ownership',

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -63,6 +63,7 @@ function labelFor(state) {
     listening: '正在听',
     thinking: '思考中',
     speaking: '正在说',
+    connecting: '正在连接语音前台',
     occupied: '其他入口正在使用',
   }[state] || state
 }
@@ -223,7 +224,7 @@ export default function App() {
           ready: response.ok && payload.backend?.ok,
           url: payload.backend?.uiPath || payload.backend?.baseUrl || '',
         })
-        setActivity(response.ok ? '已连接' : '能力服务尚未连接')
+        setActivity(response.ok ? 'Gateway 已连接' : '能力服务尚未连接')
       })
       .catch(() => {
         if (!cancelled) setActivity('qwen-audio-agent Gateway 尚未连接')
@@ -629,9 +630,12 @@ export default function App() {
       setActivity(message)
     },
   })
+  const voiceConnectionError = voice.connectionState === 'unavailable'
   const visualVoiceState = voice.ownership.state === 'busy'
     ? 'occupied'
-    : voice.visualState || voice.state
+    : voiceEnabled && voice.connectionState === 'connecting'
+      ? 'connecting'
+      : voice.visualState || voice.state
   const ownershipLabel = voice.ownership.holder
     ? frontendLabel(voice.ownership.holder)
     : ''
@@ -743,10 +747,10 @@ export default function App() {
         className={desktopOrbClassName({
           state: visualVoiceState,
           enabled: voiceEnabled,
-          error: voice.visualError,
+          error: voice.visualError || voiceConnectionError,
           dragging: orbDragging,
         })}
-        aria-label={`qwen-audio · ${voice.visualError ? '连接异常' : labelFor(visualVoiceState)}`}
+        aria-label={`qwen-audio · ${voice.visualError || voiceConnectionError ? '连接异常' : labelFor(visualVoiceState)}`}
         title={
           voice.error
           || (visualVoiceState === 'occupied' && ownershipLabel

--- a/web/src/playback-lifecycle.js
+++ b/web/src/playback-lifecycle.js
@@ -1,0 +1,28 @@
+/**
+ * Confirm that a tracked Web Audio response has reached playback.
+ *
+ * The ordinary path calls this when AudioContext.currentTime reaches the
+ * scheduled start. The source-ended path calls it as a fallback because an
+ * Electron background renderer may throttle timers while the audio thread
+ * continues rendering. A stopped/cleared source is no longer tracked and
+ * therefore cannot be acknowledged by a late onended callback.
+ */
+export function confirmTrackedPlaybackStart(
+  playback,
+  responseId,
+  onStarted,
+  clearTimer = clearTimeout,
+) {
+  if (
+    !responseId
+    || !playback?.sourceCounts?.has(responseId)
+    || playback.startedResponses.has(responseId)
+  ) return false
+
+  const timer = playback.startTimers.get(responseId)
+  if (timer !== undefined) clearTimer(timer)
+  playback.startTimers.delete(responseId)
+  playback.startedResponses.add(responseId)
+  onStarted?.(responseId)
+  return true
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -230,15 +230,26 @@ header .voice.waiting { color: #ded5ff; border-color: #927cf480; }
 .desktop-orb-stage.speaking .fluid {
   animation: desktop-fluid-speaking .52s ease-in-out infinite alternate;
 }
+.desktop-orb-stage.connecting .fluid-orb {
+  --orb-halo: #87919630;
+  --orb-ring: #a8b0b45c;
+}
+.desktop-orb-stage.connecting .fluid {
+  filter: grayscale(.62) saturate(.45) brightness(.9);
+  animation-duration: 8s;
+}
+.desktop-orb-stage.connecting .fluid-orb::before {
+  animation: desktop-orb-error 2.8s ease-in-out infinite;
+}
 .desktop-orb-stage.error .fluid-orb {
-  --orb-halo: #b96e7952;
-  --orb-ring: #dca0a992;
+  --orb-halo: #727d8233;
+  --orb-ring: #929da267;
 }
 .desktop-orb-stage.error .fluid {
-  filter: grayscale(.35) sepia(.42) hue-rotate(305deg) saturate(.72) brightness(.76);
+  filter: grayscale(.92) saturate(.18) brightness(.72);
 }
 .desktop-orb-stage.error .fluid-orb::before {
-  animation: desktop-orb-error 1.55s ease-in-out infinite;
+  animation: desktop-orb-error 2.2s ease-in-out infinite;
 }
 .goo {
   position: relative; width: 176px; height: 176px; overflow: hidden;
@@ -260,6 +271,19 @@ header .voice.waiting { color: #ded5ff; border-color: #927cf480; }
 }
 .desktop-orb-stage.input-muted:not(.speaking) .goo,
 .desktop-orb-stage.input-muted:not(.speaking) .goo .fill {
+  animation-play-state: paused;
+}
+.desktop-orb-stage.connecting .goo {
+  box-shadow: 0 12px 30px #6f7b8038, 0 0 22px #7f898e3d;
+  filter: blur(1.2px) grayscale(.66) saturate(.4) brightness(.86);
+  animation-duration: 13s;
+}
+.desktop-orb-stage.error .goo {
+  box-shadow: 0 10px 26px #5f696e38, 0 0 18px #737e8335;
+  filter: blur(1.2px) grayscale(.95) saturate(.12) brightness(.68);
+}
+.desktop-orb-stage.error .goo,
+.desktop-orb-stage.error .goo .fill {
   animation-play-state: paused;
 }
 

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -4,6 +4,7 @@ import {
   GatewayServerEvent,
 } from '../../shared/realtime-events.mjs'
 import { decodePcm, pcmBase64, resample } from './audio.js'
+import { confirmTrackedPlaybackStart } from './playback-lifecycle.js'
 
 const DEFAULT_INPUT_RATE = 16000
 const OUTPUT_RATE = 24000
@@ -80,6 +81,7 @@ export default function useRealtimeVoice({
   const [inputActive, setInputActive] = useState(false)
   const [error, setError] = useState('')
   const [visualError, setVisualError] = useState(false)
+  const [connectionState, setConnectionState] = useState('connecting')
   const [ownership, setOwnership] = useState({
     state: 'available',
     holder: null,
@@ -103,6 +105,7 @@ export default function useRealtimeVoice({
     startedResponses: new Set(),
     sourceCounts: new Map(),
     doneResponses: new Set(),
+    failedResponses: new Set(),
   })
   eventRef.current = onEvent
   inputErrorRef.current = onInputError
@@ -174,6 +177,7 @@ export default function useRealtimeVoice({
       startedResponses: new Set(),
       sourceCounts: new Map(),
       doneResponses: new Set(),
+      failedResponses: new Set(),
     }
   }
 
@@ -193,8 +197,30 @@ export default function useRealtimeVoice({
 
   const markAudioDone = responseId => {
     if (!responseId) return
-    playbackRef.current.doneResponses.add(responseId)
+    const playback = playbackRef.current
+    if (playback.failedResponses.delete(responseId)) return
+    playback.doneResponses.add(responseId)
     finishPlaybackIfReady(responseId)
+  }
+
+  const failPlayback = (responseId, reason) => {
+    const playback = playbackRef.current
+    if (responseId && !playback.failedResponses.has(responseId)) {
+      playback.failedResponses.add(responseId)
+      const timer = playback.startTimers.get(responseId)
+      if (timer !== undefined) clearTimeout(timer)
+      playback.startTimers.delete(responseId)
+      playback.startedResponses.delete(responseId)
+      playback.sourceCounts.delete(responseId)
+      playback.doneResponses.delete(responseId)
+      sendPlaybackEvent(
+        GatewayClientEvent.PLAYBACK_CANCELLED,
+        responseId,
+        'playback_error',
+      )
+    }
+    setError(reason?.message || String(reason || '语音播放失败'))
+    setVisualError(true)
   }
 
   const consumeMutedAudio = responseId => {
@@ -211,56 +237,85 @@ export default function useRealtimeVoice({
 
   const play = (base64, sampleRate = OUTPUT_RATE, responseId = '') => {
     const context = audioRef.current
-    if (!context) return
-    if (context.state === 'suspended') context.resume().catch(() => {})
-    const samples = decodePcm(base64)
-    const buffer = context.createBuffer(1, samples.length, sampleRate)
-    buffer.copyToChannel(samples, 0)
-    const source = context.createBufferSource()
-    source.buffer = buffer
-    source.connect(context.destination)
-    const start = Math.max(context.currentTime + 0.02, playbackRef.current.cursor)
-    playbackRef.current.cursor = start + buffer.duration
-    playbackRef.current.sources.push(source)
-    if (responseId) {
-      playbackRef.current.sourceCounts.set(
-        responseId,
-        (playbackRef.current.sourceCounts.get(responseId) || 0) + 1,
-      )
+    if (!context) {
+      failPlayback(responseId, '语音播放尚未启用')
+      return
+    }
+    const playback = playbackRef.current
+    if (responseId && playback.failedResponses.has(responseId)) return
+    if (context.state === 'suspended') {
+      context.resume().catch(reason => failPlayback(responseId, reason))
+    }
+    let source
+    let start
+    try {
+      const samples = decodePcm(base64)
+      const buffer = context.createBuffer(1, samples.length, sampleRate)
+      buffer.copyToChannel(samples, 0)
+      source = context.createBufferSource()
+      source.buffer = buffer
+      source.connect(context.destination)
+      start = Math.max(context.currentTime + 0.02, playback.cursor)
+      playback.cursor = start + buffer.duration
+      playback.sources.push(source)
+      if (responseId) {
+        playback.sourceCounts.set(
+          responseId,
+          (playback.sourceCounts.get(responseId) || 0) + 1,
+        )
+      }
+    } catch (reason) {
+      failPlayback(responseId, reason)
+      return
     }
     if (
       responseId
-      && !playbackRef.current.startedResponses.has(responseId)
-      && !playbackRef.current.startTimers.has(responseId)
+      && !playback.startedResponses.has(responseId)
+      && !playback.startTimers.has(responseId)
     ) {
       const checkStarted = () => {
-        const playback = playbackRef.current
-        if (!playback.startTimers.has(responseId)) return
+        const current = playbackRef.current
+        if (!current.startTimers.has(responseId)) return
         if (context.state !== 'running' || context.currentTime + 0.005 < start) {
           const timer = setTimeout(checkStarted, 20)
-          playback.startTimers.set(responseId, timer)
+          current.startTimers.set(responseId, timer)
           return
         }
-        playback.startTimers.delete(responseId)
-        playback.startedResponses.add(responseId)
-        sendPlaybackEvent(GatewayClientEvent.PLAYBACK_STARTED, responseId)
+        confirmTrackedPlaybackStart(
+          current,
+          responseId,
+          id => sendPlaybackEvent(GatewayClientEvent.PLAYBACK_STARTED, id),
+        )
       }
       const delay = Math.max(0, (start - context.currentTime) * 1000)
       const timer = setTimeout(checkStarted, delay)
-      playbackRef.current.startTimers.set(responseId, timer)
+      playback.startTimers.set(responseId, timer)
     }
     source.onended = () => {
-      const playback = playbackRef.current
-      playback.sources = playback.sources.filter(item => item !== source)
-      if (responseId && playback.sourceCounts.has(responseId)) {
-        playback.sourceCounts.set(
+      const current = playbackRef.current
+      current.sources = current.sources.filter(item => item !== source)
+      if (responseId && current.sourceCounts.has(responseId)) {
+        // Web Audio can keep rendering while Electron throttles renderer
+        // timers. Reaching onended proves that this tracked source traversed
+        // the playback timeline, so it is a safe fallback acknowledgement.
+        confirmTrackedPlaybackStart(
+          current,
           responseId,
-          Math.max(0, (playback.sourceCounts.get(responseId) || 0) - 1),
+          id => sendPlaybackEvent(GatewayClientEvent.PLAYBACK_STARTED, id),
+        )
+        current.sourceCounts.set(
+          responseId,
+          Math.max(0, (current.sourceCounts.get(responseId) || 0) - 1),
         )
         finishPlaybackIfReady(responseId)
       }
     }
-    source.start(start)
+    try {
+      source.start(start)
+    } catch (reason) {
+      playback.sources = playback.sources.filter(item => item !== source)
+      failPlayback(responseId, reason)
+    }
   }
 
   useEffect(() => {
@@ -275,6 +330,7 @@ export default function useRealtimeVoice({
         reconnectDelay = 500
         setError('')
         setVisualError(false)
+        setConnectionState('connecting')
         eventRef.current?.({ type: GatewayServerEvent.GATEWAY_CONNECTED })
         const inputEnabled = shouldAdvertiseVoice(
           enabledRef.current,
@@ -305,7 +361,18 @@ export default function useRealtimeVoice({
         }
         if (event.type === GatewayServerEvent.VOICE_READY && event.inputSampleRate) {
           inputSampleRate.current = event.inputSampleRate
+          setConnectionState('connected')
+          setError('')
           setVisualError(false)
+        }
+        if (event.type === GatewayServerEvent.VOICE_CONNECTION) {
+          setConnectionState(event.state || 'connecting')
+          if (event.state === 'connected') {
+            setError('')
+            setVisualError(false)
+          } else if (event.state === 'unavailable') {
+            setError(event.message || '语音前台连接异常，正在重试')
+          }
         }
         if (event.type === GatewayServerEvent.VOICE_OWNERSHIP) {
           setOwnership({
@@ -352,6 +419,7 @@ export default function useRealtimeVoice({
       }
       socket.onerror = () => {
         if (!disposed) {
+          setConnectionState('unavailable')
           setError('实时语音连接中断，正在重连')
           setVisualError(true)
         }
@@ -361,6 +429,7 @@ export default function useRealtimeVoice({
         if (disposed) return
         stopPlayback()
         setState('idle')
+        setConnectionState('unavailable')
         setError('实时语音连接中断，正在重连')
         setVisualError(true)
         eventRef.current?.({ type: GatewayServerEvent.GATEWAY_DISCONNECTED })
@@ -369,6 +438,7 @@ export default function useRealtimeVoice({
       }
     }
     setError('')
+    setConnectionState('connecting')
     connect()
 
     return () => {
@@ -519,6 +589,7 @@ export default function useRealtimeVoice({
     visualState: visualVoiceState(state, inputActive, enabled),
     error,
     visualError,
+    connectionState,
     ownership,
     levelElementRef,
     activateAudio,

--- a/web/test/playback-lifecycle.test.mjs
+++ b/web/test/playback-lifecycle.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { confirmTrackedPlaybackStart } from '../src/playback-lifecycle.js'
+
+function playback() {
+  return {
+    startTimers: new Map(),
+    startedResponses: new Set(),
+    sourceCounts: new Map([['response-1', 1]]),
+  }
+}
+
+test('confirms a tracked response exactly once and clears its timer', () => {
+  const state = playback()
+  const timer = { id: 'timer-1' }
+  const cleared = []
+  const started = []
+  state.startTimers.set('response-1', timer)
+
+  assert.equal(confirmTrackedPlaybackStart(
+    state,
+    'response-1',
+    id => started.push(id),
+    value => cleared.push(value),
+  ), true)
+  assert.equal(confirmTrackedPlaybackStart(
+    state,
+    'response-1',
+    id => started.push(id),
+  ), false)
+  assert.deepEqual(started, ['response-1'])
+  assert.deepEqual(cleared, [timer])
+  assert.equal(state.startTimers.has('response-1'), false)
+})
+
+test('does not acknowledge a source removed by interruption', () => {
+  const state = playback()
+  state.sourceCounts.clear()
+
+  assert.equal(confirmTrackedPlaybackStart(
+    state,
+    'response-1',
+    () => assert.fail('cleared playback must not be acknowledged'),
+  ), false)
+})


### PR DESCRIPTION
## Summary

- add desktop settings and runtime status for DashScope and user-managed speech-to-speech realtime frontends
- make playback acknowledgement and task-result delivery robust across Desktop and WebUI without backend-specific handling
- document the source-only v1.3.0 speech-to-speech preview consistently in the Chinese and English READMEs

## Validation

- `npm test`
- `npm run release:check`
- `git diff --check`

The package version remains 1.2.0; this PR does not trigger the v1.3.0 release.