### PR TITLE
perf(voice): 后台委托类工具受理即回——spawn_thinking 与权限决定零等待

### DIFF
--- a/server/src/agent/backend-availability.mjs
+++ b/server/src/agent/backend-availability.mjs
@@ -1,0 +1,57 @@
+// Cached backend availability for receipt-based tool acceptance. The voice
+// frontend must hand out spawn_thinking receipts in milliseconds, so it can
+// never block on a live health probe. This cache answers synchronously from
+// the last known state and refreshes itself in the background; a backend
+// that looks healthy here but fails at dispatch surfaces through the
+// failed-task announcement path instead of the tool receipt.
+export class BackendAvailability {
+  constructor({
+    probe,
+    ttlMs = 15_000,
+    now = () => Date.now(),
+  } = {}) {
+    if (typeof probe !== 'function') {
+      throw new Error('BackendAvailability requires a probe')
+    }
+    this.probe = probe
+    this.ttlMs = ttlMs
+    this.now = now
+    this.last = null
+    this.checkedAt = 0
+    this.refreshing = null
+  }
+
+  // Synchronous view. `known: false` means no probe has completed yet — the
+  // caller should accept optimistically and let dispatch report failures.
+  snapshot() {
+    if (this.now() - this.checkedAt >= this.ttlMs) this.refresh()
+    if (!this.last) return { configured: true, ok: true, known: false }
+    return { ...this.last, known: true }
+  }
+
+  // Background refresh; concurrent callers share one probe and the promise
+  // never rejects, so fire-and-forget call sites stay silent.
+  refresh() {
+    if (this.refreshing) return this.refreshing
+    this.refreshing = Promise.resolve()
+      .then(() => this.probe())
+      .then(result => {
+        this.last = {
+          configured: result?.configured !== false,
+          ok: result?.ok === true,
+        }
+      })
+      .catch(() => {
+        // A failing probe is itself evidence the backend is unreachable.
+        this.last = {
+          configured: this.last?.configured !== false,
+          ok: false,
+        }
+      })
+      .finally(() => {
+        this.checkedAt = this.now()
+        this.refreshing = null
+      })
+    return this.refreshing
+  }
+}

--- a/server/src/app/bootstrap.mjs
+++ b/server/src/app/bootstrap.mjs
@@ -3,6 +3,7 @@ import { createServer } from 'http'
 import { randomUUID } from 'node:crypto'
 import { resolve } from 'path'
 import { agent } from '../agent/agent-client.mjs'
+import { BackendAvailability } from '../agent/backend-availability.mjs'
 import { coordinator } from '../agent/coordinator.mjs'
 import { config } from '../core/config.mjs'
 import { logger, runWithLogContext } from '../core/logger.mjs'
@@ -373,16 +374,23 @@ app.use((error, req, res, next) => {
 
 const server = createServer(app)
 export { server }
+// Receipt-based tool acceptance reads backend availability from this cache
+// instead of probing per spawn_thinking call; the snapshot answers
+// synchronously and refreshes itself in the background.
+const backendAvailability = new BackendAvailability({
+  probe: async () => ({
+    configured: agent.enabled,
+    ok: agent.enabled && (await agent.health()).ok === true,
+  }),
+})
+backendAvailability.refresh()
 realtimeGateway = attachRealtimeGateway(server, {
   identityManager,
   memoryStore: frontendMemory,
   memoryExtractor,
   notesStore,
   coordinator,
-  coordinatorAvailable: async () => ({
-    enabled: agent.enabled,
-    ok: agent.enabled && (await agent.health()).ok === true,
-  }),
+  backendAvailability,
   respondPermission: (id, decision, options) => (
     agent.respondPermission(id, decision, options)
   ),

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -105,7 +105,7 @@ export function attachRealtimeGateway(server, {
   memoryExtractor = null,
   notesStore,
   coordinator,
-  coordinatorAvailable = async () => true,
+  backendAvailability = null,
   respondPermission,
   permissionPolicy,
 }) {
@@ -373,9 +373,20 @@ export function attachRealtimeGateway(server, {
         memories: memoryStore?.list(ownerId, { limit: 64 }) || [],
       }),
       coordinator,
-      coordinatorAvailable,
+      backendAvailability,
       respondPermission,
       permissionPolicy,
+      // The permission decision was accepted locally but never reached the
+      // backend: the authorization is still pending there, so clear the
+      // announced mark and let the standard re-announce path ask again.
+      onPermissionDeliveryFailed: ({ authorizationId, error }) => {
+        connectionLogger.warn('permission.delivery_failed', {
+          authorizationId,
+          error,
+        })
+        announcedPermissions.delete(authorizationId)
+        announcePendingPermissions()
+      },
       requestClientState: state => {
         if (!clientContext.states?.includes(state)) return
         send(ws, {

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -37,7 +37,7 @@ export class ToolCallHandler {
     getTurnId,
     getTurnGeneration,
     coordinator,
-    coordinatorAvailable = async () => true,
+    backendAvailability = null,
     memoryStore,
     notesStore,
     getClientContext = () => ({}),
@@ -45,6 +45,7 @@ export class ToolCallHandler {
     onMemoryChanged = () => {},
     respondPermission,
     permissionPolicy,
+    onPermissionDeliveryFailed = () => {},
     requestClientState = () => {},
   }) {
     this.taskManager = taskManager
@@ -55,7 +56,7 @@ export class ToolCallHandler {
     this.getTurnId = getTurnId
     this.getTurnGeneration = getTurnGeneration
     this.coordinator = coordinator
-    this.coordinatorAvailable = coordinatorAvailable
+    this.backendAvailability = backendAvailability
     this.memoryStore = memoryStore
     this.notesStore = notesStore
     this.getClientContext = getClientContext
@@ -63,6 +64,7 @@ export class ToolCallHandler {
     this.onMemoryChanged = onMemoryChanged
     this.respondPermission = respondPermission
     this.permissionPolicy = permissionPolicy
+    this.onPermissionDeliveryFailed = onPermissionDeliveryFailed
     this.requestClientState = requestClientState
     this.gatewayApprovedPermissions = new Set()
     this.processedCalls = new Set()
@@ -143,31 +145,41 @@ export class ToolCallHandler {
       })
   }
 
-  createWork({ turnId, originalRequest, objective, submissionKey }) {
+  createWork({ turnId, objective, submissionKey }) {
     let workId = ''
     const task = this.taskManager.create({
-      objective: originalRequest,
+      objective,
       ownerId: this.ownerId,
       sessionId: this.sessionId,
       turnId,
       submissionKey,
       laneKey: `coordinator:${this.ownerId}`,
       laneLimit: 1,
-      runner: async (_ignored, { onEvent, signal }) => this.coordinator.run({
-        originalRequest,
-        objective,
-        conversationContext: this.getConversationContext(),
-        userMemories: this.memoryStore?.list(this.ownerId, { limit: 64 }) || [],
-        timeZone: this.getClientContext()?.timeZone,
-        workingDirectory: this.getClientContext()?.workingDirectory,
-      }, {
-        ownerId: this.ownerId,
-        sessionId: this.sessionId,
-        turnId,
-        coordinationRunId: workId,
-        signal,
-        onEvent: event => this.forwardCoordinatorEvent(event, onEvent),
-      }),
+      runner: async (_ignored, { onEvent, signal }) => {
+        // The owner FIFO wait has already covered ASR latency, so the
+        // verbatim user request is resolved here at dispatch instead of
+        // blocking the acceptance receipt. A closed session resolves to ''
+        // and falls back to the model-provided objective.
+        const resolved = await this.transcripts.resolveDelegation(
+          turnId,
+          objective,
+        )
+        return this.coordinator.run({
+          originalRequest: resolved.originalRequest || objective,
+          objective,
+          conversationContext: this.getConversationContext(),
+          userMemories: this.memoryStore?.list(this.ownerId, { limit: 64 }) || [],
+          timeZone: this.getClientContext()?.timeZone,
+          workingDirectory: this.getClientContext()?.workingDirectory,
+        }, {
+          ownerId: this.ownerId,
+          sessionId: this.sessionId,
+          turnId,
+          coordinationRunId: workId,
+          signal,
+          onEvent: event => this.forwardCoordinatorEvent(event, onEvent),
+        })
+      },
       canceler: async ({ previousStatus, abort }) => {
         if (previousStatus === 'delegated') {
           const result = await this.coordinator.cancelDelegatedWork(
@@ -356,20 +368,67 @@ export class ToolCallHandler {
       return
     }
 
-    const resolved = await this.transcripts.resolveDelegation(
-      turnId,
-      args.objective,
-    )
-    if (this.isStale(turnId, generation)) {
-      await this.closeStaleCall(callId, turnId)
+    // Receipt-based acceptance: this receipt only acknowledges intake, so it
+    // must not wait on ASR timing or a live backend round trip. Availability
+    // comes from the cached snapshot; a backend that looks healthy here but
+    // fails at dispatch surfaces through the failed-task announcement path.
+    const availability = this.backendAvailability?.snapshot()
+      || { configured: true, ok: true, known: false }
+    if (availability.configured === false) {
+      await this.sendOutput(
+        callId,
+        failure(
+          'backend_unavailable',
+          '当前未配置后台 Agent，无法执行需要后台处理的任务。你仍然可以继续普通聊天。',
+          { retryable: false },
+        ),
+        turnId,
+        null,
+        {
+          response: {
+            instructions: [
+              '直接向用户说明当前未配置后台 Agent，无法执行这项后台任务。',
+              '不要再次调用后台工具，也不要声称任务已经创建或正在执行。',
+              '可以继续完成不需要后台 Agent 的聊天和回答。',
+            ].join('\n'),
+          },
+        },
+      )
       return
     }
-    const originalRequest = String(
-      resolved.originalRequest || resolved.objective || '',
-    ).trim()
-    const objective = String(
-      resolved.objective || resolved.originalRequest || '',
-    ).trim()
+    if (availability.known && availability.ok === false) {
+      await this.sendOutput(
+        callId,
+        failure(
+          'backend_unavailable',
+          '后台 Agent 当前未连接。你仍然可以继续普通聊天，后台恢复后再执行这项工作。',
+          { retryable: true },
+        ),
+        turnId,
+        null,
+        {
+          response: {
+            instructions: [
+              '直接向用户说明后台 Agent 当前未连接，暂时无法执行这项后台任务。',
+              '不要再次调用后台工具，也不要声称任务已经创建或正在执行。',
+              '可以继续完成不需要后台 Agent 的聊天和回答。',
+            ].join('\n'),
+          },
+        },
+      )
+      return
+    }
+
+    let objective = String(args.objective || '').replace(/\s+/g, ' ').trim()
+    if (!objective) {
+      // Rare model slip: only this fallback path waits for the transcript.
+      const resolved = await this.transcripts.resolveDelegation(turnId, '')
+      if (this.isStale(turnId, generation)) {
+        await this.closeStaleCall(callId, turnId)
+        return
+      }
+      objective = String(resolved.originalRequest || '').trim()
+    }
     if (!objective) {
       await this.sendOutput(
         callId,
@@ -379,49 +438,6 @@ export class ToolCallHandler {
           { retryable: true },
         ),
         turnId,
-      )
-      return
-    }
-
-    let coordinatorReady = false
-    let coordinatorConfigured = true
-    try {
-      const availability = await this.coordinatorAvailable()
-      if (availability && typeof availability === 'object') {
-        coordinatorConfigured = availability.enabled !== false
-        coordinatorReady = (
-          coordinatorConfigured && availability.ok === true
-        )
-      } else {
-        coordinatorReady = availability === true
-      }
-    } catch {
-      coordinatorReady = false
-    }
-    if (!coordinatorReady) {
-      const userMessage = coordinatorConfigured
-        ? '后台 Agent 当前未连接。你仍然可以继续普通聊天，后台恢复后再执行这项工作。'
-        : '当前未配置后台 Agent，无法执行需要后台处理的任务。你仍然可以继续普通聊天。'
-      await this.sendOutput(
-        callId,
-        failure(
-          'backend_unavailable',
-          userMessage,
-          { retryable: coordinatorConfigured },
-        ),
-        turnId,
-        null,
-        {
-          response: {
-            instructions: [
-              coordinatorConfigured
-                ? '直接向用户说明后台 Agent 当前未连接，暂时无法执行这项后台任务。'
-                : '直接向用户说明当前未配置后台 Agent，无法执行这项后台任务。',
-              '不要再次调用后台工具，也不要声称任务已经创建或正在执行。',
-              '可以继续完成不需要后台 Agent 的聊天和回答。',
-            ].join('\n'),
-          },
-        },
       )
       return
     }
@@ -461,7 +477,6 @@ export class ToolCallHandler {
       ].join(':')
       task = this.createWork({
         turnId,
-        originalRequest,
         objective,
         submissionKey,
       })
@@ -586,48 +601,54 @@ export class ToolCallHandler {
       this.sessionId,
       decision,
     )
-    try {
-      const permission = await this.respondPermission(
+    // Receipt-based: the local policy takes effect immediately and the ACP
+    // round trip must not delay the spoken confirmation. On delivery failure
+    // the policy rolls back and the authorization is still pending on the
+    // backend, so the gateway can re-announce it through the existing
+    // pending-permission retry path.
+    Promise.resolve()
+      .then(() => this.respondPermission(
         authorizationId,
         decision,
         { ownerId: this.ownerId },
-      )
-      await this.sendOutput(callId, {
-        status: permission.status,
-        authorization_id: permission.id,
-      }, turnId, permission.workId, {
-        response: {
-          instructions: decision === 'always'
-            ? [
-                '权限已经成功生效。',
-                '只用一句简短自然口语确认“已允许，后台继续执行”。',
-                '不要重述操作，不要再次询问或调用工具。',
-              ].join(' ')
-            : [
-                '权限已经成功拒绝。',
-                '只用一句简短自然口语确认“已拒绝，后台不会执行这项操作”。',
-                '不要重述操作，不要再次询问或调用工具。',
-              ].join(' '),
-        },
+      ))
+      .catch(error => {
+        if (previousPermissionMode) {
+          this.permissionPolicy?.setMode(
+            this.ownerId,
+            this.sessionId,
+            previousPermissionMode,
+          )
+        }
+        try {
+          this.onPermissionDeliveryFailed({
+            authorizationId,
+            decision,
+            taskId: pendingTask.id,
+            error: String(error?.message || error),
+          })
+        } catch {
+          // Delivery diagnostics must not break the voice session.
+        }
       })
-    } catch (error) {
-      if (previousPermissionMode) {
-        this.permissionPolicy?.setMode(
-          this.ownerId,
-          this.sessionId,
-          previousPermissionMode,
-        )
-      }
-      await this.sendOutput(
-        callId,
-        failure(
-          'permission_response_failed',
-          error?.message || '没有成功提交权限决定。',
-          { retryable: false },
-        ),
-        turnId,
-      )
-    }
+    await this.sendOutput(callId, {
+      status: 'submitted',
+      authorization_id: authorizationId,
+    }, turnId, pendingTask.id, {
+      response: {
+        instructions: decision === 'always'
+          ? [
+              '权限决定已提交，并在本会话立即生效。',
+              '只用一句简短自然口语确认“已允许，后台继续执行”。',
+              '不要重述操作，不要再次询问或调用工具。',
+            ].join(' ')
+          : [
+              '权限决定已提交。',
+              '只用一句简短自然口语确认“已拒绝，后台不会执行这项操作”。',
+              '不要重述操作，不要再次询问或调用工具。',
+            ].join(' '),
+      },
+    })
   }
 
   async cancelAgentTask(callId, turnId, args) {

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -145,7 +145,7 @@ export class ToolCallHandler {
       })
   }
 
-  createWork({ turnId, objective, submissionKey }) {
+  createWork({ turnId, objective, verbatimRequest, submissionKey }) {
     let workId = ''
     const task = this.taskManager.create({
       objective,
@@ -156,14 +156,9 @@ export class ToolCallHandler {
       laneKey: `coordinator:${this.ownerId}`,
       laneLimit: 1,
       runner: async (_ignored, { onEvent, signal }) => {
-        // The owner FIFO wait has already covered ASR latency, so the
-        // verbatim user request is resolved here at dispatch instead of
-        // blocking the acceptance receipt. A closed session resolves to ''
-        // and falls back to the model-provided objective.
-        const resolved = await this.transcripts.resolveDelegation(
-          turnId,
-          objective,
-        )
+        // The verbatim request was pinned at acceptance and is almost
+        // certainly settled by now; awaiting it never blocks the receipt.
+        const resolved = (await verbatimRequest) || {}
         return this.coordinator.run({
           originalRequest: resolved.originalRequest || objective,
           objective,
@@ -475,9 +470,19 @@ export class ToolCallHandler {
         this.sessionId,
         turnId || callId,
       ].join(':')
+      // Pin the verbatim user request without blocking the receipt: the
+      // transcript waiter registers now, so the ASR result is captured even
+      // if the per-connection ring buffer evicts that turn before the FIFO
+      // lane dispatches this work. resolveDelegation never rejects and a
+      // closed session resolves to the model-provided objective.
+      const verbatimRequest = this.transcripts.resolveDelegation(
+        turnId,
+        objective,
+      )
       task = this.createWork({
         turnId,
         objective,
+        verbatimRequest,
         submissionKey,
       })
     } catch {

--- a/server/test/backend-availability.test.mjs
+++ b/server/test/backend-availability.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BackendAvailability } from '../src/agent/backend-availability.mjs'
+
+test('answers optimistically before the first probe completes', async () => {
+  let resolveProbe
+  const availability = new BackendAvailability({
+    probe: () => new Promise(resolve => { resolveProbe = resolve }),
+  })
+
+  assert.deepEqual(availability.snapshot(), {
+    configured: true,
+    ok: true,
+    known: false,
+  })
+  // The snapshot kicked one background probe (started on a microtask).
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(typeof resolveProbe, 'function')
+})
+
+test('reports the cached probe result synchronously until the TTL expires', async () => {
+  let now = 0
+  let probes = 0
+  const availability = new BackendAvailability({
+    ttlMs: 1000,
+    now: () => now,
+    probe: async () => {
+      probes += 1
+      return { configured: true, ok: probes === 1 }
+    },
+  })
+
+  await availability.refresh()
+  assert.deepEqual(availability.snapshot(), {
+    configured: true,
+    ok: true,
+    known: true,
+  })
+  // Within the TTL the snapshot never re-probes.
+  now = 999
+  availability.snapshot()
+  assert.equal(probes, 1)
+
+  now = 2000
+  availability.snapshot()
+  await availability.refreshing
+  assert.equal(probes, 2)
+  assert.equal(availability.snapshot().ok, false)
+})
+
+test('treats a failing probe as an unreachable backend without rejecting', async () => {
+  const availability = new BackendAvailability({
+    probe: async () => {
+      throw new Error('probe exploded')
+    },
+  })
+
+  await availability.refresh()
+  assert.deepEqual(availability.snapshot(), {
+    configured: true,
+    ok: false,
+    known: true,
+  })
+})
+
+test('shares one in-flight probe between concurrent refreshes', async () => {
+  let probes = 0
+  const availability = new BackendAvailability({
+    probe: async () => {
+      probes += 1
+      return { configured: true, ok: true }
+    },
+  })
+
+  await Promise.all([
+    availability.refresh(),
+    availability.refresh(),
+    availability.refresh(),
+  ])
+  assert.equal(probes, 1)
+})
+
+test('remembers that the backend is not configured', async () => {
+  const availability = new BackendAvailability({
+    probe: async () => ({ configured: false, ok: false }),
+  })
+  await availability.refresh()
+  assert.deepEqual(availability.snapshot(), {
+    configured: false,
+    ok: false,
+    known: true,
+  })
+})

--- a/server/test/desktop-sleep-tool-registration.test.mjs
+++ b/server/test/desktop-sleep-tool-registration.test.mjs
@@ -74,7 +74,9 @@ async function startGateway() {
     memoryStore: fakeMemoryStore(),
     notesStore: fakeNotesStore(),
     coordinator: null,
-    coordinatorAvailable: async () => false,
+    backendAvailability: {
+      snapshot: () => ({ configured: true, ok: false, known: true }),
+    },
     respondPermission: async () => ({}),
     permissionPolicy: {
       resolveDecision: () => null,

--- a/server/test/tool-call-handler-schedule.test.mjs
+++ b/server/test/tool-call-handler-schedule.test.mjs
@@ -23,7 +23,6 @@ function harness({
     coordinator: coordinator || {
       run: async () => ({ content: '完成', metadata: {} }),
     },
-    coordinatorAvailable: async () => true,
     memoryStore: null,
     notesStore: null,
     onMemoryChanged: () => {},

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -18,6 +18,7 @@ function harness({
   onPermissionDeliveryFailed,
   clientContext = {},
   requestClientState,
+  getTurnId = () => 'turn-one',
 } = {}) {
   const outputs = []
   const transcripts = new TurnTranscripts({ waitMs: 5 })
@@ -29,7 +30,7 @@ function harness({
     getFrontend: () => ({
       sendFunctionOutput: async (...args) => outputs.push(args),
     }),
-    getTurnId: () => 'turn-one',
+    getTurnId,
     getTurnGeneration: () => 1,
     coordinator: coordinator || {
       run: async () => ({ content: '完成', metadata: {} }),
@@ -272,6 +273,53 @@ test('hands out the acceptance receipt without waiting for the turn transcript',
   await kit.manager.wait(kit.outputs[0][1].work_id)
   assert.equal(received.originalRequest, '整理会议纪要')
   assert.equal(received.objective, '整理会议纪要')
+})
+
+test('keeps the verbatim request even when later turns evict the transcript', async () => {
+  const requests = []
+  let releaseFirst
+  let currentTurn = 'turn-one'
+  const kit = harness({
+    getTurnId: () => currentTurn,
+    coordinator: {
+      run: async input => {
+        requests.push(input.originalRequest)
+        if (input.objective === '堆积任务') {
+          return new Promise(resolve => {
+            releaseFirst = () => resolve({ content: '完成', metadata: {} })
+          })
+        }
+        return { content: '完成', metadata: {} }
+      },
+    },
+  })
+  // The first work blocks the owner FIFO lane so the second one queues.
+  kit.transcripts.record('turn-one', '堆积任务')
+  await kit.handler.handle({
+    call_id: 'call-blocking',
+    name: 'spawn_thinking',
+    arguments: '{"objective":"堆积任务"}',
+  }, { turnId: 'turn-one', turnGeneration: 1 })
+
+  kit.transcripts.record('turn-two', '把上周的周报发给老板')
+  currentTurn = 'turn-two'
+  await kit.handler.handle({
+    call_id: 'call-queued',
+    name: 'spawn_thinking',
+    arguments: '{"objective":"发送上周周报"}',
+  }, { turnId: 'turn-two', turnGeneration: 1 })
+  const queuedId = kit.outputs.at(-1)[1].work_id
+
+  // While the lane is blocked, twenty-plus newer turns evict turn-two from
+  // the transcript ring buffer. The pinned promise must retain the verbatim
+  // request regardless.
+  for (let index = 0; index < 25; index += 1) {
+    kit.transcripts.record(`turn-filler-${index}`, `闲聊第 ${index} 句`)
+  }
+  releaseFirst()
+  await kit.manager.wait(queuedId)
+
+  assert.deepEqual(requests, ['堆积任务', '把上周的周报发给老板'])
 })
 
 test('explains that background work is unavailable without a configured backend', async () => {

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -12,9 +12,10 @@ function harness({
   memoryStore = null,
   notesStore = null,
   onMemoryChanged = () => {},
-  coordinatorAvailable = async () => true,
+  backendAvailability = null,
   respondPermission,
   permissionPolicy,
+  onPermissionDeliveryFailed,
   clientContext = {},
   requestClientState,
 } = {}) {
@@ -33,12 +34,13 @@ function harness({
     coordinator: coordinator || {
       run: async () => ({ content: '完成', metadata: {} }),
     },
-    coordinatorAvailable,
+    backendAvailability,
     memoryStore,
     notesStore,
     onMemoryChanged,
     respondPermission,
     permissionPolicy,
+    onPermissionDeliveryFailed,
     getClientContext: () => clientContext,
     requestClientState,
     getConversationContext: () => [
@@ -83,6 +85,7 @@ async function permissionHarness({
   authorizationId = 'auth-one',
   respondPermission,
   permissionPolicy,
+  onPermissionDeliveryFailed,
 }) {
   const manager = new TaskManager()
   let release
@@ -104,7 +107,12 @@ async function permissionHarness({
     },
   })
   await new Promise(resolve => setImmediate(resolve))
-  const kit = harness({ manager, respondPermission, permissionPolicy })
+  const kit = harness({
+    manager,
+    respondPermission,
+    permissionPolicy,
+    onPermissionDeliveryFailed,
+  })
   kit.transcripts.record('turn-one', answer)
   return {
     ...kit,
@@ -193,9 +201,11 @@ test('deduplicates repeated tool calls from one realtime turn', async () => {
   )
 })
 
-test('rejects delegated work immediately when the backend Agent is disconnected', async () => {
+test('rejects delegated work immediately when the backend is known to be down', async () => {
   const kit = harness({
-    coordinatorAvailable: async () => false,
+    backendAvailability: {
+      snapshot: () => ({ configured: true, ok: false, known: true }),
+    },
   })
   kit.transcripts.record('turn-one', '帮我修改项目')
   await kit.handler.handle({
@@ -210,9 +220,65 @@ test('rejects delegated work immediately when the backend Agent is disconnected'
   assert.equal(kit.manager.list({ ownerId: 'owner' }).length, 0)
 })
 
+test('accepts optimistically before the first health probe and fails via the task', async () => {
+  let probed = 0
+  const kit = harness({
+    backendAvailability: {
+      snapshot: () => {
+        probed += 1
+        return { configured: true, ok: true, known: false }
+      },
+    },
+    coordinator: {
+      run: async () => {
+        throw new Error('后台 Agent 未连接')
+      },
+    },
+  })
+  kit.transcripts.record('turn-one', '帮我修改项目')
+  await kit.handler.handle({
+    call_id: 'call-optimistic',
+    name: 'spawn_thinking',
+    arguments: '{"objective":"修改项目"}',
+  })
+
+  // The receipt is optimistic; the dispatch failure surfaces on the task,
+  // which the announcement path reports asynchronously.
+  assert.equal(probed, 1)
+  assert.equal(kit.outputs[0][1].status, 'accepted')
+  await kit.manager.wait(kit.outputs[0][1].work_id)
+  assert.equal(kit.manager.get(kit.outputs[0][1].work_id).status, 'failed')
+})
+
+test('hands out the acceptance receipt without waiting for the turn transcript', async () => {
+  let received
+  const kit = harness({
+    coordinator: {
+      run: async input => {
+        received = input
+        return { content: '完成', metadata: {} }
+      },
+    },
+  })
+  // No transcript is ever recorded: acceptance must not block on ASR and the
+  // dispatch-time resolution falls back to the model-provided objective.
+  await kit.handler.handle({
+    call_id: 'call-no-transcript',
+    name: 'spawn_thinking',
+    arguments: '{"objective":"整理会议纪要"}',
+  }, { turnId: 'turn-one', turnGeneration: 1 })
+
+  assert.equal(kit.outputs[0][1].status, 'accepted')
+  await kit.manager.wait(kit.outputs[0][1].work_id)
+  assert.equal(received.originalRequest, '整理会议纪要')
+  assert.equal(received.objective, '整理会议纪要')
+})
+
 test('explains that background work is unavailable without a configured backend', async () => {
   const kit = harness({
-    coordinatorAvailable: async () => ({ enabled: false, ok: false }),
+    backendAvailability: {
+      snapshot: () => ({ configured: false, ok: false, known: true }),
+    },
   })
   kit.transcripts.record('turn-one', '帮我修改项目')
   await kit.handler.handle({
@@ -442,12 +508,14 @@ test('relays a realtime semantic permission decision without evidence matching',
     }),
   })
 
+  // The receipt is issued before the fire-and-forget backend delivery lands.
+  assert.equal(kit.outputs.at(-1)[1].status, 'submitted')
+  await new Promise(resolve => setImmediate(resolve))
   assert.deepEqual(calls, [{
     id: 'auth-one',
     decision: 'always',
     options: { ownerId: 'owner' },
   }])
-  assert.equal(kit.outputs.at(-1)[1].status, 'approved')
   assert.match(
     kit.outputs.at(-1)[3].response.instructions,
     /已允许，后台继续执行/,
@@ -478,12 +546,45 @@ test('confirms a rejected realtime permission exactly once', async () => {
     }),
   })
 
-  assert.equal(kit.outputs.at(-1)[1].status, 'rejected')
+  assert.equal(kit.outputs.at(-1)[1].status, 'submitted')
   assert.match(
     kit.outputs.at(-1)[3].response.instructions,
     /已拒绝/,
   )
   assert.equal(permissionPolicy.mode('owner', 'voice'), 'ask')
+  await kit.finish()
+})
+
+test('rolls back the session policy when the permission delivery fails', async () => {
+  const failures = []
+  const permissionPolicy = new SessionPermissionPolicy()
+  const kit = await permissionHarness({
+    answer: '可以',
+    permissionPolicy,
+    respondPermission: async () => {
+      throw new Error('backend unreachable')
+    },
+    onPermissionDeliveryFailed: event => failures.push(event),
+  })
+  await kit.handler.handle({
+    call_id: 'permission-delivery-failed',
+    name: 'respond_agent_permission',
+    arguments: JSON.stringify({
+      authorization_id: 'auth-one',
+      decision: 'always',
+    }),
+  })
+
+  // The spoken confirmation is receipt-based and always issued.
+  assert.equal(kit.outputs.at(-1)[1].status, 'submitted')
+  await new Promise(resolve => setImmediate(resolve))
+  // Delivery failed: the local auto-allow rolls back and the gateway is told
+  // so the pending permission can be re-announced.
+  assert.equal(permissionPolicy.shouldAutoAllow('owner', 'voice'), false)
+  assert.equal(failures.length, 1)
+  assert.equal(failures[0].authorizationId, 'auth-one')
+  assert.equal(failures[0].decision, 'always')
+  assert.match(failures[0].error, /backend unreachable/)
   await kit.finish()
 })
 
@@ -551,8 +652,10 @@ test('accepts a semantic permission decision without an evidence field', async (
     }),
   })
 
+  // The verbatim delivery lands asynchronously behind the receipt.
+  assert.equal(kit.outputs.at(-1)[1].status, 'submitted')
+  await new Promise(resolve => setImmediate(resolve))
   assert.deepEqual(calls, [{ id: 'auth-one', decision: 'always' }])
-  assert.equal(kit.outputs.at(-1)[1].status, 'approved')
   await kit.finish()
 })
 


### PR DESCRIPTION
## 动机

前台工具按语义分两类，延迟预算应完全不同：

- **受理型**（`spawn_thinking`、`respond_agent_permission`）：回执只代表"我说到了"，真实结果走播报路径。但现状受理前同步等待 ASR 转写就绪（0–800ms）、后台健康检查往返、ACP 权限往返（数百 ms–秒级），用户说"帮我查X"到听到"好，我去查"最差要 1–2 秒。
- **结果型**（`memory`/`notes`/`get_current_time`/`schedule_reminder`）：回执就是答案，本地微秒级，本来就对，不动。

本 PR 把受理型工具的回执降到响应队列允许的最快时机；失败可见性由既有异步播报机制承接。

## 改动

### `spawn_thinking` 受理即回（最差 ~1s → ~1ms）
- 健康检查改读 **`BackendAvailability` 缓存快照**（15s TTL、后台自刷新、并发探测去重、永不 reject）：已知未配置/已知挂了仍即时失败；未知/正常乐观受理，dispatch 失败走既有 `announcements.failed` 播报
- **用户原话在受理时"钉住"**：发起转写解析但不 await（waiter 当场注册，ASR 结果一到即被 promise 捕获），dispatch 时 await 已 settle 的 promise——回执零等待、转写零丢失、对环形缓冲驱逐免疫
- 模型漏传 objective 的罕见情况保留转写慢路径兜底

### `respond_agent_permission` 受理即回（秒级 → 即时）
- 本地安全闸门全部保留（authorization 校验、转写证据、`applyDecision` 即时生效）
- ACP 往返 fire-and-forget：立即回 `submitted`；投递失败时回滚本地 policy，网关清除 announced 标记，**现成的 pending 权限重播报机制自动再次询问**（重新询问即最自然的纠正）
- 话术从"权限已经成功生效"调整为"权限决定已提交"，不再承诺后台已确认

## 语义变化（认账部分）

| 场景 | 之前 | 之后 |
|------|------|------|
| 后台"看起来正常实际刚挂" | 本轮即时报错 | 先受理，~2s 后播报纠正（已知故障仍即时报错） |
| 权限投递失败（罕见） | 本轮报错 | 先说"已允许"，随后重新询问 |
| 用户原话保真 | 受理时锁定 | 受理时钉住（同一 800ms 窗口，后台等待），dispatch 消费 |

## 测试

- **727/727 全量通过**（server 400）
- 新增 `backend-availability.test.mjs`（5 用例：乐观初值、TTL 缓存、探测失败、并发去重、未配置记忆）
- 新增/更新 handler 用例：known-down/未配置即时失败、未知乐观受理且 dispatch 失败落在任务上、无转写也即时 accepted、**驱逐免疫回归**（占住 FIFO lane → 25 轮挤出转写 → coordinator 仍收到用户原话）、权限投递失败回滚 + 回调

## 风险审查记录

评审中确认过的边界：转写按 turnId 键控不可能串轮；用户打断/ASR 缺失回落 objective；连接关闭 waiter 空串 flush；环形缓冲驱逐风险由"受理时钉住"根除（第二个 commit）。
