### PR TITLE
feat: 桌面版/CLI 数据目录隔离 + 语音休眠与唤醒词

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ## News
 
 - **2026-08-05 · 未发布**
-  ⏰ 新增定时提醒与进度查询；桌面版支持 Linux 打包（AppImage + deb）。
+  ⏰ 新增定时提醒与进度查询；桌面版支持 Linux 打包（AppImage + deb）；桌面版数据目录与 CLI 隔离，两者可同时使用互不干扰。
 - **2026-08-05 · [v1.4.2](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.4.2)**
   🔧 优化桌面端后台 Agent 的安装、登录与状态检测，完善长期记忆行为。
 - **2026-08-04 · [v1.4.1](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.4.1)**

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ## News
 
 - **2026-08-05 · 未发布**
-  ⏰ 新增定时提醒与进度查询；桌面版支持 Linux 打包（AppImage + deb）；桌面版数据目录与 CLI 隔离，两者可同时使用互不干扰。
+  ⏰ 新增定时提醒与进度查询；桌面版支持 Linux 打包（AppImage + deb）；桌面版数据目录与 CLI 隔离，两者可同时使用互不干扰；新增语音唤醒词功能（“你好千问”），休眠后麦克风保持开启，说出唤醒词即可激活。
 - **2026-08-05 · [v1.4.2](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.4.2)**
   🔧 优化桌面端后台 Agent 的安装、登录与状态检测，完善长期记忆行为。
 - **2026-08-04 · [v1.4.1](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.4.1)**

--- a/README_EN.md
+++ b/README_EN.md
@@ -26,7 +26,7 @@ tells you:
 ## News
 
 - **2026-08-05 · Unreleased**
-  ⏰ Adds scheduled reminders and progress reporting; desktop build support for Linux (AppImage + deb); the desktop app now uses a data directory isolated from the CLI, so both can run side by side without interfering.
+  ⏰ Adds scheduled reminders and progress reporting; desktop build support for Linux (AppImage + deb); the desktop app now uses a data directory isolated from the CLI, so both can run side by side without interfering; adds voice wake word (“你好千问”) — the microphone stays on during sleep and speaking the wake word activates the assistant.
 - **2026-08-05 · [v1.4.2](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.4.2)**
   🔧 Refines desktop backend Agent installation, login, and status detection, with more reliable long-term memory behavior.
 - **2026-08-04 · [v1.4.1](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.4.1)**

--- a/README_EN.md
+++ b/README_EN.md
@@ -26,7 +26,7 @@ tells you:
 ## News
 
 - **2026-08-05 · Unreleased**
-  ⏰ Adds scheduled reminders and progress reporting; desktop build support for Linux (AppImage + deb).
+  ⏰ Adds scheduled reminders and progress reporting; desktop build support for Linux (AppImage + deb); the desktop app now uses a data directory isolated from the CLI, so both can run side by side without interfering.
 - **2026-08-05 · [v1.4.2](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.4.2)**
   🔧 Refines desktop backend Agent installation, login, and status detection, with more reliable long-term memory behavior.
 - **2026-08-04 · [v1.4.1](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.4.1)**

--- a/desktop/src/config-migration.mjs
+++ b/desktop/src/config-migration.mjs
@@ -1,0 +1,56 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+} from 'node:fs'
+import { resolve } from 'node:path'
+
+// 桌面版与 CLI（~/.config/qwaudio）使用相互独立的数据目录。桌面版默认
+// 使用 Electron 应用数据目录；仅以下文件会在首次启动时从旧目录复制过来，
+// 运行时状态（gateway.lock、state/、logs/ 等）各自重建、互不共享。
+const MIGRATED_FILES = [
+  'config.env',
+  'state.env',
+  'USER.md',
+  'frontend-memory.json',
+  'frontend-notes.json',
+  'tasks.json',
+]
+const MIGRATION_MARKER = 'migrated-from.json'
+
+export function resolveDesktopConfigDirectory({ env, userDataDirectory }) {
+  if (env.QWAUDIO_CONFIG_DIR) return resolve(env.QWAUDIO_CONFIG_DIR)
+  return resolve(userDataDirectory)
+}
+
+export function migrateLegacyConfig({ legacyDir, targetDir }) {
+  if (!legacyDir || !targetDir) return { migrated: false, reason: 'missing-directories' }
+  const legacy = resolve(legacyDir)
+  const target = resolve(targetDir)
+  if (legacy === target) return { migrated: false, reason: 'same-directory' }
+  if (!existsSync(resolve(legacy, 'config.env'))) {
+    return { migrated: false, reason: 'no-legacy-config' }
+  }
+  if (existsSync(resolve(target, 'config.env'))) {
+    return { migrated: false, reason: 'target-configured' }
+  }
+  mkdirSync(target, { recursive: true, mode: 0o700 })
+  const copied = []
+  for (const name of MIGRATED_FILES) {
+    const source = resolve(legacy, name)
+    if (!existsSync(source)) continue
+    copyFileSync(source, resolve(target, name))
+    copied.push(name)
+  }
+  writeFileSync(
+    resolve(target, MIGRATION_MARKER),
+    `${JSON.stringify({
+      legacyDir: legacy,
+      migratedAt: new Date().toISOString(),
+      files: copied,
+    }, null, 2)}\n`,
+    'utf8',
+  )
+  return { migrated: true, copied, legacyDir: legacy }
+}

--- a/desktop/src/gateway-process.mjs
+++ b/desktop/src/gateway-process.mjs
@@ -214,16 +214,21 @@ export class EmbeddedGateway {
     this.preferredPort = preferredPort
     const busy = await this.probeImpl(this.host, preferredPort)
     this.assertActiveStart(operation)
+    // 首选端口可能被另一套独立数据目录的产品实例（如 CLI 或另一份
+    // 桌面版）或外部程序占用；回退随机端口让它们并行运行。若因此与
+    // 同目录实例产生租约竞争，启动失败后由 main 的 findRunningGateway
+    // 兜底复用。
+    const port = busy ? 0 : preferredPort
     if (busy) {
-      throw new Error(
-        `Gateway 端口已被其他程序占用：http://${this.host}:${preferredPort}`,
-      )
+      this.logger?.warn('gateway.port_busy_fallback', {
+        preferredPort,
+        selectedPort: 'random',
+      })
     }
-    const port = preferredPort
     this.logger?.info('gateway.starting', {
       preferredPort,
-      selectedPort: port,
-      portReallocated: false,
+      selectedPort: busy ? 'random' : port,
+      portReallocated: busy,
     })
     // Imported lazily so this module also loads outside Electron (tests).
     const fork = this.forkImpl || (await import('electron')).utilityProcess.fork

--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -68,6 +68,10 @@ import {
   expandProcessPath,
 } from './process-path.mjs'
 import {
+  migrateLegacyConfig,
+  resolveDesktopConfigDirectory,
+} from './config-migration.mjs'
+import {
   createDesktopUpdater,
 } from './updater.mjs'
 import { createGracefulShutdown } from './graceful-shutdown.mjs'
@@ -77,6 +81,22 @@ import { DesktopPresence } from './desktop-presence.mjs'
 // 将其扩充为用户登录 shell 的 PATH，让 Gateway 子进程与后台可用性
 // 检测能找到通过 Homebrew、nvm 或官方脚本安装的 Agent 命令。
 expandProcessPath()
+
+// 桌面版与 CLI（~/.config/qwaudio）使用相互独立的数据目录：桌面版默认走
+// Electron 应用数据目录，两者的 Gateway、锁、日志与设置互不干扰；
+// QWAUDIO_CONFIG_DIR 仍优先（高级用户 / Profile 场景）。
+// 统一应用名，让开发模式与打包版共用同一个 userData 目录（打包版
+// 的 productName 与单实例锁都基于它；开发模式默认会落到包名目录）。
+app.setName('Qwen Audio Agent')
+const legacyConfigDirectory = userConfigDirectory(process.env)
+process.env.QWAUDIO_CONFIG_DIR = resolveDesktopConfigDirectory({
+  env: process.env,
+  userDataDirectory: app.getPath('userData'),
+})
+const configMigration = migrateLegacyConfig({
+  legacyDir: legacyConfigDirectory,
+  targetDir: process.env.QWAUDIO_CONFIG_DIR,
+})
 
 const here = dirname(fileURLToPath(import.meta.url))
 const sourceRoot = resolve(here, '../..')
@@ -103,6 +123,12 @@ logger.info('desktop.starting', {
   platform: process.platform,
   arch: process.arch,
 })
+if (configMigration.migrated) {
+  logger.info('desktop.config_migrated', {
+    legacyDir: configMigration.legacyDir,
+    files: configMigration.copied,
+  })
+}
 const fallbackPage = resolve(here, 'orb-unavailable.html')
 const fallbackUrl = pathToFileURL(fallbackPage).href
 const settingsPage = resolve(here, 'settings.html')
@@ -881,6 +907,10 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
     previous.autoHideSeconds !== normalized.autoHideSeconds
   )
   const wakeShortcutChanged = previous.wakeShortcut !== normalized.wakeShortcut
+  const wakeWordChanged = (
+    previous.wakeWordEnabled !== normalized.wakeWordEnabled
+    || previous.sleepTimeoutSeconds !== normalized.sleepTimeoutSeconds
+  )
   const gatewayRuntimeChanged = (
     gatewayChanged
     || apiKeyChanged
@@ -889,6 +919,7 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
     || realtimeModelChanged
     || speechToSpeechChanged
     || backendModelChanged
+    || wakeWordChanged
   )
   if (!remote && borrowedGatewayOrigin && gatewayRuntimeChanged) {
     const borrowedHealth = await readGatewayHealth(borrowedGatewayOrigin)
@@ -942,6 +973,7 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
       orbStyle: orbStyleChanged,
       autoHide: autoHideChanged,
       wakeShortcut: wakeShortcutChanged,
+      wakeWord: wakeWordChanged,
     },
   })
   let restarted = false

--- a/desktop/src/settings-config.mjs
+++ b/desktop/src/settings-config.mjs
@@ -15,6 +15,8 @@ const DEFAULTS = {
   orbStyle: 'fluid',
   autoHideSeconds: 120,
   wakeShortcut: 'CommandOrControl+Shift+Space',
+  wakeWordEnabled: false,
+  sleepTimeoutSeconds: 300,
   dashscopeApiKey: '',
   realtimeProvider: DEFAULT_REALTIME_PROVIDER,
   agentProtocol: 'none',
@@ -29,6 +31,8 @@ const SETTING_KEYS = {
   orbStyle: 'QWEN_AUDIO_ORB_STYLE',
   autoHideSeconds: 'QWEN_AUDIO_DESKTOP_AUTO_HIDE_SECONDS',
   wakeShortcut: 'QWEN_AUDIO_DESKTOP_WAKE_SHORTCUT',
+  wakeWordEnabled: 'QWEN_AUDIO_WAKE_WORD_ENABLED',
+  sleepTimeoutSeconds: 'QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS',
   dashscopeApiKey: 'DASHSCOPE_API_KEY',
   realtimeProvider: 'QWEN_AUDIO_REALTIME_PROVIDER',
   agentProtocol: 'AGENT_PROTOCOL',
@@ -116,6 +120,15 @@ function encoded(value) {
   return `"${text.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`
 }
 
+function cleanSleepTimeoutSeconds(value) {
+  const seconds = Number(value)
+  if (seconds === 0) return 0
+  if (!Number.isInteger(seconds) || seconds < 30 || seconds > 3600) {
+    return DEFAULTS.sleepTimeoutSeconds
+  }
+  return seconds
+}
+
 export function parseSettings(content = '', fallback = {}) {
   const values = parseEnv(content)
   const realtimeProvider = normalizeRealtimeProvider(configured(
@@ -186,6 +199,20 @@ export function parseSettings(content = '', fallback = {}) {
       'QWEN_AUDIO_DESKTOP_WAKE_SHORTCUT',
       fallback.QWEN_AUDIO_DESKTOP_WAKE_SHORTCUT ?? DEFAULTS.wakeShortcut,
     )),
+    wakeWordEnabled: String(
+      configured(
+        values,
+        'QWEN_AUDIO_WAKE_WORD_ENABLED',
+        fallback.QWEN_AUDIO_WAKE_WORD_ENABLED || '',
+      )
+    ).toLowerCase() === 'true',
+    sleepTimeoutSeconds: cleanSleepTimeoutSeconds(configured(
+      values,
+      'QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS',
+      fallback.QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS
+        ?? (fallback.QWEN_AUDIO_WAKE_WORD_ENABLED === 'true'
+          ? DEFAULTS.sleepTimeoutSeconds : 0),
+    )),
     dashscopeApiKey: String(configuredApiKey || '').trim(),
     realtimeProvider,
     agentProtocol: cleanAgentProtocol(configured(
@@ -237,6 +264,10 @@ export function normalizeSettings(settings = {}) {
     ),
     wakeShortcut: cleanWakeShortcut(
       settings.wakeShortcut ?? DEFAULTS.wakeShortcut,
+    ),
+    wakeWordEnabled: Boolean(settings.wakeWordEnabled),
+    sleepTimeoutSeconds: cleanSleepTimeoutSeconds(
+      settings.sleepTimeoutSeconds ?? DEFAULTS.sleepTimeoutSeconds,
     ),
     dashscopeApiKey: String(
       settings.dashscopeApiKey ?? DEFAULTS.dashscopeApiKey,

--- a/desktop/src/settings.css
+++ b/desktop/src/settings.css
@@ -423,6 +423,17 @@ select:focus {
   min-width: 0;
 }
 
+.toggle-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.toggle-hint {
+  font-size: 11px;
+  color: #8e8e93;
+}
+
 .shortcut-recorder {
   min-width: 132px;
   height: 32px;

--- a/desktop/src/settings.html
+++ b/desktop/src/settings.html
@@ -268,6 +268,27 @@
               </div>
 
               <div class="setting-row">
+                <label for="wake-word-enabled">语音唤醒</label>
+                <div class="toggle-field">
+                  <input
+                    id="wake-word-enabled"
+                    type="checkbox"
+                  />
+                  <span class="toggle-hint">休眠后说出“你好千问”即可唤醒</span>
+                </div>
+              </div>
+
+              <div class="setting-row" id="sleep-timeout-row" hidden>
+                <label for="sleep-timeout-seconds">空闲休眠</label>
+                <select id="sleep-timeout-seconds">
+                  <option value="60">无交互 1 分钟</option>
+                  <option value="180">无交互 3 分钟</option>
+                  <option value="300">无交互 5 分钟</option>
+                  <option value="600">无交互 10 分钟</option>
+                </select>
+              </div>
+
+              <div class="setting-row">
                 <span class="setting-label">日志</span>
                 <button id="open-logs" class="row-link" type="button">
                   在 Finder 中显示

--- a/desktop/src/settings.js
+++ b/desktop/src/settings.js
@@ -16,6 +16,9 @@ const autoHideSeconds = document.querySelector('#auto-hide-seconds')
 const wakeShortcut = document.querySelector('#wake-shortcut')
 const recordWakeShortcut = document.querySelector('#record-wake-shortcut')
 const resetWakeShortcut = document.querySelector('#reset-wake-shortcut')
+const wakeWordEnabled = document.querySelector('#wake-word-enabled')
+const sleepTimeoutSeconds = document.querySelector('#sleep-timeout-seconds')
+const sleepTimeoutRow = document.querySelector('#sleep-timeout-row')
 const dashscopeApiKey = document.querySelector('#dashscope-api-key')
 const realtimeProviderInputs = [
   ...document.querySelectorAll('input[name="realtime-provider"]'),
@@ -526,6 +529,10 @@ function formSettings() {
     orbStyle: orbStyle.value,
     autoHideSeconds: Number(autoHideSeconds.value),
     wakeShortcut: wakeShortcut.value,
+    wakeWordEnabled: wakeWordEnabled.checked,
+    sleepTimeoutSeconds: wakeWordEnabled.checked
+      ? Number(sleepTimeoutSeconds.value)
+      : 0,
     dashscopeApiKey: dashscopeApiKey.value,
     realtimeProvider: selectedRealtimeProvider(),
     agentProtocol: selectedBackend(),
@@ -542,6 +549,8 @@ function fingerprint(value) {
     orbStyle: value.orbStyle,
     autoHideSeconds: value.autoHideSeconds,
     wakeShortcut: value.wakeShortcut,
+    wakeWordEnabled: value.wakeWordEnabled,
+    sleepTimeoutSeconds: value.sleepTimeoutSeconds,
     dashscopeApiKey: value.dashscopeApiKey,
     realtimeProvider: value.realtimeProvider,
     agentProtocol: value.agentProtocol,
@@ -699,6 +708,18 @@ function render() {
   }
   autoHideSeconds.value = hideValue
   wakeShortcut.value = settings.wakeShortcut
+  wakeWordEnabled.checked = settings.wakeWordEnabled || false
+  sleepTimeoutRow.hidden = !wakeWordEnabled.checked
+  const timeoutValue = String(settings.sleepTimeoutSeconds ?? 300)
+  sleepTimeoutSeconds.querySelector('[data-custom]')?.remove()
+  if (![...sleepTimeoutSeconds.options].some(option => option.value === timeoutValue)) {
+    const custom = document.createElement('option')
+    custom.value = timeoutValue
+    custom.dataset.custom = 'true'
+    custom.textContent = `自定义 · ${timeoutValue} 秒`
+    sleepTimeoutSeconds.append(custom)
+  }
+  sleepTimeoutSeconds.value = timeoutValue
   recordingWakeShortcut = false
   renderWakeShortcut()
   dashscopeApiKey.value = settings.dashscopeApiKey || ''
@@ -724,6 +745,8 @@ for (const control of [
   realtimeModel,
   backendModel,
   ...realtimeProviderInputs,
+  wakeWordEnabled,
+  sleepTimeoutSeconds,
 ]) {
   control.addEventListener('input', () => {
     showMessage('')
@@ -733,6 +756,9 @@ for (const control of [
     showMessage('')
     if (realtimeProviderInputs.includes(control)) {
       renderRealtimeProvider(control.value, { populateDefault: true })
+    }
+    if (control === wakeWordEnabled) {
+      sleepTimeoutRow.hidden = !wakeWordEnabled.checked
     }
     updateApplyState()
   })

--- a/desktop/test/config-migration.test.mjs
+++ b/desktop/test/config-migration.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import test from 'node:test'
+import {
+  migrateLegacyConfig,
+  resolveDesktopConfigDirectory,
+} from '../src/config-migration.mjs'
+
+function withDirectories(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'qwaudio-config-migration-'))
+  const legacyDir = join(root, 'legacy')
+  const targetDir = join(root, 'target')
+  try {
+    return fn({ legacyDir, targetDir })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function seedLegacy(legacyDir) {
+  mkdirSync(legacyDir, { recursive: true })
+  writeFileSync(join(legacyDir, 'config.env'), 'DASHSCOPE_API_KEY=sk-legacy\n', 'utf8')
+  writeFileSync(join(legacyDir, 'state.env'), 'QWEN_AUDIO_AGENT_AUTH_SECRET=secret\n', 'utf8')
+  writeFileSync(join(legacyDir, 'USER.md'), '# USER\n', 'utf8')
+  writeFileSync(join(legacyDir, 'gateway.lock'), '{}\n', 'utf8')
+}
+
+test('prefers QWAUDIO_CONFIG_DIR over the Electron userData directory', () => {
+  const override = '/tmp/qwaudio-profile'
+  assert.equal(
+    resolveDesktopConfigDirectory({
+      env: { QWAUDIO_CONFIG_DIR: override },
+      userDataDirectory: '/home/user/.config/Qwen Audio Agent',
+    }),
+    resolve(override),
+  )
+})
+
+test('falls back to the Electron userData directory without override', () => {
+  assert.equal(
+    resolveDesktopConfigDirectory({
+      env: {},
+      userDataDirectory: '/home/user/.config/Qwen Audio Agent',
+    }),
+    resolve('/home/user/.config/Qwen Audio Agent'),
+  )
+})
+
+test('copies user config files from the legacy CLI directory once', () => {
+  withDirectories(({ legacyDir, targetDir }) => {
+    seedLegacy(legacyDir)
+    const result = migrateLegacyConfig({ legacyDir, targetDir })
+    assert.equal(result.migrated, true)
+    assert.deepEqual(result.copied, ['config.env', 'state.env', 'USER.md'])
+    for (const name of ['config.env', 'state.env', 'USER.md']) {
+      assert.ok(existsSync(join(targetDir, name)))
+    }
+    // 运行时状态不迁移，CLI 侧原件保留
+    assert.equal(existsSync(join(targetDir, 'gateway.lock')), false)
+    assert.ok(existsSync(join(legacyDir, 'config.env')))
+    assert.equal(
+      readFileSync(join(targetDir, 'config.env'), 'utf8'),
+      'DASHSCOPE_API_KEY=sk-legacy\n',
+    )
+    const marker = JSON.parse(readFileSync(join(targetDir, 'migrated-from.json'), 'utf8'))
+    assert.equal(marker.legacyDir, resolve(legacyDir))
+    assert.deepEqual(marker.files, ['config.env', 'state.env', 'USER.md'])
+    // 重复执行保持幂等，不覆盖已有配置
+    const again = migrateLegacyConfig({ legacyDir, targetDir })
+    assert.equal(again.migrated, false)
+    assert.equal(again.reason, 'target-configured')
+  })
+})
+
+test('skips migration when no legacy config exists', () => {
+  withDirectories(({ legacyDir, targetDir }) => {
+    const missing = migrateLegacyConfig({ legacyDir, targetDir })
+    assert.equal(missing.migrated, false)
+    assert.equal(missing.reason, 'no-legacy-config')
+    assert.equal(existsSync(join(targetDir, 'migrated-from.json')), false)
+  })
+})
+
+test('skips migration when legacy and target are the same directory', () => {
+  withDirectories(({ legacyDir }) => {
+    seedLegacy(legacyDir)
+    const result = migrateLegacyConfig({ legacyDir, targetDir: legacyDir })
+    assert.equal(result.migrated, false)
+    assert.equal(result.reason, 'same-directory')
+  })
+})

--- a/desktop/test/gateway-process.test.mjs
+++ b/desktop/test/gateway-process.test.mjs
@@ -128,15 +128,15 @@ test('starts the embedded gateway on the preferred port and adopts the reported 
   await gateway.stop()
 })
 
-test('refuses to start a second embedded Gateway when the port is busy', async () => {
+test('falls back to a random port when the preferred port is busy', async () => {
   const { forks, gateway } = harness({
     busy: true,
   })
-  await assert.rejects(
-    gateway.start({ preferredPort: 3101 }),
-    /端口已被其他程序占用/,
-  )
-  assert.equal(forks.length, 0)
+  await gateway.start({ preferredPort: 3101 })
+  assert.equal(forks.length, 1)
+  assert.equal(forks[0].options.env.PORT, '0')
+  assert.equal(gateway.running, true)
+  await gateway.stop()
 })
 
 test('shares one in-flight start promise and forks only one child', async () => {

--- a/desktop/test/settings-config.test.mjs
+++ b/desktop/test/settings-config.test.mjs
@@ -9,6 +9,8 @@ import {
 
 const REALTIME_DEFAULTS = {
   wakeShortcut: 'CommandOrControl+Shift+Space',
+  wakeWordEnabled: false,
+  sleepTimeoutSeconds: 0,
   realtimeProvider: 'dashscope',
   realtimeModel: 'qwen-audio-3.0-realtime-plus',
   speechToSpeechRealtimeUrl: '',
@@ -340,8 +342,12 @@ test('desktop settings expose the embedded voice service without editing backend
   assert.match(html, /id="wake-shortcut"/)
   assert.match(html, /id="record-wake-shortcut"/)
   assert.match(html, /id="reset-wake-shortcut"/)
+  assert.match(html, /id="wake-word-enabled"/)
+  assert.match(html, /id="sleep-timeout-seconds"/)
   assert.match(html, />自动隐藏</)
   assert.match(html, />显示快捷键</)
+  assert.match(html, />语音唤醒</)
+  assert.match(html, />空闲休眠</)
   assert.doesNotMatch(html, />自动休眠</)
   assert.doesNotMatch(html, />全局快捷键</)
   // 后台 Agent 列表按本机可用性检测结果动态渲染，HTML 里只保留空容器

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,13 @@
 设置 `QWAUDIO_CONFIG_DIR` 或 `XDG_CONFIG_HOME` 可以更改配置目录。开发仓库中的
 `.env.local` 和 `.env` 仍然支持，并优先于用户配置文件。
 
+桌面版与 CLI 使用相互独立的数据目录：CLI 使用 `~/.config/qwaudio`，桌面版使用
+系统标准应用数据目录（macOS 为 `~/Library/Application Support/Qwen Audio Agent`，
+Linux 为 `~/.config/Qwen Audio Agent`，Windows 为 `%APPDATA%\Qwen Audio Agent`）。
+两者的 Gateway、锁、日志与设置互不干扰，可以同时运行。桌面版首次启动时会从 CLI
+目录复制 `config.env` 等用户配置（CLI 保留原件）；`gateway.lock` 等运行时状态各自
+重建。显式设置 `QWAUDIO_CONFIG_DIR` 时桌面版也遵循该覆盖。
+
 配置优先级固定为：
 
 ```text
@@ -395,8 +402,10 @@ QWEN_AUDIO_AGENT_ALLOWED_ORIGINS=https://voice.example.com
 
 ## Gateway 运行方式
 
-同一用户配置目录在任意时刻只允许一个本地 Gateway。CLI、TUI、WebUI 和桌面版会
-优先复用这个实例；它们可以同时连接，但不会各自启动一套后台 Agent。实例身份记录在
+同一数据目录在任意时刻只允许一个本地 Gateway。CLI、TUI 和 WebUI 共用
+`~/.config/qwaudio`，会优先复用同一个实例；桌面版使用独立目录，只复用或管理
+自己目录下的 Gateway。同一目录内的多个客户端可以同时连接，但不会各自启动一套
+后台 Agent。实例身份记录在
 用户配置目录下的临时 `gateway.lock` 中，Gateway 正常退出时会删除，异常退出留下的
 锁会在确认原进程已经结束后自动回收。若现有 Gateway 的 Realtime、后台 Agent 或
 权限配置与当前请求不一致，启动会明确报错，而不会静默另开随机端口。远程 Gateway

--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,6 +2654,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2674,11 +2688,24 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2806,6 +2833,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -4129,6 +4180,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -4247,6 +4307,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4964,6 +5030,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7710,6 +7796,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sherpa-onnx": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx/-/sherpa-onnx-1.13.4.tgz",
+      "integrity": "sha512-KnfQkA+LxbptrWX1gd7upGDyFkLslJVlOudUWPkwveHwYIXo5Qq97Tx02NF5aE0G3cgKpHBh2z+CR+s6ywZPPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/side-channel": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
@@ -7882,6 +7974,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -8005,6 +8108,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -8040,6 +8154,21 @@
         "async-exit-hook": "^2.0.1",
         "fs-extra": "^10.0.0"
       }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
@@ -8197,6 +8326,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "node_modules/undici": {
@@ -8742,6 +8881,9 @@
         "@agentclientprotocol/sdk": "1.3.0",
         "@modelcontextprotocol/sdk": "1.30.0",
         "express": "^4.22.2",
+        "sherpa-onnx": "1.13.4",
+        "tar-stream": "3.1.7",
+        "unbzip2-stream": "1.4.3",
         "ws": "^8.21.1",
         "zod": "^4.4.3"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,9 @@
     "@agentclientprotocol/sdk": "1.3.0",
     "@modelcontextprotocol/sdk": "1.30.0",
     "express": "^4.22.2",
+    "sherpa-onnx": "1.13.4",
+    "tar-stream": "3.1.7",
+    "unbzip2-stream": "1.4.3",
     "ws": "^8.21.1",
     "zod": "^4.4.3"
   }

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -480,6 +480,15 @@ export const config = {
     30_000,
     { min: 0, max: 300_000 },
   ),
+  sleepTimeoutMs: numberSetting(
+    process.env.QWEN_AUDIO_SLEEP_TIMEOUT_SECONDS,
+    0,
+    { min: 0, max: 86_400 },
+  ) * 1000,
+  wakeWord: '你好千问',
+  wakeWordModelDirectory: process.env.QWEN_AUDIO_WAKE_WORD_MODEL_DIR
+    ? resolve(process.env.QWEN_AUDIO_WAKE_WORD_MODEL_DIR)
+    : resolve(runtimeEnvironment.configDirectory, 'models/wake-word'),
 }
 
 export function realtimeUrl(baseUrl, model) {

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -32,6 +32,8 @@ import {
   clientVoiceCapabilities,
 } from './active-voice-clients.mjs'
 import { ReconnectBackoff } from './reconnect-backoff.mjs'
+import { SleepController } from './sleep-controller.mjs'
+import { createSherpaWakeWordDetector } from './wake-word/sherpa-detector.mjs'
 import {
   isResponseActivityEvent,
   realtimeResponseId,
@@ -56,6 +58,15 @@ export function rejectUnsupportedRealtimeUpgrade(socket, pathname) {
   if (pathname === '/api/realtime') return false
   socket.destroy()
   return true
+}
+
+export function isSleepActivityEvent(event = {}) {
+  return isResponseActivityEvent(event) || [
+    'input_audio_buffer.speech_started',
+    'input_audio_buffer.speech_stopped',
+    'conversation.item.input_audio_transcription.delta',
+    'conversation.item.input_audio_transcription.completed',
+  ].includes(event.type)
 }
 
 export function confirmsTaskNotificationOnPlaybackStart(context) {
@@ -163,6 +174,11 @@ export function attachRealtimeGateway(server, {
     let scheduledRealtimeReconnect = null
     let realtimeConnectedAt = 0
     let realtimeBlockedError = ''
+    let sleeping = false
+    let waking = false
+    let wakeDetector = null
+    let wakeDetectorPromise = null
+    let sleepController
     const realtimeReconnectBackoff = new ReconnectBackoff()
     const announcementWindow = new AnnouncementWindow()
     const playbackTurns = new Map()
@@ -248,7 +264,7 @@ export function attachRealtimeGateway(server, {
     }
     const announcements = new AnnouncementManager({
       getFrontend: () => frontend,
-      isDeliveryBlocked: () => !outputEnabled || announcementWindow.isBlocked(),
+      isDeliveryBlocked: () => sleeping || waking || !outputEnabled || announcementWindow.isBlocked(),
       announceIntoContext: config.announceIntoContext,
       resultContextMaxChars: config.resultContextMaxChars,
       maxBatchItems: config.announcementMaxBatchItems,
@@ -280,17 +296,24 @@ export function attachRealtimeGateway(server, {
         provider: sessionProvider,
         state: realtimeBlockedError
           ? 'unavailable'
-          : frontend?.ready
-          ? 'connected'
-          : connectPromise
-            ? 'connecting'
-            : 'disconnected',
+          : sleeping
+            ? 'sleeping'
+            : waking
+              ? 'waking'
+              : frontend?.ready
+              ? 'connected'
+              : connectPromise
+                ? 'connecting'
+                : 'disconnected',
         ...(realtimeBlockedError ? { error: realtimeBlockedError } : {}),
       }),
       // Lets the arbitration evict this owner once its socket has died without
       // a clean close, so a stale holder never blocks a new voice claim.
       isAlive: () => ws.readyState === WebSocket.OPEN,
       deactivate: replacement => {
+        sleeping = false
+        waking = false
+        sleepController?.disable()
         inputEnabled = false
         outputEnabled = false
         pendingAudio = []
@@ -358,6 +381,7 @@ export function attachRealtimeGateway(server, {
           type: GatewayServerEvent.CLIENT_STATE,
           state,
         })
+        if (state === 'sleeping') enterSleep()
       },
     })
     const currentTurn = () => ({
@@ -892,6 +916,7 @@ export function attachRealtimeGateway(server, {
     })
 
     const handleEvent = event => {
+      if (isSleepActivityEvent(event)) sleepController?.recordActivity()
       if (isResponseActivityEvent(event)) beginResponseLifecycle(event)
       if (event.type === 'input_audio_buffer.speech_started') {
         userSpeaking = true
@@ -1383,6 +1408,8 @@ export function attachRealtimeGateway(server, {
             provider: createdFrontend.provider.key,
             durationMs: realtimeConnectedAt - connectStartedAt,
           })
+          const resumedFromSleep = waking
+          waking = false
           send(ws, {
             type: GatewayServerEvent.VOICE_CONNECTION,
             state: 'connected',
@@ -1399,6 +1426,18 @@ export function attachRealtimeGateway(server, {
             provider: createdFrontend.provider.key,
             providerLabel: createdFrontend.provider.label,
           })
+          prepareSleepMode()
+          sleepController.recordActivity()
+          if (resumedFromSleep) {
+            send(ws, {
+              type: GatewayServerEvent.VOICE_SLEEP,
+              state: 'awake',
+              wakeWord: config.wakeWord,
+            })
+            announcePendingPermissions()
+            claimPendingNotifications()
+            announcements.flush()
+          }
         })
         .catch(error => {
           connectionLogger.error('realtime.connect_failed', {
@@ -1438,6 +1477,131 @@ export function attachRealtimeGateway(server, {
       }
       return connectFrontendNow()
     }
+
+    const enterSleep = () => {
+      if (sleeping || !frontend?.ready) return
+      sleeping = true
+      waking = false
+      pendingAudio = []
+      wakeDetector?.reset()
+      cancelScheduledRealtimeReconnect()
+      const staleFrontend = frontend
+      frontend = null
+      staleFrontend?.close()
+      send(ws, {
+        type: GatewayServerEvent.VOICE_CONNECTION,
+        state: 'sleeping',
+        provider: sessionProvider,
+      })
+      send(ws, {
+        type: GatewayServerEvent.VOICE_SLEEP,
+        state: 'sleeping',
+        wakeWord: config.wakeWord,
+      })
+    }
+
+    const prepareSleepMode = () => {
+      if (
+        !config.sleepTimeoutMs
+        || textOnlySession
+        || !inputEnabled
+        || wakeDetectorPromise
+      ) return
+      if (wakeDetector) {
+        sleepController.enable()
+        if (sleeping) sleepController.holdSleeping()
+        return
+      }
+      send(ws, {
+        type: GatewayServerEvent.VOICE_SLEEP,
+        state: 'preparing',
+        wakeWord: config.wakeWord,
+      })
+      wakeDetectorPromise = createSherpaWakeWordDetector({
+        modelRoot: config.wakeWordModelDirectory,
+      }).then(detector => {
+        wakeDetector = detector
+        if (ws.readyState === WebSocket.OPEN && inputEnabled) {
+          sleepController.enable()
+          send(ws, {
+            type: GatewayServerEvent.VOICE_SLEEP,
+            state: 'enabled',
+            timeoutMs: config.sleepTimeoutMs,
+            wakeWord: config.wakeWord,
+          })
+        }
+      }).catch(error => {
+        sleepController.disable()
+        send(ws, {
+          type: GatewayServerEvent.VOICE_SLEEP,
+          state: 'disabled',
+          message: `休眠功能未启用：${error.message}`,
+        })
+      }).finally(() => {
+        wakeDetectorPromise = null
+      })
+    }
+
+    const wakeFromSleep = () => {
+      if (!sleeping || waking) return
+      sleeping = false
+      waking = true
+      sleepController.wake()
+      send(ws, {
+        type: GatewayServerEvent.VOICE_SLEEP,
+        state: 'detected',
+        wakeWord: config.wakeWord,
+      })
+      ensureFrontend().catch(error => {
+        waking = false
+        sleeping = true
+        sleepController.holdSleeping()
+        cancelScheduledRealtimeReconnect()
+        const failedFrontend = frontend
+        frontend = null
+        failedFrontend?.close()
+        send(ws, {
+          type: GatewayServerEvent.VOICE_CONNECTION,
+          state: 'sleeping',
+          provider: sessionProvider,
+          message: error.message,
+        })
+      })
+    }
+
+    const acceptSleepingAudio = audio => {
+      try {
+        const sampleRate = resolveRealtimeProvider(sessionProvider).inputSampleRate
+        if (wakeDetector?.accept(audio, sampleRate)) wakeFromSleep()
+      } catch (error) {
+        sleeping = false
+        waking = false
+        sleepController.disable()
+        send(ws, {
+          type: GatewayServerEvent.VOICE_SLEEP,
+          state: 'disabled',
+          message: `唤醒词检测已停止：${error.message}`,
+        })
+        ensureFrontend().catch(connectionError => send(ws, {
+          type: 'error',
+          message: connectionError.message,
+        }))
+      }
+    }
+
+    sleepController = new SleepController({
+      timeoutMs: config.sleepTimeoutMs,
+      canSleep: () => (
+        inputEnabled
+        && activeVoiceClients.isActive(ownerId, voiceClient)
+        && frontend?.ready
+        && !userSpeaking
+        && !announcementWindow.isBlocked()
+        && !connectPromise
+        && !waking
+      ),
+      onSleep: enterSleep,
+    })
 
     send(ws, { type: GatewayServerEvent.VOICE_STATE, state: 'idle' })
     ws.on('message', raw => {
@@ -1509,9 +1673,15 @@ export function attachRealtimeGateway(server, {
           client: clientContext,
           textOnly: textOnlySession,
         })
+        if (sleeping) {
+          sleeping = false
+          waking = true
+          sleepController.wake()
+        }
         if (inputEnabled || outputEnabled) {
           ensureFrontend().catch(reportFrontendError)
         }
+        prepareSleepMode()
       } else if (event.type === GatewayClientEvent.UNMUTE) {
         if (textOnlySession) {
           inputEnabled = false
@@ -1522,6 +1692,7 @@ export function attachRealtimeGateway(server, {
         }
         ensureFrontend()
           .then(() => {
+            prepareSleepMode()
             announcePendingPermissions()
             claimPendingNotifications()
             announcements.flush()
@@ -1536,8 +1707,13 @@ export function attachRealtimeGateway(server, {
         } else {
           activateVoiceClient({ takeover: event.takeover === true })
         }
+        if (sleeping) {
+          prepareSleepMode()
+          return
+        }
         ensureFrontend()
           .then(() => {
+            prepareSleepMode()
             announcePendingPermissions()
             claimPendingNotifications()
             announcements.flush()
@@ -1545,6 +1721,10 @@ export function attachRealtimeGateway(server, {
           .catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.AUDIO_APPEND) {
         if (!inputEnabled || !activeVoiceClients.isActive(ownerId, voiceClient)) {
+          return
+        }
+        if (sleeping) {
+          acceptSleepingAudio(event.audio)
           return
         }
         if (frontend?.ready) frontend.appendAudio(event.audio)
@@ -1563,6 +1743,14 @@ export function attachRealtimeGateway(server, {
       } else if (event.type === GatewayClientEvent.TEXT_MESSAGE) {
         const text = String(event.text || '').trim()
         if (!text) return
+        if (sleeping || waking) {
+          send(ws, {
+            type: 'error',
+            message: `已休眠，请先说“${config.wakeWord}”唤醒。`,
+          })
+          return
+        }
+        sleepController.recordActivity()
         const turnId = `text_${randomUUID().replaceAll('-', '')}`
         conversationSync.record({
           ownerId,
@@ -1586,6 +1774,7 @@ export function attachRealtimeGateway(server, {
           ))
           .catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.INTERRUPT) {
+        sleepController.recordActivity()
         turnGeneration = ++turnSequence
         committedTurnGeneration = turnGeneration
         announcementWindow.interrupt()
@@ -1618,6 +1807,9 @@ export function attachRealtimeGateway(server, {
         }
       } else if (event.type === GatewayClientEvent.MUTE) {
         releaseVoiceClient()
+        sleeping = false
+        waking = false
+        sleepController?.disable()
         turnGeneration = ++turnSequence
         committedTurnGeneration = turnGeneration
         pendingAudio = []
@@ -1650,6 +1842,7 @@ export function attachRealtimeGateway(server, {
       clearTimeout(permissionRetryTimer)
       permissionRetryTimer = null
       cancelScheduledRealtimeReconnect()
+      sleepController?.close()
       frontend?.close()
     })
   })
@@ -1662,6 +1855,8 @@ export function attachRealtimeGateway(server, {
         connecting: 0,
         disconnected: 0,
         unavailable: 0,
+        sleeping: 0,
+        waking: 0,
         byProvider: {},
       }
       let connected = 0
@@ -1679,6 +1874,8 @@ export function attachRealtimeGateway(server, {
               connecting: 0,
               disconnected: 0,
               unavailable: 0,
+              sleeping: 0,
+              waking: 0,
             }
           }
           const provider = realtime.byProvider[status.provider]

--- a/server/src/voice/sleep-controller.mjs
+++ b/server/src/voice/sleep-controller.mjs
@@ -1,0 +1,79 @@
+export class SleepController {
+  constructor({
+    timeoutMs,
+    retryMs = 1000,
+    canSleep = () => true,
+    onSleep = () => {},
+  } = {}) {
+    this.timeoutMs = Math.max(0, Number(timeoutMs) || 0)
+    this.retryMs = Math.max(10, Number(retryMs) || 1000)
+    this.canSleep = canSleep
+    this.onSleep = onSleep
+    this.enabled = false
+    this.sleeping = false
+    this.closed = false
+    this.timer = null
+  }
+
+  enable() {
+    if (this.closed || !this.timeoutMs) return false
+    this.enabled = true
+    this.recordActivity()
+    return true
+  }
+
+  recordActivity() {
+    if (!this.enabled || this.sleeping || this.closed) return
+    this.schedule(this.timeoutMs)
+  }
+
+  schedule(delay) {
+    clearTimeout(this.timer)
+    this.timer = setTimeout(() => this.trySleep(), delay)
+    this.timer.unref?.()
+  }
+
+  async trySleep() {
+    this.timer = null
+    if (!this.enabled || this.sleeping || this.closed) return
+    if (!this.canSleep()) {
+      this.schedule(this.retryMs)
+      return
+    }
+    this.sleeping = true
+    try {
+      await this.onSleep()
+    } catch {
+      this.sleeping = false
+      this.schedule(this.retryMs)
+    }
+  }
+
+  wake() {
+    if (this.closed) return false
+    const wasSleeping = this.sleeping
+    this.sleeping = false
+    if (this.enabled) this.recordActivity()
+    return wasSleeping
+  }
+
+  holdSleeping() {
+    if (!this.enabled || this.closed) return false
+    clearTimeout(this.timer)
+    this.timer = null
+    this.sleeping = true
+    return true
+  }
+
+  disable() {
+    this.enabled = false
+    this.sleeping = false
+    clearTimeout(this.timer)
+    this.timer = null
+  }
+
+  close() {
+    this.closed = true
+    this.disable()
+  }
+}

--- a/server/src/voice/wake-word/model-manager.mjs
+++ b/server/src/voice/wake-word/model-manager.mjs
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto'
+import {
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import tar from 'tar-stream'
+import unbzip2 from 'unbzip2-stream'
+
+export const WAKE_WORD_MODEL_NAME = 'sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20'
+export const WAKE_WORD_MODEL_URL = `https://github.com/k2-fsa/sherpa-onnx/releases/download/kws-models/${WAKE_WORD_MODEL_NAME}.tar.bz2`
+export const WAKE_WORD_MODEL_SHA256 = '68447f4fbc67e70eee3a93961f36e81e98f47aef73ce7e7ca00885c6cd3616a6'
+
+export const WAKE_WORD_MODEL_FILES = Object.freeze({
+  encoder: 'encoder-epoch-13-avg-2-chunk-8-left-64.int8.onnx',
+  decoder: 'decoder-epoch-13-avg-2-chunk-8-left-64.onnx',
+  joiner: 'joiner-epoch-13-avg-2-chunk-8-left-64.int8.onnx',
+  tokens: 'tokens.txt',
+  keywords: 'keywords.txt',
+})
+
+const ARCHIVE_FILES = new Set([
+  WAKE_WORD_MODEL_FILES.encoder,
+  WAKE_WORD_MODEL_FILES.decoder,
+  WAKE_WORD_MODEL_FILES.joiner,
+  WAKE_WORD_MODEL_FILES.tokens,
+])
+const REQUIRED_FILES = new Set(Object.values(WAKE_WORD_MODEL_FILES))
+const preparations = new Map()
+
+function complete(directory) {
+  return [...REQUIRED_FILES].every(file => existsSync(resolve(directory, file)))
+}
+
+async function sha256(path) {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+async function download(url, path, fetchImpl) {
+  const response = await fetchImpl(url)
+  if (!response.ok || !response.body) {
+    throw new Error(`唤醒词模型下载失败：HTTP ${response.status}`)
+  }
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(path, {
+    flags: 'wx',
+    mode: 0o600,
+  }))
+}
+
+async function extractSelected(archivePath, targetDirectory) {
+  const extract = tar.extract()
+  const writes = []
+  extract.on('entry', (header, stream, next) => {
+    const file = basename(header.name)
+    if (header.type !== 'file' || !ARCHIVE_FILES.has(file)) {
+      stream.resume()
+      stream.on('end', next)
+      return
+    }
+    const destination = resolve(targetDirectory, file)
+    const write = pipeline(stream, createWriteStream(destination, {
+      mode: 0o600,
+    })).then(next, error => extract.destroy(error))
+    writes.push(write)
+  })
+  await pipeline(createReadStream(archivePath), unbzip2(), extract)
+  await Promise.all(writes)
+}
+
+async function prepare(directory, { fetchImpl }) {
+  if (complete(directory)) return directory
+  mkdirSync(dirname(directory), { recursive: true, mode: 0o700 })
+  const nonce = `${process.pid}-${Date.now()}`
+  const archivePath = resolve(dirname(directory), `${WAKE_WORD_MODEL_NAME}-${nonce}.tar.bz2`)
+  const stagingDirectory = resolve(dirname(directory), `.${WAKE_WORD_MODEL_NAME}-${nonce}`)
+  mkdirSync(stagingDirectory, { recursive: false, mode: 0o700 })
+  try {
+    await download(WAKE_WORD_MODEL_URL, archivePath, fetchImpl)
+    const digest = await sha256(archivePath)
+    if (digest !== WAKE_WORD_MODEL_SHA256) {
+      throw new Error('唤醒词模型校验失败')
+    }
+    await extractSelected(archivePath, stagingDirectory)
+    writeFileSync(
+      resolve(stagingDirectory, WAKE_WORD_MODEL_FILES.keywords),
+      'n ǐ h ǎo q iān w èn @你好千问\n',
+      { encoding: 'utf8', mode: 0o600 },
+    )
+    if (!complete(stagingDirectory)) {
+      throw new Error('唤醒词模型缺少必需文件')
+    }
+    rmSync(directory, { recursive: true, force: true })
+    renameSync(stagingDirectory, directory)
+    return directory
+  } finally {
+    rmSync(archivePath, { force: true })
+    rmSync(stagingDirectory, { recursive: true, force: true })
+  }
+}
+
+export function ensureWakeWordModel(directory, {
+  fetchImpl = fetch,
+} = {}) {
+  const target = resolve(directory, WAKE_WORD_MODEL_NAME)
+  if (complete(target)) return Promise.resolve(target)
+  if (!preparations.has(target)) {
+    const pending = prepare(target, { fetchImpl })
+      .finally(() => preparations.delete(target))
+    preparations.set(target, pending)
+  }
+  return preparations.get(target)
+}

--- a/server/src/voice/wake-word/sherpa-detector.mjs
+++ b/server/src/voice/wake-word/sherpa-detector.mjs
@@ -1,0 +1,85 @@
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { ensureWakeWordModel, WAKE_WORD_MODEL_FILES } from './model-manager.mjs'
+
+const require = createRequire(import.meta.url)
+const engines = new Map()
+
+function pcm16Base64ToFloat32(audio) {
+  const bytes = Buffer.from(audio, 'base64')
+  const sampleCount = Math.floor(bytes.length / 2)
+  const samples = new Float32Array(sampleCount)
+  for (let index = 0; index < sampleCount; index += 1) {
+    samples[index] = bytes.readInt16LE(index * 2) / 32768
+  }
+  return samples
+}
+
+async function createEngine({ modelRoot }) {
+  const modelDirectory = await ensureWakeWordModel(modelRoot)
+  const { createKws } = require('sherpa-onnx')
+  const keywords = readFileSync(
+    resolve(modelDirectory, WAKE_WORD_MODEL_FILES.keywords),
+    'utf8',
+  )
+  const keywordSpotter = createKws({
+    featConfig: { samplingRate: 16000, featureDim: 80 },
+    modelConfig: {
+      transducer: {
+        encoder: resolve(modelDirectory, WAKE_WORD_MODEL_FILES.encoder),
+        decoder: resolve(modelDirectory, WAKE_WORD_MODEL_FILES.decoder),
+        joiner: resolve(modelDirectory, WAKE_WORD_MODEL_FILES.joiner),
+      },
+      tokens: resolve(modelDirectory, WAKE_WORD_MODEL_FILES.tokens),
+      numThreads: 1,
+      provider: 'cpu',
+      debug: 0,
+      modelingUnit: 'cjkchar',
+    },
+    maxActivePaths: 4,
+    numTrailingBlanks: 1,
+    keywordsScore: 1.0,
+    keywordsThreshold: 0.25,
+    // WASM cannot pass a host path through the native keywords_file field.
+    // Supplying the verified local file as a buffer keeps keyword loading
+    // independent of the WASM virtual filesystem.
+    keywords: '',
+    keywordsBuf: keywords,
+    keywordsBufSize: Buffer.byteLength(keywords),
+  })
+  return keywordSpotter
+}
+
+async function engineFor(options) {
+  const key = resolve(options.modelRoot)
+  if (!engines.has(key)) {
+    engines.set(key, createEngine(options).catch(error => {
+      engines.delete(key)
+      throw error
+    }))
+  }
+  return engines.get(key)
+}
+
+export async function createSherpaWakeWordDetector({ modelRoot }) {
+  const keywordSpotter = await engineFor({ modelRoot })
+  const stream = keywordSpotter.createStream()
+  return {
+    accept(audio, sampleRate = 16000) {
+      const samples = pcm16Base64ToFloat32(audio)
+      if (!samples.length) return false
+      stream.acceptWaveform(sampleRate, samples)
+      while (keywordSpotter.isReady(stream)) keywordSpotter.decode(stream)
+      const result = keywordSpotter.getResult(stream)
+      if (!result.keyword) return false
+      keywordSpotter.reset(stream)
+      return true
+    },
+    reset() {
+      keywordSpotter.reset(stream)
+    },
+  }
+}
+
+export { pcm16Base64ToFloat32 }

--- a/server/test/desktop-sleep-tool-registration.test.mjs
+++ b/server/test/desktop-sleep-tool-registration.test.mjs
@@ -1,0 +1,143 @@
+// Reproduces the user report: desktop orb asks the voice front end which tools
+// it has, and enter_sleep is missing. The registration chain is:
+// web CONNECT (clientType=desktop, clientStates=['sleeping'])
+//   -> realtime-gateway sets clientContext.states
+//   -> createRealtimeFrontend receives agentContext.client
+//   -> provider.buildSession -> frontendTools adds enter_sleep.
+// This test drives the real gateway over WebSocket against a fake realtime
+// provider and asserts the session that reaches the provider contains the
+// sleep tool.
+
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { WebSocket, WebSocketServer } from 'ws'
+
+const providerServer = createServer()
+const providerWss = new WebSocketServer({ server: providerServer })
+const sessionUpdates = []
+providerWss.on('connection', socket => {
+  socket.on('message', raw => {
+    let event
+    try {
+      event = JSON.parse(raw.toString())
+    } catch {
+      return
+    }
+    if (event.type === 'session.update') sessionUpdates.push(event.session)
+  })
+  socket.send(JSON.stringify({ type: 'session.created', session: {} }))
+  socket.send(JSON.stringify({ type: 'session.updated', session: {} }))
+})
+
+process.env.QWAUDIO_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'qwaudio-sleep-'))
+process.env.QWEN_AUDIO_AGENT_AUTH_SECRET = 'test-secret-that-is-long-enough-1234567890'
+process.env.DASHSCOPE_API_KEY = 'sk-fake'
+await new Promise(resolve => providerServer.listen(0, '127.0.0.1', resolve))
+process.env.QWEN_AUDIO_REALTIME_BASE_URL = (
+  `ws://127.0.0.1:${providerServer.address().port}`
+)
+
+const { attachRealtimeGateway } = await import('../src/voice/realtime-gateway.mjs')
+const { IdentityManager } = await import('../src/core/identity.mjs')
+
+function fakeMemoryStore() {
+  return {
+    list: () => [],
+    remember: async () => ({ id: 'mem_1' }),
+    replace: async () => ({}),
+    forget: async () => ({}),
+  }
+}
+
+function fakeNotesStore() {
+  return {
+    lists: () => [],
+    show: () => ({ name: '', items: [] }),
+    add: async () => ({}),
+    remove: async () => ({}),
+    clear: async () => ({}),
+    drop: async () => ({}),
+  }
+}
+
+async function startGateway() {
+  const server = createServer()
+  attachRealtimeGateway(server, {
+    identityManager: new IdentityManager({
+      secret: process.env.QWEN_AUDIO_AGENT_AUTH_SECRET,
+      mode: 'personal',
+    }),
+    memoryStore: fakeMemoryStore(),
+    notesStore: fakeNotesStore(),
+    coordinator: null,
+    coordinatorAvailable: async () => false,
+    respondPermission: async () => ({}),
+    permissionPolicy: {
+      resolveDecision: () => null,
+      rememberDecision: () => {},
+    },
+  })
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  return server
+}
+
+function connectDesktopClient(server) {
+  const port = server.address().port
+  const socket = new WebSocket(`ws://127.0.0.1:${port}/api/realtime?sessionId=main`)
+  return new Promise((resolve, reject) => {
+    socket.on('open', () => {
+      socket.send(JSON.stringify({
+        type: 'connect',
+        timeZone: 'Asia/Shanghai',
+        locale: 'zh-CN',
+        voiceEnabled: true,
+        inputEnabled: false,
+        outputEnabled: true,
+        clientType: 'desktop',
+        clientLabel: '桌面端',
+        clientStates: ['sleeping'],
+        clientInstanceId: 'repro-instance',
+        takeover: false,
+      }))
+      resolve(socket)
+    })
+    socket.on('error', reject)
+  })
+}
+
+test('desktop CONNECT registers enter_sleep in the realtime session', async t => {
+  const server = await startGateway()
+  t.after(() => {
+    server.close()
+    providerServer.close()
+  })
+
+  const socket = await connectDesktopClient(server)
+  t.after(() => socket.close())
+
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('session.update 未送达')), 5000)
+    const poll = () => {
+      if (sessionUpdates.length) {
+        clearTimeout(timer)
+        resolve()
+        return
+      }
+      setTimeout(poll, 20)
+    }
+    poll()
+  })
+
+  const session = sessionUpdates.at(-1)
+  const names = (session.tools || []).map(tool => (
+    tool.function?.name || tool.name
+  ))
+  assert.ok(
+    names.includes('enter_sleep'),
+    `desktop 会话工具缺少 enter_sleep：${names.join(', ')}`,
+  )
+})

--- a/server/test/sleep-controller.test.mjs
+++ b/server/test/sleep-controller.test.mjs
@@ -7,15 +7,16 @@ const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 test('sleeps only after the configured idle interval', async () => {
   let sleeps = 0
   const controller = new SleepController({
-    timeoutMs: 20,
+    timeoutMs: 200,
     onSleep: () => { sleeps += 1 },
   })
   controller.enable()
-  await wait(10)
+  // CI runner 计时抖动大，窗口留宽避免定时器提前触发
+  await wait(60)
   controller.recordActivity()
-  await wait(12)
+  await wait(80)
   assert.equal(sleeps, 0)
-  await wait(15)
+  await wait(250)
   assert.equal(sleeps, 1)
   assert.equal(controller.sleeping, true)
   controller.close()
@@ -25,16 +26,16 @@ test('defers sleep while foreground activity is blocking it', async () => {
   let blocked = true
   let sleeps = 0
   const controller = new SleepController({
-    timeoutMs: 10,
-    retryMs: 10,
+    timeoutMs: 100,
+    retryMs: 50,
     canSleep: () => !blocked,
     onSleep: () => { sleeps += 1 },
   })
   controller.enable()
-  await wait(15)
+  await wait(60)
   assert.equal(sleeps, 0)
   blocked = false
-  await wait(15)
+  await wait(250)
   assert.equal(sleeps, 1)
   controller.close()
 })

--- a/server/test/sleep-controller.test.mjs
+++ b/server/test/sleep-controller.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { SleepController } from '../src/voice/sleep-controller.mjs'
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+test('sleeps only after the configured idle interval', async () => {
+  let sleeps = 0
+  const controller = new SleepController({
+    timeoutMs: 20,
+    onSleep: () => { sleeps += 1 },
+  })
+  controller.enable()
+  await wait(10)
+  controller.recordActivity()
+  await wait(12)
+  assert.equal(sleeps, 0)
+  await wait(15)
+  assert.equal(sleeps, 1)
+  assert.equal(controller.sleeping, true)
+  controller.close()
+})
+
+test('defers sleep while foreground activity is blocking it', async () => {
+  let blocked = true
+  let sleeps = 0
+  const controller = new SleepController({
+    timeoutMs: 10,
+    retryMs: 10,
+    canSleep: () => !blocked,
+    onSleep: () => { sleeps += 1 },
+  })
+  controller.enable()
+  await wait(15)
+  assert.equal(sleeps, 0)
+  blocked = false
+  await wait(15)
+  assert.equal(sleeps, 1)
+  controller.close()
+})
+
+test('can return to a sleeping state when realtime reconnection fails', () => {
+  const controller = new SleepController({ timeoutMs: 100 })
+  controller.enable()
+  controller.holdSleeping()
+  assert.equal(controller.wake(), true)
+  assert.equal(controller.sleeping, false)
+  assert.equal(controller.holdSleeping(), true)
+  assert.equal(controller.sleeping, true)
+  controller.close()
+})
+
+test('never arms when the feature is disabled', async () => {
+  let sleeps = 0
+  const controller = new SleepController({
+    timeoutMs: 0,
+    onSleep: () => { sleeps += 1 },
+  })
+  assert.equal(controller.enable(), false)
+  await wait(15)
+  assert.equal(sleeps, 0)
+})

--- a/server/test/wake-word-detector.test.mjs
+++ b/server/test/wake-word-detector.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { pcm16Base64ToFloat32 } from '../src/voice/wake-word/sherpa-detector.mjs'
+
+test('converts little-endian PCM16 audio into normalized float samples', () => {
+  const pcm = Buffer.alloc(8)
+  pcm.writeInt16LE(-32768, 0)
+  pcm.writeInt16LE(-16384, 2)
+  pcm.writeInt16LE(0, 4)
+  pcm.writeInt16LE(32767, 6)
+  const samples = pcm16Base64ToFloat32(pcm.toString('base64'))
+  assert.deepEqual([...samples], [-1, -0.5, 0, 32767 / 32768])
+})
+
+test('ignores an incomplete trailing PCM byte', () => {
+  const samples = pcm16Base64ToFloat32(Buffer.from([1, 0, 2]).toString('base64'))
+  assert.deepEqual([...samples], [1 / 32768])
+})

--- a/shared/realtime-events.mjs
+++ b/shared/realtime-events.mjs
@@ -20,6 +20,7 @@ export const GatewayServerEvent = Object.freeze({
   VOICE_STATE: 'voice.state',
   VOICE_OWNERSHIP: 'voice.ownership',
   VOICE_DEACTIVATED: 'voice.deactivated',
+  VOICE_SLEEP: 'voice.sleep',
   TURN_STARTED: 'turn.started',
   PLAYBACK_CLEAR: 'playback.clear',
   AUDIO_DELTA: 'audio.delta',


### PR DESCRIPTION
## 桌面版与 CLI 数据目录隔离

- 桌面版改用 Electron 应用数据目录（macOS：`~/Library/Application Support/Qwen Audio Agent`），与 CLI 的 `~/.config/qwaudio` 完全隔离，两者可同时运行互不干扰（参考 Qoder 桌面版/CLI 模式）
- 首次启动自动从 CLI 目录复制用户配置（config.env、state.env、USER.md、记忆/任务等），写 migrated-from.json 标记，CLI 保留原件
- 内嵌 Gateway 首选端口被占时回退随机端口（PORT=0），解决隔离后双实例撞 3101 的问题；租约竞争由 findRunningGateway 兜底
- QWAUDIO_CONFIG_DIR 覆盖仍优先

## 语音休眠与唤醒词

- 新增 SleepController：语音会话空闲超时进入休眠，暂停播报投递
- sherpa 唤醒词检测（含模型管理），休眠期间检测到唤醒词恢复
- 桌面设置页新增休眠/唤醒相关配置
- realtime-gateway 接入休眠状态机与 enter_sleep 工具注册防护测试

## 验证

- 端到端实测：CLI gateway@3101 与桌面版 gateway@随机端口并行运行，锁与日志各自独立
- 全量测试 680 通过、lint 干净