### PR TITLE
fix(desktop): package open-computer-use for built-in computer-use fallback

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -5,6 +5,9 @@ asar: true
 npmRebuild: false
 asarUnpack:
   - node_modules/sherpa-onnx/**/*.wasm
+  # open-computer-use is spawned by external backend Agent processes (plain
+  # node + native runtimes), which cannot read files inside the asar archive.
+  - node_modules/@qwen-code/open-computer-use/**/*
 extraMetadata:
   main: desktop/src/main.mjs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "1.3.0",
         "@modelcontextprotocol/sdk": "1.30.0",
+        "@qwen-code/open-computer-use": "^0.2.3",
         "electron-updater": "6.8.9",
         "express": "^4.22.2",
         "sherpa-onnx": "1.13.4",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "1.3.0",
     "@modelcontextprotocol/sdk": "1.30.0",
+    "@qwen-code/open-computer-use": "^0.2.3",
     "electron-updater": "6.8.9",
     "express": "^4.22.2",
     "ws": "^8.21.1",

--- a/server/src/agent/builtin-mcp.mjs
+++ b/server/src/agent/builtin-mcp.mjs
@@ -9,7 +9,7 @@
 // provides click/type/screenshot-style tools, giving every backend a
 // computer-use baseline even when the user has not configured one.
 import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
+import { dirname, join, sep } from 'node:path'
 import { existsSync } from 'node:fs'
 
 const require = createRequire(import.meta.url)
@@ -20,6 +20,16 @@ function settingEnabled(value, fallback = true) {
   return !['false', 'off', '0', 'no', 'disabled'].includes(normalized)
 }
 
+// Inside Electron, require.resolve returns paths within the asar archive.
+// Backend Agents are external processes that cannot read archived files, so
+// point them at the asarUnpack mirror instead.
+function externallyReadable(path) {
+  return path.replace(
+    `${sep}app.asar${sep}`,
+    `${sep}app.asar.unpacked${sep}`,
+  )
+}
+
 function resolvePackageBin(specifier, binName) {
   try {
     const packagePath = require.resolve(`${specifier}/package.json`)
@@ -28,7 +38,7 @@ function resolvePackageBin(specifier, binName) {
       ? manifest.bin
       : manifest.bin?.[binName]
     if (!relative) return null
-    const binPath = join(dirname(packagePath), relative)
+    const binPath = externallyReadable(join(dirname(packagePath), relative))
     return existsSync(binPath) ? binPath : null
   } catch {
     return null


### PR DESCRIPTION
## 修复内容

桌面版打包后的应用无法真正使用内置的 `open-computer-use` MCP server：包虽然代码里有注入逻辑，但 `@qwen-code/open-computer-use` 没被 electron-builder 收集进产物，且即使收集进 asar，外部后台 Agent 进程也读不了 asar 里的文件。

## 改动

- `package.json`：在根依赖声明 `@qwen-code/open-computer-use`，让 electron-builder 收集到 app.asar。
- `desktop/electron-builder.yml`：将 `node_modules/@qwen-code/open-computer-use/**/*` 从 asar 解包；后台 Agent 是外部进程，必须能直接访问文件系统路径。
- `server/src/agent/builtin-mcp.mjs`：当运行在打包后的 Electron 应用内时，把 `require.resolve` 得到的路径重定向到 `app.asar.unpacked` 镜像。

## 验证

- `npm run desktop:build:local` 构建成功
- 打包产物内 `app.asar.unpacked/node_modules/@qwen-code/open-computer-use/bin/open-computer-use` 可执行
- 启动桌面版后，`ps` 可见 `open-computer-use mcp` / `OpenComputerUse.app` 子进程
- 实际对话中调用 `mcp__open-computer-use__get_app_state` 成功，Finder 状态可获取

## 影响范围

仅桌面版打包产物；开发模式（`npm run desktop`）和 CLI 模式原有路径不受影响。
