### PR TITLE
docs: align v1.3.0 preview heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## News
 
-- **v1.3.0 · 测试中**
+- **测试中 · v1.3.0**
   🧪 新增 [🤗 speech-to-speech](https://github.com/huggingface/speech-to-speech) 前台接入，支持本地部署 VAD、STT、LLM 与 TTS 全链路。当前可从源码体验，正式 Release 将在完成测试后发布。
 - **2026-07-30 · [v1.0.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.0.0)**
   🚀 正式版发布，推出内置 Gateway 的 macOS 桌面版。

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,7 +25,7 @@ tells you:
 
 ## News
 
-- **v1.3.0 · In testing**
+- **In testing · v1.3.0**
   🧪 Adds a [🤗 speech-to-speech](https://github.com/huggingface/speech-to-speech) frontend for a locally deployed VAD–STT–LLM–TTS pipeline. Available from source; the formal Release will follow after testing.
 - **2026-07-30 · [v1.0.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.0.0)**
   🚀 First stable release with a macOS desktop app and integrated Gateway.


### PR DESCRIPTION
## Summary

- align the English News heading with the updated Chinese README
- present the testing status before the upcoming v1.3.0 version in both languages

## Validation

- `git diff --check`