### PR TITLE
release: v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.6.1
+
+- 后台委托类工具受理即回：提交任务与回复权限决定不再等待转写就绪、后台健康检查
+  或 ACP 往返，语音确认从最差 1–2 秒降到即时；失败由既有播报路径异步纠正。
+- 修复快捷键唤醒后前台语音连接无法恢复的问题；修复静音期间唤醒词监听失效。
+- 内置 computer-use：每个后台 Agent Session 自动注入 open-computer-use 内置 MCP
+  （点击/输入/截屏类工具），后台 Agent 未配置 computer-use 能力时开箱可用；
+  CLI 与桌面版均支持，可用 QWEN_AUDIO_AGENT_COMPUTER_USE=off 关闭。
+- 文档双语化：README 英文优先展示（中文版移至 README_ZH），主题文档中英文
+  平行并存；新增 Qwen3-TTS 中文稳定配置指南；修复 CI 依赖漏洞。
+
 ## 1.6.0
 
 - 桌面版正式支持 Windows：启动脚本全面迁移到跨平台 .mjs，修复 Windows 下的

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ tells you:
 
 ## News
 
+- **2026-08-07 · [v1.6.1](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.6.1)**
+  ⚡ Task delegation and permission decisions confirm instantly; 🖥️ built-in computer-use lets backend Agents operate the computer out of the box; 🎙️ more reliable wake; 📚 fully bilingual docs.
 - **2026-08-06 · [v1.6.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.6.0)**
   🪟 Desktop app now officially supports Windows; 🧠 adds invisible memory with automatic extraction after each session.
 - **2026-08-05 · [v1.5.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.5.0)**

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -20,6 +20,8 @@
 
 ## News
 
+- **2026-08-07 · [v1.6.1](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.6.1)**
+  ⚡ 委派任务与权限确认即说即回；🖥️ 内置 computer-use，后台 Agent 开箱可操作电脑；🎙️ 唤醒更可靠；📚 文档全面双语化。
 - **2026-08-06 · [v1.6.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.6.0)**
   🪟 桌面版正式支持 Windows；🧠 新增无感记忆，会话结束后自动提取。
 - **2026-08-05 · [v1.5.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.5.0)**

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/cli",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "bin": {
     "qwenaudio": "./bin/qwenaudio.mjs"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/desktop",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "main": "src/main.mjs",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-audio-agent",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-audio-agent",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "workspaces": [
         "server",
@@ -44,14 +44,14 @@
     },
     "cli": {
       "name": "@qwen-audio-agent/cli",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "bin": {
         "qwenaudio": "bin/qwenaudio.mjs"
       }
     },
     "desktop": {
       "name": "@qwen-audio-agent/desktop",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "ws": "8.21.1"
       },
@@ -8891,7 +8891,7 @@
     },
     "server": {
       "name": "@qwen-audio-agent/server",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.3.0",
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -8906,14 +8906,14 @@
     },
     "tui": {
       "name": "@qwen-audio-agent/tui",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "ws": "^8.18.3"
       }
     },
     "web": {
       "name": "@qwen-audio-agent/web",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "@vitejs/plugin-react": "^4.7.0",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-audio-agent",
   "desktopName": "qwen-audio-agent.desktop",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A realtime voice frontend for mainstream AI agents.",
   "author": "qwen-audio-agent contributors",
   "license": "Apache-2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/server",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "dev": "node --watch src/index.mjs",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/tui",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "start": "node src/index.mjs",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qwen-audio-agent/web",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",


### PR DESCRIPTION
v1.6.1 补丁发版。自 v1.6.0 以来 10 个 PR（#100–#110），已完成合理性审查与全面测试。

## 本版核心

- **后台委托类工具受理即回**（#109）：提交任务与回复权限决定不再等待转写就绪、后台健康检查或 ACP 往返，语音确认从最差 1–2 秒降到即时；失败由既有播报路径异步纠正
- **内置 computer-use**（#103/#106）：每个后台 Agent Session 自动注入 open-computer-use 内置 MCP（点击/输入/截屏类工具），CLI 与桌面版开箱可用，`QWEN_AUDIO_AGENT_COMPUTER_USE=off` 可关闭
- **唤醒可靠性**（#101/#107）：快捷键唤醒后语音连接稳定恢复；静音期间唤醒词持续监听
- **文档双语化**（#103/#104/#105/#108/#110）：README 英文优先、主题文档中英平行、Qwen3-TTS 中文稳定配置指南、英文架构图、CI 依赖漏洞修复

## 发版检查

- 728/728 单测全绿（六个 workspace）
- memory 提取 E2E 4/4、全进程网关冒烟通过、依赖审计通过
- release:check / verify-package 通过（1.6.1 tgz，179 文件）
- revert #97 残留检查干净
- README News（中英）与 CHANGELOG 已更新

合并本 PR 后 Release workflow 将自动完成 verify/tag/npm publish/桌面签名公证/GitHub Release。
