### PR TITLE
feat: add local sleep and wake word mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,21 @@ SPEECH_TO_SPEECH_REALTIME_URL=ws://127.0.0.1:8765/v1/realtime
 如果 Realtime 接口位于需要 Bearer 认证的代理后方，可设置
 `SPEECH_TO_SPEECH_AUTH_TOKEN`。
 
+### 休眠与唤醒（可选）
+
+可设置空闲时间，让 Gateway 在无交互时断开 Realtime 连接：
+
+```dotenv
+QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS=120
+```
+
+休眠后，麦克风音频只在本地用于唤醒词检测，不会发送给 Realtime 服务。
+说“你好千问”后，等待界面提示“已唤醒，请说”，再说出指令。后台 Agent
+和已提交任务不会因休眠停止，任务结果会在唤醒后播报。
+
+该功能默认关闭。首次启用时会自动下载并校验约 33 MB 的
+[`sherpa-onnx`](https://github.com/k2-fsa/sherpa-onnx) 中英文 KWS 模型，之后直接使用本地缓存。
+
 ### TUI 使用注意
 
 | 平台 | 默认模式 | 打断方式 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -242,6 +242,25 @@ TTS, or voice configured in speech-to-speech. Set
 `SPEECH_TO_SPEECH_AUTH_TOKEN` only when the Realtime endpoint is behind a proxy
 that requires Bearer authentication.
 
+### Sleep and wake (optional)
+
+Set an idle timeout to let the Gateway disconnect its Realtime session when no
+interaction is taking place:
+
+```dotenv
+QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS=120
+```
+
+While asleep, microphone audio is used only for local wake-word detection and
+is never sent to the Realtime service. Say “你好千问”, wait for the “Awake,
+please speak” cue, and then give your command. The backend Agent and submitted
+work keep running while the voice frontend sleeps; completed results are spoken
+after wake-up.
+
+This feature is disabled by default. On first use, qwen-audio-agent automatically
+downloads and verifies the roughly 33 MB bilingual KWS model from
+[`sherpa-onnx`](https://github.com/k2-fsa/sherpa-onnx), then reuses its local cache.
+
 ### TUI Notes
 
 | Platform | Default mode | How to interrupt |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,19 @@ tasks.json            # 后台任务、结果和待播报通知的恢复状态
 `QWEN_AUDIO_AGENT_FRONTEND_MEMORY_PATH` 和 `QWEN_AUDIO_AGENT_TASK_STATE_PATH`
 覆盖位置。
 
+## 休眠与本地唤醒
+
+默认不启用自动休眠。设置正整数秒数后，Gateway 会在无语音交互时断开
+Realtime 连接，以减少长时间占用和误触发：
+
+```dotenv
+QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS=120
+```
+
+休眠时 Gateway 仍保持 UI 和后台 Agent 连接，但麦克风音频只进入本地
+sherpa-onnx KWS。固定唤醒词为“你好千问”。唤醒后等待连接就绪提示，再说命令。
+设为 `0` 或留空表示关闭。
+
 ## 选择后台
 
 `AGENT_PROTOCOL` 没有默认值，也是可选配置。留空时 Gateway 仅提供前台实时语音

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "@modelcontextprotocol/sdk": "1.30.0",
         "electron-updater": "6.8.9",
         "express": "^4.22.2",
+        "sherpa-onnx": "1.13.4",
+        "tar-stream": "3.1.7",
+        "unbzip2-stream": "1.4.3",
         "ws": "^8.21.1",
         "zod": "^4.4.3"
       },
@@ -2441,6 +2444,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2461,11 +2478,24 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2593,6 +2623,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -3697,6 +3751,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -3815,6 +3878,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -4424,6 +4493,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -7003,6 +7092,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sherpa-onnx": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx/-/sherpa-onnx-1.13.4.tgz",
+      "integrity": "sha512-KnfQkA+LxbptrWX1gd7upGDyFkLslJVlOudUWPkwveHwYIXo5Qq97Tx02NF5aE0G3cgKpHBh2z+CR+s6ywZPPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/side-channel": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
@@ -7175,6 +7270,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -7298,6 +7404,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -7333,6 +7450,21 @@
         "async-exit-hook": "^2.0.1",
         "fs-extra": "^10.0.0"
       }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
@@ -7477,6 +7609,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "node_modules/undici": {
@@ -7976,6 +8118,9 @@
         "@agentclientprotocol/sdk": "1.3.0",
         "@modelcontextprotocol/sdk": "1.30.0",
         "express": "^4.22.2",
+        "sherpa-onnx": "1.13.4",
+        "tar-stream": "3.1.7",
+        "unbzip2-stream": "1.4.3",
         "ws": "^8.21.1",
         "zod": "^4.4.3"
       }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,9 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "electron-updater": "6.8.9",
     "express": "^4.22.2",
+    "sherpa-onnx": "1.13.4",
+    "tar-stream": "3.1.7",
+    "unbzip2-stream": "1.4.3",
     "ws": "^8.21.1",
     "zod": "^4.4.3"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,9 @@
     "@agentclientprotocol/sdk": "1.3.0",
     "@modelcontextprotocol/sdk": "1.30.0",
     "express": "^4.22.2",
+    "sherpa-onnx": "1.13.4",
+    "tar-stream": "3.1.7",
+    "unbzip2-stream": "1.4.3",
     "ws": "^8.21.1",
     "zod": "^4.4.3"
   }

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -229,6 +229,15 @@ export const config = {
   speechToSpeechAuthToken: realtimeFrontend.speechToSpeechAuthToken,
   audioModel: realtimeFrontend.dashscopeModel,
   audioVoice: realtimeFrontend.dashscopeVoice,
+  sleepTimeoutMs: numberSetting(
+    process.env.QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS,
+    0,
+    { min: 0, max: 86_400 },
+  ) * 1000,
+  wakeWord: '你好千问',
+  wakeWordModelDirectory: process.env.QWEN_AUDIO_WAKE_WORD_MODEL_DIR
+    ? resolve(process.env.QWEN_AUDIO_WAKE_WORD_MODEL_DIR)
+    : resolve(runtimeEnvironment.configDirectory, 'models/wake-word'),
   allowedOrigins: String(process.env.QWEN_AUDIO_AGENT_ALLOWED_ORIGINS || '')
     .split(',')
     .map(value => value.trim())

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -27,6 +27,8 @@ import {
   clientVoiceCapabilities,
 } from './active-voice-clients.mjs'
 import { ReconnectBackoff } from './reconnect-backoff.mjs'
+import { SleepController } from './sleep-controller.mjs'
+import { createSherpaWakeWordDetector } from './wake-word/sherpa-detector.mjs'
 import {
   isResponseActivityEvent,
   realtimeResponseId,
@@ -69,6 +71,15 @@ export function acceptsPlaybackReceipt({
   responseKnown,
 }) {
   return outputEnabled === true && active === true && responseKnown === true
+}
+
+export function isSleepActivityEvent(event = {}) {
+  return isResponseActivityEvent(event) || [
+    'input_audio_buffer.speech_started',
+    'input_audio_buffer.speech_stopped',
+    'conversation.item.input_audio_transcription.delta',
+    'conversation.item.input_audio_transcription.completed',
+  ].includes(event.type)
 }
 
 function clientDescriptor(event = {}) {
@@ -141,6 +152,11 @@ export function attachRealtimeGateway(server, {
     let inputEnabled = false
     let outputEnabled = false
     let textOnlySession = false
+    let sleeping = false
+    let waking = false
+    let wakeDetector = null
+    let wakeDetectorPromise = null
+    let sleepController
     // Realtime front end for this session. Defaults to the configured provider
     // and can be switched by the client through the connect event.
     let sessionProvider = config.audioProvider
@@ -235,7 +251,9 @@ export function attachRealtimeGateway(server, {
     }
     const announcements = new AnnouncementManager({
       getFrontend: () => frontend,
-      isDeliveryBlocked: () => !outputEnabled || announcementWindow.isBlocked(),
+      isDeliveryBlocked: () => (
+        sleeping || waking || !outputEnabled || announcementWindow.isBlocked()
+      ),
       announceIntoContext: config.announceIntoContext,
       resultContextMaxChars: config.resultContextMaxChars,
       maxBatchItems: config.announcementMaxBatchItems,
@@ -265,7 +283,11 @@ export function attachRealtimeGateway(server, {
       descriptor,
       realtimeStatus: () => ({
         provider: sessionProvider,
-        state: frontend?.ready
+        state: sleeping
+          ? 'sleeping'
+          : waking
+            ? 'waking'
+            : frontend?.ready
           ? 'connected'
           : connectPromise
             ? 'connecting'
@@ -275,6 +297,9 @@ export function attachRealtimeGateway(server, {
       // a clean close, so a stale holder never blocks a new voice claim.
       isAlive: () => ws.readyState === WebSocket.OPEN,
       deactivate: replacement => {
+        sleeping = false
+        waking = false
+        sleepController?.disable()
         inputEnabled = false
         outputEnabled = false
         pendingAudio = []
@@ -832,6 +857,7 @@ export function attachRealtimeGateway(server, {
     })
 
     const handleEvent = event => {
+      if (isSleepActivityEvent(event)) sleepController?.recordActivity()
       if (isResponseActivityEvent(event)) beginResponseLifecycle(event)
       if (event.type === 'input_audio_buffer.speech_started') {
         userSpeaking = true
@@ -1218,6 +1244,131 @@ export function attachRealtimeGateway(server, {
       }
     }
 
+    const enterSleep = () => {
+      if (sleeping || !frontend?.ready) return
+      sleeping = true
+      waking = false
+      pendingAudio = []
+      wakeDetector?.reset()
+      cancelScheduledRealtimeReconnect()
+      const staleFrontend = frontend
+      frontend = null
+      staleFrontend?.close()
+      send(ws, {
+        type: GatewayServerEvent.VOICE_CONNECTION,
+        state: 'sleeping',
+        provider: sessionProvider,
+      })
+      send(ws, {
+        type: GatewayServerEvent.VOICE_SLEEP,
+        state: 'sleeping',
+        wakeWord: config.wakeWord,
+      })
+    }
+
+    const prepareSleepMode = () => {
+      if (
+        !config.sleepTimeoutMs
+        || textOnlySession
+        || !inputEnabled
+        || wakeDetectorPromise
+      ) return
+      if (wakeDetector) {
+        sleepController.enable()
+        if (sleeping) sleepController.holdSleeping()
+        return
+      }
+      send(ws, {
+        type: GatewayServerEvent.VOICE_SLEEP,
+        state: 'preparing',
+        wakeWord: config.wakeWord,
+      })
+      wakeDetectorPromise = createSherpaWakeWordDetector({
+        modelRoot: config.wakeWordModelDirectory,
+      }).then(detector => {
+        wakeDetector = detector
+        if (ws.readyState === WebSocket.OPEN && inputEnabled) {
+          sleepController.enable()
+          send(ws, {
+            type: GatewayServerEvent.VOICE_SLEEP,
+            state: 'enabled',
+            timeoutMs: config.sleepTimeoutMs,
+            wakeWord: config.wakeWord,
+          })
+        }
+      }).catch(error => {
+        sleepController.disable()
+        send(ws, {
+          type: GatewayServerEvent.VOICE_SLEEP,
+          state: 'disabled',
+          message: `休眠功能未启用：${error.message}`,
+        })
+      }).finally(() => {
+        wakeDetectorPromise = null
+      })
+    }
+
+    const wakeFromSleep = () => {
+      if (!sleeping || waking) return
+      sleeping = false
+      waking = true
+      sleepController.wake()
+      send(ws, {
+        type: GatewayServerEvent.VOICE_SLEEP,
+        state: 'detected',
+        wakeWord: config.wakeWord,
+      })
+      ensureFrontend().catch(error => {
+        waking = false
+        sleeping = true
+        sleepController.holdSleeping()
+        cancelScheduledRealtimeReconnect()
+        const failedFrontend = frontend
+        frontend = null
+        failedFrontend?.close()
+        send(ws, {
+          type: GatewayServerEvent.VOICE_CONNECTION,
+          state: 'sleeping',
+          provider: sessionProvider,
+          message: error.message,
+        })
+      })
+    }
+
+    const acceptSleepingAudio = audio => {
+      try {
+        const sampleRate = resolveRealtimeProvider(sessionProvider).inputSampleRate
+        if (wakeDetector?.accept(audio, sampleRate)) wakeFromSleep()
+      } catch (error) {
+        sleeping = false
+        waking = false
+        sleepController.disable()
+        send(ws, {
+          type: GatewayServerEvent.VOICE_SLEEP,
+          state: 'disabled',
+          message: `唤醒词检测已停止：${error.message}`,
+        })
+        ensureFrontend().catch(connectionError => send(ws, {
+          type: 'error',
+          message: connectionError.message,
+        }))
+      }
+    }
+
+    sleepController = new SleepController({
+      timeoutMs: config.sleepTimeoutMs,
+      canSleep: () => (
+        inputEnabled
+        && activeVoiceClients.isActive(ownerId, voiceClient)
+        && frontend?.ready
+        && !userSpeaking
+        && !announcementWindow.isBlocked()
+        && !connectPromise
+        && !waking
+      ),
+      onSleep: enterSleep,
+    })
+
     const connectFrontendNow = () => {
       if (frontend?.ready) return Promise.resolve()
       if (connectPromise) return connectPromise
@@ -1278,6 +1429,8 @@ export function attachRealtimeGateway(server, {
         .then(() => {
           if (frontend !== createdFrontend) return
           realtimeConnectedAt = Date.now()
+          const resumedFromSleep = waking
+          waking = false
           send(ws, {
             type: GatewayServerEvent.VOICE_CONNECTION,
             state: 'connected',
@@ -1294,6 +1447,18 @@ export function attachRealtimeGateway(server, {
             provider: createdFrontend.provider.key,
             providerLabel: createdFrontend.provider.label,
           })
+          prepareSleepMode()
+          sleepController.recordActivity()
+          if (resumedFromSleep) {
+            send(ws, {
+              type: GatewayServerEvent.VOICE_SLEEP,
+              state: 'awake',
+              wakeWord: config.wakeWord,
+            })
+            announcePendingPermissions()
+            claimPendingNotifications()
+            announcements.flush()
+          }
         })
         .catch(error => {
           if (frontend === createdFrontend) {
@@ -1384,6 +1549,7 @@ export function attachRealtimeGateway(server, {
             message: error.message,
           }))
         }
+        prepareSleepMode()
       } else if (event.type === GatewayClientEvent.UNMUTE) {
         if (textOnlySession) {
           inputEnabled = false
@@ -1394,6 +1560,7 @@ export function attachRealtimeGateway(server, {
         }
         ensureFrontend()
           .then(() => {
+            prepareSleepMode()
             announcePendingPermissions()
             claimPendingNotifications()
             announcements.flush()
@@ -1408,8 +1575,13 @@ export function attachRealtimeGateway(server, {
         } else {
           activateVoiceClient({ takeover: event.takeover === true })
         }
+        if (sleeping) {
+          prepareSleepMode()
+          return
+        }
         ensureFrontend()
           .then(() => {
+            prepareSleepMode()
             announcePendingPermissions()
             claimPendingNotifications()
             announcements.flush()
@@ -1417,6 +1589,10 @@ export function attachRealtimeGateway(server, {
           .catch(error => send(ws, { type: 'error', message: error.message }))
       } else if (event.type === GatewayClientEvent.AUDIO_APPEND) {
         if (!inputEnabled || !activeVoiceClients.isActive(ownerId, voiceClient)) {
+          return
+        }
+        if (sleeping) {
+          acceptSleepingAudio(event.audio)
           return
         }
         if (frontend?.ready) frontend.appendAudio(event.audio)
@@ -1438,6 +1614,14 @@ export function attachRealtimeGateway(server, {
       } else if (event.type === GatewayClientEvent.TEXT_MESSAGE) {
         const text = String(event.text || '').trim()
         if (!text) return
+        if (sleeping || waking) {
+          send(ws, {
+            type: 'error',
+            message: `已休眠，请先说“${config.wakeWord}”唤醒。`,
+          })
+          return
+        }
+        sleepController.recordActivity()
         const turnId = `text_${randomUUID().replaceAll('-', '')}`
         conversationSync.record({
           ownerId,
@@ -1461,6 +1645,7 @@ export function attachRealtimeGateway(server, {
           ))
           .catch(error => send(ws, { type: 'error', message: error.message }))
       } else if (event.type === GatewayClientEvent.INTERRUPT) {
+        sleepController.recordActivity()
         turnGeneration = ++turnSequence
         committedTurnGeneration = turnGeneration
         announcementWindow.interrupt()
@@ -1492,6 +1677,9 @@ export function attachRealtimeGateway(server, {
           })
         }
       } else if (event.type === GatewayClientEvent.MUTE) {
+        sleeping = false
+        waking = false
+        sleepController.disable()
         releaseVoiceClient()
         turnGeneration = ++turnSequence
         committedTurnGeneration = turnGeneration
@@ -1501,6 +1689,7 @@ export function attachRealtimeGateway(server, {
         frontend?.close()
       } else if (event.type === GatewayClientEvent.INPUT_MUTE) {
         inputEnabled = false
+        sleepController.disable()
         pendingAudio = []
       }
     })
@@ -1519,6 +1708,7 @@ export function attachRealtimeGateway(server, {
       playbackTurns.clear()
       inputTurns.clear()
       announcements.close()
+      sleepController.close()
       clearTimeout(permissionRetryTimer)
       permissionRetryTimer = null
       cancelScheduledRealtimeReconnect()

--- a/server/src/voice/sleep-controller.mjs
+++ b/server/src/voice/sleep-controller.mjs
@@ -1,0 +1,79 @@
+export class SleepController {
+  constructor({
+    timeoutMs,
+    retryMs = 1000,
+    canSleep = () => true,
+    onSleep = () => {},
+  } = {}) {
+    this.timeoutMs = Math.max(0, Number(timeoutMs) || 0)
+    this.retryMs = Math.max(10, Number(retryMs) || 1000)
+    this.canSleep = canSleep
+    this.onSleep = onSleep
+    this.enabled = false
+    this.sleeping = false
+    this.closed = false
+    this.timer = null
+  }
+
+  enable() {
+    if (this.closed || !this.timeoutMs) return false
+    this.enabled = true
+    this.recordActivity()
+    return true
+  }
+
+  recordActivity() {
+    if (!this.enabled || this.sleeping || this.closed) return
+    this.schedule(this.timeoutMs)
+  }
+
+  schedule(delay) {
+    clearTimeout(this.timer)
+    this.timer = setTimeout(() => this.trySleep(), delay)
+    this.timer.unref?.()
+  }
+
+  async trySleep() {
+    this.timer = null
+    if (!this.enabled || this.sleeping || this.closed) return
+    if (!this.canSleep()) {
+      this.schedule(this.retryMs)
+      return
+    }
+    this.sleeping = true
+    try {
+      await this.onSleep()
+    } catch {
+      this.sleeping = false
+      this.schedule(this.retryMs)
+    }
+  }
+
+  wake() {
+    if (this.closed) return false
+    const wasSleeping = this.sleeping
+    this.sleeping = false
+    if (this.enabled) this.recordActivity()
+    return wasSleeping
+  }
+
+  holdSleeping() {
+    if (!this.enabled || this.closed) return false
+    clearTimeout(this.timer)
+    this.timer = null
+    this.sleeping = true
+    return true
+  }
+
+  disable() {
+    this.enabled = false
+    this.sleeping = false
+    clearTimeout(this.timer)
+    this.timer = null
+  }
+
+  close() {
+    this.closed = true
+    this.disable()
+  }
+}

--- a/server/src/voice/wake-word/model-manager.mjs
+++ b/server/src/voice/wake-word/model-manager.mjs
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto'
+import {
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import tar from 'tar-stream'
+import unbzip2 from 'unbzip2-stream'
+
+export const WAKE_WORD_MODEL_NAME = 'sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20'
+export const WAKE_WORD_MODEL_URL = `https://github.com/k2-fsa/sherpa-onnx/releases/download/kws-models/${WAKE_WORD_MODEL_NAME}.tar.bz2`
+export const WAKE_WORD_MODEL_SHA256 = '68447f4fbc67e70eee3a93961f36e81e98f47aef73ce7e7ca00885c6cd3616a6'
+
+export const WAKE_WORD_MODEL_FILES = Object.freeze({
+  encoder: 'encoder-epoch-13-avg-2-chunk-8-left-64.int8.onnx',
+  decoder: 'decoder-epoch-13-avg-2-chunk-8-left-64.onnx',
+  joiner: 'joiner-epoch-13-avg-2-chunk-8-left-64.int8.onnx',
+  tokens: 'tokens.txt',
+  keywords: 'keywords.txt',
+})
+
+const ARCHIVE_FILES = new Set([
+  WAKE_WORD_MODEL_FILES.encoder,
+  WAKE_WORD_MODEL_FILES.decoder,
+  WAKE_WORD_MODEL_FILES.joiner,
+  WAKE_WORD_MODEL_FILES.tokens,
+])
+const REQUIRED_FILES = new Set(Object.values(WAKE_WORD_MODEL_FILES))
+const preparations = new Map()
+
+function complete(directory) {
+  return [...REQUIRED_FILES].every(file => existsSync(resolve(directory, file)))
+}
+
+async function sha256(path) {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+async function download(url, path, fetchImpl) {
+  const response = await fetchImpl(url)
+  if (!response.ok || !response.body) {
+    throw new Error(`唤醒词模型下载失败：HTTP ${response.status}`)
+  }
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(path, {
+    flags: 'wx',
+    mode: 0o600,
+  }))
+}
+
+async function extractSelected(archivePath, targetDirectory) {
+  const extract = tar.extract()
+  const writes = []
+  extract.on('entry', (header, stream, next) => {
+    const file = basename(header.name)
+    if (header.type !== 'file' || !ARCHIVE_FILES.has(file)) {
+      stream.resume()
+      stream.on('end', next)
+      return
+    }
+    const destination = resolve(targetDirectory, file)
+    const write = pipeline(stream, createWriteStream(destination, {
+      mode: 0o600,
+    })).then(next, error => extract.destroy(error))
+    writes.push(write)
+  })
+  await pipeline(createReadStream(archivePath), unbzip2(), extract)
+  await Promise.all(writes)
+}
+
+async function prepare(directory, { fetchImpl }) {
+  if (complete(directory)) return directory
+  mkdirSync(dirname(directory), { recursive: true, mode: 0o700 })
+  const nonce = `${process.pid}-${Date.now()}`
+  const archivePath = resolve(dirname(directory), `${WAKE_WORD_MODEL_NAME}-${nonce}.tar.bz2`)
+  const stagingDirectory = resolve(dirname(directory), `.${WAKE_WORD_MODEL_NAME}-${nonce}`)
+  mkdirSync(stagingDirectory, { recursive: false, mode: 0o700 })
+  try {
+    await download(WAKE_WORD_MODEL_URL, archivePath, fetchImpl)
+    const digest = await sha256(archivePath)
+    if (digest !== WAKE_WORD_MODEL_SHA256) {
+      throw new Error('唤醒词模型校验失败')
+    }
+    await extractSelected(archivePath, stagingDirectory)
+    writeFileSync(
+      resolve(stagingDirectory, WAKE_WORD_MODEL_FILES.keywords),
+      'n ǐ h ǎo q iān w èn @你好千问\n',
+      { encoding: 'utf8', mode: 0o600 },
+    )
+    if (!complete(stagingDirectory)) {
+      throw new Error('唤醒词模型缺少必需文件')
+    }
+    rmSync(directory, { recursive: true, force: true })
+    renameSync(stagingDirectory, directory)
+    return directory
+  } finally {
+    rmSync(archivePath, { force: true })
+    rmSync(stagingDirectory, { recursive: true, force: true })
+  }
+}
+
+export function ensureWakeWordModel(directory, {
+  fetchImpl = fetch,
+} = {}) {
+  const target = resolve(directory, WAKE_WORD_MODEL_NAME)
+  if (complete(target)) return Promise.resolve(target)
+  if (!preparations.has(target)) {
+    const pending = prepare(target, { fetchImpl })
+      .finally(() => preparations.delete(target))
+    preparations.set(target, pending)
+  }
+  return preparations.get(target)
+}

--- a/server/src/voice/wake-word/sherpa-detector.mjs
+++ b/server/src/voice/wake-word/sherpa-detector.mjs
@@ -1,0 +1,85 @@
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { ensureWakeWordModel, WAKE_WORD_MODEL_FILES } from './model-manager.mjs'
+
+const require = createRequire(import.meta.url)
+const engines = new Map()
+
+function pcm16Base64ToFloat32(audio) {
+  const bytes = Buffer.from(audio, 'base64')
+  const sampleCount = Math.floor(bytes.length / 2)
+  const samples = new Float32Array(sampleCount)
+  for (let index = 0; index < sampleCount; index += 1) {
+    samples[index] = bytes.readInt16LE(index * 2) / 32768
+  }
+  return samples
+}
+
+async function createEngine({ modelRoot }) {
+  const modelDirectory = await ensureWakeWordModel(modelRoot)
+  const { createKws } = require('sherpa-onnx')
+  const keywords = readFileSync(
+    resolve(modelDirectory, WAKE_WORD_MODEL_FILES.keywords),
+    'utf8',
+  )
+  const keywordSpotter = createKws({
+    featConfig: { samplingRate: 16000, featureDim: 80 },
+    modelConfig: {
+      transducer: {
+        encoder: resolve(modelDirectory, WAKE_WORD_MODEL_FILES.encoder),
+        decoder: resolve(modelDirectory, WAKE_WORD_MODEL_FILES.decoder),
+        joiner: resolve(modelDirectory, WAKE_WORD_MODEL_FILES.joiner),
+      },
+      tokens: resolve(modelDirectory, WAKE_WORD_MODEL_FILES.tokens),
+      numThreads: 1,
+      provider: 'cpu',
+      debug: 0,
+      modelingUnit: 'cjkchar',
+    },
+    maxActivePaths: 4,
+    numTrailingBlanks: 1,
+    keywordsScore: 1.0,
+    keywordsThreshold: 0.25,
+    // WASM cannot pass a host path through the native keywords_file field.
+    // Supplying the verified local file as a buffer keeps keyword loading
+    // independent of the WASM virtual filesystem.
+    keywords: '',
+    keywordsBuf: keywords,
+    keywordsBufSize: Buffer.byteLength(keywords),
+  })
+  return keywordSpotter
+}
+
+async function engineFor(options) {
+  const key = resolve(options.modelRoot)
+  if (!engines.has(key)) {
+    engines.set(key, createEngine(options).catch(error => {
+      engines.delete(key)
+      throw error
+    }))
+  }
+  return engines.get(key)
+}
+
+export async function createSherpaWakeWordDetector({ modelRoot }) {
+  const keywordSpotter = await engineFor({ modelRoot })
+  const stream = keywordSpotter.createStream()
+  return {
+    accept(audio, sampleRate = 16000) {
+      const samples = pcm16Base64ToFloat32(audio)
+      if (!samples.length) return false
+      stream.acceptWaveform(sampleRate, samples)
+      while (keywordSpotter.isReady(stream)) keywordSpotter.decode(stream)
+      const result = keywordSpotter.getResult(stream)
+      if (!result.keyword) return false
+      keywordSpotter.reset(stream)
+      return true
+    },
+    reset() {
+      keywordSpotter.reset(stream)
+    },
+  }
+}
+
+export { pcm16Base64ToFloat32 }

--- a/server/test/realtime-gateway.test.mjs
+++ b/server/test/realtime-gateway.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   acceptsPlaybackReceipt,
   confirmsTaskNotificationOnPlaybackStart,
+  isSleepActivityEvent,
   rejectUnsupportedRealtimeUpgrade,
 } from '../src/voice/realtime-gateway.mjs'
 import { isResponseActivityEvent } from '../src/voice/response-lifecycle.mjs'
@@ -86,4 +87,16 @@ test('recognizes response activity when response.created is omitted', () => {
   }
   assert.equal(isResponseActivityEvent({ type: 'response.text.delta' }), false)
   assert.equal(isResponseActivityEvent({ type: 'session.updated' }), false)
+})
+
+test('counts speech and response lifecycle events as sleep activity', () => {
+  for (const event of [
+    { type: 'input_audio_buffer.speech_started' },
+    { type: 'conversation.item.input_audio_transcription.completed' },
+    { type: 'response.output_audio.delta', response_id: 'response-1' },
+    { type: 'response.done', response: { id: 'response-1' } },
+  ]) assert.equal(isSleepActivityEvent(event), true, event.type)
+
+  assert.equal(isSleepActivityEvent({ type: 'session.updated' }), false)
+  assert.equal(isSleepActivityEvent({ type: 'rate_limits.updated' }), false)
 })

--- a/server/test/sleep-controller.test.mjs
+++ b/server/test/sleep-controller.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { SleepController } from '../src/voice/sleep-controller.mjs'
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+test('sleeps only after the configured idle interval', async () => {
+  let sleeps = 0
+  const controller = new SleepController({
+    timeoutMs: 20,
+    onSleep: () => { sleeps += 1 },
+  })
+  controller.enable()
+  await wait(10)
+  controller.recordActivity()
+  await wait(12)
+  assert.equal(sleeps, 0)
+  await wait(15)
+  assert.equal(sleeps, 1)
+  assert.equal(controller.sleeping, true)
+  controller.close()
+})
+
+test('defers sleep while foreground activity is blocking it', async () => {
+  let blocked = true
+  let sleeps = 0
+  const controller = new SleepController({
+    timeoutMs: 10,
+    retryMs: 10,
+    canSleep: () => !blocked,
+    onSleep: () => { sleeps += 1 },
+  })
+  controller.enable()
+  await wait(15)
+  assert.equal(sleeps, 0)
+  blocked = false
+  await wait(15)
+  assert.equal(sleeps, 1)
+  controller.close()
+})
+
+test('can return to a sleeping state when realtime reconnection fails', () => {
+  const controller = new SleepController({ timeoutMs: 100 })
+  controller.enable()
+  controller.holdSleeping()
+  assert.equal(controller.wake(), true)
+  assert.equal(controller.sleeping, false)
+  assert.equal(controller.holdSleeping(), true)
+  assert.equal(controller.sleeping, true)
+  controller.close()
+})
+
+test('never arms when the feature is disabled', async () => {
+  let sleeps = 0
+  const controller = new SleepController({
+    timeoutMs: 0,
+    onSleep: () => { sleeps += 1 },
+  })
+  assert.equal(controller.enable(), false)
+  await wait(15)
+  assert.equal(sleeps, 0)
+})

--- a/server/test/wake-word-detector.test.mjs
+++ b/server/test/wake-word-detector.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { pcm16Base64ToFloat32 } from '../src/voice/wake-word/sherpa-detector.mjs'
+
+test('converts little-endian PCM16 audio into normalized float samples', () => {
+  const pcm = Buffer.alloc(8)
+  pcm.writeInt16LE(-32768, 0)
+  pcm.writeInt16LE(-16384, 2)
+  pcm.writeInt16LE(0, 4)
+  pcm.writeInt16LE(32767, 6)
+  const samples = pcm16Base64ToFloat32(pcm.toString('base64'))
+  assert.deepEqual([...samples], [-1, -0.5, 0, 32767 / 32768])
+})
+
+test('ignores an incomplete trailing PCM byte', () => {
+  const samples = pcm16Base64ToFloat32(Buffer.from([1, 0, 2]).toString('base64'))
+  assert.deepEqual([...samples], [1 / 32768])
+})

--- a/shared/realtime-events.mjs
+++ b/shared/realtime-events.mjs
@@ -16,6 +16,7 @@ export const GatewayServerEvent = Object.freeze({
   GATEWAY_CONNECTED: 'gateway.connected',
   GATEWAY_DISCONNECTED: 'gateway.disconnected',
   VOICE_CONNECTION: 'voice.connection',
+  VOICE_SLEEP: 'voice.sleep',
   VOICE_READY: 'voice.ready',
   VOICE_STATE: 'voice.state',
   VOICE_OWNERSHIP: 'voice.ownership',

--- a/shared/runtime-environment.mjs
+++ b/shared/runtime-environment.mjs
@@ -22,6 +22,8 @@ const USER_CONFIG_TEMPLATE = [
   'QWEN_AUDIO_REALTIME_PROVIDER=dashscope',
   '# Hugging Face speech-to-speech：将上一行改为 speech-to-speech，并设置服务地址',
   '# SPEECH_TO_SPEECH_REALTIME_URL=ws://127.0.0.1:8765/v1/realtime',
+  '# 可选：空闲后断开实时语音；设为正整数秒启用，0 表示关闭',
+  '# QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS=0',
   '',
   '# 可选：选择后台 Agent；留空时仅使用前台实时语音聊天',
   '# 可选 openclaw、opencode、qoder、kimi、hermes、codebuddy、codex、claude、acp 或 none',

--- a/tui/src/index.mjs
+++ b/tui/src/index.mjs
@@ -967,6 +967,21 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
       }
       if (ownsVoice) startMicrophone()
     }
+    if (event.type === GatewayServerEvent.VOICE_SLEEP) {
+      if (event.state === 'sleeping') {
+        print(style(
+          `[已休眠 · 说“${event.wakeWord || '你好千问'}”唤醒]`,
+          'yellow',
+        ))
+      } else if (event.state === 'detected') {
+        print(style('[已识别唤醒词，正在重连语音前台]', 'cyan'))
+      } else if (event.state === 'awake') {
+        process.stdout.write('\u0007')
+        print(style('[已唤醒，请说]', 'green'))
+      } else if (event.state === 'disabled' && event.message) {
+        print(style(`[${event.message}]`, 'yellow'))
+      }
+    }
     if (event.type === GatewayServerEvent.VOICE_OWNERSHIP) {
       if (event.state === 'active') {
         ownsVoice = true

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -64,8 +64,29 @@ function labelFor(state) {
     thinking: '思考中',
     speaking: '正在说',
     connecting: '正在连接语音前台',
+    sleeping: '已休眠',
     occupied: '其他入口正在使用',
   }[state] || state
+}
+
+function playWakeChime() {
+  const AudioContext = window.AudioContext || window.webkitAudioContext
+  if (!AudioContext) return
+  try {
+    const context = new AudioContext()
+    const oscillator = context.createOscillator()
+    const gain = context.createGain()
+    oscillator.frequency.value = 660
+    gain.gain.setValueAtTime(0.0001, context.currentTime)
+    gain.gain.exponentialRampToValueAtTime(0.08, context.currentTime + 0.01)
+    gain.gain.exponentialRampToValueAtTime(0.0001, context.currentTime + 0.14)
+    oscillator.connect(gain).connect(context.destination)
+    oscillator.start()
+    oscillator.stop(context.currentTime + 0.15)
+    oscillator.addEventListener('ended', () => context.close())
+  } catch {
+    // The visible wake state remains available when a browser blocks audio.
+  }
 }
 
 function frontendLabel(holder) {
@@ -305,6 +326,19 @@ export default function App() {
   }, [])
 
   const onRealtimeEvent = useCallback(event => {
+    if (event.type === 'voice.sleep') {
+      if (event.state === 'sleeping') {
+        setActivity(`已休眠 · 说“${event.wakeWord || '你好千问'}”唤醒`)
+      }
+      if (event.state === 'detected') setActivity('正在唤醒')
+      if (event.state === 'awake') {
+        setActivity('已唤醒，请说')
+        playWakeChime()
+      }
+      if (event.state === 'disabled' && event.message) {
+        setActivity(event.message)
+      }
+    }
     if (event.type === 'turn.started') {
       currentTurnId.current = event.turnId || ''
       activeVoiceResponse.current = ''
@@ -633,9 +667,11 @@ export default function App() {
   const voiceConnectionError = voice.connectionState === 'unavailable'
   const visualVoiceState = voice.ownership.state === 'busy'
     ? 'occupied'
-    : voiceEnabled && voice.connectionState === 'connecting'
-      ? 'connecting'
-      : voice.visualState || voice.state
+    : voiceEnabled && voice.connectionState === 'sleeping'
+      ? 'sleeping'
+      : voiceEnabled && voice.connectionState === 'connecting'
+        ? 'connecting'
+        : voice.visualState || voice.state
   const ownershipLabel = voice.ownership.holder
     ? frontendLabel(voice.ownership.holder)
     : ''

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -58,6 +58,7 @@ header {
 .status i.listening { background: #50dfab; box-shadow: 0 0 12px #50dfab; }
 .status i.thinking { background: #f1c665; box-shadow: 0 0 12px #f1c665; }
 .status i.speaking { background: #9a7dff; box-shadow: 0 0 12px #9a7dff; }
+.status i.sleeping { background: #70809a; box-shadow: 0 0 8px #70809a; }
 header button { padding: 9px 13px; border-radius: 10px; color: #ddd; border: 1px solid #ffffff18; background: #ffffff08; }
 header .voice.active { color: white; border-color: #785cf4; background: #785cf4; }
 header .voice.waiting { color: #ded5ff; border-color: #927cf480; }


### PR DESCRIPTION
## Summary

- add an opt-in idle sleep mode that disconnects the Realtime provider while keeping the Gateway, UI, and backend Agent alive
- add local wake-word detection for “你好千问” using sherpa-onnx and an automatically cached KWS model
- restore the same logical frontend conversation through the existing in-memory conversation synchronization after wake-up
- expose sleep/wake status in WebUI, Desktop, and TUI

## Status

This is a forward-looking experimental direction and is intentionally opened as a Draft PR. It is not ready to merge yet. Follow-up work should further validate session-context continuity, long-running stability, wake accuracy, model download experience, and cross-platform behavior.

## Validation

- `npm test`
- `npm run audit:release`
- `npm pack --dry-run`
- verified real model download/checksum/extraction
- verified sleep → local wake detection → Realtime reconnection with a running Gateway
