### PR TITLE
docs: use English architecture diagrams in the English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ https://github.com/user-attachments/assets/42022655-36d1-46b2-9c26-ff0765284000
 
 ## Architecture
 
-![qwen-audio-agent architecture](docs/architecture-overview.png)
+![qwen-audio-agent architecture](docs/architecture-overview-en.png)
 
 Questions that can be answered directly are answered immediately; when tools
 or sustained processing are needed, the task is delegated to the backend Agent.
@@ -75,7 +75,7 @@ Throughout, the user always faces the same assistant.
 <details open>
 <summary>View detailed architecture</summary>
 
-![qwen-audio-agent reference architecture](docs/qwen-audio-agent-three-layer-architecture.png)
+![qwen-audio-agent reference architecture](docs/qwen-audio-agent-three-layer-architecture-en.png)
 
 For the full design and module breakdown, see the [architecture document](docs/architecture.md).
 


### PR DESCRIPTION
README.md 翻转为英文主页后，Architecture 小节引用的两张图（架构总览 `architecture-overview.png`、三层参考架构 `qwen-audio-agent-three-layer-architecture.png`）仍是中文渲染版。改为指向已存在的 `-en` 英文版本；`README_ZH.md` 保持引用中文图不变。

- 已目检两张 `-en` 图内容为英文且与当前架构一致（spawn/status/cancel 工具、TaskManager 生命周期、ACP Adapter、三层结构）
- verify-package 自检通过（图片在 files 白名单内，无失效链接）