### PR TITLE
docs: add ongoing development news

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ## News
 
+- **2026-08-04 · New**
+  🧠 新增个性化前台能力，支持常驻用户规则与命名笔记，已合入主分支，可从源码体验。
 - **2026-08-03 · [v1.3.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.3.0)**
   🎙️ 新增 [🤗 speech-to-speech](https://github.com/huggingface/speech-to-speech) 前台接入，支持本地部署 VAD、STT、LLM 与 TTS 全链路。
 - **2026-08-01 · [v1.2.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.2.0)**

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,6 +25,8 @@ tells you:
 
 ## News
 
+- **2026-08-04 · New**
+  🧠 Adds personalized frontend capabilities with standing user directives and named notes. Now on the main branch and available from source.
 - **2026-08-03 · [v1.3.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.3.0)**
   🎙️ Adds a [🤗 speech-to-speech](https://github.com/huggingface/speech-to-speech) frontend for a locally deployed VAD–STT–LLM–TTS pipeline.
 - **2026-08-01 · [v1.2.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.2.0)**


### PR DESCRIPTION
## Summary

- add a dated News entry for personalized frontend capabilities already merged to main
- distinguish source-available development updates from formal releases
- keep Chinese and English README content aligned

## Verification

- `git diff --check`