### PR TITLE
fix(desktop): keep wake-word listening after mute

### DIFF
--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -1541,7 +1541,7 @@ export function attachRealtimeGateway(server, {
         modelRoot: config.wakeWordModelDirectory,
       }).then(detector => {
         wakeDetector = detector
-        if (ws.readyState === WebSocket.OPEN && inputEnabled) {
+        if (ws.readyState === WebSocket.OPEN) {
           sleepController.enable()
           send(ws, {
             type: GatewayServerEvent.VOICE_SLEEP,
@@ -1642,7 +1642,7 @@ export function attachRealtimeGateway(server, {
     sleepController = new SleepController({
       timeoutMs: config.sleepTimeoutMs,
       canSleep: () => (
-        inputEnabled
+        (inputEnabled || config.wakeWordEnabled)
         && activeVoiceClients.isActive(ownerId, voiceClient)
         && frontend?.ready
         && !userSpeaking
@@ -1770,11 +1770,11 @@ export function attachRealtimeGateway(server, {
           })
           .catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.AUDIO_APPEND) {
-        if (!inputEnabled || !activeVoiceClients.isActive(ownerId, voiceClient)) {
+        if (sleeping) {
+          if (wakeDetector) acceptSleepingAudio(event.audio)
           return
         }
-        if (sleeping) {
-          acceptSleepingAudio(event.audio)
+        if (!inputEnabled || !activeVoiceClients.isActive(ownerId, voiceClient)) {
           return
         }
         if (frontend?.ready) frontend.appendAudio(event.audio)

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -647,9 +647,18 @@ export default function App() {
     waitingForVoice,
   ])
 
+  // Keep the microphone alive while the desktop orb is hidden and the wake
+  // word is enabled, even if the user has muted the realtime conversation.
+  // Muting only suppresses input/output processing; wake-word detection still
+  // needs a live audio stream to resume on "你好千问".
+  const voiceEnabledForWakeWord = (
+    desktopOrbMode
+    && desktopLifecycle === 'hidden'
+    && wakeWordEnabled
+  )
   const voice = useRealtimeVoice({
     sessionId,
-    enabled: voiceEnabled,
+    enabled: voiceEnabled || voiceEnabledForWakeWord,
     suspended: desktopOrbMode && desktopLifecycle === 'hidden' && !wakeWordEnabled,
     outputMuted: false,
     inputOnlyMute: desktopOrbMode,


### PR DESCRIPTION
## Bug 描述

桌面版静音后，orb 自动休眠隐藏，无法通过唤醒词“你好千问”重新唤醒。

## 根因

- 用户点击静音 → `voiceEnabled=false` → `useRealtimeVoice` 的 `enabled=false` → 麦克风完全关闭。
- 即使设置了“语音唤醒”，休眠后也没有音频流可供唤醒词检测。
- 服务端同时要求 `inputEnabled=true` 才会进入休眠/检测唤醒词，而静音状态下 `inputEnabled=false`。

## 修复

**`web/src/App.jsx`**
- 当桌面版处于 hidden 状态且开启唤醒词时，即使 `voiceEnabled=false` 也保持 `enabled=true`。
- 静音只应关闭实时对话的输入/输出处理，不应关闭唤醒词监听。

**`server/src/voice/realtime-gateway.mjs`**
- `canSleep` 允许在 `wakeWordEnabled` 时即使 `inputEnabled=false` 也进入休眠。
- `prepareSleepMode()` 中 wake-word detector 准备就绪后即启用 sleep controller，不再检查当前是否 `inputEnabled`。
- `AUDIO_APPEND` 处理：sleeping 状态下直接把音频交给唤醒词检测器，不再要求 `inputEnabled`。

## 验证

- `npx eslint web/src/App.jsx server/src/voice/realtime-gateway.mjs` 通过
- 全量测试 `npm test`：719/719 通过

## 影响范围

仅桌面版语音唤醒 + 静音的组合场景。WebUI 和非静音场景行为不变。
