### PR TITLE
fix: surface Realtime connection failures

### DIFF
--- a/desktop/src/realtime-status.mjs
+++ b/desktop/src/realtime-status.mjs
@@ -10,3 +10,10 @@ export function realtimeModelStatusLabel(model) {
   if (value === 'qwen-audio-3.0-realtime-flash') return 'flash'
   return value
 }
+
+export function realtimeConnectionStatus(status) {
+  if (!status) return 'configured'
+  if (status.connected > 0) return 'connected'
+  if (status.connecting > 0) return 'connecting'
+  return status.unavailable > 0 ? 'unavailable' : 'disconnected'
+}

--- a/desktop/src/settings.js
+++ b/desktop/src/settings.js
@@ -1,5 +1,6 @@
 import { backendOptionStates } from './backend-options.mjs'
 import {
+  realtimeConnectionStatus,
   realtimeModelStatusLabel,
   realtimeStatusLabel,
 } from './realtime-status.mjs'
@@ -190,14 +191,6 @@ function setBackendStatus(text, connected) {
   currentBackend.className = `connection-status ${connected ? 'connected' : 'disconnected'}`
 }
 
-function realtimeConnectionState(provider) {
-  const status = runtime?.realtimeConnection?.byProvider?.[provider]
-  if (!status) return 'configured'
-  if (status.connected > 0) return 'connected'
-  if (status.connecting > 0) return 'connecting'
-  return 'disconnected'
-}
-
 function setRealtimeStatus(text, state) {
   currentRealtime.textContent = text
   currentRealtime.className = state === 'configured'
@@ -221,15 +214,27 @@ function renderRuntime() {
   if (!runtime.voiceConfigured) {
     setRealtimeStatus(`${realtimeLabel} · 配置不完整`, 'disconnected')
   } else {
-    const state = realtimeConnectionState(runtime.realtimeProvider)
+    const state = realtimeConnectionStatus(
+      runtime.realtimeConnection?.byProvider?.[runtime.realtimeProvider],
+    )
     const stateLabel = {
       connected: '已连接',
       connecting: '正在连接',
+      unavailable: '连接失败',
       disconnected: '连接异常',
       configured: '已配置',
     }[state]
     setRealtimeStatus(
-      [realtimeLabel, realtimeModelLabel, stateLabel]
+      [
+        realtimeLabel,
+        realtimeModelLabel,
+        stateLabel,
+        state === 'unavailable'
+          ? truncate(
+            runtime.realtimeConnection?.byProvider?.[runtime.realtimeProvider]?.error,
+          )
+          : '',
+      ]
         .filter(Boolean)
         .join(' · '),
       state,

--- a/desktop/test/realtime-status.test.mjs
+++ b/desktop/test/realtime-status.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  realtimeConnectionStatus,
   realtimeModelStatusLabel,
   realtimeStatusLabel,
 } from '../src/realtime-status.mjs'
@@ -23,4 +24,12 @@ test('shortens known Qwen Audio realtime model names', () => {
     'flash',
   )
   assert.equal(realtimeModelStatusLabel('custom-model'), 'custom-model')
+})
+
+test('keeps a fatal realtime failure distinct from Gateway connectivity', () => {
+  assert.equal(realtimeConnectionStatus(), 'configured')
+  assert.equal(realtimeConnectionStatus({ connecting: 1 }), 'connecting')
+  assert.equal(realtimeConnectionStatus({ connected: 1 }), 'connected')
+  assert.equal(realtimeConnectionStatus({ unavailable: 1 }), 'unavailable')
+  assert.equal(realtimeConnectionStatus({ disconnected: 1 }), 'disconnected')
 })

--- a/server/src/voice/providers/dashscope.mjs
+++ b/server/src/voice/providers/dashscope.mjs
@@ -13,6 +13,14 @@ function classifyError(message) {
   if (isRecoverableRealtimeInactivityError(message)) return 'inactivity'
   if (/user is speaking/i.test(message)) return 'input_busy'
   if (/no active response/i.test(message)) return 'no_active_response'
+  if (
+    /invalid[_ -]?api[_ -]?key|incorrect api key|authentication failed|unauthorized|unexpected server response: (?:401|403)/i
+      .test(message)
+    || /\barrearage\b|account is not in good standing/i.test(message)
+    || /allocationquota\.freetieronly|free allocated quota exceeded|free tier .* exhausted/i
+      .test(message)
+    || /model(?:\.|_)?accessdenied|model[_ -]?not[_ -]?found/i.test(message)
+  ) return 'fatal'
   return 'other'
 }
 

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -9,7 +9,11 @@ import { AnnouncementWindow } from './announcement/announcement-window.mjs'
 import { config } from '../core/config.mjs'
 import { conversationSync } from '../conversation/conversation-sync.mjs'
 import { normalizeClientContext } from '../conversation/frontend-agent-context.mjs'
-import { createRealtimeFrontend, resolveRealtimeProvider } from './realtime-provider.mjs'
+import {
+  createRealtimeFrontend,
+  realtimeEventErrorMessage,
+  resolveRealtimeProvider,
+} from './realtime-provider.mjs'
 import { isAllowedOrigin } from '../core/request-security.mjs'
 import { taskManager } from '../task/task-manager.mjs'
 import { recordTaskResult } from '../conversation/task-result-projector.mjs'
@@ -150,6 +154,7 @@ export function attachRealtimeGateway(server, {
     let permissionResponseTimer = null
     let scheduledRealtimeReconnect = null
     let realtimeConnectedAt = 0
+    let realtimeBlockedError = ''
     const realtimeReconnectBackoff = new ReconnectBackoff()
     const announcementWindow = new AnnouncementWindow()
     const playbackTurns = new Map()
@@ -265,11 +270,14 @@ export function attachRealtimeGateway(server, {
       descriptor,
       realtimeStatus: () => ({
         provider: sessionProvider,
-        state: frontend?.ready
+        state: realtimeBlockedError
+          ? 'unavailable'
+          : frontend?.ready
           ? 'connected'
           : connectPromise
             ? 'connecting'
             : 'disconnected',
+        ...(realtimeBlockedError ? { error: realtimeBlockedError } : {}),
       }),
       // Lets the arbitration evict this owner once its socket has died without
       // a clean close, so a stale holder never blocks a new voice claim.
@@ -373,6 +381,7 @@ export function attachRealtimeGateway(server, {
     }
 
     const scheduleRealtimeReconnect = () => {
+      if (realtimeBlockedError) return Promise.resolve()
       if (frontend?.ready) return Promise.resolve()
       if (scheduledRealtimeReconnect) {
         return scheduledRealtimeReconnect.promise
@@ -403,6 +412,11 @@ export function attachRealtimeGateway(server, {
       scheduled.timer.unref?.()
       scheduledRealtimeReconnect = scheduled
       return promise
+    }
+    const reportFrontendError = error => {
+      if (error?.realtimeConnectionReported) return
+      if (error) error.realtimeConnectionReported = true
+      send(ws, { type: 'error', message: error?.message || String(error) })
     }
     const ensurePermissionResponseFor = context => {
       clearTimeout(permissionResponseTimer)
@@ -1151,9 +1165,7 @@ export function attachRealtimeGateway(server, {
         // A response refused by a busy single-slot provider is retried by the
         // frontend transparently; nothing user-facing happened.
         if (event.__voiceRetried) return
-        const errorMessage = event.error?.message
-          || event.message
-          || '实时语音服务错误'
+        const errorMessage = realtimeEventErrorMessage(event)
         const providerError = frontend.provider.classifyError(errorMessage)
         const recoverableInactivity = providerError === 'inactivity'
         // A local or otherwise capacity-bounded provider can still be draining
@@ -1173,6 +1185,20 @@ export function attachRealtimeGateway(server, {
         // 也不应触发失败簿记(此时本就没有响应在跑)。
         const benignCancelRace = providerError === 'no_active_response'
         if (benignCancelRace) return
+        if (providerError === 'fatal') {
+          realtimeBlockedError = errorMessage
+          pendingAudio = []
+          cancelScheduledRealtimeReconnect()
+          const blockedFrontend = frontend
+          frontend = null
+          blockedFrontend?.close()
+          send(ws, {
+            type: GatewayServerEvent.VOICE_CONNECTION,
+            state: 'unavailable',
+            provider: sessionProvider,
+            message: errorMessage,
+          })
+        }
         const id = realtimeResponseId(event)
         const context = responseContexts.get(id)
         if (context?.origin === 'announcement') {
@@ -1212,7 +1238,7 @@ export function attachRealtimeGateway(server, {
         // backend task is still running. The task remains healthy, and any
         // pending announcement has already returned to the retry queue, so this
         // provider housekeeping event is not user-facing.
-        if (!recoverableInactivity) {
+        if (!recoverableInactivity && providerError !== 'fatal') {
           send(ws, { type: 'error', message: errorMessage })
         }
       }
@@ -1240,11 +1266,14 @@ export function attachRealtimeGateway(server, {
         },
         onEvent: handleEvent,
         onError: error => {
-          if (
-            createdFrontend.provider.classifyError(error.message)
-            !== 'inactivity'
-          ) {
-            send(ws, { type: 'error', message: error.message })
+          const classification = createdFrontend.provider.classifyError(error.message)
+          if (classification === 'fatal') {
+            realtimeBlockedError = error.message
+            pendingAudio = []
+            error.realtimeConnectionReported = true
+          }
+          if (classification !== 'inactivity') {
+            reportFrontendError(error)
           }
         },
         onClose: () => {
@@ -1256,7 +1285,9 @@ export function attachRealtimeGateway(server, {
             type: GatewayServerEvent.VOICE_CONNECTION,
             state: 'unavailable',
             provider: sessionProvider,
+            ...(realtimeBlockedError ? { message: realtimeBlockedError } : {}),
           })
+          if (realtimeBlockedError) return
           if (
             realtimeConnectedAt
             && Date.now() - realtimeConnectedAt >= REALTIME_STABLE_CONNECTION_MS
@@ -1277,6 +1308,7 @@ export function attachRealtimeGateway(server, {
       createdConnectPromise = createdFrontend.connect()
         .then(() => {
           if (frontend !== createdFrontend) return
+          realtimeBlockedError = ''
           realtimeConnectedAt = Date.now()
           send(ws, {
             type: GatewayServerEvent.VOICE_CONNECTION,
@@ -1296,6 +1328,10 @@ export function attachRealtimeGateway(server, {
           })
         })
         .catch(error => {
+          if (createdFrontend.provider.classifyError(error.message) === 'fatal') {
+            realtimeBlockedError = error.message
+            pendingAudio = []
+          }
           if (frontend === createdFrontend) {
             send(ws, {
               type: GatewayServerEvent.VOICE_CONNECTION,
@@ -1314,6 +1350,9 @@ export function attachRealtimeGateway(server, {
     }
 
     const ensureFrontend = () => {
+      if (realtimeBlockedError) {
+        return Promise.reject(new Error(realtimeBlockedError))
+      }
       if (frontend?.ready) return Promise.resolve()
       if (connectPromise) return connectPromise
       if (scheduledRealtimeReconnect) {
@@ -1341,6 +1380,7 @@ export function attachRealtimeGateway(server, {
           try {
             const requested = resolveRealtimeProvider(event.provider)
             sessionProvider = requested.key
+            realtimeBlockedError = ''
             const staleFrontend = frontend
             frontend = null
             cancelScheduledRealtimeReconnect()
@@ -1379,10 +1419,7 @@ export function attachRealtimeGateway(server, {
           textOnly: textOnlySession,
         })
         if (inputEnabled || outputEnabled) {
-          ensureFrontend().catch(error => send(ws, {
-            type: 'error',
-            message: error.message,
-          }))
+          ensureFrontend().catch(reportFrontendError)
         }
       } else if (event.type === GatewayClientEvent.UNMUTE) {
         if (textOnlySession) {
@@ -1398,7 +1435,7 @@ export function attachRealtimeGateway(server, {
             claimPendingNotifications()
             announcements.flush()
           })
-          .catch(error => send(ws, { type: 'error', message: error.message }))
+          .catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.INPUT_UNMUTE) {
         if (textOnlySession) return
         if (activeVoiceClients.isActive(ownerId, voiceClient)) {
@@ -1414,7 +1451,7 @@ export function attachRealtimeGateway(server, {
             claimPendingNotifications()
             announcements.flush()
           })
-          .catch(error => send(ws, { type: 'error', message: error.message }))
+          .catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.AUDIO_APPEND) {
         if (!inputEnabled || !activeVoiceClients.isActive(ownerId, voiceClient)) {
           return
@@ -1429,10 +1466,7 @@ export function attachRealtimeGateway(server, {
           // arriving during a close/backoff window is buffered, but must never
           // bypass that window and create a second Realtime connection.
           if (!connectPromise && !scheduledRealtimeReconnect) {
-            ensureFrontend().catch(error => send(ws, {
-              type: 'error',
-              message: error.message,
-            }))
+            ensureFrontend().catch(reportFrontendError)
           }
         }
       } else if (event.type === GatewayClientEvent.TEXT_MESSAGE) {
@@ -1459,7 +1493,7 @@ export function attachRealtimeGateway(server, {
                 : undefined,
             },
           ))
-          .catch(error => send(ws, { type: 'error', message: error.message }))
+          .catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.INTERRUPT) {
         turnGeneration = ++turnSequence
         committedTurnGeneration = turnGeneration
@@ -1533,6 +1567,7 @@ export function attachRealtimeGateway(server, {
         connected: 0,
         connecting: 0,
         disconnected: 0,
+        unavailable: 0,
         byProvider: {},
       }
       let connected = 0
@@ -1549,10 +1584,12 @@ export function attachRealtimeGateway(server, {
               connected: 0,
               connecting: 0,
               disconnected: 0,
+              unavailable: 0,
             }
           }
           const provider = realtime.byProvider[status.provider]
           provider[status.state] = (provider[status.state] || 0) + 1
+          if (status.error) provider.error = status.error
         }
       }
       return {

--- a/server/src/voice/realtime-provider.mjs
+++ b/server/src/voice/realtime-provider.mjs
@@ -36,6 +36,16 @@ function normalizedEvents(value) {
   return Array.isArray(value) ? value.filter(Boolean) : [value]
 }
 
+export function realtimeEventErrorMessage(event, fallback = '实时语音服务错误') {
+  const details = [
+    event?.error?.code,
+    event?.error?.type,
+    event?.error?.message,
+    event?.message,
+  ].map(value => String(value || '').trim()).filter(Boolean)
+  return [...new Set(details)].join(': ') || fallback
+}
+
 // Behavioural capabilities of a provider's Realtime implementation. Every
 // default describes the fully specification-compliant behaviour, so providers
 // only declare the guarantees they do NOT uphold and the frontend compensates
@@ -144,6 +154,11 @@ export class RealtimeFrontend {
       this.protocol.normalizeIncoming(providerEvent),
     )
     for (const event of events) {
+      if (event.type === 'error' && !this.ready) {
+        const error = new Error(realtimeEventErrorMessage(event))
+        error.realtimeEvent = true
+        throw error
+      }
       if (event.type === 'session.created') {
         this.updateSession()
         if (!this.capabilities.acknowledgesSessionUpdate) {

--- a/server/test/realtime-provider.test.mjs
+++ b/server/test/realtime-provider.test.mjs
@@ -5,6 +5,7 @@ import {
   buildFrontendInstructions,
   REALTIME_PROVIDERS,
   RealtimeFrontend,
+  realtimeEventErrorMessage,
 } from '../src/voice/realtime-provider.mjs'
 
 const FRONTEND_TOOL_NAMES = [
@@ -22,6 +23,50 @@ function createQwenFrontend(options = {}) {
     ...options,
   })
 }
+
+test('rejects a provider error before the realtime session becomes ready', () => {
+  const frontend = createQwenFrontend()
+
+  assert.throws(
+    () => frontend.handleProviderEvent({
+      type: 'error',
+      error: {
+        code: 'InvalidApiKey',
+        message: 'Invalid API-key provided.',
+      },
+    }),
+    /InvalidApiKey: Invalid API-key provided/,
+  )
+  assert.equal(frontend.ready, false)
+})
+
+test('preserves provider error codes in the user-facing realtime error', () => {
+  assert.equal(realtimeEventErrorMessage({
+    type: 'error',
+    error: {
+      code: 'AllocationQuota.FreeTierOnly',
+      type: 'insufficient_quota',
+      message: 'The free tier of the model has been exhausted.',
+    },
+  }), 'AllocationQuota.FreeTierOnly: insufficient_quota: The free tier of the model has been exhausted.')
+})
+
+test('classifies non-recoverable DashScope account errors as fatal', () => {
+  const provider = REALTIME_PROVIDERS.qwen
+  for (const message of [
+    'InvalidApiKey: Invalid API-key provided.',
+    'Arrearage: Access denied, please make sure your account is in good standing.',
+    'AllocationQuota.FreeTierOnly: The free tier of the model has been exhausted.',
+    'Free allocated quota exceeded.',
+    'Unexpected server response: 401',
+  ]) {
+    assert.equal(provider.classifyError(message), 'fatal', message)
+  }
+  assert.equal(
+    provider.classifyError('You exceeded your current quota, please check your plan.'),
+    'other',
+  )
+})
 
 test('carries originating turn metadata to a created realtime response', () => {
   const frontend = createQwenFrontend()

--- a/tui/src/index.mjs
+++ b/tui/src/index.mjs
@@ -967,6 +967,14 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
       }
       if (ownsVoice) startMicrophone()
     }
+    if (
+      event.type === GatewayServerEvent.VOICE_CONNECTION
+      && event.state === 'unavailable'
+    ) {
+      frontendReady = false
+      setCaptureEnabled(false)
+      print(`${style('[语音前台连接失败]', 'red')} ${event.message || '请检查前台服务配置'}`)
+    }
     if (event.type === GatewayServerEvent.VOICE_OWNERSHIP) {
       if (event.state === 'active') {
         ownsVoice = true

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -633,7 +633,9 @@ export default function App() {
   const voiceConnectionError = voice.connectionState === 'unavailable'
   const visualVoiceState = voice.ownership.state === 'busy'
     ? 'occupied'
-    : voiceEnabled && voice.connectionState === 'connecting'
+    : voiceConnectionError
+      ? 'error'
+      : voiceEnabled && voice.connectionState === 'connecting'
       ? 'connecting'
       : voice.visualState || voice.state
   const ownershipLabel = voice.ownership.holder

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -372,6 +372,7 @@ export default function useRealtimeVoice({
             setVisualError(false)
           } else if (event.state === 'unavailable') {
             setError(event.message || '语音前台连接异常，正在重试')
+            setVisualError(true)
           }
         }
         if (event.type === GatewayServerEvent.VOICE_OWNERSHIP) {


### PR DESCRIPTION
## Summary

- distinguish Gateway connectivity, microphone availability, and Realtime provider readiness
- reject provider errors received before session initialization completes
- classify non-recoverable DashScope authentication, account, free-tier, and model-access failures at the provider boundary
- stop audio buffering and reconnect loops after a fatal provider failure
- expose the unavailable state and error reason through Gateway health
- show an explicit failure state in Desktop, WebUI, and TUI instead of a healthy listening animation

## Error handling boundary

Permanent authentication/account/free-tier failures block the current Realtime session until configuration is updated and the Gateway restarts. Temporary throttling remains a normal request error and is not treated as a permanent disconnection.

## Validation

- `npm test`
- `npm run build`
- real DashScope WebSocket handshake with an invalid API Key: `connecting -> unavailable (401)`
- verified no `voice.ready` event is emitted and `/api/health` reports `unavailable: 1` with the failure reason
