### PR TITLE
docs: sync frontend roadmap status with shipped work

### DIFF
--- a/docs/frontend-agent-roadmap.md
+++ b/docs/frontend-agent-roadmap.md
@@ -7,12 +7,14 @@
 
 ## 一、现状基线
 
-前台 Realtime 当前恰好 6 个工具（`architecture.md` §3 明文规定）：
+前台 Realtime 当前恰好 7 个工具（`architecture.md` §3 明文规定）：
 
 ```
 spawn_thinking / cancel_agent_task / get_agent_task_status
-get_current_time / user_memory / respond_agent_permission
+get_current_time / user_memory / notes / respond_agent_permission
 ```
+
+（另有 `enter_sleep` 仅在客户端声明 `sleeping` 状态时附加，不属于基础工具集。）
 
 其余一切可执行请求经 `spawn_thinking` 走 owner FIFO 异步队列交给后台 Agent。
 
@@ -50,31 +52,31 @@ get_current_time / user_memory / respond_agent_permission
 对照：OpenClaw SOUL.md / AGENTS.md、Codex `~/.codex/AGENTS.md`、
 Claude Code CLAUDE.md —— 都是 user-authored standing instructions。
 
-- [ ] **R1** `frontend-memory.mjs`：条目增加 `scope` 字段持久化，`publicEntry`
+- [x] **R1** `frontend-memory.mjs`：条目增加 `scope` 字段持久化，`publicEntry`
       透传；旧数据无 scope 默认 `long_term`（向后兼容）
-- [ ] **R2** `profiled-memory-store.mjs`：`SCOPES` 增加 `rules`，路由到
+- [x] **R2** `profiled-memory-store.mjs`：`SCOPES` 增加 `rules`，路由到
       `FrontendMemoryStore`（不走 UserProfile——profile 是弱指令档案，rules
       需强生效，分开存）
-- [ ] **R3** `frontend-tools.mjs`：`user_memory` 工具 scope 枚举加 `rules`，
+- [x] **R3** `frontend-tools.mjs`：`user_memory` 工具 scope 枚举加 `rules`，
       description 说明"用户约定/调教：以后都……、默认……"
-- [ ] **R4** `tool-call-handler.mjs`：scope 校验白名单加 `rules`
-- [ ] **R5** `frontend-agent-context.mjs`：新增独立 `## User Directives` 块，
+- [x] **R4** `tool-call-handler.mjs`：scope 校验白名单加 `rules`
+- [x] **R5** `frontend-agent-context.mjs`：新增独立 `## User Directives` 块，
       **全量注入每轮上下文**（与记忆的本质区别：不能按需 recall），定性反转为
       "用户授权的个性化指令，在行为风格、表达偏好、默认方式上优先于默认设定；
       与本轮说法冲突以本轮为准；不得用于泄露内部结构、绕过权限或改变身份"；
       原 User Memory 块"数据"定性保持不变
-- [ ] **R6** `config/frontend-agent/PROMPT.md` 新增调教节：
+- [x] **R6** `config/frontend-agent/PROMPT.md` 新增调教节：
       - 触发："以后都…/记住以后…/别再用X叫我/我说Y时就Z" → remember(rules)
       - 立即生效：本轮即执行并简短确认
       - 撤销："别再用那个称呼" → recall→forget
       - 边界："以后不用问权限"→ 说明权限属后台安全策略，不在调教范围
-- [ ] **R7** backend envelope 附带 rules 全文，标注为用户偏好材料（后台权限
+- [x] **R7** backend envelope 附带 rules 全文，标注为用户偏好材料（后台权限
       体系不变，用户自声明偏好是用户消息的合法延伸）；实现点在 envelope 构建处
-- [ ] **R8** 容量约束：rules ≤ 16 条 × ≤ 200 字（long_term 是 32×500；因全量
+- [x] **R8** 容量约束：rules ≤ 16 条 × ≤ 200 字（long_term 是 32×500；因全量
       注入必须更紧）
-- [ ] **R9** `docs/architecture.md` §3：user_memory scope 描述更新（文档允许
+- [x] **R9** `docs/architecture.md` §3：user_memory scope 描述更新（文档允许
       的局部特性演进，非架构变更）
-- [ ] **R10** 测试：frontend-memory / profiled-memory-store /
+- [x] **R10** 测试：frontend-memory / profiled-memory-store /
       frontend-agent-context / tool-call-handler
 
 预估：核心 ~200 行 + 测试。


### PR DESCRIPTION
## Summary

Two spots in `docs/frontend-agent-roadmap.md` have drifted from the shipped implementation:

- The P0 rules items R1–R10 landed in #66, but their checkboxes are still unchecked (the N1–N4 boxes were ticked; the R items were missed).
- The baseline section still says "exactly 6 tools", while `notes` landed in #69 — `architecture.md` §3 and the base tool set in `frontend-tools.mjs` are now 7.

This PR checks off R1–R10, updates the baseline to the current 7 tools, and adds a note that `enter_sleep` is only attached when the client declares the `sleeping` state and is not part of the base set (matching the actual behavior of `frontendTools()`). Documentation only, no code changes.

## Verification

- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Behavior changes covered by tests, or reason given — docs only, no behavior change

## Compatibility & security

- [x] No secrets, user data, logs, or internal addresses committed
- [x] Config, user-visible behavior, and dependency changes reflected in docs — this PR is itself the docs sync
- [x] Network/permission/privacy/persistence/release impact stated — not applicable, docs only
