### PR TITLE
fix(desktop): skip cmd.exe shell wrapper for .exe ACP commands on windows

### DIFF
--- a/server/src/agent/acp-process-client.mjs
+++ b/server/src/agent/acp-process-client.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { extname } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { stripVTControlCharacters } from 'node:util'
 import * as acp from '@agentclientprotocol/sdk'
@@ -119,11 +120,16 @@ export class AcpProcessClient {
 
   async startProcess() {
     this.stderr = ''
+    const isWindows = process.platform === 'win32'
+    // .exe 文件不需要 cmd.exe 包装；直接 spawn 避免路径含空格时
+    // cmd.exe 将第一个空格前的内容误解析为命令名。
+    const commandExt = isWindows ? extname(String(this.command)).toLowerCase() : ''
+    const useShell = isWindows && commandExt !== '.exe'
     const child = this.spawn(this.command, this.args, {
         cwd: this.cwd,
         env: this.env,
         stdio: ['pipe', 'pipe', 'pipe'],
-        shell: process.platform === 'win32',
+        shell: useShell,
       })
     const processLogger = logger.child({ subsystem: 'acp', backend: this.label })
     processLogger.info('acp.process_started', {


### PR DESCRIPTION
## Summary

修复 Windows 打包版（`desktop:build:win`）中 OpenCode 等部分后台 Agent 无法启动的问题。

## Problem

Windows 打包版中，OpenCode 后台 Agent 显示 `closed` 状态，错误信息为安装路径前缀（如 `D:\projects\...\installed\Qwen…`）。Qoder 等其他后端正常。

### Root Cause

`AcpProcessClient` 在 Windows 上统一使用 `shell: true` 启动 ACP 子进程。当应用名含空格时（如 `Qwen Audio Agent`），Electron 可执行文件路径为：

```
D:\...\Qwen Audio Agent\Qwen Audio Agent.exe
```

`shell: true` 将命令传给 `cmd.exe` 时不做引号包裹，`cmd.exe` 将第一个空格前的内容当作命令名：

```
cmd.exe /d /s /c D:\...\Qwen Audio Agent.exe ...
              → 命令: D:\...\Qwen  ← 报错: '...\Qwen' is not recognized
```

OpenCode 的 ACP 命令为 `process.execPath`（完整 exe 路径，含空格），而 Qoder 的 ACP 命令为 `qodercli`（纯命令名，无空格），故 Qoder 不受影响。开发模式下 `electron.exe` 路径通常不含空格，也不受影响。

## Change

`server/src/agent/acp-process-client.mjs`

对 `.exe` 文件跳过 `shell: true`，直接通过 `spawn` 启动。Windows 的 `CreateProcessW` 原生支持 `.exe` 文件，无需 `cmd.exe` 包装。`.cmd` / `.bat` 文件仍使用 `shell: true`。

```diff
- import { spawn } from 'node:child_process'
+ import { spawn } from 'node:child_process'
+ import { extname } from 'node:path'

- shell: process.platform === 'win32',
+ const isWindows = process.platform === 'win32'
+ const commandExt = isWindows ? extname(String(this.command)).toLowerCase() : ''
+ const useShell = isWindows && commandExt !== '.exe'
+ shell: useShell,
```

## Test Plan

- [x] 打包版 Windows 应用中 OpenCode 可正常启动
- [x] Qoder Agent 仍正常工作
- [x] 开发模式下 OpenCode 仍正常工作
- [x] Server 单测 ACP 相关用例全部通过