### PR TITLE
fix(server): prevent leaking opencode coordinatorAgent to non-opencod…

### DIFF
--- a/server/src/agent/agent-client.mjs
+++ b/server/src/agent/agent-client.mjs
@@ -25,17 +25,13 @@ export class AgentClient {
     // backends only need a config.backends entry; nothing to thread here.
     const backend = {
       ...(config.backends?.[driver.id] || {}),
-      ...(backends[driver.id] || {}),
+      ...(backends?.[driver.id] || {}),
     }
     const options = {
       baseUrl: '',
       ...backend,
       model: model ?? backend.model,
-      coordinatorAgent: (
-        coordinatorAgent
-        ?? backend.coordinatorAgent
-        ?? config.backends?.opencode?.coordinatorAgent
-      ),
+      coordinatorAgent: coordinatorAgent ?? backend.coordinatorAgent,
     }
     const profile = driver.createProfile({
       protocol,

--- a/server/test/agent-client-selection.test.mjs
+++ b/server/test/agent-client-selection.test.mjs
@@ -123,3 +123,29 @@ for (const protocol of [
     assert.equal(client.describe().capabilities.nativeSessionHistory, true)
   })
 }
+
+test('does not leak opencode coordinatorAgent to drivers without a coordinatorAgent', () => {
+  const client = new AgentClient({
+    protocol: 'qoder',
+    backends: {
+      opencode: { coordinatorAgent: 'opencode-coordinator' },
+      qoder: { directory: '/qoder' },
+    },
+    sessionStatePath: null,
+    acpClient: fakeAcpClient(),
+    sessionToolServer: fakeToolServer(),
+  })
+  assert.equal(client.adapter.coordinatorAgent, '')
+})
+
+test('handles null backends option gracefully', () => {
+  const client = new AgentClient({
+    protocol: 'opencode',
+    backends: null,
+    sessionStatePath: null,
+    acpClient: fakeAcpClient(),
+    sessionToolServer: fakeToolServer(),
+  })
+  assert.equal(client.protocol, 'opencode')
+})
+


### PR DESCRIPTION
## 变更说明

 **问题:**
    `AgentClient` 的构造函数中存在配置泄漏的问题。在处理后端驱动的 `coordinatorAgent`
  选项时，代码中硬编码了错误的回退逻辑，指向了 `opencode` 的配置 (`config.backends?.opencode?.
  coordinatorAgent`)。这会导致在使用其他后端驱动时，错误地混入 `opencode` 的配置。

    **解决方式:**
    修改了 `server/src/agent/agent-client.mjs`，移除了硬编码的回退逻辑。现在，`coordinatorAgent`
  将严格通过各驱动自身的配置 (`backends?.[driver.id]?.coordinatorAgent`)
  进行解析，同时修复了对可选链调用的安全处理。

    **为何需要这项变更:**
    确保各个后端驱动的配置完全隔离，防止配置泄漏引发不可预期的行为，并增强代码的健壮性。

## 验证

    - [x] `npm test`
    - [x] `npm run lint`
    - [x] `npm run build`
    - [x] 行为变化已补充测试或说明无法自动测试的原因 (已在 `server/test/agent-client-selection.
  test.mjs` 中补充了关于 `coordinatorAgent` 配置隔离与空安全处理的回归测试)

## 兼容性与安全

    - [x] 未提交密钥、用户数据、日志或内部地址
    - [x] 配置、用户可见行为和依赖变化已同步更新文档
    - [x] 已说明网络、权限、隐私、持久化或发布流程影响；不适用时请注明 (不适用，仅属于内部逻辑修复)