### PR TITLE
feat: inject open-computer-use as builtin MCP server for all backend sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "@modelcontextprotocol/sdk": "1.30.0",
         "electron-updater": "6.8.9",
         "express": "^4.22.2",
+        "sherpa-onnx": "1.13.4",
+        "tar-stream": "3.1.7",
+        "unbzip2-stream": "1.4.3",
         "ws": "^8.21.1",
         "zod": "^4.4.3"
       },
@@ -1709,6 +1712,17 @@
     "node_modules/@qwen-audio-agent/web": {
       "resolved": "web",
       "link": true
+    },
+    "node_modules/@qwen-code/open-computer-use": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@qwen-code/open-computer-use/-/open-computer-use-0.2.3.tgz",
+      "integrity": "sha512-Cnoofoc/1sx0zaXvktbm6mOLPlw1w3tF++KREO4gBR1VM+Oy+ZYRgkoAjY3ckhGqPywDyHLv+2iq1gfDowU08Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "open-computer-use": "bin/open-computer-use",
+        "open-computer-use-mcp": "bin/open-computer-use-mcp"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -8880,6 +8894,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "1.3.0",
         "@modelcontextprotocol/sdk": "1.30.0",
+        "@qwen-code/open-computer-use": "^0.2.3",
         "express": "^4.22.2",
         "sherpa-onnx": "1.13.4",
         "tar-stream": "3.1.7",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "1.3.0",
     "@modelcontextprotocol/sdk": "1.30.0",
+    "@qwen-code/open-computer-use": "^0.2.3",
     "express": "^4.22.2",
     "sherpa-onnx": "1.13.4",
     "tar-stream": "3.1.7",

--- a/server/src/agent/acp-backend-adapter.mjs
+++ b/server/src/agent/acp-backend-adapter.mjs
@@ -20,6 +20,7 @@ import {
   ACP_SESSION_TOOL_NAMES,
   AcpSessionToolServer,
 } from './acp-session-tools.mjs'
+import { builtinMcpServers } from './builtin-mcp.mjs'
 
 const MAX_SESSION_RESULTS = 100
 const MAX_DELEGATION_RESULT_CHARS = 12_000
@@ -144,6 +145,7 @@ export class AcpBackendAdapter {
     backendAvailable = endpointAvailable,
     sessionToolServer,
     nativeDelegationAdapter,
+    builtinMcp = builtinMcpServers(),
   } = {}) {
     this.protocol = protocol
     this.root = root
@@ -173,6 +175,9 @@ export class AcpBackendAdapter {
     })
     this.registry = new AcpSessionRegistry({ filePath: sessionStatePath })
     this.sessionToolServer = sessionToolServer || new AcpSessionToolServer()
+    // Baseline stdio MCP servers (e.g. open-computer-use) injected into every
+    // Session; backends spawn and connect to them on their own.
+    this.builtinMcp = Array.isArray(builtinMcp) ? builtinMcp : []
     this.pendingPermissions = new Map()
     this.resolvedPermissions = new Map()
     this.coordinatorSessions = new Map()
@@ -849,6 +854,7 @@ export class AcpBackendAdapter {
     const cwd = clean(directory)
     const session = await this.client.newSession({
       cwd,
+      mcpServers: this.builtinMcp,
       ownerId: run.ownerId,
       role: 'project',
     })
@@ -905,6 +911,7 @@ export class AcpBackendAdapter {
     }
     const session = await this.client.resumeSession(clean(sessionId), {
       cwd,
+      mcpServers: this.builtinMcp,
       ownerId: run.ownerId,
       role: 'project',
     })
@@ -1062,7 +1069,10 @@ export class AcpBackendAdapter {
       ownerId,
       this.toolContext(run),
     )
-    const mcpServers = registration ? [registration.descriptor] : []
+    const mcpServers = [
+      ...(registration ? [registration.descriptor] : []),
+      ...this.builtinMcp,
+    ]
     const session = await this.ensureCoordinatorSession(ownerId, mcpServers)
     const permissionScopeId = `prompt_${randomUUID()}`
     run.sessionId = session.sessionId
@@ -1074,7 +1084,7 @@ export class AcpBackendAdapter {
     try {
       // Re-supply MCP definitions on resume: ACP Sessions do not require the
       // agent to persist client-provided MCP connections across processes.
-      if (registration && !session.isNew) {
+      if (mcpServers.length && !session.isNew) {
         await this.client.resumeSession(session.sessionId, {
           cwd: session.cwd || this.directory,
           mcpServers,

--- a/server/src/agent/builtin-mcp.mjs
+++ b/server/src/agent/builtin-mcp.mjs
@@ -1,0 +1,57 @@
+// Built-in MCP servers injected into every backend Agent Session.
+//
+// ACP treats stdio as the baseline MCP transport: descriptors passed via
+// `session/new` are spawned and connected by the backend Agent itself, so
+// the Gateway only needs to describe where the server lives. Verified
+// against Qoder and OpenCode — both spawn the stdio process directly.
+//
+// open-computer-use ships three platform runtimes in one npm package and
+// provides click/type/screenshot-style tools, giving every backend a
+// computer-use baseline even when the user has not configured one.
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { existsSync } from 'node:fs'
+
+const require = createRequire(import.meta.url)
+
+function settingEnabled(value, fallback = true) {
+  const normalized = String(value ?? '').trim().toLowerCase()
+  if (!normalized) return fallback
+  return !['false', 'off', '0', 'no', 'disabled'].includes(normalized)
+}
+
+function resolvePackageBin(specifier, binName) {
+  try {
+    const packagePath = require.resolve(`${specifier}/package.json`)
+    const manifest = require(`${specifier}/package.json`)
+    const relative = typeof manifest.bin === 'string'
+      ? manifest.bin
+      : manifest.bin?.[binName]
+    if (!relative) return null
+    const binPath = join(dirname(packagePath), relative)
+    return existsSync(binPath) ? binPath : null
+  } catch {
+    return null
+  }
+}
+
+export function computerUseMcpServer(env = process.env) {
+  if (!settingEnabled(env.QWEN_AUDIO_AGENT_COMPUTER_USE)) return null
+  const binPath = resolvePackageBin(
+    '@qwen-code/open-computer-use',
+    'open-computer-use',
+  )
+  if (!binPath) return null
+  return {
+    name: 'open-computer-use',
+    command: process.execPath,
+    args: [binPath, 'mcp'],
+    // The bin is a Node script; when the Gateway runs inside Electron the
+    // backend inherits execPath, so force plain Node semantics.
+    env: [{ name: 'ELECTRON_RUN_AS_NODE', value: '1' }],
+  }
+}
+
+export function builtinMcpServers(env = process.env) {
+  return [computerUseMcpServer(env)].filter(Boolean)
+}

--- a/server/test/acp-backend-adapter.test.mjs
+++ b/server/test/acp-backend-adapter.test.mjs
@@ -1723,3 +1723,111 @@ test('releases completed ACP tool-call state instead of retaining it globally', 
   assert.equal(run.toolCalls.size, 0)
   assert.equal(Object.hasOwn(adapter, 'toolCalls'), false)
 })
+
+test('injects builtin MCP servers into coordinator and project sessions', async () => {
+  const builtin = {
+    name: 'open-computer-use',
+    command: process.execPath,
+    args: ['/repo/node_modules/open-computer-use/bin', 'mcp'],
+    env: [{ name: 'ELECTRON_RUN_AS_NODE', value: '1' }],
+  }
+  const tools = fakeToolServer()
+  const sessionMcp = new Map()
+  let prompted = false
+  const client = {
+    async newSession(options) {
+      const sessionId = options.role === 'coordinator'
+        ? 'coordinator-session'
+        : 'project-session'
+      sessionMcp.set(sessionId, options.mcpServers)
+      return { sessionId, cwd: options.cwd, response: {} }
+    },
+    async resumeSession(sessionId, options) {
+      sessionMcp.set(`resume:${sessionId}`, options.mcpServers)
+      return { sessionId, cwd: options.cwd, response: {} }
+    },
+    async prompt(sessionId) {
+      if (sessionId === 'project-session') {
+        return {
+          content: 'project complete',
+          response: { stopReason: 'end_turn' },
+        }
+      }
+      if (!prompted) {
+        prompted = true
+        await tools.registrations[0].call('startSession', {
+          prompt: 'inspect the project',
+          directory: '/project',
+        })
+      }
+      return {
+        content: completed('coordinator done'),
+        response: { stopReason: 'end_turn' },
+      }
+    },
+    async close() {},
+  }
+  const adapter = new AcpBackendAdapter({
+    protocol: 'qoder',
+    directory: '/coordinator',
+    client,
+    sessionToolServer: tools,
+    builtinMcp: [builtin],
+  })
+
+  const result = await adapter.coordinatorTurn('first turn', {
+    ownerId: 'owner-one',
+    coordinationRunId: 'work-one',
+  })
+  await result.run.delegation?.promise
+
+  const coordinator = sessionMcp.get('coordinator-session')
+  assert.equal(coordinator.length, 2)
+  assert.equal(coordinator[0].type, 'http')
+  assert.equal(coordinator[1], builtin)
+
+  const project = sessionMcp.get('project-session')
+  assert.deepEqual(project, [builtin])
+  await adapter.close()
+})
+
+test('builtinMcp defaults keep sessions working when disabled', async () => {
+  const tools = fakeToolServer()
+  const sessionMcp = new Map()
+  const client = {
+    async newSession(options) {
+      sessionMcp.set('coordinator-session', options.mcpServers)
+      return {
+        sessionId: 'coordinator-session',
+        cwd: options.cwd,
+        response: {},
+      }
+    },
+    async resumeSession(sessionId, options) {
+      return { sessionId, cwd: options.cwd, response: {} }
+    },
+    async prompt() {
+      return {
+        content: completed('done'),
+        response: { stopReason: 'end_turn' },
+      }
+    },
+    async close() {},
+  }
+  const adapter = new AcpBackendAdapter({
+    protocol: 'qoder',
+    directory: '/coordinator',
+    client,
+    sessionToolServer: tools,
+    builtinMcp: [],
+  })
+
+  await adapter.coordinatorTurn('turn', {
+    ownerId: 'owner-one',
+    coordinationRunId: 'work-one',
+  })
+  const coordinator = sessionMcp.get('coordinator-session')
+  assert.equal(coordinator.length, 1)
+  assert.equal(coordinator[0].type, 'http')
+  await adapter.close()
+})

--- a/server/test/builtin-mcp.test.mjs
+++ b/server/test/builtin-mcp.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  builtinMcpServers,
+  computerUseMcpServer,
+} from '../src/agent/builtin-mcp.mjs'
+
+test('computer-use MCP server resolves as stdio descriptor by default', () => {
+  const descriptor = computerUseMcpServer({})
+  assert.ok(descriptor, 'expected descriptor when package is installed')
+  assert.equal(descriptor.name, 'open-computer-use')
+  assert.equal(descriptor.command, process.execPath)
+  assert.equal(descriptor.args.length, 2)
+  assert.match(descriptor.args[0], /open-computer-use/)
+  assert.equal(descriptor.args[1], 'mcp')
+  assert.deepEqual(descriptor.env, [
+    { name: 'ELECTRON_RUN_AS_NODE', value: '1' },
+  ])
+})
+
+test('computer-use MCP server can be disabled via environment', () => {
+  for (const value of ['false', 'off', '0', 'no', 'disabled', 'OFF']) {
+    assert.equal(
+      computerUseMcpServer({ QWEN_AUDIO_AGENT_COMPUTER_USE: value }),
+      null,
+      `expected null for ${value}`,
+    )
+  }
+})
+
+test('computer-use MCP server stays enabled for truthy values', () => {
+  for (const value of ['', 'true', 'on', '1', 'yes']) {
+    assert.ok(
+      computerUseMcpServer({ QWEN_AUDIO_AGENT_COMPUTER_USE: value }),
+      `expected descriptor for "${value}"`,
+    )
+  }
+})
+
+test('builtinMcpServers returns descriptor list and filters disabled entries', () => {
+  const enabled = builtinMcpServers({})
+  assert.equal(enabled.length, 1)
+  assert.equal(enabled[0].name, 'open-computer-use')
+
+  const disabled = builtinMcpServers({ QWEN_AUDIO_AGENT_COMPUTER_USE: 'off' })
+  assert.deepEqual(disabled, [])
+})


### PR DESCRIPTION
## 概述

为所有后台 Agent Session 注入内置 computer-use MCP 服务器（`@qwen-code/open-computer-use`），作为前台提供的兜底能力。用户无需任何配置，任何后端都能点击、输入、读屏。

## 背景与验证

**为什么需要兜底**：实测各后端 computer-use 生态差异很大——Qoder 有原生插件（需手动 `qodercli plugin install`）、Codex 自带但默认禁用、Claude Code 内置但需交互式启用、OpenCode/Kimi/CodeBuddy/Hermes 无原生方案。一键安装后任何后端都没有开箱即用的 computer-use。

**为什么走 ACP 注入而非写各后端配置**：MCP 有标准协议通道（`session/new` 的 `mcpServers`），网关注入一次全后端生效；写各后端配置则要为每家维护格式适配，且后端升级可能丢配置。

**关键实测**（决定实现形态）：
- ACP 把 stdio 作为基线 MCP 传输——直接传 stdio 描述符，后端自己 spawn 并连接。对真实 Qoder 和 OpenCode 验证通过，无需网关侧 stdio→HTTP 代理
- 后端对 MCP 工具名自动加服务器名前缀（adapter 中已有 `__` 前缀兼容逻辑），与用户自配的 computer-use MCP 共存不冲突

## 改动

| 文件 | 内容 |
| --- | --- |
| `server/package.json` | 新增依赖 `@qwen-code/open-computer-use@^0.2.3`（13MB，三平台原生 runtime，MIT） |
| `server/src/agent/builtin-mcp.mjs`（新增） | 解析包内 bin 绝对路径，构造 stdio 描述符；`QWEN_AUDIO_AGENT_COMPUTER_USE=off` 可关（默认开）；包缺失时降级为空列表 |
| `server/src/agent/acp-backend-adapter.mjs` | 协调器 Session 与委派 project Session（此前完全无 MCP）合并注入内置描述符；resume 重供条件同步调整 |
| 测试 | `builtin-mcp.test.mjs` 4 例 + adapter 合并行为 2 例 |

描述符 env 带 `ELECTRON_RUN_AS_NODE=1`：bin 是 Node 脚本，桌面版下后端继承的 execPath 是 Electron，需强制纯 Node 语义。

## 提供的工具（9 个）

`click / drag / type_text / press_key / scroll / get_app_state / list_apps / set_value / perform_secondary_action`

权限：这些工具不在内部工具自动放行集合中，走现有 `handlePermission` 用户确认流。macOS 首次实际调用时系统弹辅助功能/屏幕录制授权。

## 测试

- 全量 719/719（6 workspace）
- lint / verify-package 通过
- 端到端：用 `builtinMcpServers()` 真实描述符对真实 Qoder `session/new`，确认后端自行 spawn `open-computer-use mcp` 子进程 ✅
