### PR TITLE
feat(desktop): 悬浮球皮肤解耦，支持自定义皮肤导入

### DIFF
--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -17,7 +17,7 @@ import {
   readFileSync,
   writeFileSync,
 } from 'node:fs'
-import { dirname, resolve, win32 } from 'node:path'
+import { dirname, join, resolve, win32 } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { parseEnv } from 'node:util'
 import {
@@ -61,6 +61,16 @@ import {
   realtimeSettingsConfigured,
   updateSettingsContent,
 } from './settings-config.mjs'
+import {
+  importSkin,
+  listSkins,
+  removeSkin,
+  skinsDirectory,
+} from './skin-store.mjs'
+import {
+  BUILTIN_ORB_SKINS,
+  isBuiltinOrbSkin,
+} from '../../shared/orb-skin-catalog.mjs'
 import {
   startDesktopRendererServer,
 } from './renderer-server.mjs'
@@ -117,6 +127,14 @@ const logger = createLogger({
   component: 'desktop',
   fileName: 'desktop.log',
 })
+const skinsRoot = skinsDirectory(runtimeEnvironment.configDirectory)
+
+// 生效皮肤：内置 id 直接用；导入皮肤需皮肤包仍在，缺失回退 fluid。
+function effectiveOrbSkin(orbSkin) {
+  if (isBuiltinOrbSkin(orbSkin)) return orbSkin
+  if (existsSync(join(skinsRoot, orbSkin, 'pet.json'))) return orbSkin
+  return 'fluid'
+}
 logger.info('desktop.starting', {
   version: app.getVersion(),
   packaged: app.isPackaged,
@@ -310,6 +328,7 @@ async function ensureDesktopUi() {
     rendererServer = await startDesktopRendererServer({
       webRoot,
       target: () => appOrigin,
+      skinsRoot,
     })
   }
   if (!mainWindow || mainWindow.isDestroyed()) {
@@ -324,6 +343,7 @@ async function startConfiguredRuntime(settings = configuredOrigin().settings) {
     : configuredGatewayOrigin
   process.env.QWEN_AUDIO_AGENT_URL = appOrigin
   process.env.QWEN_AUDIO_ORB_STYLE = settings.orbStyle
+  process.env.QWEN_AUDIO_ORB_SKIN = settings.orbSkin
   await ensureDesktopUi()
   lastRuntimeError = ''
   return appOrigin
@@ -410,7 +430,7 @@ async function loadQwenAudioAgent(window) {
       process.env,
     )
     await window.loadURL(desktopOrbUrl(rendererServer.baseUrl, {
-      orbStyle: settings.orbStyle,
+      orbSkin: effectiveOrbSkin(settings.orbSkin),
       autoHideSeconds: settings.autoHideSeconds,
       wakeWordEnabled: settings.wakeWordEnabled,
     }))
@@ -691,6 +711,7 @@ ipcMain.handle('qwen-audio-agent:settings-load', async event => {
   )
   return {
     settings,
+    skins: [...BUILTIN_ORB_SKINS, ...listSkins(skinsRoot)],
     runtime: setupRequired
       ? {
           gatewayConnected: false,
@@ -1011,7 +1032,7 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
       !== normalized.speechToSpeechAuthToken
   )
   const backendModelChanged = previous.backendModel !== normalized.backendModel
-  const orbStyleChanged = previous.orbStyle !== normalized.orbStyle
+  const orbSkinChanged = previous.orbSkin !== normalized.orbSkin
   const autoHideChanged = (
     previous.autoHideSeconds !== normalized.autoHideSeconds
   )
@@ -1078,7 +1099,7 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
       realtimeModel: realtimeModelChanged,
       speechToSpeech: speechToSpeechChanged,
       backendModel: backendModelChanged,
-      orbStyle: orbStyleChanged,
+      orbSkin: orbSkinChanged,
       autoHide: autoHideChanged,
       wakeShortcut: wakeShortcutChanged,
       wakeWord: wakeWordChanged,
@@ -1109,10 +1130,11 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
   lastRuntimeError = ''
   process.env.QWEN_AUDIO_AGENT_URL = appOrigin
   process.env.QWEN_AUDIO_ORB_STYLE = normalized.orbStyle
+  process.env.QWEN_AUDIO_ORB_SKIN = normalized.orbSkin
   await ensureDesktopUi()
   const runtime = await runtimeStatus(appOrigin)
   if (
-    (restarted || gatewayChanged || orbStyleChanged || autoHideChanged)
+    (restarted || gatewayChanged || orbSkinChanged || autoHideChanged)
     && mainWindow
     && !mainWindow.isDestroyed()
   ) {
@@ -1125,6 +1147,36 @@ ipcMain.handle('qwen-audio-agent:settings-save', async (event, settings) => {
     runtime,
     wakeShortcutRegistered: desktopPresence.shortcutRegistered,
   }
+})
+
+ipcMain.handle('qwen-audio-agent:skin-import', async event => {
+  if (!settingsWindow || event.sender !== settingsWindow.webContents) {
+    throw new Error('无权导入皮肤')
+  }
+  const selection = await dialog.showOpenDialog(settingsWindow, {
+    title: '导入皮肤',
+    // macOS 支持同时选文件与文件夹；其余平台选 zip 或皮肤包里的 pet.json。
+    properties: process.platform === 'darwin'
+      ? ['openFile', 'openDirectory']
+      : ['openFile'],
+    filters: [{ name: '皮肤包', extensions: ['zip', 'json'] }],
+  })
+  if (selection.canceled || !selection.filePaths.length) return null
+  const imported = await importSkin({
+    source: selection.filePaths[0],
+    skinsRoot,
+  })
+  logger.info('skin.imported', { id: imported.id })
+  return imported
+})
+
+ipcMain.handle('qwen-audio-agent:skin-remove', async (event, id) => {
+  if (!settingsWindow || event.sender !== settingsWindow.webContents) {
+    throw new Error('无权删除皮肤')
+  }
+  const removed = removeSkin({ id, skinsRoot })
+  if (removed) logger.info('skin.removed', { id: String(id) })
+  return { removed }
 })
 
 ipcMain.on('qwen-audio-agent:quit', event => {

--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -73,6 +73,8 @@ contextBridge.exposeInMainWorld('qwenAudioAgentDesktop', {
     'qwen-audio-agent:settings-save',
     settings,
   ),
+  importSkin: () => ipcRenderer.invoke('qwen-audio-agent:skin-import'),
+  removeSkin: id => ipcRenderer.invoke('qwen-audio-agent:skin-remove', id),
   setNodePath: nodePath => ipcRenderer.invoke(
     'qwen-audio-agent:set-node-path',
     nodePath,

--- a/desktop/src/renderer-server.mjs
+++ b/desktop/src/renderer-server.mjs
@@ -216,9 +216,43 @@ async function serveStatic(response, request, webRoot, pathname) {
   createReadStream(filePath).pipe(response)
 }
 
+async function serveSkinStatic(response, request, skinsRoot, pathname) {
+  if (!['GET', 'HEAD'].includes(request.method || 'GET')) {
+    sendError(response, 405, 'method not allowed')
+    return
+  }
+  const filePath = skinsRoot ? safeStaticPath(skinsRoot, pathname) : null
+  if (!filePath) {
+    sendError(response, 404, 'not found')
+    return
+  }
+  try {
+    if (!(await stat(filePath)).isFile()) throw new Error('not a file')
+  } catch {
+    // 皮肤资源缺失直接 404，不回退 index.html。
+    sendError(response, 404, 'not found')
+    return
+  }
+  const extension = extname(filePath).toLowerCase()
+  response.writeHead(200, {
+    'cache-control': 'no-store',
+    'content-security-policy': CSP,
+    'content-type': CONTENT_TYPES.get(extension) || 'application/octet-stream',
+    'cross-origin-resource-policy': 'same-origin',
+    'x-content-type-options': 'nosniff',
+    'x-frame-options': 'DENY',
+  })
+  if (request.method === 'HEAD') {
+    response.end()
+    return
+  }
+  createReadStream(filePath).pipe(response)
+}
+
 export async function startDesktopRendererServer({
   webRoot,
   target,
+  skinsRoot = '',
   token = randomBytes(24).toString('hex'),
 } = {}) {
   if (!webRoot) throw new Error('desktop renderer web root is required')
@@ -243,6 +277,15 @@ export async function startDesktopRendererServer({
       }
       request.url = `/${pathname}${url.search}`
       proxyHttp(request, response, target)
+      return
+    }
+    if (pathname.startsWith('skins/')) {
+      void serveSkinStatic(
+        response,
+        request,
+        skinsRoot,
+        pathname.slice('skins/'.length),
+      )
       return
     }
     void serveStatic(response, request, webRoot, pathname)

--- a/desktop/src/security.mjs
+++ b/desktop/src/security.mjs
@@ -1,3 +1,8 @@
+import {
+  isBuiltinOrbSkin,
+  normalizeOrbSkinId,
+} from '../../shared/orb-skin-catalog.mjs'
+
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '[::1]'])
 
 export function validateAppUrl(value) {
@@ -36,13 +41,18 @@ export function isSafeExternalUrl(value) {
 }
 
 export function desktopOrbUrl(value, {
-  orbStyle,
+  orbSkin,
   autoHideSeconds,
   wakeWordEnabled = false,
 } = {}) {
   const url = new URL(value)
   url.searchParams.set('desktop', 'orb')
-  if (orbStyle) url.searchParams.set('orbStyle', orbStyle)
+  const skinId = normalizeOrbSkinId(orbSkin)
+  if (skinId) {
+    url.searchParams.set('orbSkin', skinId)
+    // 内置 id 同时写旧参数，作为与旧 web/dist 的兼容缓冲。
+    if (isBuiltinOrbSkin(skinId)) url.searchParams.set('orbStyle', skinId)
+  }
   if (Number.isFinite(autoHideSeconds)) {
     url.searchParams.set('autoHideSeconds', String(autoHideSeconds))
   }

--- a/desktop/src/settings-config.mjs
+++ b/desktop/src/settings-config.mjs
@@ -4,6 +4,10 @@ import {
   normalizeBackendProtocol,
 } from '../../shared/backend-catalog.mjs'
 import {
+  normalizeOrbSkinId,
+  resolveOrbSkinId,
+} from '../../shared/orb-skin-catalog.mjs'
+import {
   DEFAULT_DASHSCOPE_REALTIME_MODEL,
   DEFAULT_REALTIME_PROVIDER,
   DEFAULT_SPEECH_TO_SPEECH_REALTIME_URL,
@@ -13,6 +17,7 @@ import {
 const DEFAULTS = {
   gatewayUrl: 'http://127.0.0.1:3101',
   orbStyle: 'fluid',
+  orbSkin: 'fluid',
   autoHideSeconds: 60,
   wakeShortcut: 'CommandOrControl+Shift+Space',
   wakeWordEnabled: false,
@@ -29,6 +34,7 @@ const DEFAULTS = {
 const SETTING_KEYS = {
   gatewayUrl: 'QWEN_AUDIO_AGENT_URL',
   orbStyle: 'QWEN_AUDIO_ORB_STYLE',
+  orbSkin: 'QWEN_AUDIO_ORB_SKIN',
   autoHideSeconds: 'QWEN_AUDIO_DESKTOP_AUTO_HIDE_SECONDS',
   wakeShortcut: 'QWEN_AUDIO_DESKTOP_WAKE_SHORTCUT',
   wakeWordEnabled: 'QWEN_AUDIO_WAKE_WORD_ENABLED',
@@ -143,6 +149,11 @@ export function parseSettings(content = '', fallback = {}) {
     'QWEN_AUDIO_ORB_STYLE',
     fallback.QWEN_AUDIO_ORB_STYLE || '',
   )
+  const configuredOrbSkin = configured(
+    values,
+    'QWEN_AUDIO_ORB_SKIN',
+    fallback.QWEN_AUDIO_ORB_SKIN || '',
+  )
   const configuredS2sUrl = configured(
     values,
     'SPEECH_TO_SPEECH_REALTIME_URL',
@@ -174,6 +185,11 @@ export function parseSettings(content = '', fallback = {}) {
     orbStyle: ['fluid', 'goo'].includes(
       String(configuredOrbStyle).toLowerCase(),
     ) ? String(configuredOrbStyle).toLowerCase() : DEFAULTS.orbStyle,
+    // 旧配置只有 QWEN_AUDIO_ORB_STYLE 时自动收敛为 orbSkin。
+    orbSkin: resolveOrbSkinId({
+      orbSkin: configuredOrbSkin,
+      orbStyle: configuredOrbStyle,
+    }),
     autoHideSeconds: cleanAutoHideSeconds(configured(
       values,
       'QWEN_AUDIO_DESKTOP_AUTO_HIDE_SECONDS',
@@ -248,6 +264,7 @@ export function normalizeSettings(settings = {}) {
     )
       ? String(settings.orbStyle || DEFAULTS.orbStyle).toLowerCase()
       : DEFAULTS.orbStyle,
+    orbSkin: normalizeOrbSkinId(settings.orbSkin) || DEFAULTS.orbSkin,
     autoHideSeconds: cleanAutoHideSeconds(
       settings.autoHideSeconds ?? DEFAULTS.autoHideSeconds,
     ),

--- a/desktop/src/settings.css
+++ b/desktop/src/settings.css
@@ -291,6 +291,56 @@ h2 {
   font-weight: 540;
 }
 
+.setting-inline {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.setting-inline > select {
+  flex: 1;
+  min-width: 0;
+}
+
+/* macOS 可编辑列表的 +/- 迷你按钮组（网络位置、登录项同款范式）。 */
+.manage-buttons {
+  display: flex;
+  flex: none;
+  border: 1px solid #c8c8cd;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 1px 1px #0000000a;
+}
+
+.manage-buttons button {
+  width: 26px;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: #3a3a3c;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.manage-buttons button + button {
+  border-left: 1px solid #d9d9de;
+}
+
+.manage-buttons button:hover:not(:disabled) {
+  background: #f0f0f3;
+}
+
+.manage-buttons button:active:not(:disabled) {
+  background: #e4e4e9;
+}
+
+.manage-buttons button:disabled {
+  color: #c0c2c8;
+}
+
 .provider-panel {
   display: contents;
 }

--- a/desktop/src/settings.html
+++ b/desktop/src/settings.html
@@ -248,10 +248,13 @@
 
               <div class="setting-row">
                 <label for="orb-style">外观</label>
-                <select id="orb-style">
-                  <option value="fluid">流光声波球</option>
-                  <option value="goo">液态渐变球</option>
-                </select>
+                <div class="setting-inline">
+                  <select id="orb-style"></select>
+                  <div class="manage-buttons" role="group" aria-label="管理皮肤">
+                    <button type="button" id="import-skin" title="导入皮肤…" aria-label="导入皮肤">＋</button>
+                    <button type="button" id="remove-skin" title="删除所选皮肤" aria-label="删除所选皮肤" disabled>－</button>
+                  </div>
+                </div>
               </div>
 
               <div class="setting-row">

--- a/desktop/src/settings.js
+++ b/desktop/src/settings.js
@@ -11,7 +11,9 @@ import { updaterButtonState, updaterStatusText } from './update-status.mjs'
 
 const form = document.querySelector('#settings-form')
 const gatewayUrl = document.querySelector('#gateway-url')
-const orbStyle = document.querySelector('#orb-style')
+const orbSkinSelect = document.querySelector('#orb-style')
+const importSkinButton = document.querySelector('#import-skin')
+const removeSkinButton = document.querySelector('#remove-skin')
 const autoHideSeconds = document.querySelector('#auto-hide-seconds')
 const wakeShortcut = document.querySelector('#wake-shortcut')
 const recordWakeShortcut = document.querySelector('#record-wake-shortcut')
@@ -50,6 +52,7 @@ const settingsTabs = [...document.querySelectorAll('[data-settings-tab]')]
 const settingsPanels = [...document.querySelectorAll('[data-settings-panel]')]
 
 let settings
+let skins = []
 let runtime
 let backendReport = null
 let appliedFingerprint = ''
@@ -543,7 +546,7 @@ const BAILIAN_API_KEY_URL = 'https://bailian.console.aliyun.com/?tab=model#/api-
 function formSettings() {
   return {
     gatewayUrl: gatewayUrl.value,
-    orbStyle: orbStyle.value,
+    orbSkin: orbSkinSelect.value,
     autoHideSeconds: Number(autoHideSeconds.value),
     wakeShortcut: wakeShortcut.value,
     wakeWordEnabled: wakeWordEnabled.checked,
@@ -561,7 +564,7 @@ function formSettings() {
 function fingerprint(value) {
   return JSON.stringify({
     gatewayUrl: value.gatewayUrl,
-    orbStyle: value.orbStyle,
+    orbSkin: value.orbSkin,
     autoHideSeconds: value.autoHideSeconds,
     wakeShortcut: value.wakeShortcut,
     wakeWordEnabled: value.wakeWordEnabled,
@@ -709,9 +712,46 @@ refreshBackends.addEventListener('click', () => {
   void detectBackendOptions(true)
 })
 
+function updateRemoveSkinState() {
+  // 只有选中已导入的 sprite 皮肤时才可删除；内置外观不可。
+  removeSkinButton.disabled = !skins.some(skin => (
+    skin.type === 'sprite' && skin.id === orbSkinSelect.value
+  ))
+}
+
+function renderSkinOptions(selected) {
+  orbSkinSelect.textContent = ''
+  const groups = [
+    { label: '内置', type: 'theme' },
+    { label: '已导入皮肤', type: 'sprite' },
+  ]
+  for (const group of groups) {
+    const items = skins.filter(skin => skin.type === group.type)
+    if (!items.length) continue
+    const optgroup = document.createElement('optgroup')
+    optgroup.label = group.label
+    for (const skin of items) {
+      const option = document.createElement('option')
+      option.value = skin.id
+      option.textContent = skin.displayName || skin.id
+      optgroup.append(option)
+    }
+    orbSkinSelect.append(optgroup)
+  }
+  // 皮肤包被手动删除后配置仍可能指向它：保留选项让用户看到现状。
+  if (selected && !skins.some(skin => skin.id === selected)) {
+    const missing = document.createElement('option')
+    missing.value = selected
+    missing.textContent = `${selected}（缺失）`
+    orbSkinSelect.append(missing)
+  }
+  orbSkinSelect.value = selected || 'fluid'
+  updateRemoveSkinState()
+}
+
 function render() {
   gatewayUrl.value = settings.gatewayUrl
-  orbStyle.value = settings.orbStyle
+  renderSkinOptions(settings.orbSkin)
   const hideValue = String(settings.autoHideSeconds ?? 120)
   autoHideSeconds.querySelector('[data-custom]')?.remove()
   if (![...autoHideSeconds.options].some(option => option.value === hideValue)) {
@@ -742,7 +782,7 @@ function render() {
 
 for (const control of [
   gatewayUrl,
-  orbStyle,
+  orbSkinSelect,
   autoHideSeconds,
   dashscopeApiKey,
   speechToSpeechRealtimeUrl,
@@ -768,6 +808,47 @@ for (const control of [
 
 getApiKey.addEventListener('click', () => {
   window.qwenAudioAgentDesktop.openExternal(BAILIAN_API_KEY_URL)
+})
+
+orbSkinSelect.addEventListener('change', updateRemoveSkinState)
+
+importSkinButton.addEventListener('click', async () => {
+  importSkinButton.disabled = true
+  try {
+    const imported = await window.qwenAudioAgentDesktop.importSkin()
+    if (!imported) return
+    skins = [
+      ...skins.filter(skin => skin.id !== imported.id),
+      { id: imported.id, type: 'sprite', displayName: imported.displayName },
+    ]
+    renderSkinOptions(imported.id)
+    showMessage(`已导入皮肤 ${imported.displayName}，点击应用后生效。`, 'notice')
+    updateApplyState()
+  } catch (error) {
+    showMessage(friendlyError(error, '导入皮肤失败'), 'error')
+  } finally {
+    importSkinButton.disabled = false
+    updateRemoveSkinState()
+  }
+})
+
+removeSkinButton.addEventListener('click', async () => {
+  const id = orbSkinSelect.value
+  const skin = skins.find(item => item.type === 'sprite' && item.id === id)
+  if (!skin) return
+  removeSkinButton.disabled = true
+  try {
+    await window.qwenAudioAgentDesktop.removeSkin(id)
+    skins = skins.filter(item => item.id !== id)
+    // 删掉的可能正是当前皮肤：回到内置外观，由用户点应用持久化。
+    renderSkinOptions('fluid')
+    showMessage(`已删除皮肤 ${skin.displayName}，点击应用后生效。`, 'notice')
+    updateApplyState()
+  } catch (error) {
+    showMessage(friendlyError(error, '删除皮肤失败'), 'error')
+  } finally {
+    updateRemoveSkinState()
+  }
 })
 
 // "确认"按钮：保存自定义 Node.js 路径后立即重检并重试安装
@@ -838,6 +919,7 @@ form.addEventListener('submit', async event => {
 
 window.qwenAudioAgentDesktop.loadSettings().then(value => {
   settings = value.settings
+  skins = value.skins || []
   runtime = value.runtime
   renderWakeShortcutStatus(value.wakeShortcutRegistered)
   render()

--- a/desktop/src/skin-store.mjs
+++ b/desktop/src/skin-store.mjs
@@ -1,0 +1,362 @@
+// 桌面版皮肤存储与导入：Codex pet 包格式（pet.json + spritesheet.webp）。
+// 纯 Node 模块，不依赖 Electron，zip 解压通过注入的系统工具执行。
+
+import { execFile } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from 'node:fs'
+import { basename, dirname, join, relative, resolve } from 'node:path'
+import { promisify } from 'node:util'
+import {
+  isBuiltinOrbSkin,
+  ORB_SKIN_ID_PATTERN,
+} from '../../shared/orb-skin-catalog.mjs'
+
+const execFileAsync = promisify(execFile)
+
+const MAX_SPRITESHEET_BYTES = 8 * 1024 * 1024
+// 与 Codex App 的 MAX_PET_FRAMES 对齐。
+const MAX_PET_FRAMES = 256
+const MAX_ANIMATION_FPS = 60
+const DEFAULT_FRAME_SPEC = Object.freeze({
+  width: 192,
+  height: 208,
+  columns: 8,
+  rows: 9,
+})
+const V2_DEFAULT_ROWS = 11
+// 渲染端默认轨道名，自定义 animations 的 fallback 必须落在
+// 自定义名或这张表内。
+export const DEFAULT_ANIMATION_NAMES = Object.freeze([
+  'idle',
+  'running-right',
+  'running-left',
+  'waving',
+  'jumping',
+  'failed',
+  'waiting',
+  'running',
+  'review',
+  'working',
+  'attention',
+])
+
+export function skinsDirectory(configDirectory) {
+  return join(configDirectory, 'skins')
+}
+
+function readUInt24LE(buffer, offset) {
+  return buffer[offset] | (buffer[offset + 1] << 8) | (buffer[offset + 2] << 16)
+}
+
+// 最小 WebP 头解析，覆盖 VP8X（扩展）、VP8（有损）、VP8L（无损）三种布局。
+export function webpDimensions(buffer) {
+  if (
+    buffer.length < 30
+    || buffer.toString('latin1', 0, 4) !== 'RIFF'
+    || buffer.toString('latin1', 8, 12) !== 'WEBP'
+  ) {
+    return null
+  }
+  const chunk = buffer.toString('latin1', 12, 16)
+  if (chunk === 'VP8X') {
+    return {
+      width: 1 + readUInt24LE(buffer, 24),
+      height: 1 + readUInt24LE(buffer, 27),
+    }
+  }
+  if (chunk === 'VP8 ') {
+    if (buffer[23] !== 0x9d || buffer[24] !== 0x01 || buffer[25] !== 0x2a) {
+      return null
+    }
+    return {
+      width: buffer.readUInt16LE(26) & 0x3fff,
+      height: buffer.readUInt16LE(28) & 0x3fff,
+    }
+  }
+  if (chunk === 'VP8L') {
+    if (buffer[20] !== 0x2f) return null
+    const bits = buffer.readUInt32LE(21)
+    return {
+      width: (bits & 0x3fff) + 1,
+      height: ((bits >> 14) & 0x3fff) + 1,
+    }
+  }
+  return null
+}
+
+function positiveInteger(value) {
+  return Number.isInteger(value) && value > 0
+}
+
+function frameSpec(manifest) {
+  const version = manifest.spriteVersionNumber ?? 1
+  const fallbackRows = version === 2 ? V2_DEFAULT_ROWS : DEFAULT_FRAME_SPEC.rows
+  const spec = manifest.frame && typeof manifest.frame === 'object'
+    ? manifest.frame
+    : {
+        ...DEFAULT_FRAME_SPEC,
+        rows: fallbackRows,
+      }
+  for (const key of ['width', 'height', 'columns', 'rows']) {
+    if (!positiveInteger(spec[key])) {
+      throw new Error(`皮肤包 frame.${key} 必须是正整数`)
+    }
+  }
+  return {
+    width: spec.width,
+    height: spec.height,
+    columns: spec.columns,
+    rows: spec.rows,
+  }
+}
+
+function validateAnimations(manifest, frameCount) {
+  const specs = manifest.animations
+  if (specs === undefined) return undefined
+  if (!specs || typeof specs !== 'object' || Array.isArray(specs)) {
+    throw new Error('皮肤包 animations 必须是对象')
+  }
+  const names = new Set([
+    ...DEFAULT_ANIMATION_NAMES,
+    ...Object.keys(specs),
+  ])
+  for (const [name, spec] of Object.entries(specs)) {
+    if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+      throw new Error(`皮肤包动画 ${name} 定义必须是对象`)
+    }
+    if (!Array.isArray(spec.frames) || spec.frames.length === 0) {
+      throw new Error(`皮肤包动画 ${name} 至少要包含一帧`)
+    }
+    for (const index of spec.frames) {
+      if (!Number.isInteger(index) || index < 0 || index >= frameCount) {
+        throw new Error(`皮肤包动画 ${name} 引用了越界的帧索引 ${index}`)
+      }
+    }
+    if (spec.fps !== undefined) {
+      if (
+        typeof spec.fps !== 'number'
+        || !Number.isFinite(spec.fps)
+        || spec.fps <= 0
+        || spec.fps > MAX_ANIMATION_FPS
+      ) {
+        throw new Error(
+          `皮肤包动画 ${name} 的 fps 必须在 0 到 ${MAX_ANIMATION_FPS} 之间`,
+        )
+      }
+    }
+    if (spec.fallback !== undefined && spec.fallback !== '') {
+      if (!names.has(spec.fallback)) {
+        throw new Error(`皮肤包动画 ${name} 的 fallback ${spec.fallback} 不存在`)
+      }
+    }
+  }
+  return specs
+}
+
+export function validateSkinPackage(dir) {
+  const manifestPath = join(dir, 'pet.json')
+  if (!existsSync(manifestPath)) {
+    throw new Error('皮肤包缺少 pet.json')
+  }
+  let manifest
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+  } catch {
+    throw new Error('皮肤包 pet.json 不是有效的 JSON')
+  }
+  const id = String(manifest.id || '').trim()
+  if (!ORB_SKIN_ID_PATTERN.test(id)) {
+    throw new Error('皮肤包 pet.json 缺少合法的 id')
+  }
+  const spritesheetRelative = String(
+    manifest.spritesheetPath || 'spritesheet.webp',
+  ).trim()
+  const spritesheetPath = resolve(dir, spritesheetRelative)
+  const pathFromDir = relative(resolve(dir), spritesheetPath)
+  if (pathFromDir.startsWith('..') || pathFromDir.includes('\0')) {
+    throw new Error('皮肤包 spritesheetPath 不能指向包目录之外')
+  }
+  if (!existsSync(spritesheetPath) || !statSync(spritesheetPath).isFile()) {
+    throw new Error(`皮肤包缺少贴图文件 ${spritesheetRelative}`)
+  }
+  if (statSync(spritesheetPath).size > MAX_SPRITESHEET_BYTES) {
+    throw new Error('皮肤包贴图超过 8MB 上限')
+  }
+  const frame = frameSpec(manifest)
+  const frameCount = frame.columns * frame.rows
+  if (frameCount > MAX_PET_FRAMES) {
+    throw new Error(`皮肤包总帧数不能超过 ${MAX_PET_FRAMES}`)
+  }
+  const dimensions = webpDimensions(readFileSync(spritesheetPath))
+  if (!dimensions) {
+    throw new Error('皮肤包贴图不是有效的 WebP 文件')
+  }
+  const expectedWidth = frame.columns * frame.width
+  const expectedHeight = frame.rows * frame.height
+  if (
+    dimensions.width !== expectedWidth
+    || dimensions.height !== expectedHeight
+  ) {
+    throw new Error(
+      `皮肤包贴图尺寸应为 ${expectedWidth}x${expectedHeight}，`
+      + `实际是 ${dimensions.width}x${dimensions.height}`,
+    )
+  }
+  return {
+    id,
+    displayName: String(manifest.displayName || id).trim() || id,
+    spriteVersionNumber: manifest.spriteVersionNumber ?? 1,
+    spritesheetPath: spritesheetRelative,
+    frame,
+    animations: validateAnimations(manifest, frameCount),
+  }
+}
+
+export async function extractZipArchive(zipPath, destination) {
+  mkdirSync(destination, { recursive: true })
+  if (process.platform === 'darwin') {
+    await execFileAsync('ditto', ['-x', '-k', zipPath, destination])
+    return
+  }
+  if (process.platform === 'win32') {
+    await execFileAsync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      'Expand-Archive -LiteralPath $env:QWEN_AUDIO_SKIN_ZIP '
+      + '-DestinationPath $env:QWEN_AUDIO_SKIN_DEST -Force',
+    ], {
+      env: {
+        ...process.env,
+        QWEN_AUDIO_SKIN_ZIP: zipPath,
+        QWEN_AUDIO_SKIN_DEST: destination,
+      },
+    })
+    return
+  }
+  await execFileAsync('unzip', ['-o', '-q', zipPath, '-d', destination])
+}
+
+function locateSkinRoot(extractedDir) {
+  if (existsSync(join(extractedDir, 'pet.json'))) return extractedDir
+  const entries = readdirSync(extractedDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && !entry.name.startsWith('.'))
+  if (
+    entries.length === 1
+    && existsSync(join(extractedDir, entries[0].name, 'pet.json'))
+  ) {
+    return join(extractedDir, entries[0].name)
+  }
+  throw new Error('压缩包内没有找到 pet.json')
+}
+
+function stageSkin(sourceDir, info, skinsRoot) {
+  const staging = join(
+    skinsRoot,
+    `.install-${randomBytes(6).toString('hex')}`,
+  )
+  try {
+    mkdirSync(join(staging, dirname(info.spritesheetPath)), {
+      recursive: true,
+    })
+    cpSync(join(sourceDir, 'pet.json'), join(staging, 'pet.json'))
+    cpSync(
+      resolve(sourceDir, info.spritesheetPath),
+      join(staging, info.spritesheetPath),
+    )
+    const target = join(skinsRoot, info.id)
+    rmSync(target, { recursive: true, force: true })
+    renameSync(staging, target)
+  } catch (error) {
+    rmSync(staging, { recursive: true, force: true })
+    throw error
+  }
+}
+
+export async function importSkin({
+  source,
+  skinsRoot,
+  extractZip = extractZipArchive,
+}) {
+  const sourcePath = resolve(String(source || ''))
+  if (!existsSync(sourcePath)) {
+    throw new Error('皮肤路径不存在')
+  }
+  mkdirSync(skinsRoot, { recursive: true })
+  let packageDir = ''
+  let temporaryDir = ''
+  if (statSync(sourcePath).isDirectory()) {
+    packageDir = sourcePath
+  } else if (basename(sourcePath) === 'pet.json') {
+    packageDir = dirname(sourcePath)
+  } else if (sourcePath.toLowerCase().endsWith('.zip')) {
+    temporaryDir = join(
+      skinsRoot,
+      `.import-${randomBytes(6).toString('hex')}`,
+    )
+    await extractZip(sourcePath, temporaryDir)
+    packageDir = locateSkinRoot(temporaryDir)
+  } else {
+    throw new Error('请选择皮肤文件夹、pet.json 或 zip 压缩包')
+  }
+  try {
+    const info = validateSkinPackage(packageDir)
+    if (isBuiltinOrbSkin(info.id)) {
+      throw new Error(`皮肤 id ${info.id} 是内置皮肤保留名`)
+    }
+    stageSkin(packageDir, info, skinsRoot)
+    return { id: info.id, displayName: info.displayName }
+  } finally {
+    if (temporaryDir) rmSync(temporaryDir, { recursive: true, force: true })
+  }
+}
+
+export function removeSkin({ id, skinsRoot }) {
+  const skinId = String(id || '').trim()
+  // id 模式校验同时排除了路径分隔符，join 不会逃出 skins 目录。
+  if (!ORB_SKIN_ID_PATTERN.test(skinId)) {
+    throw new Error('皮肤 id 不合法')
+  }
+  if (isBuiltinOrbSkin(skinId)) {
+    throw new Error('内置外观不能删除')
+  }
+  const target = join(skinsRoot, skinId)
+  if (!existsSync(target)) return false
+  rmSync(target, { recursive: true, force: true })
+  return true
+}
+
+export function listSkins(skinsRoot) {
+  let entries
+  try {
+    entries = readdirSync(skinsRoot, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const skins = []
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.startsWith('.')) continue
+    try {
+      const info = validateSkinPackage(join(skinsRoot, entry.name))
+      // 目录名必须与 pet.json id 一致，URL 路由按目录名寻址。
+      if (info.id !== entry.name) continue
+      skins.push({
+        id: info.id,
+        type: 'sprite',
+        displayName: info.displayName,
+      })
+    } catch {
+      // 坏包跳过，不影响其他皮肤。
+    }
+  }
+  return skins.sort((a, b) => a.id.localeCompare(b.id))
+}

--- a/desktop/test/renderer-server.test.mjs
+++ b/desktop/test/renderer-server.test.mjs
@@ -75,6 +75,81 @@ test('serves bundled assets and proxies only the protected API path', async t =>
   assert.equal(unprotectedResponse.status, 404)
 })
 
+test('serves imported skin assets without falling back to index.html', async t => {
+  const webRoot = await mkdtemp(resolve(tmpdir(), 'qwaudio-renderer-'))
+  await writeFile(resolve(webRoot, 'index.html'), '<!doctype html>')
+  const skinsRoot = await mkdtemp(resolve(tmpdir(), 'qwaudio-skins-'))
+  await mkdir(resolve(skinsRoot, 'firefly--lingxiaotian'))
+  await writeFile(
+    resolve(skinsRoot, 'firefly--lingxiaotian/pet.json'),
+    '{"id":"firefly--lingxiaotian"}',
+  )
+  await writeFile(
+    resolve(skinsRoot, 'firefly--lingxiaotian/spritesheet.webp'),
+    Buffer.from('RIFFxxxxWEBP', 'latin1'),
+  )
+  t.after(() => rm(webRoot, { recursive: true, force: true }))
+  t.after(() => rm(skinsRoot, { recursive: true, force: true }))
+
+  const renderer = await startDesktopRendererServer({
+    webRoot,
+    target: 'http://127.0.0.1:9',
+    skinsRoot,
+    token: 'test-token',
+  })
+  t.after(() => renderer.close())
+
+  const manifestResponse = await fetch(
+    `${renderer.baseUrl}skins/firefly--lingxiaotian/pet.json`,
+  )
+  assert.equal(manifestResponse.status, 200)
+  assert.match(
+    manifestResponse.headers.get('content-type'),
+    /application\/json/,
+  )
+  assert.equal(manifestResponse.headers.get('cache-control'), 'no-store')
+  assert.deepEqual(await manifestResponse.json(), {
+    id: 'firefly--lingxiaotian',
+  })
+
+  const sheetResponse = await fetch(
+    `${renderer.baseUrl}skins/firefly--lingxiaotian/spritesheet.webp`,
+  )
+  assert.equal(sheetResponse.status, 200)
+  assert.match(sheetResponse.headers.get('content-type'), /image\/webp/)
+
+  // 皮肤资源缺失直接 404，不回退 index.html。
+  const missingResponse = await fetch(
+    `${renderer.baseUrl}skins/missing/pet.json`,
+  )
+  assert.equal(missingResponse.status, 404)
+
+  // 路径穿越被拒绝。
+  const traversalResponse = await fetch(
+    `${renderer.baseUrl}skins/%2e%2e%2f%2e%2e%2fetc%2fpasswd`,
+  )
+  assert.equal(traversalResponse.status, 404)
+
+  // 非 GET/HEAD 拒绝。
+  const postResponse = await fetch(
+    `${renderer.baseUrl}skins/firefly--lingxiaotian/pet.json`,
+    { method: 'POST' },
+  )
+  assert.equal(postResponse.status, 405)
+
+  // 未配置 skinsRoot 时皮肤路由不可用。
+  const bare = await startDesktopRendererServer({
+    webRoot,
+    target: 'http://127.0.0.1:9',
+    token: 'bare-token',
+  })
+  t.after(() => bare.close())
+  const disabledResponse = await fetch(
+    `${bare.baseUrl}skins/firefly--lingxiaotian/pet.json`,
+  )
+  assert.equal(disabledResponse.status, 404)
+})
+
 test('relays the protected realtime WebSocket to the Gateway', async t => {
   let upgradeRequest
   const gateway = createServer()

--- a/desktop/test/security.test.mjs
+++ b/desktop/test/security.test.mjs
@@ -43,10 +43,28 @@ test('distinguishes loopback gateway targets from remote ones', () => {
 test('builds a dedicated desktop orb URL without losing existing parameters', () => {
   assert.equal(
     desktopOrbUrl('http://127.0.0.1:3101/?channel=desktop', {
-      orbStyle: 'goo',
+      orbSkin: 'goo',
       autoHideSeconds: 120,
       wakeWordEnabled: true,
     }),
-    'http://127.0.0.1:3101/?channel=desktop&desktop=orb&orbStyle=goo&autoHideSeconds=120&wakeWordEnabled=true',
+    'http://127.0.0.1:3101/?channel=desktop&desktop=orb&orbSkin=goo&orbStyle=goo&autoHideSeconds=120&wakeWordEnabled=true',
+  )
+})
+
+test('passes sprite skins through and drops invalid skin ids', () => {
+  // 导入皮肤只写 orbSkin，不带内置兼容参数 orbStyle。
+  assert.equal(
+    desktopOrbUrl('http://127.0.0.1:3101/', {
+      orbSkin: 'firefly--lingxiaotian',
+    }),
+    'http://127.0.0.1:3101/?desktop=orb&orbSkin=firefly--lingxiaotian',
+  )
+  assert.equal(
+    desktopOrbUrl('http://127.0.0.1:3101/', { orbSkin: '../escape' }),
+    'http://127.0.0.1:3101/?desktop=orb',
+  )
+  assert.equal(
+    desktopOrbUrl('http://127.0.0.1:3101/', {}),
+    'http://127.0.0.1:3101/?desktop=orb',
   )
 })

--- a/desktop/test/settings-config.test.mjs
+++ b/desktop/test/settings-config.test.mjs
@@ -20,6 +20,7 @@ test('reads desktop-owned settings with friendly defaults', () => {
   assert.deepEqual(parseSettings(''), {
     gatewayUrl: 'http://127.0.0.1:3101',
     orbStyle: 'fluid',
+    orbSkin: 'fluid',
     autoHideSeconds: 60,
     dashscopeApiKey: '',
     ...REALTIME_DEFAULTS,
@@ -37,6 +38,7 @@ test('shows effective client settings when user config is empty', () => {
   }), {
     gatewayUrl: 'http://127.0.0.1:3200',
     orbStyle: 'goo',
+    orbSkin: 'goo',
     autoHideSeconds: 60,
     dashscopeApiKey: 'sk-from-env',
     ...REALTIME_DEFAULTS,
@@ -71,6 +73,7 @@ test('updates client settings without changing Gateway-owned configuration', () 
   assert.deepEqual(parseSettings(content), {
     gatewayUrl: 'http://127.0.0.1:3200',
     orbStyle: 'goo',
+    orbSkin: 'goo',
     autoHideSeconds: 120,
     dashscopeApiKey: 'secret',
     ...REALTIME_DEFAULTS,
@@ -125,6 +128,7 @@ test('an explicitly empty key and backend override stale process values', () => 
   }), {
     gatewayUrl: 'http://127.0.0.1:3101',
     orbStyle: 'fluid',
+    orbSkin: 'fluid',
     autoHideSeconds: 60,
     dashscopeApiKey: '',
     ...REALTIME_DEFAULTS,
@@ -160,6 +164,35 @@ test('reads, updates, and disables desktop auto hide', () => {
   assert.equal(parseSettings(
     'QWEN_AUDIO_DESKTOP_AUTO_SLEEP_SECONDS=300\n',
   ).autoHideSeconds, 300)
+})
+
+test('reads, updates, and falls back the orb skin selection', () => {
+  // 新配置：QWEN_AUDIO_ORB_SKIN 直接生效，写回不碰旧 orbStyle 行。
+  const content = updateSettingsContent(
+    'QWEN_AUDIO_ORB_STYLE=goo\n',
+    { orbSkin: 'firefly--lingxiaotian' },
+  )
+  assert.match(content, /QWEN_AUDIO_ORB_SKIN=firefly--lingxiaotian/)
+  assert.match(content, /QWEN_AUDIO_ORB_STYLE=goo/)
+  assert.equal(parseSettings(content).orbSkin, 'firefly--lingxiaotian')
+
+  // 旧配置只有 orbStyle 时收敛为 orbSkin。
+  assert.equal(parseSettings('QWEN_AUDIO_ORB_STYLE=goo\n').orbSkin, 'goo')
+
+  // 非法 id 回退 fluid；空值回退 orbStyle。
+  assert.equal(
+    parseSettings('QWEN_AUDIO_ORB_SKIN=../escape\n').orbSkin,
+    'fluid',
+  )
+  assert.equal(parseSettings([
+    'QWEN_AUDIO_ORB_SKIN=',
+    'QWEN_AUDIO_ORB_STYLE=goo',
+    '',
+  ].join('\n')).orbSkin, 'goo')
+  assert.match(
+    updateSettingsContent('', { orbSkin: 'bad id!' }),
+    /QWEN_AUDIO_ORB_SKIN=fluid\n$/,
+  )
 })
 
 test('reads and updates a supported desktop wake shortcut', () => {

--- a/desktop/test/skin-store.test.mjs
+++ b/desktop/test/skin-store.test.mjs
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict'
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import {
+  importSkin,
+  listSkins,
+  removeSkin,
+  skinsDirectory,
+  validateSkinPackage,
+  webpDimensions,
+} from '../src/skin-store.mjs'
+
+function makeWebp(width, height) {
+  // 最小 VP8X 头：RIFF + WEBP + VP8X chunk（宽高按 minus-one 24 位小端）。
+  const buffer = Buffer.alloc(30)
+  buffer.write('RIFF', 0, 'latin1')
+  buffer.writeUInt32LE(22, 4)
+  buffer.write('WEBP', 8, 'latin1')
+  buffer.write('VP8X', 12, 'latin1')
+  buffer.writeUInt32LE(10, 16)
+  buffer.writeUIntLE(width - 1, 24, 3)
+  buffer.writeUIntLE(height - 1, 27, 3)
+  return buffer
+}
+
+function writeSkin(dir, {
+  id = 'firefly--lingxiaotian',
+  manifest = {},
+  width = 1536,
+  height = 1872,
+  spritesheet = 'spritesheet.webp',
+} = {}) {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'pet.json'), JSON.stringify({
+    id,
+    displayName: 'Firefly',
+    spritesheetPath: spritesheet,
+    ...manifest,
+  }))
+  writeFileSync(join(dir, spritesheet), makeWebp(width, height))
+}
+
+function temporaryRoot(t) {
+  const root = mkdtempSync(join(tmpdir(), 'qwen-audio-skins-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  return root
+}
+
+test('parses WebP dimensions from VP8X, VP8, and VP8L headers', () => {
+  assert.deepEqual(
+    webpDimensions(makeWebp(1536, 1872)),
+    { width: 1536, height: 1872 },
+  )
+
+  const lossy = Buffer.alloc(30)
+  lossy.write('RIFF', 0, 'latin1')
+  lossy.write('WEBP', 8, 'latin1')
+  lossy.write('VP8 ', 12, 'latin1')
+  lossy[23] = 0x9d
+  lossy[24] = 0x01
+  lossy[25] = 0x2a
+  lossy.writeUInt16LE(1536, 26)
+  lossy.writeUInt16LE(2288, 28)
+  assert.deepEqual(webpDimensions(lossy), { width: 1536, height: 2288 })
+
+  const lossless = Buffer.alloc(30)
+  lossless.write('RIFF', 0, 'latin1')
+  lossless.write('WEBP', 8, 'latin1')
+  lossless.write('VP8L', 12, 'latin1')
+  lossless[20] = 0x2f
+  lossless.writeUInt32LE((1535 & 0x3fff) | ((1871 & 0x3fff) << 14), 21)
+  assert.deepEqual(webpDimensions(lossless), { width: 1536, height: 1872 })
+
+  assert.equal(webpDimensions(Buffer.from('not a webp file at all')), null)
+})
+
+test('validates Codex pet packages against the grid contract', t => {
+  const root = temporaryRoot(t)
+
+  const v1 = join(root, 'v1')
+  writeSkin(v1)
+  assert.deepEqual(validateSkinPackage(v1), {
+    id: 'firefly--lingxiaotian',
+    displayName: 'Firefly',
+    spriteVersionNumber: 1,
+    spritesheetPath: 'spritesheet.webp',
+    frame: { width: 192, height: 208, columns: 8, rows: 9 },
+    animations: undefined,
+  })
+
+  // v2 缺省 11 行网格。
+  const v2 = join(root, 'v2')
+  writeSkin(v2, { manifest: { spriteVersionNumber: 2 }, height: 2288 })
+  assert.equal(validateSkinPackage(v2).frame.rows, 11)
+
+  // 自定义 frame spec 决定期望尺寸。
+  const custom = join(root, 'custom')
+  writeSkin(custom, {
+    manifest: { frame: { width: 64, height: 64, columns: 4, rows: 2 } },
+    width: 256,
+    height: 128,
+  })
+  assert.equal(validateSkinPackage(custom).frame.columns, 4)
+
+  // 尺寸与网格不符被拒绝。
+  const wrong = join(root, 'wrong')
+  writeSkin(wrong, { width: 1536, height: 1000 })
+  assert.throws(() => validateSkinPackage(wrong), /贴图尺寸应为 1536x1872/)
+
+  // 缺 pet.json、非法 id、贴图路径穿越。
+  const empty = join(root, 'empty')
+  mkdirSync(empty)
+  assert.throws(() => validateSkinPackage(empty), /缺少 pet\.json/)
+
+  const badId = join(root, 'bad-id')
+  writeSkin(badId, { id: '../escape' })
+  assert.throws(() => validateSkinPackage(badId), /缺少合法的 id/)
+
+  const traversal = join(root, 'traversal')
+  writeSkin(traversal)
+  writeFileSync(join(traversal, 'pet.json'), JSON.stringify({
+    id: 'traversal',
+    spritesheetPath: '../v1/spritesheet.webp',
+  }))
+  assert.throws(() => validateSkinPackage(traversal), /包目录之外/)
+})
+
+test('validates optional custom animation tracks', t => {
+  const root = temporaryRoot(t)
+
+  const good = join(root, 'good')
+  writeSkin(good, {
+    manifest: {
+      animations: {
+        'spin': { frames: [0, 1, 2], fps: 12, fallback: 'idle' },
+      },
+    },
+  })
+  assert.deepEqual(validateSkinPackage(good).animations.spin.frames, [0, 1, 2])
+
+  const badFps = join(root, 'bad-fps')
+  writeSkin(badFps, {
+    manifest: { animations: { 'spin': { frames: [0], fps: 120 } } },
+  })
+  assert.throws(() => validateSkinPackage(badFps), /fps 必须在 0 到 60/)
+
+  const badIndex = join(root, 'bad-index')
+  writeSkin(badIndex, {
+    manifest: { animations: { 'spin': { frames: [999] } } },
+  })
+  assert.throws(() => validateSkinPackage(badIndex), /越界的帧索引/)
+
+  const badFallback = join(root, 'bad-fallback')
+  writeSkin(badFallback, {
+    manifest: { animations: { 'spin': { frames: [0], fallback: 'nope' } } },
+  })
+  assert.throws(() => validateSkinPackage(badFallback), /fallback nope 不存在/)
+})
+
+test('imports skins from directories, pet.json paths, and zip archives', async t => {
+  const root = temporaryRoot(t)
+  const skinsRoot = skinsDirectory(join(root, 'config'))
+
+  // 目录导入。
+  const source = join(root, 'source')
+  writeSkin(source)
+  assert.deepEqual(await importSkin({ source, skinsRoot }), {
+    id: 'firefly--lingxiaotian',
+    displayName: 'Firefly',
+  })
+  assert.deepEqual(listSkins(skinsRoot), [{
+    id: 'firefly--lingxiaotian',
+    type: 'sprite',
+    displayName: 'Firefly',
+  }])
+
+  // pet.json 路径导入（Windows 文件对话框兜底），同 id 覆盖。
+  const updated = join(root, 'updated')
+  writeSkin(updated, { manifest: { displayName: '流萤' } })
+  await importSkin({ source: join(updated, 'pet.json'), skinsRoot })
+  assert.equal(listSkins(skinsRoot)[0].displayName, '流萤')
+
+  // zip 导入走注入的解压器，皮肤位于压缩包唯一子目录。
+  const zipContent = join(root, 'zip-content', 'acheron--lingxiaotian')
+  writeSkin(zipContent, { id: 'acheron--lingxiaotian' })
+  writeFileSync(join(root, 'skin.zip'), 'placeholder zip bytes')
+  const imported = await importSkin({
+    source: join(root, 'skin.zip'),
+    skinsRoot,
+    extractZip: async (zipPath, destination) => {
+      assert.equal(zipPath, join(root, 'skin.zip'))
+      cpSync(join(root, 'zip-content'), destination, { recursive: true })
+    },
+  })
+  assert.equal(imported.id, 'acheron--lingxiaotian')
+  assert.deepEqual(
+    listSkins(skinsRoot).map(skin => skin.id),
+    ['acheron--lingxiaotian', 'firefly--lingxiaotian'],
+  )
+  // 导入的临时目录已清理。
+  assert.deepEqual(
+    readdirSync(skinsRoot).filter(name => name.startsWith('.')),
+    [],
+  )
+})
+
+test('rejects builtin ids and unsupported sources', async t => {
+  const root = temporaryRoot(t)
+  const skinsRoot = join(root, 'skins')
+
+  const reserved = join(root, 'reserved')
+  writeSkin(reserved, { id: 'fluid' })
+  await assert.rejects(
+    importSkin({ source: reserved, skinsRoot }),
+    /内置皮肤保留名/,
+  )
+
+  writeFileSync(join(root, 'skin.rar'), 'not supported')
+  await assert.rejects(
+    importSkin({ source: join(root, 'skin.rar'), skinsRoot }),
+    /请选择皮肤文件夹/,
+  )
+  await assert.rejects(
+    importSkin({ source: join(root, 'missing'), skinsRoot }),
+    /皮肤路径不存在/,
+  )
+})
+
+test('removes imported skins but never builtin appearances', t => {
+  const root = temporaryRoot(t)
+  const skinsRoot = join(root, 'skins')
+
+  writeSkin(join(skinsRoot, 'firefly--lingxiaotian'))
+  assert.equal(removeSkin({ id: 'firefly--lingxiaotian', skinsRoot }), true)
+  assert.deepEqual(listSkins(skinsRoot), [])
+  // 重复删除是 no-op。
+  assert.equal(removeSkin({ id: 'firefly--lingxiaotian', skinsRoot }), false)
+
+  assert.throws(() => removeSkin({ id: 'fluid', skinsRoot }), /内置外观/)
+  assert.throws(() => removeSkin({ id: '../escape', skinsRoot }), /不合法/)
+  assert.throws(() => removeSkin({ id: '', skinsRoot }), /不合法/)
+})
+
+test('listSkins skips broken packages and mismatched directory names', t => {
+  const root = temporaryRoot(t)
+  const skinsRoot = join(root, 'skins')
+
+  writeSkin(join(skinsRoot, 'firefly--lingxiaotian'))
+  // 坏包：贴图缺失。
+  mkdirSync(join(skinsRoot, 'broken'), { recursive: true })
+  writeFileSync(join(skinsRoot, 'broken', 'pet.json'), JSON.stringify({
+    id: 'broken',
+    spritesheetPath: 'missing.webp',
+  }))
+  // 目录名与 pet.json id 不一致：跳过（URL 按目录名寻址）。
+  writeSkin(join(skinsRoot, 'renamed'), { id: 'other-id' })
+  // 隐藏目录忽略。
+  writeSkin(join(skinsRoot, '.staging'))
+
+  assert.deepEqual(listSkins(skinsRoot).map(skin => skin.id), [
+    'firefly--lingxiaotian',
+  ])
+  assert.deepEqual(listSkins(join(root, 'missing')), [])
+})

--- a/docs/backends/overview.zh.md
+++ b/docs/backends/overview.zh.md
@@ -1,57 +1,66 @@
-# Backend Agent
+# 后台 Agent
 
-The Backend Agent handles tasks that require tools, file operations, or sustained processing. When the frontend voice LLM determines that a request needs execution, it delegates the goal to the Backend Agent for asynchronous execution; once the result is ready, it naturally returns to the current conversation.
+后台 Agent 负责需要工具、文件操作或持续处理的任务。前台语音 LLM 判断请求
+需要执行时，会把目标交给后台 Agent 异步执行，结果完成后自然回到当前对话。
 
-## Supported Agents
+## 支持的 Agent
 
-| Backend Agent | Integration Method | Setup Requirements | Recommendation |
+| 后台 Agent | 接入方式 | 接入准备 | 推荐指数 |
 | --- | --- | --- | --- |
-| None | N/A | Frontend-only mode, no configuration needed | ★★★★★ |
-| OpenCode | Native ACP | Supports one-click install and Bailian configuration | ★★★★★ |
-| OpenClaw | Built-in ACP bridge | Supports one-click install and Bailian configuration | ★★★★★ |
-| Qoder | Native ACP | Supports one-click install, requires user configuration | ★★★★★ |
-| Kimi Code | Native ACP | Supports one-click install, requires user configuration | ★★★★★ |
-| Hermes | Native ACP | Supports one-click install, requires user configuration | ★★★★☆ |
-| CodeBuddy | Native ACP | Supports one-click install, requires user configuration | ★★★★☆ |
-| Codex | External ACP adapter | Supports one-click install of both the core and adapter, requires user configuration | ★★★★☆ |
-| Claude Code | External ACP adapter | Supports one-click install of both the core and adapter, requires user configuration | ★★★★☆ |
+| 无 | N/A | 仅前台模式，无需配置 | ★★★★★ |
+| OpenCode | 原生 ACP | 支持一键安装和百炼配置 | ★★★★★ |
+| OpenClaw | 内置 ACP 桥接 | 支持一键安装和百炼配置 | ★★★★★ |
+| Qoder | 原生 ACP | 支持一键安装，需用户配置 | ★★★★★ |
+| Kimi Code | 原生 ACP | 支持一键安装，需用户配置 | ★★★★★ |
+| Hermes | 原生 ACP | 支持一键安装，需用户配置 | ★★★★☆ |
+| CodeBuddy | 原生 ACP | 支持一键安装，需用户配置 | ★★★★☆ |
+| Codex | 外部 ACP 适配 | 支持一键安装本体与适配器，需用户配置 | ★★★★☆ |
+| Claude Code | 外部 ACP 适配 | 支持一键安装本体与适配器，需用户配置 | ★★★★☆ |
 
-The recommendation rating reflects the current integration completeness, compatibility, and extent of real-world verification: five stars indicates a fully tested and recommended integration, while four stars indicates ongoing development or incomplete verification of the same scope.
+推荐指数综合反映当前集成完整度、兼容性和实际验证程度：五星表示已经过充分测试的
+推荐集成，四星表示正在开发或尚未完成同等范围验证。
 
-## One-Click Install
+## 一键安装
 
-Uninstalled backend agents can be installed locally with a unified command:
+未安装的后台 Agent 可用统一命令安装到本机：
 
 ```bash
 qwenaudio install codex
 ```
 
-Before installation, a detection step runs to **only fill in missing components**: native ACP backends are ready to use once installed; if the core is missing, the core is installed; if the core is already installed and only the ACP adapter is missing, only the adapter is installed; if everything is ready, a prompt confirms availability. In the desktop settings page's "Backend Agent" list, an "Install" button appears at the end of rows for uninstalled backends that support one-click install, using the same installation logic as the CLI.
+安装前先检测，**只补齐缺失的组件**：原生 ACP 后台装好即可用；本体缺失时装本体；
+本体已装、仅缺 ACP 适配器时只装适配器；全部就绪时直接提示已可用。桌面版设置页
+的“后台 Agent”列表中，未安装且支持一键安装的后台行尾会显示“安装”按钮，与 CLI
+使用同一份安装逻辑。
 
-View currently available backend agents:
+查看当前可用的后台 Agent：
 
 ```bash
 qwenaudio setup
 ```
 
-This command only checks — it does not install, download, or verify credentials. To check only a specific backend or get machine-readable results:
+该命令只检查，不会安装、下载或验证凭据。只检查指定后台或获取机器可读结果：
 
 ```bash
 qwenaudio setup --backend codex
 qwenaudio setup --json
 ```
 
-## Choosing a Backend
+## 选择后台
 
-`AGENT_PROTOCOL` is an optional configuration. When left empty, the Gateway runs in frontend-only mode, and real-time voice chat remains available; requests requiring backend execution will return a clear explanation without creating a task or guessing results. You can also use `qwenaudio --backend none` on the command line to explicitly start in frontend-only mode.
+`AGENT_PROTOCOL` 是可选配置。留空时，Gateway 以仅前台模式运行，实时语音聊天
+保持可用；需要后台执行的请求会返回明确说明，不会创建任务或猜测执行结果。
+也可以在命令行中使用 `qwenaudio --backend none`，明确要求仅启动前台模式。
 
 ```dotenv
 AGENT_PROTOCOL=openclaw
 ```
 
-OpenCode and OpenClaw support automatic download and installation; after configuring `DASHSCOPE_API_KEY` and `QWEN_AUDIO_AGENT_BACKEND_MODEL`, they can automatically connect to Bailian models. Other backends require prior installation and native configuration; qwen-audio-agent will reuse their user-level models, tools, MCPs, Skills, and authentication.
+OpenCode 和 OpenClaw 支持自动下载安装；配置 `DASHSCOPE_API_KEY` 和
+`QWEN_AUDIO_AGENT_BACKEND_MODEL` 后即可自动接入百炼模型。其他后台需先安装并完成
+原生配置，qwen-audio-agent 会复用其用户级模型、工具、MCP、Skill 和认证。
 
-To use other agents that support ACP stdio:
+使用其他支持 ACP stdio 的 Agent：
 
 ```dotenv
 AGENT_PROTOCOL=acp
@@ -59,23 +68,27 @@ ACP_COMMAND=your-agent
 ACP_ARGS=["--acp"]
 ```
 
-The command, arguments, display name, and working directory can be configured via `ACP_COMMAND`, `ACP_ARGS`, `ACP_LABEL`, and `ACP_WORKSPACE` respectively. The generic ACP entry does not provide one-click install; please install it yourself.
+命令、参数、显示名称和工作目录可分别通过 `ACP_COMMAND`、`ACP_ARGS`、
+`ACP_LABEL` 和 `ACP_WORKSPACE` 配置。通用 ACP 入口不提供一键安装，请自行安装。
 
-## Permission Modes
+## 权限模式
 
-`QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE` can be set to:
+`QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE` 可设为：
 
-- `native` (default): Permissions are determined and prompted by the backend agent itself; the Gateway only forwards requests as-is.
-- `full`: Grants the highest permissions at startup, allowing the backend to directly execute commands, read and write files without per-action confirmation.
+- `native`（默认）：权限由后台 Agent 自己判断和询问，Gateway 只负责原样转发。
+- `full`：启动时明确授予最高权限，后台可直接执行命令、读写文件，不再逐次确认。
 
-`full` currently supports OpenCode, Qoder, Kimi Code, Hermes, CodeBuddy, Codex, and Claude Code; the Gateway will automatically approve permission requests from these backends. OpenClaw's execution authorization is constrained by exec approvals, elevated, and other configuration settings, and cannot be expressed via a single toggle — when `full` is selected, the Gateway will explicitly refuse to start. The highest permissions amplify the risk of accidental operations and should only be enabled in trusted projects.
+`full` 当前支持 OpenCode、Qoder、Kimi Code、Hermes、CodeBuddy、Codex 和
+Claude Code，Gateway 会自动批准这些后台发起的权限请求。OpenClaw 的执行授权受
+exec approvals、elevated 等配置约束，无法由统一开关表达，选择 `full` 时
+Gateway 会明确拒绝启动。最高权限会放大误操作风险，只应在可信项目中启用。
 
-## Backend Service
+## 后台常驻
 
-To keep your personal assistant online long-term, you can install it as a user-level background service:
+希望个人助理长期在线时，可以安装为用户后台服务：
 
 ```bash
-qwenaudio gateway install    # Install and start immediately
+qwenaudio gateway install    # 安装并立即启动
 qwenaudio gateway status
 qwenaudio gateway restart
 qwenaudio gateway stop
@@ -83,7 +96,8 @@ qwenaudio gateway start
 qwenaudio gateway uninstall
 ```
 
-The background service re-reads `config.env` on every startup; after modifying configuration, run `gateway restart` to apply changes.
+后台服务每次启动都会重新读取 `config.env`，修改配置后执行 `gateway restart`
+即可生效。
 
-For advanced configuration of each backend (executable paths, working directories, model overrides, etc.), see
-[Configuration Guide](../configuration.md).
+各后台的高级配置（可执行文件路径、工作目录、模型覆盖等）见
+[配置说明](../configuration.zh.md)。

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -1,187 +1,161 @@
-# Configuration
+# 配置
 
-After formal installation, qwen-audio-agent reads settings from a user configuration file:
+正式安装后，qwen-audio-agent 从用户配置文件读取设置：
 
 ```text
 ~/.config/qwaudio/config.env
 ```
 
-Setting `QWAUDIO_CONFIG_DIR` or `XDG_CONFIG_HOME` can change the configuration directory. The
-`.env.local` and `.env` files in the development repository are still supported and take priority
-over the user configuration file.
+设置 `QWAUDIO_CONFIG_DIR` 或 `XDG_CONFIG_HOME` 可以更改配置目录。开发仓库中的
+`.env.local` 和 `.env` 仍然支持，并优先于用户配置文件。
 
-The desktop edition and CLI use mutually independent data directories: the CLI uses
-`~/.config/qwaudio`, while the desktop edition uses the system standard application data directory
-(`~/Library/Application Support/Qwen Audio Agent` on macOS, `~/.config/Qwen Audio Agent` on Linux,
-and `%APPDATA%\Qwen Audio Agent` on Windows). Their Gateways, locks, logs, and settings do not
-interfere with each other and can run simultaneously. On first launch, the desktop edition copies
-user configuration files such as `config.env` from the CLI directory (the CLI retains the
-originals); runtime states such as `gateway.lock` are rebuilt independently. When
-`QWAUDIO_CONFIG_DIR` is explicitly set, the desktop edition also respects this override.
+桌面版与 CLI 使用相互独立的数据目录：CLI 使用 `~/.config/qwaudio`，桌面版使用
+系统标准应用数据目录（macOS 为 `~/Library/Application Support/Qwen Audio Agent`，
+Linux 为 `~/.config/Qwen Audio Agent`，Windows 为 `%APPDATA%\Qwen Audio Agent`）。
+两者的 Gateway、锁、日志与设置互不干扰，可以同时运行。桌面版首次启动时会从 CLI
+目录复制 `config.env` 等用户配置（CLI 保留原件）；`gateway.lock` 等运行时状态各自
+重建。显式设置 `QWAUDIO_CONFIG_DIR` 时桌面版也遵循该覆盖。
 
-The configuration priority is fixed as:
+配置优先级固定为：
 
 ```text
-CLI parameters > process environment variables > .env.local > .env > user configuration file > built-in defaults
+CLI 参数 > 进程环境变量 > .env.local > .env > 用户配置文件 > 内置默认值
 ```
 
-Run the following command to display the exact location of the current user configuration file:
+运行下面的命令可以显示当前用户配置文件的准确位置：
 
 ```bash
 qwenaudio config
 ```
 
-## Backend Setup Check
+## 后台 Setup 检查
 
-After configuring the backend Agent, you can run a unified read-only check:
+配置后台 Agent 后，可运行统一的只读检查：
 
 ```bash
 qwenaudio setup
 ```
 
-It checks the backend executable, ACP integration method, and necessary Adapters, and clearly
-displays the current selection. The check command itself does not install or download the backend
-Agent, does not trigger login, and does not output or validate credentials or modify model
-configuration. It indicates whether OpenCode/OpenClaw can automatically download and configure
-itself at formal startup; the authentication status of other backends is managed by the Agent
-itself.
+它会检查后台可执行文件、ACP 接入方式和必要的 Adapter，并明确显示当前选择。
+检查命令本身不会安装或下载后台 Agent，不会触发登录，也不会输出或验证凭据、修改模型
+配置。它会提示 OpenCode/OpenClaw 是否能在正式启动时自动下载和配置；其他后台
+的认证状态由 Agent 自己管理。
 
-To check only a specified backend or get machine-readable results:
+只检查指定后台或获取机器可读结果：
 
 ```bash
 qwenaudio setup --backend codex
 qwenaudio setup --json
 ```
 
-The JSON output uses the same shared detection module as the CLI, which can be directly reused
-by the desktop edition and other tools.
+JSON 输出与 CLI 使用同一个共享检测模块，可供桌面版和其他工具直接复用。
 
-## One-Click Installation of Backend Agents
+## 一键安装后台 Agent
 
-Backend Agents that are not installed can be installed on the local machine using a unified
-command:
+未安装的后台 Agent 可用统一命令安装到本机：
 
 ```bash
 qwenaudio install codex
 ```
 
-- Before installation, it detects and only fills in missing components: a native ACP backend is
-  ready to use once installed; if the main body is missing, it installs the main body; if the
-  main body is installed but only the ACP adapter is missing, it installs only the adapter; if
-  everything is ready, it directly prompts that it is available.
-- The installation specification (official npm packages with locked versions, official
-  installation scripts) is shared between the CLI and desktop edition from the same definition;
-  versions are consistent with the managed launcher scripts under `scripts/`; they can be
-  overridden with corresponding environment variables, such as `OPENCODE_PACKAGE`,
-  `CODEX_ACP_PACKAGE`, `CLAUDE_CODE_ACP_PACKAGE`.
-- ACP adapters for Codex and Claude Code are provided together with the main body; Hermes uses
-  the official installation script. Script-type steps display the full command before execution
-  and wait for confirmation; `--yes` skips confirmation (use with caution).
-- After installation is complete, the availability of the backend is automatically re-detected;
-  backends that require login will provide login instructions.
-- The generic `acp` backend does not provide one-click installation; please install it yourself
-  and configure it via `ACP_COMMAND`.
-- In the "Backend Agent" list on the desktop edition settings page, backends that are not
-  installed and support one-click installation will display an "Install" button at the end of
-  the row, using the same installation logic as the CLI; script-type installations will pop up
-  a native confirmation dialog.
+- 安装前先检测，只补齐缺失的组件：原生 ACP 后台装好即可用；本体缺失时装本体；
+  本体已装、仅缺 ACP 适配器时只装适配器；全部就绪时直接提示已可用。
+- 安装规格（官方 npm 包与锁定版本、官方安装脚本）由 CLI 与桌面版共享同一份
+  定义，版本与 `scripts/` 下 managed 启动脚本保持一致；可用对应环境变量覆盖，
+  如 `OPENCODE_PACKAGE`、`CODEX_ACP_PACKAGE`、`CLAUDE_CODE_ACP_PACKAGE`。
+- Codex、Claude Code 的 ACP 适配器随本体一并提供；Hermes 使用官方安装
+  脚本。脚本类步骤执行前会逐个展示完整命令并等待确认，`--yes` 跳过确认
+  （谨慎使用）。
+- 安装完成后自动重新检测该后台的可用状态；需要登录的后台会给出登录提示。
+- 通用 `acp` 后台不提供一键安装，请自行安装后通过 `ACP_COMMAND` 配置。
+- 桌面版设置页的“后台 Agent”列表中，未安装且支持一键安装的后台行尾会显示
+  “安装”按钮，与 CLI 使用同一份安装逻辑；脚本类安装会弹出原生确认框。
 
-## Minimal Configuration
+## 最小配置
 
-The minimal configuration only requires real-time voice credentials:
+最小配置只需要填写实时语音凭据：
 
 ```dotenv
 DASHSCOPE_API_KEY=your-key
 ```
 
-When you need to execute backend tasks, select a backend Agent (using OpenClaw as an example):
+需要执行后台任务时，再选择后台 Agent（以 OpenClaw 为例）：
 
 ```dotenv
 AGENT_PROTOCOL=openclaw
 QWEN_AUDIO_AGENT_BACKEND_MODEL=qwen3.7-max
 ```
 
-With the above configuration, OpenCode and OpenClaw can automatically download compatible
-versions and configure the Bailian model, enabling one-click startup. If no backend model is
-specified, the user's already installed and configured Agent is used preferentially, without
-overwriting its models, providers, tools, MCPs, Skills, and authentication. Other backends
-currently require users to install and configure them manually.
+OpenCode 和 OpenClaw 在以上配置下可以自动下载兼容版本并配置百炼模型，实现
+一键启动。若未指定后台模型，则优先使用用户已经安装和配置的 Agent，不覆盖其
+模型、Provider、工具、MCP、Skill 和认证。其他后台暂时需要用户自行安装配置。
 
-This is the only backend model configuration entry for qwen-audio-agent. The Gateway maps this
-value to the model identifier used by the selected backend; the model ID is still defined by each
-Agent and is not uniformly named by ACP. The backend's own native model environment variables can
-still be read by the backend, but the Gateway does not interpret them as model override requests.
+这是 qwen-audio-agent 唯一的后台模型配置入口。Gateway 会把该值映射为所选后台
+使用的模型标识；模型 ID 仍由各 Agent 定义，并不由 ACP 统一命名。后台自身的
+原生模型环境变量可以继续由后台读取，但 Gateway 不会把它们解释为模型覆盖请求。
 
-When no model is specified, the Gateway does not pass a model and does not guess a default value:
-the model for a newly created Session is entirely chosen by the backend Agent based on user
-configuration, and a restored Session retains its original model. The model used by a historical
-Session may differ from the user's current default model; this is the Session semantics of the
-backend Agent, and the Gateway does not reset it on its own.
+未指定模型时，Gateway 不传模型，也不猜测默认值：新建 Session 的模型完全由
+后台 Agent 根据用户配置选择，恢复 Session 则保留其原有模型。历史 Session
+使用的模型可能与用户当前默认模型不同，这是后台 Agent 的 Session 语义，
+Gateway 不会擅自重置。
 
-An explicit model is applied to the coordination Session, new project Sessions, and restored
-project Sessions. The Gateway discovers model options from ACP `configOptions` by
-`category: model` and sets them via `session/set_config_option`; if the Agent does not provide
-model configuration, the target model is not in the selectable list, the call fails, or the
-returned result cannot be confirmed as effective, the current request will explicitly fail
-without silently switching to another model. When `QWEN_AUDIO_AGENT_BACKEND_MODEL` is not set,
-the model setting interface is not called at all.
+显式模型会应用于协调 Session、新建项目 Session 和恢复的项目 Session。Gateway
+从 ACP `configOptions` 中按 `category: model` 发现模型选项，并通过
+`session/set_config_option` 设置；如果 Agent 没有提供模型配置、目标模型不在
+可选清单中、调用失败或返回结果无法确认生效，当前请求会明确失败，不会静默换用
+其他模型。未设置 `QWEN_AUDIO_AGENT_BACKEND_MODEL` 时完全不调用模型设置接口。
 
-The local identity key is automatically generated when the program first starts, saved in
-`state.env` in the same configuration directory, with file permissions restricted to read and
-write by the current user only.
+本地身份密钥由程序首次启动时自动生成，保存在同一配置目录的 `state.env`，
+文件权限为仅当前用户可读写。
 
-The same directory also automatically creates `USER.md` for saving a stable user profile. The
-program only modifies the managed area marked within the file; other handwritten content is
-preserved as-is; modifications take effect in the next conversation round. Please do not store
-passwords, API keys, verification codes, or tokens in it.
-If you need to place the profile elsewhere, you can set:
+同一目录还会自动创建 `USER.md`，用于保存稳定用户档案。程序只会改动文件内带标记
+的托管区域，其他手写内容会原样保留；修改后下一轮对话即可生效。请勿在其中保存
+密码、API Key、验证码或令牌。
+如需把档案放在其他位置，可设置：
 
 ```dotenv
 QWEN_AUDIO_AGENT_USER_PROFILE_PATH=/absolute/path/to/USER.md
 ```
 
-The local `USER.md` is only injected into context in the default `personal` identity mode; the
-multi-user `browser` mode does not share this profile.
+本机 `USER.md` 只在默认的 `personal` 身份模式下注入上下文；多用户 `browser`
+模式不会共享这份档案。
 
-The same user directory also stores:
+同一用户目录还保存：
 
 ```text
-frontend-memory.json  # Long-term information remembered across sessions (explicit requests + automatic sedimentation after sessions)
-memory-audit.jsonl    # Audit log for automatic memory (appended entry by entry, for post-hoc review only)
-tasks.json            # Recovery state for backend tasks, results, and pending broadcast notifications
+frontend-memory.json  # 跨会话记住的长期信息（明确要求 + 会话后自动沉淀）
+memory-audit.jsonl    # 自动记忆的审计日志（逐条追加，仅供事后查阅）
+tasks.json            # 后台任务、结果和待播报通知的恢复状态
 ```
 
-These files, like `USER.md` and `state.env`, are only readable and writable by the current user
-and are not written to the source code repository. Corresponding files in the legacy repository
-`runtime/` directory are automatically migrated on first launch. Advanced users can still
-override the location via `QWEN_AUDIO_AGENT_FRONTEND_MEMORY_PATH` and
-`QWEN_AUDIO_AGENT_TASK_STATE_PATH`.
+这些文件和 `USER.md`、`state.env` 一样只允许当前用户读写，不会写入源码仓库。
+旧版仓库 `runtime/` 目录中的对应文件会在首次启动时自动迁移。高级用户仍可通过
+`QWEN_AUDIO_AGENT_FRONTEND_MEMORY_PATH` 和 `QWEN_AUDIO_AGENT_TASK_STATE_PATH`
+覆盖位置。
 
-### Automatic Memory Sedimentation
+### 自动记忆沉淀
 
-After a session ends, the Gateway uses a lightweight text model to extract stable personal facts
-from the conversation and silently writes them to long-term memory (see
-[User Profile and Memory](reference/memory.md) for details). Related optional configuration:
+会话结束后，Gateway 会用一个轻量文本模型从对话中提取稳定的个人事实，
+静默写入长期记忆（详见[用户档案与记忆](reference/memory.zh.md)）。相关可选配置：
 
 ```bash
-QWEN_AUDIO_MEMORY_AUTO=on         # off globally disables automatic sedimentation (default on)
-QWEN_AUDIO_MEMORY_MODEL=qwen-flash  # Extraction model (default qwen-flash)
+QWEN_AUDIO_MEMORY_AUTO=on         # off 全局关闭自动沉淀（默认 on）
+QWEN_AUDIO_MEMORY_MODEL=qwen-flash  # 提取模型（默认 qwen-flash）
 QWEN_AUDIO_MEMORY_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
-                                  # Any OpenAI-compatible endpoint, including local Ollama
-QWEN_AUDIO_MEMORY_API_KEY=        # Defaults to reusing DASHSCOPE_API_KEY
+                                  # 任意 OpenAI 兼容端点，含本地 Ollama
+QWEN_AUDIO_MEMORY_API_KEY=        # 默认复用 DASHSCOPE_API_KEY
 ```
 
-When neither Key is configured (e.g., a purely local speech-to-speech frontend), automatic
-sedimentation is silently disabled; explicitly requested memory is not affected.
+两个 Key 都未配置时（如纯本地 speech-to-speech 前台），自动沉淀静默关闭，
+明确要求的记忆不受影响。
 
-## Selecting a Backend
+## 选择后台
 
-`AGENT_PROTOCOL` has no default value and is also an optional configuration. When left blank,
-the Gateway only provides frontend real-time voice chat; requests requiring backend execution
-will return a clear error without creating tasks or guessing execution results.
-You can also use `qwenaudio --backend none` to explicitly start frontend-only mode.
+`AGENT_PROTOCOL` 没有默认值，也是可选配置。留空时 Gateway 仅提供前台实时语音
+聊天；需要后台执行的请求会返回明确错误，不会创建任务或猜测执行结果。
+也可以使用 `qwenaudio --backend none` 显式启动仅前台模式。
 
-The default OpenClaw address is `http://127.0.0.1:18789`:
+OpenClaw 默认地址为 `http://127.0.0.1:18789`：
 
 ```dotenv
 AGENT_PROTOCOL=openclaw
@@ -189,56 +163,52 @@ OPENCLAW_BASE_URL=http://127.0.0.1:18789
 OPENCLAW_GATEWAY_TOKEN=
 ```
 
-It defaults to preferentially launching the `openclaw` in the user environment. When both
-`DASHSCOPE_API_KEY` and `QWEN_AUDIO_AGENT_BACKEND_MODEL` are provided, an independent Bailian
-configuration and state directory is generated for the qwen-audio-agent process, without
-modifying the user's native configuration. When no backend model is specified, it inherits the
-user's native configuration, models, and authentication, but does not enable external messaging
-channels such as DingTalk in the independent instance. If the original configuration has enabled
-a Gateway Token, it will be automatically read and used for local ACP connections; it can also
-be overridden via `OPENCLAW_GATEWAY_TOKEN`, or `OPENCLAW_CONFIG_PATH` can be set to explicitly
-specify a different OpenClaw configuration.
+默认优先启动用户环境中的 `openclaw`。同时提供 `DASHSCOPE_API_KEY` 和
+`QWEN_AUDIO_AGENT_BACKEND_MODEL` 时，会为 qwen-audio-agent 进程生成独立的
+百炼配置和状态目录，不修改用户原生配置。未指定后台模型时则继承用户的原生
+配置、模型和认证，但不会在独立实例中启用钉钉等外部消息渠道。若原配置启用了
+Gateway Token，会自动读取并用于本地 ACP 连接；也可以通过
+`OPENCLAW_GATEWAY_TOKEN` 覆盖，或设置 `OPENCLAW_CONFIG_PATH` 明确指定另一份
+OpenClaw 配置。
 
-OpenCode: The Gateway interacts with it via `opencode acp` and manages the local service used
-to open the native Session interface. When there is no compatible installation, it automatically
-uses a fixed npm package; users do not need to separately install or start the service:
+OpenCode：Gateway 通过 `opencode acp` 与它交互，并管理用于打开原生 Session
+界面的本地服务。没有兼容安装时会自动使用固定 npm 包，用户不需要另行安装或
+启动服务：
 
 ```dotenv
 AGENT_PROTOCOL=opencode
 QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
 ```
 
-Qoder uses the local `qodercli --acp` and has no HTTP backend address:
+Qoder 使用本机 `qodercli --acp`，没有 HTTP 后台地址：
 
 ```dotenv
 AGENT_PROTOCOL=qoder
 QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
 ```
 
-The unified ACP Adapter maintains a fixed native coordination Session for each user, and
-provides the ability to list, create, continue, query, and cancel project Sessions through
-ACP's Session list/resume/new capabilities and dynamic MCP tools. When continuing an existing
-project, it executes `session/resume` using the target Session's original `session_id` and
-working directory; interactions are appended to the native CLI Session history.
+统一 ACP Adapter 为每个用户维护一个固定的原生协调 Session，并通过 ACP 的
+Session list/resume/new 能力和动态 MCP 工具提供列出、新建、继续、查询和取消
+项目 Session 的能力。继续已有项目时使用目标 Session 的原始 `session_id` 和
+工作目录执行 `session/resume`，交互会追加到原生 CLI Session 历史。
 
-Authentication reuses the `qodercli` current login state or its supported environment variables.
-Advanced configuration:
+认证复用 `qodercli` 当前登录状态或它支持的环境变量。高级配置：
 
 ```dotenv
 QODERCLI_PATH=
 QODER_CONFIG_DIR=
 ```
 
-The Gateway manages the Qoder ACP subprocess; Qoder does not accept `--backend-url`.
+Gateway 管理 Qoder ACP 子进程；Qoder 不接受 `--backend-url`。
 
 ### Kimi Code
 
-Kimi Code ([MoonshotAI/kimi-code](https://github.com/MoonshotAI/kimi-code))
-connects via the official native ACP entry point `kimi acp`. The current integration verifies
-and requires Kimi Code `0.31.0` or higher; `qwenaudio setup --backend kimi` checks both the
-executable and version, and rejects older implementations below the compatible baseline.
+Kimi Code（[MoonshotAI/kimi-code](https://github.com/MoonshotAI/kimi-code)）
+通过官方原生 ACP 入口 `kimi acp` 接入。当前集成验证并要求 Kimi Code `0.31.0`
+或更高版本；`qwenaudio setup --backend kimi` 会同时检查可执行文件和版本，并拒绝
+低于兼容基线的旧实现。
 
-You can install the verified version using the official installation script:
+可使用官方安装脚本安装经过验证的版本：
 
 ```bash
 curl -fsSL https://code.kimi.com/kimi-code/install.sh | \
@@ -246,16 +216,15 @@ curl -fsSL https://code.kimi.com/kimi-code/install.sh | \
   KIMI_NO_MODIFY_PATH=1 bash
 ```
 
-When you have already completed login through Kimi Code itself, you only need to select the
-backend:
+已经通过 Kimi Code 自身完成登录时，只需选择后台：
 
 ```dotenv
 AGENT_PROTOCOL=kimi
 QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
 ```
 
-You can also use Kimi Code's official temporary model environment variables to provide a Kimi
-Code API Key without modifying `~/.kimi-code/config.toml`:
+也可以使用 Kimi Code 官方的临时模型环境变量，在不改写
+`~/.kimi-code/config.toml` 的情况下提供 Kimi Code API Key：
 
 ```dotenv
 AGENT_PROTOCOL=kimi
@@ -264,16 +233,14 @@ KIMI_MODEL_API_KEY=your-kimi-code-key
 KIMI_MODEL_BASE_URL=https://api.kimi.com/coding/v1
 ```
 
-`config.env` is created by qwen-audio-agent as a `0600` file readable and writable only by the
-current user; writing actual API keys to the repository is prohibited. Kimi Code's native
-configuration, OAuth credentials, and Session storage are still managed by Kimi by default;
-qwen-audio-agent does not modify these files. Setting `KIMI_CODE_HOME` can explicitly select a
-different Kimi data directory, and setting `KIMI_WORKSPACE` can override the coordination
-workspace.
+`config.env` 由 qwen-audio-agent 创建为仅当前用户可读写的 `0600` 文件，禁止将
+实际 API Key 写入仓库。Kimi Code 的原生配置、OAuth 凭据和 Session 存储默认仍
+由 Kimi 自己管理；qwen-audio-agent 不修改这些文件。设置 `KIMI_CODE_HOME` 可以
+显式选择另一套 Kimi 数据目录，设置 `KIMI_WORKSPACE` 可以覆盖协调工作区。
 
-When `QWEN_AUDIO_AGENT_BACKEND_MODEL` is explicitly set, the Gateway overrides the Kimi Session
-model via ACP `session/set_config_option` and confirms it takes effect; if left blank, Kimi
-selects its own default model. Advanced configuration:
+显式设置 `QWEN_AUDIO_AGENT_BACKEND_MODEL` 时，Gateway 会通过 ACP
+`session/set_config_option` 覆盖 Kimi Session 模型并确认生效；留空则由 Kimi
+选择自身默认模型。高级配置：
 
 ```dotenv
 KIMI_CODE_BIN=
@@ -281,7 +248,7 @@ KIMI_WORKSPACE=
 KIMI_CODE_HOME=
 ```
 
-Other Agents that support ACP stdio can use the generic entry point:
+其他支持 ACP stdio 的 Agent 可使用通用入口：
 
 ```dotenv
 AGENT_PROTOCOL=acp
@@ -291,49 +258,47 @@ ACP_LABEL=Your Agent
 ACP_WORKSPACE=
 ```
 
-The generic entry point has the Gateway directly manage the ACP subprocess. `ACP_ARGS` is
-recommended to be written as a JSON string array so that arguments containing spaces can still
-be parsed accurately. It uses standard ACP Sessions and Gateway-provided Session MCP tools, and
-does not assume any Agent's private startup, permission, or UI capabilities.
+通用入口由 Gateway 直接管理 ACP 子进程。`ACP_ARGS` 推荐写成
+JSON 字符串数组，以便参数中包含空格时仍能准确解析。它使用标准 ACP Session 和
+Gateway 提供的 Session MCP 工具，不假设某个 Agent 私有的启动、权限或 UI 能力。
 
 ### Hermes
 
-Hermes Agent ([nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent))
-comes with an ACP mode; the Gateway starts it using `hermes acp`:
+Hermes Agent（[nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent)）
+自带 ACP 模式，Gateway 使用 `hermes acp` 启动：
 
 ```dotenv
 AGENT_PROTOCOL=hermes
 QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
 ```
 
-Hermes uses its own configured model and provider by default. Only when
-`QWEN_AUDIO_AGENT_BACKEND_MODEL` is explicitly set will the Gateway override its Session
-model via ACP. Before first use, you can run `hermes acp --check` to check dependencies.
-Advanced configuration:
+Hermes 默认使用自身配置的模型与 provider。显式设置
+`QWEN_AUDIO_AGENT_BACKEND_MODEL` 时，Gateway 才会通过 ACP 覆盖其 Session
+模型。首次使用前可运行 `hermes acp --check` 检查依赖。高级配置：
 
 ```dotenv
 HERMES_BIN=
 HERMES_WORKSPACE=
 ```
 
-If `session/new` waits for a long time due to an unreachable provider model catalog, you can
-exclude unused providers via `model_catalog.excluded_providers` in `~/.hermes/config.yaml`.
+如果 `session/new` 因不可达的 provider 模型目录而长时间等待，可在
+`~/.hermes/config.yaml` 中通过 `model_catalog.excluded_providers` 排除没有使用的
+provider。
 
 ### CodeBuddy
 
-CodeBuddy Code (Tencent's `@tencent-ai/codebuddy-code`) uses `codebuddy --acp`. Its ACP mode
-requires account authentication; before first use, you should run `codebuddy` interactively
-and complete a login via `/login`.
+CodeBuddy Code（腾讯 `@tencent-ai/codebuddy-code`）使用
+`codebuddy --acp`。其 ACP 模式需要账号认证；首次使用前应交互式运行
+`codebuddy`，并通过 `/login` 完成一次登录。
 
 ```dotenv
 AGENT_PROTOCOL=codebuddy
 QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
 ```
 
-By default, it directly uses CodeBuddy's existing model configuration. Only when
-`QWEN_AUDIO_AGENT_BACKEND_MODEL` is explicitly set will the coordination workspace generate a
-project-level `.codebuddy/models.json`, reading the specified model and address via environment
-variables. Advanced configuration:
+默认直接使用 CodeBuddy 已有的模型配置。只有显式设置
+`QWEN_AUDIO_AGENT_BACKEND_MODEL` 时，协调工作区才会生成项目级
+`.codebuddy/models.json`，通过环境变量读取指定的模型与地址。高级配置：
 
 ```dotenv
 CODEBUDDY_BIN=
@@ -341,28 +306,25 @@ CODEBUDDY_WORKSPACE=
 CODEBUDDY_MODEL_URL=https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions
 ```
 
-After canceling the model override, the Gateway removes the `.codebuddy/models.json` it
-generated and restores CodeBuddy's original model; user-modified files are always preserved.
-When the override is enabled, changes to `QWEN_AUDIO_AGENT_BACKEND_MODEL` are automatically
-synced to the system-generated file.
+取消模型覆盖后，Gateway 会移除自己生成的 `.codebuddy/models.json`，恢复
+CodeBuddy 原有模型；用户手动修改的文件始终保留。启用覆盖时，
+`QWEN_AUDIO_AGENT_BACKEND_MODEL` 的变化会自动同步到系统生成的文件。
 
 ### Codex
 
-Codex ([openai/codex](https://github.com/openai/codex)) connects via
-[codex-acp](https://github.com/agentclientprotocol/codex-acp) maintained by the ACP project.
-The launcher script preferentially binds the `codex` already installed in the user environment,
-and preferentially uses the installed `codex-acp`; when the adapter is missing, it uses a fixed
-version via `npx`.
+Codex（[openai/codex](https://github.com/openai/codex)）通过 ACP 项目维护的
+[codex-acp](https://github.com/agentclientprotocol/codex-acp) 接入。启动脚本优先
+绑定用户环境中已安装的 `codex`，并优先使用已安装的 `codex-acp`；缺少 Adapter
+时通过 `npx` 使用固定版本。
 
 ```dotenv
 AGENT_PROTOCOL=codex
 QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
 ```
 
-By default, it reuses the user's `~/.codex`, login state, and model. The model is only
-overridden when `QWEN_AUDIO_AGENT_BACKEND_MODEL` is explicitly set; `CODEX_BASE_URL` is only
-used to configure a custom model service address. Neither modifies the user's configuration
-file. Advanced configuration:
+默认复用用户的 `~/.codex`、登录状态和模型。只有显式设置
+`QWEN_AUDIO_AGENT_BACKEND_MODEL` 时才覆盖模型；`CODEX_BASE_URL` 只用于配置
+自定义模型服务地址。两者都不会修改用户配置文件。高级配置：
 
 ```dotenv
 CODEX_ACP_BIN=
@@ -375,21 +337,19 @@ CODEX_BASE_URL=
 
 ### Claude Code
 
-Claude Code connects via
+Claude Code 通过 Zed 维护的
 [@zed-industries/claude-code-acp](https://github.com/zed-industries/claude-code-acp)
-maintained by Zed. The launcher script preferentially uses the already installed
-`claude-code-acp`, otherwise uses a fixed version via `npx`; no separate installation of the
-ACP adapter is needed, but Claude Code must be installed and authenticated first.
+接入。启动脚本优先使用已经安装的 `claude-code-acp`，否则通过 `npx` 使用固定
+版本；无需单独安装 ACP 适配器，但需要先安装并认证 Claude Code。
 
 ```dotenv
 AGENT_PROTOCOL=claude
 QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
 ```
 
-Model and credentials are managed by Claude Code itself by default, reusing the existing login
-state in `~/.claude`; you can also set `ANTHROPIC_API_KEY`. Only when
-`QWEN_AUDIO_AGENT_BACKEND_MODEL` is explicitly set will the Gateway override its Session
-model via ACP. Advanced configuration:
+模型和凭据默认由 Claude Code 自己管理，并复用 `~/.claude` 中已有的登录状态；
+也可以设置 `ANTHROPIC_API_KEY`。显式设置 `QWEN_AUDIO_AGENT_BACKEND_MODEL`
+时，Gateway 才会通过 ACP 覆盖其 Session 模型。高级配置：
 
 ```dotenv
 CLAUDE_CODE_ACP_BIN=
@@ -400,97 +360,86 @@ CLAUDE_CODE_EXECUTABLE=
 CLAUDE_CONFIG_DIR=
 ```
 
-Setting `CLAUDE_CONFIG_DIR` switches to a separate configuration directory, requiring separate
-authentication in that directory. `CLAUDE_CODE_EXECUTABLE` is only used to override the Claude
-Code executable used by the adapter by default.
+设置 `CLAUDE_CONFIG_DIR` 会改用独立配置目录，需要在该目录中单独完成认证。
+`CLAUDE_CODE_EXECUTABLE` 只用于覆盖适配器默认使用的 Claude Code 可执行文件。
 
-Kimi Code, Hermes, CodeBuddy, Codex, and Claude Code all have their ACP subprocesses directly
-managed by the Gateway, and do not accept `--backend-url`.
+Kimi Code、Hermes、CodeBuddy、Codex 和 Claude Code 均由 Gateway 直接管理 ACP
+子进程，不接受 `--backend-url`。
 
-## Backend Permission Modes
+## 后台权限模式
 
-`QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE` can be set to:
+`QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE` 可设为：
 
-- `native` (default): Permissions are determined and requested by the backend Agent itself;
-  the Gateway only forwards them as-is.
-- `full`: Explicitly grants the highest permission at startup; the backend can directly execute
-  commands, read and write files, without per-request confirmation.
+- `native`（默认）：权限由后台 Agent 自己判断和询问，Gateway 只负责原样转发。
+- `full`：启动时明确授予最高权限，后台可直接执行命令、读写文件，不再逐次确认。
 
-`full` currently supports OpenCode, Qoder, Kimi Code, Hermes, CodeBuddy, Codex, and
-Claude Code. The Gateway automatically approves permission requests initiated by these ACP
-backends; in addition, Kimi Code switches to an Auto mode that does not ask again via ACP
-Session configuration, Qoder and CodeBuddy CLI use `--dangerously-skip-permissions`, OpenCode
-sets `permission: "allow"` in the managed process's inline configuration for both the
-coordination Agent and task Agents, and Codex uses `agent-full-access` mode. Kimi Code's YOLO
-mode may still ask the user, so it is not used to map `full` here.
+`full` 当前支持 OpenCode、Qoder、Kimi Code、Hermes、CodeBuddy、Codex 和
+Claude Code。Gateway 会自动批准这些 ACP 后台发起的权限请求；此外 Kimi Code
+会通过 ACP Session 配置切换到不会再提问的 Auto 模式，Qoder 和 CodeBuddy CLI
+会使用 `--dangerously-skip-permissions`，OpenCode 会在受管进程的内联配置中为协调
+Agent 和任务 Agent 设置 `permission: "allow"`，Codex 会使用
+`agent-full-access` 模式。Kimi Code 的 YOLO 模式仍可能向用户提问，因此这里不会
+用它映射 `full`。
 
-OpenClaw's execution authorization is simultaneously constrained by exec approvals, elevated,
-and execution host configurations, and cannot be safely and completely expressed by a single
-unified switch; when `full` is selected, the Gateway explicitly refuses to start, requiring
-separate configuration via OpenClaw's own method. The highest permission amplifies the risk of
-misoperation and should only be enabled in trusted projects and trusted prompt environments.
+OpenClaw 的执行授权同时受 exec approvals、elevated 和执行 host 等配置约束，
+无法由一个统一开关安全、完整地表达；选择 `full` 时 Gateway 会明确拒绝启动，
+需要按 OpenClaw 自身方式单独配置。最高权限会放大误操作风险，只应在可信项目和
+可信提示词环境中启用。
 
-The desktop edition, CLI, and WebUI can reuse the same Gateway, but only one active voice
-entry point is allowed per user at a time. The CLI does not preempt the existing desktop voice
-by default; use this when you need to explicitly take over:
+桌面版、CLI 和 WebUI 可以复用同一个 Gateway，但同一用户同时只有一个活跃语音
+入口。CLI 默认不抢占现有桌面语音；需要明确接管时使用：
 
 ```bash
 qwenaudio tui --takeover
 ```
 
-Only one TUI can run per user. The Gateway, desktop app, and WebUI can all reside
-simultaneously; the desktop orb displays an occupied status during TUI voice takeover.
+同一用户只能运行一个 TUI。Gateway、桌面应用和 WebUI 可以同时驻留；桌面球会在
+TUI 接管语音期间显示占用状态。
 
-## Remote Access Security
+## 远程访问安全
 
-By default, the Gateway only trusts literal loopback Host/Origin, preventing malicious web
-pages from connecting to local voice and backend Agents via DNS rebinding. To access from other
-devices, do not simply set `HOST=0.0.0.0` and expose the port; instead, use an HTTPS reverse
-proxy with access authentication, and configure the public Origin:
+Gateway 默认只信任字面量 loopback Host/Origin，避免恶意网页通过 DNS rebinding
+连接本机语音与后台 Agent。若要从其他设备访问，不要直接设置 `HOST=0.0.0.0`
+后暴露端口；应使用具备访问认证的 HTTPS 反向代理，并配置公开 Origin：
 
 ```dotenv
 HOST=127.0.0.1
 QWEN_AUDIO_AGENT_ALLOWED_ORIGINS=https://voice.example.com
 ```
 
-The reverse proxy must:
+反向代理必须：
 
-- Complete user authentication before forwarding;
-- Only accept HTTPS, and correctly forward WebSocket;
-- Preserve the public `Host`;
-- Forward traffic to the local `127.0.0.1:3101`.
+- 在转发前完成用户认证；
+- 只接受 HTTPS，并正确转发 WebSocket；
+- 保留公开 `Host`；
+- 将流量转发至本机 `127.0.0.1:3101`。
 
-`QWEN_AUDIO_AGENT_AUTH_SECRET` is only used to sign the local identity, not as a remote access
-password. It must not be used as a substitute for reverse proxy authentication. Multiple
-trusted Origins can be separated by English commas.
+`QWEN_AUDIO_AGENT_AUTH_SECRET` 只用于签署本地身份，不是远程访问密码。不得用它
+替代反向代理认证。多个可信 Origin 可使用英文逗号分隔。
 
-## Gateway Operation
+## Gateway 运行方式
 
-A single data directory only allows one local Gateway at any time. The CLI, TUI, and WebUI
-share `~/.config/qwaudio` and preferentially reuse the same instance; the desktop edition uses
-a separate directory and only reuses or manages the Gateway under its own directory. Multiple
-clients within the same directory can connect simultaneously, but do not each start a set of
-backend Agents. The instance identity is recorded in a temporary `gateway.lock` file under the
-user configuration directory; it is deleted when the Gateway exits normally, and locks left by
-abnormal exits are automatically reclaimed after confirming the original process has ended. If
-the existing Gateway's Realtime, backend Agent, or permission configuration is inconsistent with
-the current request, startup will explicitly error rather than silently opening a random port.
-Remote Gateways do not participate in the local single-instance lease.
+同一数据目录在任意时刻只允许一个本地 Gateway。CLI、TUI 和 WebUI 共用
+`~/.config/qwaudio`，会优先复用同一个实例；桌面版使用独立目录，只复用或管理
+自己目录下的 Gateway。同一目录内的多个客户端可以同时连接，但不会各自启动一套
+后台 Agent。实例身份记录在
+用户配置目录下的临时 `gateway.lock` 中，Gateway 正常退出时会删除，异常退出留下的
+锁会在确认原进程已经结束后自动回收。若现有 Gateway 的 Realtime、后台 Agent 或
+权限配置与当前请求不一致，启动会明确报错，而不会静默另开随机端口。远程 Gateway
+不参与本地单实例租约。
 
-By default, the Gateway starts and manages the selected Agent's ACP process. If the local
-service port of OpenCode or OpenClaw is already occupied by another process, it will select an
-idle port and will not take over or close the user's process. OpenClaw is always started as an
-independent Gateway by qwen-audio-agent, using isolated runtime state and Session storage; it
-can read the user's existing model and capability configuration, but does not share Sessions
-with the user's persistent Gateway, nor does it reconnect to the external messaging channels
-configured by the user. OpenCode's ACP process always reuses its native configuration and
-Session storage; the native interface being unavailable does not affect ACP task execution.
+Gateway 默认启动并管理所选 Agent 的 ACP 进程。若 OpenCode 或 OpenClaw 的本地
+服务端口已被其他进程占用，会选择空闲端口，不会接管或关闭用户进程。OpenClaw
+始终由 qwen-audio-agent 启动独立 Gateway，并使用隔离的运行状态和 Session
+存储；它可以读取用户已有的模型与能力配置，但不会与用户常驻 Gateway 共享
+Session，也不会重复连接用户配置的外部消息渠道。OpenCode 的 ACP 进程始终
+复用其原生配置和 Session 存储，原生界面不可用不影响 ACP 任务执行。
 
-`qwenaudio`, `qwenaudio gateway`, and `qwenaudio gateway run` all run in the foreground.
-When you need it to run persistently in the background, use:
+`qwenaudio`、`qwenaudio gateway` 和 `qwenaudio gateway run` 都在前台运行。
+需要后台常驻时使用：
 
 ```bash
-qwenaudio gateway install    # Install and immediately start the user service
+qwenaudio gateway install    # 安装并立即启动用户服务
 qwenaudio gateway status
 qwenaudio gateway restart
 qwenaudio gateway stop
@@ -498,143 +447,125 @@ qwenaudio gateway start
 qwenaudio gateway uninstall
 ```
 
-The background service re-reads `config.env` each time it starts. After modifying configuration,
-run `qwenaudio gateway restart` to apply it. Service logs are located at
-`~/.config/qwaudio/logs/gateway.log`; on Linux, you can also view them via
-`journalctl --user -u qwen-audio-agent-gateway`.
+后台服务每次启动都会重新读取 `config.env`。修改配置后执行
+`qwenaudio gateway restart` 即可生效。服务日志位于
+`~/.config/qwaudio/logs/gateway.log`；Linux 也可以通过
+`journalctl --user -u qwen-audio-agent-gateway` 查看。
 
-## Local Logs
+## 本地日志
 
-qwen-audio-agent uses a unified local structured log, written by default to:
+qwen-audio-agent 使用统一的本地结构化日志，默认写入：
 
 ```text
 ~/.config/qwaudio/logs/
-├── gateway.log   # Gateway, Realtime, ACP, and task lifecycle
-├── desktop.log   # Desktop main process and embedded Gateway lifecycle
-├── cli.log       # CLI command lifecycle
-└── tui.log       # Lifecycle when directly starting TUI
+├── gateway.log   # Gateway、Realtime、ACP 与任务生命周期
+├── desktop.log   # 桌面主进程与内嵌 Gateway 生命周期
+├── cli.log       # CLI 命令生命周期
+└── tui.log       # 直接启动 TUI 时的生命周期
 ```
 
-The logs use a JSON Lines format with one JSON object per line, including stable `schema`,
-`time`, `level`, `component`, `event`, and `pid` fields, and carrying `sessionId`, `turnId`,
-`taskId`, `provider`, `backend`, `durationMs`, and other correlation information as needed. API
-keys, tokens, Authorization, cookies, passwords, and secret fields are desensitized before
-writing; by default, microphone audio, user transcription text, model reply text, task
-objectives, and task results are not recorded.
+日志采用一行一个 JSON 对象的 JSON Lines 格式，包含稳定的 `schema`、`time`、
+`level`、`component`、`event` 和 `pid` 字段，并按需携带 `sessionId`、`turnId`、
+`taskId`、`provider`、`backend`、`durationMs` 等关联信息。API Key、Token、
+Authorization、Cookie、密码和 Secret 字段会在写入前脱敏；默认不记录麦克风音频、
+用户转写正文、模型回复正文、任务目标或任务结果。
 
-The desktop edition can open the log directory in "Settings → Application → Logs". The default
-log level is `info`; individual files rotate after reaching 10 MiB, with a total of 5 files
-retained. These can be adjusted via the following environment variables:
+桌面版可在“设置 → 应用 → 日志”中打开日志目录。默认日志级别为 `info`，单个文件
+达到 10 MiB 后轮转，总共保留 5 份。可通过以下环境变量调整：
 
-| Setting | Default | Description |
+| 设置 | 默认值 | 说明 |
 | --- | --- | --- |
-| `QWEN_AUDIO_LOG_LEVEL` | `info` | `trace`, `debug`, `info`, `warn`, `error`, `fatal`, or `silent` |
-| `QWEN_AUDIO_LOG_DIR` | `logs` under the user config directory | Custom log directory |
-| `QWEN_AUDIO_LOG_MAX_BYTES` | `10485760` | Rotation threshold for a single log file |
-| `QWEN_AUDIO_LOG_MAX_FILES` | `5` | Total number of current and rotated files to retain |
-| `QWEN_AUDIO_LOG_FILE` | `1` | Set to `0` to disable file logging |
-| `QWEN_AUDIO_LOG_CONSOLE` | `1` | Set to `0` to disable terminal log output |
+| `QWEN_AUDIO_LOG_LEVEL` | `info` | `trace`、`debug`、`info`、`warn`、`error`、`fatal` 或 `silent` |
+| `QWEN_AUDIO_LOG_DIR` | 用户配置目录下的 `logs` | 自定义日志目录 |
+| `QWEN_AUDIO_LOG_MAX_BYTES` | `10485760` | 单个日志文件的轮转阈值 |
+| `QWEN_AUDIO_LOG_MAX_FILES` | `5` | 当前文件和轮转文件的总保留数量 |
+| `QWEN_AUDIO_LOG_FILE` | `1` | 设为 `0` 禁用文件日志 |
+| `QWEN_AUDIO_LOG_CONSOLE` | `1` | 设为 `0` 禁用终端日志输出 |
 
-Logs are only stored locally and are not automatically uploaded. Before reporting issues, check
-and share relevant snippets as needed; even though the system automatically desensitizes, you
-should re-confirm before sending that they do not contain local paths or business information
-you do not want to be public.
+日志仅保存在本机，不会自动上传。反馈问题前可按需检查并分享相关片段；即使系统会
+自动脱敏，也应在发送前再次确认其中没有不希望公开的本机路径或业务信息。
 
-The TUI, WebUI, and desktop edition only connect to the Gateway and do not directly connect
-to, start, or stop any backend Agent. Core configuration in desktop settings is saved to the
-user configuration file and takes effect on the next Gateway startup; the Gateway address is
-validated and switched immediately.
+TUI、WebUI 和桌面版只连接 Gateway，不直接连接、启动或停止任何后台 Agent。
+桌面设置中的核心配置会保存到用户配置文件，在下次启动 Gateway 时生效；
+Gateway 地址会立即验证并切换。
 
-OpenCode and OpenClaw use a consistent user environment priority order:
+OpenCode 和 OpenClaw 使用一致的用户环境优先顺序：
 
-1. The executable explicitly specified by `OPENCODE_BIN` / `OPENCLAW_BIN`.
-2. The source directory explicitly specified by `OPENCODE_SOURCE_DIR` / `OPENCLAW_SOURCE_DIR`.
-3. The `opencode` / `openclaw` already installed by the user in PATH.
-4. When no compatible installation is found, a fixed npm package with the current verified
-   version is automatically used via `npx`.
+1. `OPENCODE_BIN` / `OPENCLAW_BIN` 明确指定的可执行文件。
+2. `OPENCODE_SOURCE_DIR` / `OPENCLAW_SOURCE_DIR` 明确指定的源码目录。
+3. PATH 中用户已经安装的 `opencode` / `openclaw`。
+4. 找不到兼容安装时，通过 `npx` 自动使用当前版本验证过的固定 npm 包。
 
-Source directories are only used when explicitly configured by the user, without inferring
-adjacent project directories. To force a particular launch method, configure:
+源码目录只在用户明确配置后使用，不再推测相邻项目目录。需要强制选择某种启动
+方式时可配置：
 
 ```dotenv
-# auto (default), binary, source, installed, or package
+# auto（默认）、binary、source、installed 或 package
 OPENCODE_RUNTIME=auto
 OPENCLAW_RUNTIME=auto
 ```
 
-To temporarily verify other fixed package versions or internal mirrors, you can explicitly
-override the full package specifier:
+需要临时验证其他固定包版本或内部镜像时，可以显式覆盖完整 package specifier：
 
 ```dotenv
 OPENCODE_PACKAGE=opencode-ai@1.18.5
 OPENCLAW_PACKAGE=openclaw@2026.6.33
 ```
 
-The OpenCode ACP integration currently requires OpenCode `1.18.0` or higher. In `auto` mode,
-when an older version is discovered, a fixed compatible package is used without modifying the
-user's installation; when `installed` is explicitly set, it directly errors.
-The minimum version can be overridden by `OPENCODE_MIN_VERSION` for validating other
-compatible versions.
+OpenCode ACP 接入当前要求 OpenCode `1.18.0` 或更高版本。`auto` 模式发现更旧
+版本时会使用固定兼容包，不修改用户安装；显式设置 `installed` 时直接报错。
+最低版本可由 `OPENCODE_MIN_VERSION` 覆盖，用于验证其他兼容版本。
 
-The OpenCode started by qwen-audio-agent inherits the user's original global configuration by
-default (usually `~/.config/opencode/opencode.json`), so already installed MCPs, Skills,
-permissions, models, and plugins can continue to be used. The coordination rules and
-third-layer Session tools are dynamically provided by the Gateway through ACP in each request
-round, without additionally installing or overwriting the OpenCode Agent.
+qwen-audio-agent 启动的 OpenCode 默认继承用户原有的全局配置（通常是
+`~/.config/opencode/opencode.json`），因此已经安装的 MCP、Skill、权限、模型和
+插件可以继续使用。协调规则和第三层 Session 工具由 Gateway 在每轮请求中通过
+ACP 动态提供，不会额外安装或覆盖 OpenCode Agent。
 
-If the user's configuration or third-party plugins conflict with qwen-audio-agent, you can
-temporarily enable isolation mode for troubleshooting:
+如果用户配置或第三方插件与 qwen-audio-agent 冲突，可以临时启用隔离模式排查：
 
 ```dotenv
 QWEN_AUDIO_AGENT_OPENCODE_ISOLATE_USER_CONFIG=true
 ```
 
-You can also specify a different OpenCode user configuration directory via
-`QWEN_AUDIO_AGENT_OPENCODE_XDG_CONFIG_HOME`. After isolation, MCPs and plugins from the
-original global configuration are not automatically loaded.
+也可以通过 `QWEN_AUDIO_AGENT_OPENCODE_XDG_CONFIG_HOME` 指定另一套 OpenCode 用户
+配置目录。隔离后，原全局配置中的 MCP 和插件不会自动加载。
 
-## Advanced Settings
+## 高级设置
 
-The following settings all have stable default values; ordinary users do not need to write
-them to the configuration file:
+以下设置都有稳定默认值，普通用户不需要写入配置文件：
 
-| Setting | Default |
+| 设置 | 默认值 |
 | --- | --- |
 | `HOST` / `PORT` | `127.0.0.1` / `3101` |
-| `QWEN_AUDIO_AGENT_ALLOWED_ORIGINS` | Empty; only loopback allowed |
-| `OPENCODE_WORKSPACE` | `workspaces/opencode` under the user config directory |
-| `QODER_WORKSPACE` | `workspaces/qoder` under the user config directory |
-| `QWEN_AUDIO_AGENT_BACKEND_MODEL` | Empty; uses the backend Agent's original model |
+| `QWEN_AUDIO_AGENT_ALLOWED_ORIGINS` | 空；只允许 loopback |
+| `OPENCODE_WORKSPACE` | 用户配置目录下的 `workspaces/opencode` |
+| `QODER_WORKSPACE` | 用户配置目录下的 `workspaces/qoder` |
+| `QWEN_AUDIO_AGENT_BACKEND_MODEL` | 空；使用后台 Agent 原有模型 |
 | `QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE` | `native` |
 | `QWEN_AUDIO_REALTIME_MODEL` | `qwen-audio-3.0-realtime-plus` |
 | `QWEN_AUDIO_REALTIME_PROVIDER` | `dashscope` |
 | `QWEN_AUDIO_REALTIME_VOICE` | `longanqian` |
 | `SPEECH_TO_SPEECH_REALTIME_URL` | `ws://127.0.0.1:8765/v1/realtime` |
-| `SPEECH_TO_SPEECH_AUTH_TOKEN` | Empty; only for proxies with Bearer authentication |
+| `SPEECH_TO_SPEECH_AUTH_TOKEN` | 空；仅用于带 Bearer 认证的代理 |
 | `QWEN_AUDIO_AGENT_IDENTITY_MODE` | `personal` |
 | `QWEN_AUDIO_AGENT_TUI_AUDIO_MODE` | `half` |
 | `AGENT_TIMEOUT_MS` | `300000` |
 
-The macOS TUI CoreAudio helper is compiled by default to
-`~/Library/Caches/qwaudio/tui/macos-voice-io`, requiring no additional configuration. It
-continuously records audio during playback, and only supports voice interruption.
-The Linux and Windows minimal TUI uses the bundled Python audio bridge with
-`sounddevice`/PortAudio half-duplex; during reply playback the microphone is paused, only
-supporting manual interruption via the `x` key, and resumes after playback ends or is manually
-interrupted.
+macOS TUI 的 CoreAudio 辅助程序默认编译到
+`~/Library/Caches/qwaudio/tui/macos-voice-io`，无需额外配置。它在播报期间
+持续收音，只支持语音打断。
+Linux 和 Windows 的 minimal TUI 通过随包提供的 Python 音频桥接使用
+`sounddevice`/PortAudio 半双工；播放回复时麦克风会暂停，只支持通过 `x` 键
+手动打断，播放结束或手动打断后恢复。
 
-On Linux and Windows, you can explicitly enable PortAudio full-duplex via
-`qwenaudio tui --audio-mode full` or by setting `QWEN_AUDIO_AGENT_TUI_AUDIO_MODE=full`. This
-mode has no echo cancellation and only supports direct speech interruption; wearing headphones
-is recommended to avoid speaker echo triggering false recognition or false interruption.
-macOS always uses CoreAudio AEC full-duplex and is not affected by this option.
+Linux 和 Windows 可通过 `qwenaudio tui --audio-mode full` 或设置
+`QWEN_AUDIO_AGENT_TUI_AUDIO_MODE=full` 明确开启 PortAudio 全双工。此模式没有
+回声消除，只支持直接说话打断；推荐佩戴耳机，避免扬声器回声触发误识别或误打断。
+macOS 始终使用 CoreAudio AEC 全双工，不受该选项影响。
 
-If PortAudio full-duplex persistently reports input overflow, output underflow, or device
-errors, please exit the TUI and switch to `qwenaudio tui --audio-mode half`. Different
-Linux/Windows sound cards and Bluetooth headsets have varying levels of support for
-simultaneous input and output streams with different sampling rates; half-duplex is the
-compatibility fallback.
+如果 PortAudio 全双工持续报告输入溢出、输出欠载或设备错误，请退出 TUI 并改用
+`qwenaudio tui --audio-mode half`。不同 Linux/Windows 声卡和蓝牙耳机对同时使用
+不同采样率的输入、输出流支持程度不同，半双工是兼容性兜底。
 
-Runtime parameters such as task status, notification retry, memory capacity, and retention
-time also use built-in default values. Overriding is only recommended when explicitly
-performing capacity planning or fault diagnosis.
+任务状态、通知重试、记忆容量与保留时间等运行参数同样使用内置默认值。只有明确
+进行容量规划或故障诊断时才建议覆盖。

--- a/docs/desktop/overview.md
+++ b/docs/desktop/overview.md
@@ -16,6 +16,32 @@ The desktop app supports two appearance styles: the Aurora Soundwave Orb and the
 | --- | --- |
 | ![Aurora Soundwave Orb thinking animation](../desktop-fluid-orb-thinking.gif) | ![Liquid Gradient Orb thinking animation](../desktop-goo-orb-thinking.gif) |
 
+## Skins
+
+Beyond the built-in appearances, the orb supports sprite skins in the
+[Codex pet](https://github.com/legeling/awesome-codex-pet) package format:
+a directory containing `pet.json` and `spritesheet.webp` (8-column grid,
+v1 is 1536x1872 with 9 rows, v2 is 1536x2288 with 11 rows). Assets from the
+Codex pet ecosystem work without any conversion, and no Codex installation
+is required.
+
+To import a skin you already downloaded, open "Settings → Application →
+Appearance", click "Import Skin…", and select the skin folder, its
+`pet.json`, or a zip archive. Imported skins are stored under `skins/` in
+the desktop data directory and appear in the appearance dropdown alongside
+the built-in styles. Selecting an imported skin enables the "Delete"
+button next to it; built-in appearances cannot be deleted.
+
+The orb maps voice and task states to pet animations: waiting while
+listening, reviewing while thinking, waving while speaking or greeting you
+on wake, running left continuously while background tasks are executing,
+jumping continuously while a task waits for your confirmation, running
+while another frontend holds the voice channel, and the failed pose on
+errors. Conversation states always take priority over background states.
+Skin packages are static assets only (JSON + WebP) and are validated on
+import; if a selected skin package is removed, the orb falls back to the
+built-in appearance.
+
 ## Installation
 
 Download the installer for your platform from the releases page:

--- a/docs/desktop/overview.zh.md
+++ b/docs/desktop/overview.zh.md
@@ -1,45 +1,79 @@
-# Desktop
+# 桌面版
 
-The desktop app provides a persistent on-screen voice orb and includes a built-in Gateway, eliminating the need to start a service beforehand. If a local Gateway already exists in the same user configuration directory, it will connect directly and use the Gateway's current runtime configuration; otherwise, the desktop app will start and manage it automatically. On first run, the app creates a configuration file and guides you to fill in the DashScope API Key on the settings page and select a backend agent (frontend-only mode is also available).
+桌面版提供常驻桌面的语音悬浮球，并内置 Gateway，无需事先启动服务。同一用户配置
+目录已有本地 Gateway 时会直接连接并以其当前运行配置为准，否则由桌面版自动启动和管理。首次运行时，
+应用会创建配置文件，并引导你在设置页填写 DashScope API Key、选择后台 Agent
+（也可以使用仅前台模式）。
 
-## Orb and Auto Sleep
+## 悬浮球与自动休眠
 
-When idle, the orb automatically hides and disconnects real-time voice; you can also say "可以退下了" (you may step down) to hide it. The app remains in the menu bar and can be re-summoned from the menu bar or via a show shortcut. The default shortcut is `⇧⌘ Space` and can be changed in app settings.
+闲置后悬浮球会自动隐藏并断开实时语音；也可以直接说“可以退下了”让它隐藏。应用仍
+常驻菜单栏，可从菜单栏或显示快捷键重新唤出。默认快捷键为 `⇧⌘ Space`，也可以在
+应用设置中更换。
 
-The sleep timeout and auto-hide are unified into a single "Auto Sleep" setting: during sleep, the microphone continues local listening, and saying the wake word "你好千问" (hello Qianwen) will resume the conversation. Backend agents and submitted tasks are not stopped by sleep; task results will be announced after wake-up. When the wake word is enabled for the first time, it automatically downloads and validates approximately 33 MB of the [`sherpa-onnx`](https://github.com/k2-fsa/sherpa-onnx) Chinese-English KWS model, and uses the local cache thereafter.
+休眠超时与自动隐藏合并为统一的“自动休眠”设置：休眠期间麦克风保持本地监听，说出
+唤醒词“你好千问”即可恢复对话。后台 Agent 和已提交任务不会因休眠停止，任务结果
+会在唤醒后播报。首次启用唤醒词时会自动下载并校验约 33 MB 的
+[`sherpa-onnx`](https://github.com/k2-fsa/sherpa-onnx) 中英文 KWS 模型，之后直接使用本地缓存。
 
-## Appearance
+## 外观
 
-The desktop app supports two appearance styles: the Aurora Soundwave Orb and the Liquid Gradient Orb. The following shows their raw animations in the thinking / breathing state:
+桌面版支持流光声波球和液态渐变球两种外观。下面分别展示它们在思考 / 呼吸状态
+下的原始动态效果：
 
-| Aurora Soundwave Orb | Liquid Gradient Orb |
+| 流光声波球 | 液态渐变球 |
 | --- | --- |
-| ![Aurora Soundwave Orb thinking animation](../desktop-fluid-orb-thinking.gif) | ![Liquid Gradient Orb thinking animation](../desktop-goo-orb-thinking.gif) |
+| ![流光声波球思考动画](../desktop-fluid-orb-thinking.gif) | ![液态渐变球思考动画](../desktop-goo-orb-thinking.gif) |
 
-## Installation
+## 皮肤
 
-Download the installer for your platform from the releases page:
+除内置外观外，悬浮球还支持
+[Codex pet](https://github.com/legeling/awesome-codex-pet) 包格式的精灵皮肤：
+一个包含 `pet.json` 与 `spritesheet.webp` 的目录（8 列网格，v1 为
+1536x1872 共 9 行，v2 为 1536x2288 共 11 行）。Codex pet 生态的素材无需
+任何转换即可使用，也不要求安装 Codex。
 
-- **macOS**: Download the `.dmg`, open it, and drag **Qwen Audio Agent** into "Applications".
-- **Windows**: Download the `.exe` installer, double-click to run, and follow the wizard to complete installation.
+导入已下载好的皮肤：打开“设置 → 应用 → 外观”，点击“导入皮肤…”，选择
+皮肤文件夹、其中的 `pet.json` 或 zip 压缩包。导入的皮肤存放在桌面版数据
+目录的 `skins/` 下，与内置外观一起出现在外观下拉框中；选中已导入的皮肤时
+可用旁边的“删除”按钮移除，内置外观不可删除。
 
-To build a local test version from source:
+悬浮球会把语音与任务状态映射为宠物动作：听你说话时专注等待，思考时低头审阅，
+说话或唤醒露面时挥手，后台任务执行中持续向左奔跑，任务等待你确认时持续跳跃
+求关注，语音被其他前台占用时奔跑，出错时呈现失败姿态；对话态始终优先于
+后台态。皮肤包只包含静态资源（JSON + WebP），导入时会校验格式与尺寸；若选中的
+皮肤包被删除，悬浮球会自动回退到内置外观。
+
+## 安装
+
+从发布页下载对应平台的安装包：
+
+- **macOS**：下载 `.dmg`，打开后将 **Qwen Audio Agent** 拖入"应用程序"。
+- **Windows**：下载 `.exe` 安装程序，双击运行并按向导完成安装。
+
+从源码生成本机测试版：
 
 ```bash
 npm run desktop:build:local      # macOS
 npm run desktop:build:win        # Windows
-npm run desktop:build:linux      # Linux (AppImage + deb, no signing required)
+npm run desktop:build:linux      # Linux（AppImage + deb，无需签名）
 ```
 
-The output is located in `dist/desktop/`.
+产物位于 `dist/desktop/`。
 
-## Data Directory and Isolation
+## 数据目录与隔离
 
-The desktop app uses the standard system application data directory (`~/Library/Application Support/Qwen Audio Agent` on macOS, `%APPDATA%/Qwen Audio Agent` on Windows, and `~/.config/Qwen Audio Agent` on Linux), which is completely isolated from the CLI's `~/.config/qwaudio`. The Gateway, locks, logs, and settings of the two do not interfere with each other and can run simultaneously. On first launch, the desktop app copies `config.env` and other user configurations from the CLI directory (the CLI retains the originals).
+桌面版使用系统标准应用数据目录（macOS 为
+`~/Library/Application Support/Qwen Audio Agent`，Windows 为
+`%APPDATA%/Qwen Audio Agent`，Linux 为
+`~/.config/Qwen Audio Agent`），与 CLI 的 `~/.config/qwaudio` 完全隔离。
+两者的 Gateway、锁、日志与设置互不干扰，可以同时运行。桌面版首次启动时会从
+CLI 目录复制 `config.env` 等用户配置（CLI 保留原件）。
 
-## Auto Update and Logs
+## 自动更新与日志
 
-The settings page displays the current version and allows manual update checks. When a new version is found, the background downloads a delta update, and once complete, a one-click restart installs it.
+设置页显示当前版本并可手动检查更新，发现新版本后台差量下载，完成后一键重启安装。
 
-The desktop app can open the log directory from "Settings → Application → Logs". Along with the Gateway, it records structured JSONL logs with automatic credential redaction and log rotation. For log configuration details, see
-[Configuration Guide](../configuration.md#本地日志).
+桌面版可在“设置 → 应用 → 日志”中打开日志目录，与 Gateway 一起记录结构化
+JSONL 日志，凭据自动脱敏并自动轮转。日志配置详见
+[配置说明](../configuration.zh.md#本地日志)。

--- a/docs/getting-started/install.zh.md
+++ b/docs/getting-started/install.zh.md
@@ -1,24 +1,24 @@
-# Installation
+# 安装
 
-Requires Node.js 22.22.2+ or 24.15.0+ and npm 10+. When using the default DashScope
-real-time voice frontend, a DashScope API Key is also required.
-The repository provides `.nvmrc` and `.node-version`; when using nvm, you can simply run `nvm use`.
+需要 Node.js 22.22.2+ 或 24.15.0+、npm 10+。使用默认的 DashScope
+实时语音前台时，还需要 DashScope API Key。
+仓库提供 `.nvmrc` 和 `.node-version`；使用 nvm 时可直接运行 `nvm use`。
 
-## One-line Install
+## 一键安装
 
-Install from npm (recommended):
+推荐从 npm 安装：
 
 ```bash
 npm install -g qwen-audio-agent
 ```
 
-You can also install the latest code directly from GitHub:
+也可以直接从 GitHub 安装最新代码：
 
 ```bash
 npm install -g git+https://github.com/QwenAudio/qwen-audio-agent.git
 ```
 
-## Install from Source
+## 从源码安装
 
 ```bash
 git clone https://github.com/QwenAudio/qwen-audio-agent.git
@@ -27,51 +27,51 @@ npm install
 npm run install:global
 ```
 
-## Upgrade
+## 升级
 
-Upgrade to the latest npm version:
+升级到最新 npm 版本：
 
 ```bash
 npm install -g qwen-audio-agent@latest
 ```
 
-Upgrade to the latest GitHub code:
+升级到 GitHub 最新代码：
 
 ```bash
 npm install -g git+https://github.com/QwenAudio/qwen-audio-agent.git
 ```
 
-After upgrading, if the Gateway is running as a background service, run `qwenaudio gateway restart` for the new version to take effect.
+升级后如果以后台服务方式运行 Gateway，需执行 `qwenaudio gateway restart` 让新版本生效。
 
-## Verify Installation
+## 验证安装
 
-View the exact location of the configuration file and confirm the installation is ready:
+查看配置文件的准确位置并确认安装就绪：
 
 ```bash
 qwenaudio config
 ```
 
-After configuring the backend agent, you can run a read-only check to confirm whether the backend executable, ACP integration, and adapter are ready:
+配置后台 Agent 后，可运行只读检查确认后台可执行文件、ACP 接入和适配器是否就绪：
 
 ```bash
 qwenaudio setup
 ```
 
-## Configuration File Location
+## 配置文件位置
 
-The CLI uses `~/.config/qwaudio/config.env`; the desktop version uses the system's standard application data directory
-(`~/Library/Application Support/Qwen Audio Agent` on macOS). The two have separate Gateways,
-locks, logs, and settings, and can run simultaneously. Set `QWAUDIO_CONFIG_DIR` or
-`XDG_CONFIG_HOME` to change the configuration directory. See [Configuration](../configuration.md) for details.
+CLI 使用 `~/.config/qwaudio/config.env`；桌面版使用系统标准应用数据目录
+（macOS 为 `~/Library/Application Support/Qwen Audio Agent`），两者的 Gateway、
+锁、日志与设置互不干扰，可以同时运行。设置 `QWAUDIO_CONFIG_DIR` 或
+`XDG_CONFIG_HOME` 可以更改配置目录。详见[配置说明](../configuration.zh.md)。
 
-## Obtain a DashScope API Key
+## 获取 DashScope API Key
 
-Alibaba Cloud Model Studio (Bailian) provides a
-[free trial quota](https://help.aliyun.com/zh/model-studio/new-free-quota) for Qwen Audio 3.0 Realtime. After creating an API Key,
-you can start using qwen-audio-agent for free.
+阿里云百炼为 Qwen Audio 3.0 Realtime 提供
+[新人免费额度](https://help.aliyun.com/zh/model-studio/new-free-quota)，创建 API Key 后
+即可免费开始使用 qwen-audio-agent。
 
-1. Open the [API Key page](https://bailian.console.aliyun.com/?tab=model#/api-key) in the Bailian console,
-   log in to your account, and click **Create API Key**.
-2. Copy the generated Key and fill it into `config.env` later. Do not publicly share or commit your API Key.
+1. 打开百炼控制台的 [API Key 页面](https://bailian.console.aliyun.com/?tab=model#/api-key)，
+   登录账号，单击**创建 API Key**。
+2. 复制生成的 Key，稍后填入 `config.env`。请勿公开或提交 API Key。
 
-For detailed instructions, see the [official Bailian documentation](https://help.aliyun.com/zh/model-studio/get-api-key).
+详细说明见[百炼官方文档](https://help.aliyun.com/zh/model-studio/get-api-key)。

--- a/docs/getting-started/quickstart.zh.md
+++ b/docs/getting-started/quickstart.zh.md
@@ -1,64 +1,64 @@
-# Quick Start
+# 快速开始
 
-If you haven't installed yet, see [Installation](install.md) first.
+如果还没安装，先看[安装](install.zh.md)。
 
-## 1. Create Configuration
+## 1. 创建配置
 
 ```bash
 qwenaudio config
 ```
 
-The command will display the configuration file path and create a `config.env` template with comments.
+命令会显示配置文件路径，并创建带注释的 `config.env` 模板。
 
-## 2. Fill in Configuration
+## 2. 填写配置
 
-The minimal configuration only requires a DashScope API Key:
+最小配置只需要 DashScope API Key：
 
 ```dotenv
 DASHSCOPE_API_KEY=your-key
 ```
 
-When you need to execute backend tasks, select a backend agent and specify the backend model:
+需要执行后台任务时，再选择后台 Agent 并指定后台模型：
 
 ```dotenv
 DASHSCOPE_API_KEY=your-key
-# Voice frontend model: flash for lower latency and cost savings, plus (default) for better quality
+# 语音前台模型：flash 低延迟更省，plus（默认）质量更好
 QWEN_AUDIO_REALTIME_MODEL=qwen-audio-3.0-realtime-plus
-# Backend agent: leave empty or set to none to start in frontend-only mode
+# 后台 Agent：留空或不设为 none 时启动仅前台模式
 AGENT_PROTOCOL=openclaw
-# Backend model: leave empty to use the agent's own user configuration; if not reused, the agent selects one
+# 后台模型：留空则沿用 Agent 自身的用户配置，不复用则由 Agent 自选
 QWEN_AUDIO_AGENT_BACKEND_MODEL=qwen3.7-max
 ```
 
-> The default uses the DashScope real-time voice frontend; you can also switch to a local [speech-to-speech frontend](../voice-frontends/speech-to-speech.md), which does not require a cloud API Key.
+> 默认使用 DashScope 实时语音前台；也可切换为本地 [speech-to-speech 前台](../voice-frontends/speech-to-speech.zh.md)，无需云端 API Key。
 
-## 3. Start
+## 3. 启动
 
-Start the Gateway in one terminal:
+在一个终端中启动 Gateway：
 
 ```bash
 qwenaudio
 ```
 
-Open another terminal and start the TUI:
+另开一个终端，启动 TUI：
 
 ```bash
 qwenaudio tui
 ```
 
-You can also use the browser interface (default `http://127.0.0.1:3101`):
+也可以使用浏览器界面（默认 `http://127.0.0.1:3101`）：
 
 ```bash
 qwenaudio webui
 ```
 
-## Frontend-Only Mode
+## 仅前台模式
 
-When `AGENT_PROTOCOL` is not set (or set to `none`), the Gateway only provides real-time voice chat.
-Requests that require backend execution will return a clear explanation and will not create tasks or guess execution results. You can also
-explicitly start in frontend-only mode with `qwenaudio --backend none`.
+不设置 `AGENT_PROTOCOL`（或设为 `none`）时，Gateway 只提供实时语音聊天。
+需要后台执行的请求会返回明确说明，不会创建任务或猜测执行结果。也可以用
+`qwenaudio --backend none` 显式启动仅前台模式。
 
-For selecting, one-click installing, permission modes, and persistent service of backend agents, see
-[Backend Agents](../backends/overview.md). For a complete list of environment variables, see
-[Configuration](../configuration.md). For TUI platform differences, see
-[TUI Notes](tui.md).
+后台 Agent 的选择、一键安装、权限模式和常驻服务见
+[后台 Agent](../backends/overview.zh.md)，完整环境变量见
+[配置说明](../configuration.zh.md)，TUI 平台差异见
+[TUI 注意](tui.zh.md)。

--- a/docs/getting-started/tui.zh.md
+++ b/docs/getting-started/tui.zh.md
@@ -1,41 +1,41 @@
-# TUI Usage Notes
+# TUI 使用注意
 
-## Platform Differences
+## 平台差异
 
-| Platform | Default Mode | Interruption Method |
+| 平台 | 默认模式 | 打断方式 |
 | --- | --- | --- |
-| macOS | Full-duplex with echo cancellation | Speak directly |
-| Linux / Windows | Half-duplex | Press `x` during playback |
+| macOS | 带回声消除的全双工 | 直接说话 |
+| Linux / Windows | 半双工 | 播报时按 `x` |
 
 ## macOS
 
-macOS always uses CoreAudio AEC full-duplex: audio is continuously captured during playback, supporting direct-speech interruption,
-without additional configuration. The CoreAudio helper program is compiled by default to
-`~/Library/Caches/qwaudio/tui/macos-voice-io` and is automatically built on first launch.
+macOS 始终使用 CoreAudio AEC 全双工：播报期间持续收音，支持直接说话打断，
+无需额外配置。CoreAudio 辅助程序默认编译到
+`~/Library/Caches/qwaudio/tui/macos-voice-io`，首次启动时自动构建。
 
 ## Linux / Windows
 
-By default, half-duplex mode is used via the bundled Python audio bridge using `sounddevice` / PortAudio:
-the microphone is paused during reply playback, only supporting manual interruption with the `x` key, and resumes after playback ends or is interrupted.
-Before first use, install `sounddevice` and the system PortAudio.
+默认通过随包提供的 Python 音频桥接使用 `sounddevice` / PortAudio 半双工：
+播放回复时麦克风会暂停，只支持 `x` 键手动打断，播放结束或打断后恢复。
+首次使用前需安装 `sounddevice` 和系统 PortAudio。
 
-You can also enable full-duplex mode without echo cancellation:
+也可以开启无回声消除的全双工模式：
 
 ```bash
 qwenaudio tui --audio-mode full
 ```
 
-This mode has no echo cancellation; please wear headphones to avoid misrecognition or false interruptions caused by speaker audio.
-Different sound cards and Bluetooth headsets have varying levels of support for simultaneous input and output streams at different sample rates; if you continuously
-experience input overflow, output underflow, or device errors, please exit and fall back to `--audio-mode half`.
+此模式没有回声消除，请佩戴耳机，避免扬声器声音造成误识别或误打断。
+不同声卡和蓝牙耳机对同时使用不同采样率的输入、输出流支持程度不同；如果持续
+报告输入溢出、输出欠载或设备错误，请退出并改用 `--audio-mode half` 兜底。
 
-## Configuration
+## 配置
 
-The default audio mode can also be set persistently via an environment variable:
+默认音频模式也可通过环境变量持久设置：
 
 ```dotenv
 QWEN_AUDIO_AGENT_TUI_AUDIO_MODE=half
 ```
 
-Setting it to `full` is equivalent to `--audio-mode full`. For full parameter details, see
-[Configuration](../configuration.md).
+设为 `full` 等效于 `--audio-mode full`。完整参数见
+[配置说明](../configuration.zh.md)。

--- a/docs/reference/memory.zh.md
+++ b/docs/reference/memory.zh.md
@@ -1,59 +1,48 @@
-# User Profile and Memory
+# 用户档案与记忆
 
-User data is stored under the configuration directory (`~/.config/qwaudio/` for the CLI):
+用户数据保存在配置目录下（CLI 为 `~/.config/qwaudio/`）：
 
-| File | Description |
+| 文件 | 说明 |
 | --- | --- |
-| `USER.md` | Name, location, preferences, and frequently used projects |
-| `frontend-memory.json` | Cross-session long-term memory (explicitly requested to remember, plus automatically distilled after sessions) |
-| `memory-audit.jsonl` | Audit log for automatic memory (writes, skips, and failures appended per entry, for retrospective review only) |
-| `tasks.json` | Background task results and pending notification states |
-| `state.env` | Local identity key (auto-generated on first launch, readable and writable only by the current user) |
-| `logs/` | Credential-redacted, auto-rotated local runtime logs |
+| `USER.md` | 称呼、所在地、偏好和常用项目 |
+| `frontend-memory.json` | 跨会话长期记住的信息（明确要求记住的，以及会话后自动沉淀的） |
+| `memory-audit.jsonl` | 自动记忆的审计日志（写入、跳过、失败逐条追加，仅供事后查阅） |
+| `tasks.json` | 后台任务结果和待通知状态 |
+| `state.env` | 本地身份密钥（首次启动自动生成，仅当前用户可读写） |
+| `logs/` | 经过凭据脱敏并自动轮转的本地运行日志 |
 
-These files are stored only on the local machine, are never committed to the source
-repository, and have file permissions restricted to the current user only.
+这些文件只保存在本机，不会写入源码仓库，文件权限为仅当前用户可读写。
 
 ## USER.md
 
-You can edit `USER.md` directly to write content by hand, or ask the assistant during a
-conversation to remember or forget information. The program only modifies marked managed
-regions within the file; all other hand-written content is preserved as-is. Changes take
-effect in the next conversation turn. To store the profile in a different location, set
-`QWEN_AUDIO_AGENT_USER_PROFILE_PATH`.
+可以直接编辑 `USER.md` 手写内容，也可以在对话中要求助理记住或忘记信息。
+程序只会改动文件内带标记的托管区域，其他手写内容原样保留；修改后下一轮对话
+即可生效。如需把档案放在其他位置，可设置
+`QWEN_AUDIO_AGENT_USER_PROFILE_PATH`。
 
-Do not store passwords, API Keys, verification codes, or tokens in this file.
+请勿在其中保存密码、API Key、验证码或令牌。
 
-## Long-Term Memory
+## 长期记忆
 
-`frontend-memory.json` stores personal facts, preferences, and agreements remembered
-across sessions, from two sources:
+`frontend-memory.json` 保存跨会话记住的个人事实、喜好和约定，来源有两种：
 
-- **Explicitly requested**: When you say "remember, change, no longer" etc. in a
-  conversation, the assistant updates or replaces old records with the corresponding
-  memory operation.
-- **Automatic distillation**: After a session ends, a lightweight text model extracts
-  stable personal facts (such as preferences, habits, long-term plans) from the
-  conversation and saves them silently — no need to say "remember." Automatic
-  distillation uses DashScope's `qwen-flash` model by default (reusing
-  `DASHSCOPE_API_KEY`); it is automatically disabled when no API Key is available, and
-  explicitly requested memory is unaffected. Set `QWEN_AUDIO_MEMORY_AUTO=off` to disable
-  it globally; `QWEN_AUDIO_MEMORY_MODEL`, `QWEN_AUDIO_MEMORY_BASE_URL`, and
-  `QWEN_AUDIO_MEMORY_API_KEY` can point to any OpenAI-compatible endpoint (including
-  local Ollama).
+- **明确要求**：对话中说“记住、改成、不再”等，助理会用对应记忆操作更新或
+  替换旧记录。
+- **自动沉淀**：会话结束后，一个轻量文本模型会从对话中提取稳定的个人事实
+  （如喜好、习惯、长期计划）静默保存，不需要说“记住”。自动沉淀默认使用
+  DashScope 的 `qwen-flash` 模型（复用 `DASHSCOPE_API_KEY`）；没有可用 API Key
+  时自动关闭，明确要求的记忆不受影响。设置 `QWEN_AUDIO_MEMORY_AUTO=off`
+  可全局关闭；`QWEN_AUDIO_MEMORY_MODEL`、`QWEN_AUDIO_MEMORY_BASE_URL`、
+  `QWEN_AUDIO_MEMORY_API_KEY` 可指向任意 OpenAI 兼容端点（含本地 Ollama）。
 
-Automatic distillation only writes to general long-term memory and does not create or
-modify long-term agreements or the user profile; sensitive content such as passwords and
-keys is intercepted by dual filtering. Every automatic write is logged in
-`memory-audit.jsonl` for review. If you think a memory entry is incorrect, simply say
-"that one is wrong" or "forget it" in the conversation. Memory capacity and retention
-period use built-in defaults; see [configuration guide](../configuration.md) for
-details.
+自动沉淀只会写入普通长期记忆，不会创建或修改长期约定与用户档案；密码、
+密钥等敏感内容会被双重过滤拦截。每次自动写入都记录在 `memory-audit.jsonl`
+中可供查阅。觉得某条记忆不对，直接在对话中说“那条记错了”或“忘掉它”即可。
+记忆容量与保留时间使用内置默认值，详见[配置说明](../configuration.zh.md)。
 
-## Logs
+## 日志
 
-Logs use JSON Lines format. API Keys, Tokens, Authorization headers, Cookies, passwords,
-and Secret fields are redacted before writing. By default, microphone audio, user
-transcription text, model reply text, and task results are not logged. In the desktop
-edition, you can open the log directory via "Settings → Application → Logs." See
-[configuration guide](../configuration.md#本地日志) for details.
+日志采用 JSON Lines 格式，API Key、Token、Authorization、Cookie、密码和
+Secret 字段会在写入前脱敏，默认不记录麦克风音频、用户转写正文、模型回复正文
+或任务结果。桌面版可在“设置 → 应用 → 日志”中打开日志目录。详见
+[配置说明](../configuration.zh.md#本地日志)。

--- a/docs/voice-frontends/speech-to-speech.zh.md
+++ b/docs/voice-frontends/speech-to-speech.zh.md
@@ -1,29 +1,20 @@
-# Using the Hugging Face speech-to-speech Frontend
+# 使用 Hugging Face speech-to-speech 前台
 
-qwen-audio-agent can also connect to a self-hosted
-[Hugging Face speech-to-speech](https://github.com/huggingface/speech-to-speech).
-It combines VAD, STT, LLM, and TTS into an OpenAI Realtime compatible service. The entire
-voice pipeline can run fully locally, or you can swap out individual models or services
-as needed. The Gateway only connects to the Realtime interface and does not modify the
-STT, LLM, TTS, or voice configuration of speech-to-speech.
+qwen-audio-agent 也可以连接用户自行运行的
+[Hugging Face speech-to-speech](https://github.com/huggingface/speech-to-speech)。
+它将 VAD、STT、LLM 和 TTS 组合成 OpenAI Realtime 兼容服务，整条语音链路既可以
+完全运行在本地，也可以按需替换其中的模型或服务。Gateway 只连接 Realtime 接口，
+不会修改 speech-to-speech 的 STT、LLM、TTS 或音色配置。
 
-## Installing speech-to-speech
+## 安装 speech-to-speech
 
 ```bash
 pip install "speech-to-speech[paraformer]"
 ```
 
-The Chinese profile below relies on CJK punctuation and Qwen3-TTS long-utterance budgeting
-fixes merged after v0.2.12. Until a release containing them is available, install the merged
-revision directly:
+## 启动服务
 
-```bash
-pip install "speech-to-speech[paraformer] @ git+https://github.com/huggingface/speech-to-speech.git@f75d6b435d89b8dff911f639672c172166595409"
-```
-
-## Starting the Service
-
-Linux / Windows (NVIDIA GPU):
+Linux / Windows（NVIDIA GPU）：
 
 ```bash
 speech-to-speech \
@@ -32,28 +23,7 @@ speech-to-speech \
   --device cuda
 ```
 
-For the tested Chinese Qwen3-TTS profile, use explicit model, language, speaker, and delivery
-settings while keeping the backend sampling defaults:
-
-```bash
-speech-to-speech \
-  --stt paraformer \
-  --llm_backend transformers \
-  --model_name Qwen/Qwen3-4B-Instruct-2507 \
-  --tts qwen3 \
-  --qwen3_tts_backend torch \
-  --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
-  --qwen3_tts_speaker Vivian \
-  --qwen3_tts_language chinese \
-  --qwen3_tts_instruct "请用平稳、自然、克制的语气说话，保持均匀语速，避免夸张的音高变化，句末自然收束。" \
-  --device cuda
-```
-
-The merged speech-to-speech fix preserves Chinese punctuation and scales the Qwen3-TTS codec
-token budget for CJK text automatically. No sampling override or larger fixed token limit is
-needed.
-
-Apple Silicon:
+Apple Silicon：
 
 ```bash
 speech-to-speech \
@@ -62,26 +32,24 @@ speech-to-speech \
   --device mps
 ```
 
-The service runs at `ws://127.0.0.1:8765/v1/realtime` by default. Without an NVIDIA GPU,
-you can also choose smaller CPU-friendly local models; the LLM can point to a locally
-running vLLM / llama.cpp, or to cloud models such as Bailian via an OpenAI-compatible
-endpoint. See the official speech-to-speech documentation for specific parameters.
+服务默认运行在 `ws://127.0.0.1:8765/v1/realtime`。没有 NVIDIA GPU 时，也可以
+选择适合 CPU 的更小本地模型；LLM 还可以指向本机运行的 vLLM / llama.cpp，或通过
+OpenAI 兼容端点指向百炼等云端模型。具体参数见 speech-to-speech 官方文档。
 
-## Connecting to qwen-audio-agent
+## 接入 qwen-audio-agent
 
-Set the following in `config.env`:
+在 `config.env` 中设置：
 
 ```dotenv
 QWEN_AUDIO_REALTIME_PROVIDER=speech-to-speech
 SPEECH_TO_SPEECH_REALTIME_URL=ws://127.0.0.1:8765/v1/realtime
 ```
 
-In full-local mode, no cloud API Key is required. If the Realtime interface sits behind a
-proxy that requires Bearer authentication, you can set:
+在全本地模式下无需云端 API Key。如果 Realtime 接口位于需要 Bearer 认证的代理
+后方，可设置：
 
 ```dotenv
 SPEECH_TO_SPEECH_AUTH_TOKEN=your-token
 ```
 
-`SPEECH_TO_SPEECH_AUTH_TOKEN` is only used for proxy authentication and is not an access
-password for the local service.
+`SPEECH_TO_SPEECH_AUTH_TOKEN` 仅用于代理认证，不是本地服务的访问密码。

--- a/server/src/agent/acp-process-client.mjs
+++ b/server/src/agent/acp-process-client.mjs
@@ -299,11 +299,11 @@ export class AcpProcessClient {
   rememberSession(sessionId, details = {}) {
     const id = String(sessionId || '')
     if (!id) return null
-    const session = {
-      ...(this.sessions.get(id) || {}),
-      ...details,
-      sessionId: id,
-    }
+    // 原地合并，保持对象身份稳定：adapter 会在同一引用上维护运行时路由字段
+    // （onEvent/ownerId/coordinationRunId 等）。若每次 resume 都替换对象，
+    // 权限请求会拿到旧闭包快照，被路由到已完成的旧任务上。
+    const session = this.sessions.get(id) || {}
+    Object.assign(session, details, { sessionId: id })
     this.sessions.set(id, session)
     return session
   }

--- a/server/test/acp-process-client.test.mjs
+++ b/server/test/acp-process-client.test.mjs
@@ -3,6 +3,28 @@ import test from 'node:test'
 import { AcpProcessClient } from '../src/agent/acp-process-client.mjs'
 import { openClawBackendDriver } from '../src/agent/backends/openclaw.mjs'
 
+test('keeps session object identity stable across re-registration', () => {
+  const client = new AcpProcessClient({
+    label: 'Test Agent',
+    command: 'unused',
+  })
+  const first = client.rememberSession('sess-1', { role: 'coordinator' })
+  // adapter 在同一引用上维护运行时路由字段（如权限事件回调）。
+  const onEvent = () => {}
+  first.onEvent = onEvent
+  first.coordinationRunId = 'work_current'
+
+  // resume 重新注册后必须仍是同一对象，否则权限请求会拿到
+  // 旧闭包快照，被路由到已完成的旧任务上。
+  const second = client.rememberSession('sess-1', { cwd: '/next' })
+  assert.equal(second, first)
+  assert.equal(client.sessions.get('sess-1'), first)
+  assert.equal(second.onEvent, onEvent)
+  assert.equal(second.coordinationRunId, 'work_current')
+  assert.equal(second.cwd, '/next')
+  assert.equal(second.role, 'coordinator')
+})
+
 test('shares an in-flight ACP initialization across concurrent callers', async () => {
   const client = new AcpProcessClient({
     label: 'Test Agent',

--- a/shared/orb-skin-catalog.mjs
+++ b/shared/orb-skin-catalog.mjs
@@ -1,0 +1,28 @@
+// 悬浮球皮肤目录：主进程与 web 渲染层共用的单一事实来源。
+// 皮肤 = { id, type, displayName }。内置皮肤是 theme 类型（CSS 渲染），
+// 导入皮肤是 sprite 类型（Codex pet 包渲染），两者共用同一选择链。
+
+export const BUILTIN_ORB_SKINS = Object.freeze([
+  Object.freeze({ id: 'fluid', type: 'theme', displayName: '流光声波球' }),
+  Object.freeze({ id: 'goo', type: 'theme', displayName: '液态渐变球' }),
+])
+
+export const ORB_SKIN_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/i
+
+export function isBuiltinOrbSkin(id) {
+  return BUILTIN_ORB_SKINS.some(skin => skin.id === String(id || ''))
+}
+
+export function normalizeOrbSkinId(value) {
+  const id = String(value || '').trim()
+  return ORB_SKIN_ID_PATTERN.test(id) ? id : ''
+}
+
+// 统一回退链：orbSkin → orbStyle（旧配置只读兼容）→ fluid。
+export function resolveOrbSkinId({ orbSkin, orbStyle } = {}) {
+  return (
+    normalizeOrbSkinId(orbSkin)
+    || normalizeOrbSkinId(orbStyle)
+    || 'fluid'
+  )
+}

--- a/test/orb-skin-catalog.test.mjs
+++ b/test/orb-skin-catalog.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  BUILTIN_ORB_SKINS,
+  isBuiltinOrbSkin,
+  normalizeOrbSkinId,
+  ORB_SKIN_ID_PATTERN,
+  resolveOrbSkinId,
+} from '../shared/orb-skin-catalog.mjs'
+
+test('exposes the builtin theme skins as first-class catalog entries', () => {
+  assert.deepEqual(BUILTIN_ORB_SKINS.map(skin => skin.id), ['fluid', 'goo'])
+  for (const skin of BUILTIN_ORB_SKINS) {
+    assert.equal(skin.type, 'theme')
+    assert.ok(skin.displayName)
+    assert.match(skin.id, ORB_SKIN_ID_PATTERN)
+  }
+  assert.equal(isBuiltinOrbSkin('fluid'), true)
+  assert.equal(isBuiltinOrbSkin('goo'), true)
+  assert.equal(isBuiltinOrbSkin('firefly--lingxiaotian'), false)
+  assert.equal(isBuiltinOrbSkin(''), false)
+})
+
+test('normalizes skin ids against the shared naming contract', () => {
+  assert.equal(normalizeOrbSkinId('firefly--lingxiaotian'), 'firefly--lingxiaotian')
+  assert.equal(normalizeOrbSkinId('  goo  '), 'goo')
+  assert.equal(normalizeOrbSkinId('../escape'), '')
+  assert.equal(normalizeOrbSkinId('bad id'), '')
+  assert.equal(normalizeOrbSkinId('-leading-dash'), '')
+  assert.equal(normalizeOrbSkinId(''), '')
+  assert.equal(normalizeOrbSkinId(undefined), '')
+  assert.equal(normalizeOrbSkinId('a'.repeat(65)), '')
+})
+
+test('resolves the effective skin through the unified fallback chain', () => {
+  assert.equal(
+    resolveOrbSkinId({ orbSkin: 'firefly--lingxiaotian', orbStyle: 'goo' }),
+    'firefly--lingxiaotian',
+  )
+  assert.equal(resolveOrbSkinId({ orbSkin: '', orbStyle: 'goo' }), 'goo')
+  assert.equal(resolveOrbSkinId({ orbSkin: '../bad', orbStyle: 'goo' }), 'goo')
+  assert.equal(resolveOrbSkinId({}), 'fluid')
+  assert.equal(resolveOrbSkinId(), 'fluid')
+})

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -15,7 +15,12 @@ import {
 } from './message-order.js'
 import MessageContent from './MessageContent.jsx'
 import DesktopFluidOrb from './DesktopFluidOrb.jsx'
-import { desktopOrbClassName } from './orb-presentation.js'
+import DesktopSpriteOrb from './DesktopSpriteOrb.jsx'
+import { desktopOrbClassName, resolveOrbVisualState } from './orb-presentation.js'
+import {
+  isBuiltinOrbSkin,
+  resolveOrbSkinId,
+} from '../../shared/orb-skin-catalog.mjs'
 import { resultLabel } from './presentation.js'
 import {
   removeDeliveredTask,
@@ -37,6 +42,8 @@ import {
   desktopHideDeadline,
   desktopWakeWordEnabled,
   desktopWorkSettled,
+  desktopTasksActive,
+  desktopTasksAttention,
 } from './desktop-hide.js'
 
 const desktopOrbMode = (
@@ -45,11 +52,10 @@ const desktopOrbMode = (
 const takeoverRequested = (
   new URLSearchParams(window.location.search).get('takeover') === '1'
 )
-const orbStyle = (
-  new URLSearchParams(window.location.search).get('orbStyle') === 'goo'
-    ? 'goo'
-    : 'fluid'
-)
+const orbSkinId = resolveOrbSkinId({
+  orbSkin: new URLSearchParams(window.location.search).get('orbSkin'),
+  orbStyle: new URLSearchParams(window.location.search).get('orbStyle'),
+})
 const autoHideSeconds = desktopAutoHideSeconds(window.location.search)
 const wakeWordEnabled = desktopWakeWordEnabled(window.location.search)
 
@@ -72,6 +78,8 @@ function labelFor(state) {
     listening: '正在听',
     thinking: '思考中',
     speaking: '正在说',
+    working: '正在处理任务',
+    attention: '等待你的确认',
     connecting: '正在连接语音前台',
     occupied: '其他入口正在使用',
     hidden: '已隐藏',
@@ -130,6 +138,7 @@ export default function App() {
   const [backend, setBackend] = useState({ label: 'Agent', ready: false })
   const [agentTasks, setAgentTasks] = useState([])
   const [orbDragging, setOrbDragging] = useState(false)
+  const [spriteOrbFailed, setSpriteOrbFailed] = useState(false)
   const [desktopLifecycle, setDesktopLifecycle] = useState('active')
   const [lastInteractionAt, setLastInteractionAt] = useState(Date.now)
   const [workSettledAt, setWorkSettledAt] = useState(Date.now)
@@ -144,6 +153,7 @@ export default function App() {
   const suppressOrbClick = useRef(false)
   const previousWorkSettled = useRef(true)
   const workSettledAtRef = useRef(workSettledAt)
+  const lastWakeAtRef = useRef(0)
 
   const noteInteraction = useCallback(() => {
     setLastInteractionAt(Date.now())
@@ -351,6 +361,7 @@ export default function App() {
       desktop: desktopOrbMode,
       bridge: window.qwenAudioAgentDesktop,
       onLifecycle: setDesktopLifecycle,
+      lastWakeAt: lastWakeAtRef.current,
     }).catch(() => {})
     if (
       event.type === 'voice.sleep'
@@ -680,17 +691,21 @@ export default function App() {
   const voiceConnectionError = (
     !lifecycleTransition && voice.connectionState === 'unavailable'
   )
-  const visualVoiceState = desktopLifecycle === 'hidden'
-    ? 'hidden'
-    : desktopLifecycle === 'waking'
-      ? 'waking'
-      : voice.ownership.state === 'busy'
-    ? 'occupied'
-    : voiceConnectionError
-      ? 'error'
-      : voiceEnabled && voice.connectionState === 'connecting'
-      ? 'connecting'
-      : voice.visualState || voice.state
+  // 统一视觉状态仲裁：生命周期 → 异常 → 对话态 → 后台态。
+  // 后台任务态（attention/working）仅在桌面悬浮球展示，
+  // WebUI 由任务卡片承载同类信息。
+  const orbVisualState = resolveOrbVisualState({
+    lifecycle: desktopLifecycle,
+    connectionError: voiceConnectionError,
+    connecting: voiceEnabled && voice.connectionState === 'connecting',
+    ownershipBusy: voice.ownership.state === 'busy',
+    voiceState: voice.visualState || voice.state,
+    tasksActive: desktopOrbMode && desktopTasksActive(agentTasks),
+    attentionPending: desktopOrbMode && desktopTasksAttention(agentTasks),
+  })
+  const attentionTask = agentTasks.find(
+    task => task.authorization?.status === 'pending',
+  )
   const ownershipLabel = voice.ownership.holder
     ? frontendLabel(voice.ownership.holder)
     : ''
@@ -718,6 +733,7 @@ export default function App() {
     const applyLifecycle = lifecycle => {
       if (!lifecycle?.state) return
       setDesktopLifecycle(lifecycle.state)
+      if (lifecycle.state === 'waking') lastWakeAtRef.current = Date.now()
       if (lifecycle.reason === 'activity') noteInteraction()
       if (lifecycle.state === 'hidden') setActivity('已隐藏')
       if (lifecycle.state === 'waking') setActivity('正在显示悬浮球')
@@ -895,20 +911,22 @@ export default function App() {
       <section
         ref={voice.levelElementRef}
         className={desktopOrbClassName({
-          state: visualVoiceState,
+          state: orbVisualState,
           enabled: voiceEnabled,
           error: voice.visualError || voiceConnectionError,
           dragging: orbDragging,
           lifecycle: desktopLifecycle,
         })}
-        aria-label={`qwen-audio · ${voice.visualError || voiceConnectionError ? '连接异常' : labelFor(visualVoiceState)}`}
+        aria-label={`qwen-audio · ${voice.visualError || voiceConnectionError ? '连接异常' : labelFor(orbVisualState)}`}
         title={
           desktopLifecycle === 'waking'
             ? '正在显示悬浮球'
             : voice.error
-          || (visualVoiceState === 'occupied' && ownershipLabel
-            ? `${ownershipLabel}正在使用语音`
-            : labelFor(visualVoiceState))
+          || (orbVisualState === 'attention' && attentionTask
+            ? taskDetail(attentionTask)
+            : orbVisualState === 'occupied' && ownershipLabel
+              ? `${ownershipLabel}正在使用语音`
+              : labelFor(orbVisualState))
         }
         onClick={handleOrbClick}
         onPointerDown={beginOrbDrag}
@@ -916,7 +934,20 @@ export default function App() {
         onPointerUp={endOrbDrag}
         onPointerCancel={endOrbDrag}
       >
-        <DesktopFluidOrb style={orbStyle} />
+        {isBuiltinOrbSkin(orbSkinId) || spriteOrbFailed
+          ? (
+              <DesktopFluidOrb
+                style={isBuiltinOrbSkin(orbSkinId) ? orbSkinId : 'fluid'}
+              />
+            )
+          : (
+              <DesktopSpriteOrb
+                skin={orbSkinId}
+                state={orbVisualState}
+                dragging={orbDragging}
+                onError={() => setSpriteOrbFailed(true)}
+              />
+            )}
         <nav
           className="desktop-orb-controls"
           aria-label="语音控制"
@@ -1052,7 +1083,7 @@ export default function App() {
           前台：{item.label}
         </option>)}
       </select>}
-      <div className="status"><i className={visualVoiceState} />{labelFor(visualVoiceState)}</div>
+      <div className="status"><i className={orbVisualState} />{labelFor(orbVisualState)}</div>
       <button className="ghost" onClick={resetSession}>新会话</button>
       <button
         className={[
@@ -1078,7 +1109,7 @@ export default function App() {
       <div className="hero">
         <button
           ref={voice.levelElementRef}
-          className={`orb ${visualVoiceState}`}
+          className={`orb ${orbVisualState}`}
           onClick={handleOrbClick}
           aria-label="语音交互"
         >

--- a/web/src/DesktopSpriteOrb.jsx
+++ b/web/src/DesktopSpriteOrb.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  frameAtElapsed,
+  frameRect,
+  resolveAnimations,
+  spriteAnimationForOrbState,
+  spriteGeometry,
+} from './sprite-orb.js'
+
+// 精灵皮肤渲染器：从同源 skins/<id>/ 加载 Codex pet 包，canvas 直接
+// 从整张 spritesheet 裁帧绘制。状态机与窗口交互都在组件外层，
+// 这里只负责把共享的语音状态翻译成精灵动画。
+export default function DesktopSpriteOrb({
+  skin,
+  state,
+  dragging = false,
+  onError,
+}) {
+  const canvasRef = useRef(null)
+  const onErrorRef = useRef(onError)
+  const [assets, setAssets] = useState(null)
+  onErrorRef.current = onError
+
+  useEffect(() => {
+    let cancelled = false
+    setAssets(null)
+    const fail = error => {
+      if (!cancelled) onErrorRef.current?.(error)
+    }
+    fetch(`skins/${encodeURIComponent(skin)}/pet.json`)
+      .then(response => {
+        if (!response.ok) throw new Error(`皮肤 ${skin} 不存在`)
+        return response.json()
+      })
+      .then(manifest => {
+        const geometry = spriteGeometry(manifest)
+        if (!geometry) throw new Error(`皮肤 ${skin} 的网格定义非法`)
+        const animations = resolveAnimations(manifest, geometry.frameCount)
+        const spritesheet = String(
+          manifest.spritesheetPath || 'spritesheet.webp',
+        )
+        const image = new Image()
+        image.decoding = 'async'
+        image.onload = () => {
+          if (cancelled) return
+          if (
+            image.naturalWidth !== geometry.width * geometry.columns
+            || image.naturalHeight !== geometry.height * geometry.rows
+          ) {
+            fail(new Error(`皮肤 ${skin} 的贴图尺寸与网格不符`))
+            return
+          }
+          setAssets({ image, geometry, animations })
+        }
+        image.onerror = () => fail(new Error(`皮肤 ${skin} 的贴图加载失败`))
+        image.src = `skins/${encodeURIComponent(skin)}/${spritesheet}`
+      })
+      .catch(fail)
+    return () => {
+      cancelled = true
+    }
+  }, [skin])
+
+  const animationName = spriteAnimationForOrbState({ state, dragging })
+
+  useEffect(() => {
+    if (!assets) return undefined
+    const canvas = canvasRef.current
+    const context = canvas?.getContext('2d')
+    if (!context) return undefined
+    const { image, geometry, animations } = assets
+    let track = animations[animationName] || animations.idle
+    let startedAt = performance.now()
+    let timer = 0
+    const draw = () => {
+      let frame = frameAtElapsed(track, performance.now() - startedAt)
+      if (!frame) {
+        // one-shot 播完交棒 fallback 轨道。
+        track = animations[track.fallback] || animations.idle
+        startedAt = performance.now()
+        frame = frameAtElapsed(track, 0)
+        if (!frame) return
+      }
+      const source = frameRect(geometry, frame.spriteIndex)
+      context.clearRect(0, 0, canvas.width, canvas.height)
+      context.imageSmoothingEnabled = false
+      context.drawImage(
+        image,
+        source.x,
+        source.y,
+        source.width,
+        source.height,
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+      )
+      timer = setTimeout(draw, Math.max(16, frame.remainingMs))
+    }
+    draw()
+    return () => clearTimeout(timer)
+  }, [assets, animationName])
+
+  if (!assets) return <div className="stage sprite-orb" />
+  return (
+    <div className="stage sprite-orb">
+      <canvas
+        ref={canvasRef}
+        className="sprite-orb-canvas"
+        width={assets.geometry.width}
+        height={assets.geometry.height}
+      />
+    </div>
+  )
+}

--- a/web/src/desktop-hide.js
+++ b/web/src/desktop-hide.js
@@ -32,16 +32,25 @@ export function desktopWakeWordEnabled(search = '') {
   return new URLSearchParams(search).get('wakeWordEnabled') === 'true'
 }
 
+export function desktopTasksActive(tasks = []) {
+  return tasks.some(task => (
+    ACTIVE_TASK_PHASES.has(task.phase)
+    || task.authorization?.status === 'pending'
+  ))
+}
+
+// 后台任务在等待用户授权：不确认就永远卡住，优先级高于普通执行态。
+export function desktopTasksAttention(tasks = []) {
+  return tasks.some(task => task.authorization?.status === 'pending')
+}
+
 export function desktopWorkSettled({
   tasks = [],
   messages = [],
   voiceState = 'idle',
 } = {}) {
   return (
-    !tasks.some(task => (
-      ACTIVE_TASK_PHASES.has(task.phase)
-      || task.authorization?.status === 'pending'
-    ))
+    !desktopTasksActive(tasks)
     && !messages.some(message => message.live)
     && !ACTIVE_VOICE_STATES.has(voiceState)
   )
@@ -72,16 +81,24 @@ export function desktopHideDeadline({
 
 // Client state is a provider- and Gateway-level capability. This adapter owns
 // only its desktop presentation: the generic "sleeping" state hides the orb.
+// 刚被用户显式唤醒的宽限期内忽略 sleeping 广播：Gateway 的休眠计时器
+// 可能恰好在唤醒瞬间到期，迟到的过期指令不应把悬浮球藏回去
+// （随后的 voice.wake 会重新唤醒 Gateway）。
+export const DESKTOP_WAKE_GRACE_MS = 5000
+
 export async function applyDesktopClientState(event, {
   desktop = false,
   bridge,
   onLifecycle = () => {},
+  lastWakeAt = 0,
+  now = Date.now(),
 } = {}) {
   if (
     !desktop
     || event?.type !== GatewayServerEvent.CLIENT_STATE
     || event.state !== 'sleeping'
     || typeof bridge?.enterHide !== 'function'
+    || now - lastWakeAt < DESKTOP_WAKE_GRACE_MS
   ) return false
 
   const lifecycle = await bridge.enterHide()

--- a/web/src/orb-presentation.js
+++ b/web/src/orb-presentation.js
@@ -1,3 +1,30 @@
+// 对话态：秒级瞬态，实时交互永远优先于后台态展示。
+const CONVERSATION_STATES = new Set(['listening', 'thinking', 'speaking'])
+
+// 悬浮球视觉状态仲裁器：所有事件源收敛为单一状态，优先级从高到低：
+// 生命周期（hidden/waking）→ 连接异常（error）→ 对话态 →
+// attention（后台等你确认）→ working（任务执行中）→
+// occupied（他端占用）→ connecting → idle。
+export function resolveOrbVisualState({
+  lifecycle = 'active',
+  connectionError = false,
+  connecting = false,
+  ownershipBusy = false,
+  voiceState = 'idle',
+  tasksActive = false,
+  attentionPending = false,
+} = {}) {
+  if (lifecycle === 'hidden') return 'hidden'
+  if (lifecycle === 'waking') return 'waking'
+  if (connectionError) return 'error'
+  if (CONVERSATION_STATES.has(voiceState)) return voiceState
+  if (attentionPending) return 'attention'
+  if (tasksActive) return 'working'
+  if (ownershipBusy) return 'occupied'
+  if (connecting) return 'connecting'
+  return voiceState
+}
+
 export function desktopOrbClassName({
   state,
   enabled,

--- a/web/src/sprite-orb.js
+++ b/web/src/sprite-orb.js
@@ -1,0 +1,213 @@
+// 精灵皮肤动画模型：对齐 Codex App 开源实现（codex-rs/tui/src/pets）。
+// 轨道 = { frames: [{spriteIndex, durationMs}], loopStart, fallback }；
+// loopStart 为 null 表示 one-shot，播完总时长后交棒 fallback 轨道。
+
+const DEFAULT_COLUMNS = 8
+const DEFAULT_FRAME_WIDTH = 192
+const DEFAULT_FRAME_HEIGHT = 208
+const DEFAULT_ROWS = 9
+const V2_ROWS = 11
+const DEFAULT_FPS = 8
+const MAX_FPS = 60
+
+function idleAnimation() {
+  const durations = [1680, 660, 660, 840, 840, 1920]
+  return {
+    frames: durations.map((durationMs, spriteIndex) => ({
+      spriteIndex,
+      durationMs,
+    })),
+    loopStart: 0,
+    fallback: 'idle',
+  }
+}
+
+// 状态动画 = 该行帧序列重复 3 遍 + 拼接 idle 帧，loopStart 指向 idle 段——
+// 动作播 3 遍后自动沉降回 idle 循环，持续态不会一直播动作。
+function appStateAnimation(
+  rowIndex,
+  frameCount,
+  frameDurationMs,
+  finalFrameDurationMs,
+) {
+  const primary = Array.from({ length: frameCount }, (_, column) => ({
+    spriteIndex: rowIndex * DEFAULT_COLUMNS + column,
+    durationMs: column === frameCount - 1
+      ? finalFrameDurationMs
+      : frameDurationMs,
+  }))
+  return {
+    frames: [...primary, ...primary, ...primary, ...idleAnimation().frames],
+    loopStart: primary.length * 3,
+    fallback: 'idle',
+  }
+}
+
+export function defaultAnimations() {
+  return {
+    'idle': idleAnimation(),
+    'running-right': appStateAnimation(1, 8, 120, 220),
+    'running-left': appStateAnimation(2, 8, 120, 220),
+    'waving': appStateAnimation(3, 4, 140, 280),
+    'jumping': appStateAnimation(4, 5, 140, 280),
+    'failed': appStateAnimation(5, 8, 140, 240),
+    'waiting': appStateAnimation(6, 6, 150, 260),
+    'running': appStateAnimation(7, 6, 120, 220),
+    'review': appStateAnimation(8, 6, 150, 280),
+    // 后台任务进行中：running-left 行持续循环不沉降，“跑去干活了”。
+    'working': rowLoopAnimation(2, 8, 120, 220),
+    // 后台在等你确认：jumping 行持续循环，跳跃求关注。
+    'attention': rowLoopAnimation(4, 5, 140, 280),
+  }
+}
+
+// 持续循环的行动画：不拼接 idle 沉降段，状态存续期间一直播放。
+function rowLoopAnimation(
+  rowIndex,
+  frameCount,
+  frameDurationMs,
+  finalFrameDurationMs,
+) {
+  const { frames } = appStateAnimation(
+    rowIndex,
+    frameCount,
+    frameDurationMs,
+    finalFrameDurationMs,
+  )
+  return {
+    frames: frames.slice(0, frameCount),
+    loopStart: 0,
+    fallback: 'idle',
+  }
+}
+
+// 语音状态 → 动画名。状态由 orb-presentation.js 的仲裁器产出：
+// 对话态（idle/listening/thinking/speaking）与后台/系统态
+// （attention/working/occupied/error/connecting/waking/hidden）。
+export function spriteAnimationForOrbState({ state, dragging = false } = {}) {
+  if (dragging) return 'running-right'
+  switch (state) {
+    case 'listening':
+    case 'connecting':
+      return 'waiting'
+    case 'thinking':
+      return 'review'
+    case 'occupied':
+      return 'running'
+    case 'working':
+      return 'working'
+    case 'attention':
+      return 'attention'
+    case 'speaking':
+      return 'waving'
+    case 'waking':
+      // 出现时挥手打招呼（jumping 行让给 attention）。
+      return 'waving'
+    case 'error':
+      return 'failed'
+    default:
+      return 'idle'
+  }
+}
+
+export function spriteGeometry(manifest = {}) {
+  const version = manifest.spriteVersionNumber ?? 1
+  const frame = manifest.frame && typeof manifest.frame === 'object'
+    ? manifest.frame
+    : {
+        width: DEFAULT_FRAME_WIDTH,
+        height: DEFAULT_FRAME_HEIGHT,
+        columns: DEFAULT_COLUMNS,
+        rows: version === 2 ? V2_ROWS : DEFAULT_ROWS,
+      }
+  for (const key of ['width', 'height', 'columns', 'rows']) {
+    if (!Number.isInteger(frame[key]) || frame[key] <= 0) return null
+  }
+  return {
+    width: frame.width,
+    height: frame.height,
+    columns: frame.columns,
+    rows: frame.rows,
+    frameCount: frame.columns * frame.rows,
+  }
+}
+
+export function frameRect(geometry, spriteIndex) {
+  return {
+    x: (spriteIndex % geometry.columns) * geometry.width,
+    y: Math.floor(spriteIndex / geometry.columns) * geometry.height,
+    width: geometry.width,
+    height: geometry.height,
+  }
+}
+
+// 合并 pet.json 可选 animations 覆盖与默认轨道表，并校验帧索引与 fallback。
+export function resolveAnimations(manifest = {}, frameCount = 0) {
+  const animations = defaultAnimations()
+  const specs = manifest.animations
+  if (specs && typeof specs === 'object' && !Array.isArray(specs)) {
+    for (const [name, spec] of Object.entries(specs)) {
+      if (!spec || !Array.isArray(spec.frames) || spec.frames.length === 0) {
+        throw new Error(`皮肤动画 ${name} 至少要包含一帧`)
+      }
+      const fps = spec.fps === undefined ? DEFAULT_FPS : spec.fps
+      if (!Number.isFinite(fps) || fps <= 0 || fps > MAX_FPS) {
+        throw new Error(`皮肤动画 ${name} 的 fps 非法`)
+      }
+      const durationMs = 1000 / fps
+      animations[name] = {
+        frames: spec.frames.map(spriteIndex => ({ spriteIndex, durationMs })),
+        loopStart: (spec.loop ?? true) ? 0 : null,
+        fallback: spec.fallback || 'idle',
+      }
+    }
+  }
+  for (const [name, animation] of Object.entries(animations)) {
+    for (const frame of animation.frames) {
+      if (
+        !Number.isInteger(frame.spriteIndex)
+        || frame.spriteIndex < 0
+        || frame.spriteIndex >= frameCount
+      ) {
+        throw new Error(`皮肤动画 ${name} 引用了越界的帧索引`)
+      }
+    }
+    if (!animations[animation.fallback]) {
+      throw new Error(`皮肤动画 ${name} 的 fallback 不存在`)
+    }
+  }
+  return animations
+}
+
+function totalDuration(animation) {
+  return animation.frames.reduce((sum, frame) => sum + frame.durationMs, 0)
+}
+
+// 无状态帧解析（仿 Codex current_animation_frame）：由动画开始至今的
+// elapsed 算当前帧与到下一帧的延时。one-shot 播完返回 null，由调用方
+// 切到 fallback 轨道。
+export function frameAtElapsed(animation, elapsedMs) {
+  const total = totalDuration(animation)
+  if (total <= 0) return null
+  let position = Math.max(0, elapsedMs)
+  if (position >= total) {
+    if (animation.loopStart === null) return null
+    const introDuration = animation.frames
+      .slice(0, animation.loopStart)
+      .reduce((sum, frame) => sum + frame.durationMs, 0)
+    const loopDuration = total - introDuration
+    if (loopDuration <= 0) return null
+    position = introDuration + ((position - total) % loopDuration)
+  }
+  let cursor = 0
+  for (const frame of animation.frames) {
+    if (position < cursor + frame.durationMs) {
+      return {
+        spriteIndex: frame.spriteIndex,
+        remainingMs: cursor + frame.durationMs - position,
+      }
+    }
+    cursor += frame.durationMs
+  }
+  return null
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -173,6 +173,25 @@ header .voice.waiting { color: #ded5ff; border-color: #927cf480; }
   --orb-halo: #8588912e;
   --orb-ring: #aaadb53d;
 }
+.sprite-orb {
+  display: grid;
+  place-items: center;
+}
+.sprite-orb-canvas {
+  height: 112px;
+  width: auto;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 4px 10px #1f2a4426);
+}
+.desktop-orb-stage.input-muted:not(.speaking) .sprite-orb-canvas {
+  filter: grayscale(.85) opacity(.72);
+}
+.desktop-orb-stage.occupied .sprite-orb-canvas {
+  filter: grayscale(.55) saturate(.55) brightness(.82);
+}
+.desktop-orb-stage.connecting .sprite-orb-canvas {
+  filter: grayscale(.66) saturate(.4) brightness(.86);
+}
 .desktop-orb-stage.occupied .fluid-orb {
   --orb-halo: #73829335;
   --orb-ring: #93a2b35c;
@@ -217,6 +236,33 @@ header .voice.waiting { color: #ded5ff; border-color: #927cf480; }
 .desktop-orb-stage.thinking .fluid .b2 { animation-duration: 3.6s; }
 .desktop-orb-stage.thinking .fluid .b3 { animation-duration: 2.6s; }
 .desktop-orb-stage.thinking .fluid .b4 { animation-duration: 4s; }
+.desktop-orb-stage.working .fluid-orb {
+  --orb-halo: #f0b35c52;
+  --orb-ring: #f3ca8fa0;
+}
+.desktop-orb-stage.working .fluid-orb::before {
+  border-color: #f0b35c3d;
+  border-top-color: #ffd9a0c8;
+  border-right-color: #f0975c7d;
+  animation: desktop-orb-orbit 2.2s linear infinite;
+}
+.desktop-orb-stage.working .fluid {
+  animation-duration: 3.6s;
+  filter: saturate(1.25) brightness(1.05);
+}
+.desktop-orb-stage.attention .fluid-orb {
+  --orb-halo: #f4c04f66;
+  --orb-ring: #f7d489b3;
+}
+.desktop-orb-stage.attention .fluid-orb::before {
+  border-color: #f4c04f4d;
+  border-top-color: #ffe1a3d9;
+  animation: desktop-orb-attention .9s ease-in-out infinite;
+}
+.desktop-orb-stage.attention .fluid {
+  animation-duration: 2s;
+  filter: saturate(1.35) brightness(1.12);
+}
 .desktop-orb-stage.speaking .fluid-orb {
   --orb-halo: #9b86c05c;
   --orb-ring: #c5b4e6a3;
@@ -297,6 +343,21 @@ header .voice.waiting { color: #ded5ff; border-color: #927cf480; }
 .desktop-orb-stage.waking .goo {
   filter: blur(1.2px) grayscale(.58) saturate(.45) brightness(.82);
   animation-duration: 4s;
+}
+.desktop-orb-stage.working .goo {
+  filter: blur(1.2px) brightness(1.08) saturate(1.22) hue-rotate(18deg);
+  animation-duration: 5s;
+}
+.desktop-orb-stage.working .goo .fill {
+  animation-duration: 8s;
+}
+.desktop-orb-stage.attention .goo {
+  box-shadow: 0 16px 38px #f4c04f4d, 0 0 30px #f4c04f66;
+  filter: blur(1.2px) brightness(1.16) saturate(1.3) hue-rotate(38deg);
+  animation-duration: 3.5s;
+}
+.desktop-orb-stage.attention .goo .fill {
+  animation-duration: 6s;
 }
 
 .desktop-orb-stage {
@@ -679,6 +740,18 @@ article.user .message-body .inline-code { background: #5e44c9; color: #f0eaff; }
 }
 @keyframes desktop-orb-orbit {
   to { transform: rotate(360deg); }
+}
+@keyframes desktop-orb-attention {
+  0%, 100% {
+    opacity: .16;
+    transform: scale(1);
+    box-shadow: 0 0 10px var(--orb-halo);
+  }
+  50% {
+    opacity: .5;
+    transform: scale(1.12);
+    box-shadow: 0 0 22px var(--orb-halo);
+  }
 }
 @keyframes fluid-breathe {
   0%, 100% { transform: scale(1); }

--- a/web/test/desktop-hide.test.mjs
+++ b/web/test/desktop-hide.test.mjs
@@ -4,10 +4,56 @@ import {
   applyDesktopClientState,
   desktopAutoHideSeconds,
   desktopCanHide,
+  DESKTOP_WAKE_GRACE_MS,
   desktopHideDeadline,
+  desktopTasksActive,
+  desktopTasksAttention,
   desktopWakeWordEnabled,
   desktopWorkSettled,
 } from '../src/desktop-hide.js'
+
+test('distinguishes active tasks from tasks waiting for authorization', () => {
+  assert.equal(desktopTasksActive([]), false)
+  assert.equal(desktopTasksAttention([]), false)
+
+  const running = { phase: 'delegated' }
+  assert.equal(desktopTasksActive([running]), true)
+  assert.equal(desktopTasksAttention([running]), false)
+
+  // 等待授权的任务同时是 active（阻止自动休眠）与 attention。
+  const pending = {
+    phase: 'running',
+    authorization: { status: 'pending' },
+  }
+  assert.equal(desktopTasksActive([pending]), true)
+  assert.equal(desktopTasksAttention([pending]), true)
+
+  const done = { phase: 'completed' }
+  assert.equal(desktopTasksActive([done]), false)
+  assert.equal(desktopTasksAttention([done]), false)
+})
+
+test('ignores stale sleeping broadcasts right after an explicit wake', async () => {
+  const bridge = { enterHide: async () => ({ state: 'hidden' }) }
+  const event = { type: 'client.state', state: 'sleeping' }
+  const wakeAt = 1_000_000
+
+  // 宽限期内：Gateway 休眠计时器恰好在唤醒瞬间到期，迟到的指令不生效。
+  assert.equal(await applyDesktopClientState(event, {
+    desktop: true,
+    bridge,
+    lastWakeAt: wakeAt,
+    now: wakeAt + DESKTOP_WAKE_GRACE_MS - 1,
+  }), false)
+
+  // 宽限期外照常隐藏。
+  assert.equal(await applyDesktopClientState(event, {
+    desktop: true,
+    bridge,
+    lastWakeAt: wakeAt,
+    now: wakeAt + DESKTOP_WAKE_GRACE_MS,
+  }), true)
+})
 
 test('maps a supported sleeping client state to the desktop bridge', async () => {
   const lifecycle = []

--- a/web/test/orb-presentation.test.mjs
+++ b/web/test/orb-presentation.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { desktopOrbClassName } from '../src/orb-presentation.js'
+import {
+  desktopOrbClassName,
+  resolveOrbVisualState,
+} from '../src/orb-presentation.js'
 
 test('keeps speaking animation active while microphone input is muted', () => {
   assert.equal(desktopOrbClassName({
@@ -26,4 +29,71 @@ test('keeps the waking lifecycle distinct from an error', () => {
   })
   assert.match(className, /\bwaking\b/)
   assert.doesNotMatch(className, /\berror\b/)
+})
+
+test('arbitrates visual states by layered priority', () => {
+  // 满载输入：每一层压过下一层。
+  const everything = {
+    lifecycle: 'hidden',
+    connectionError: true,
+    connecting: true,
+    ownershipBusy: true,
+    voiceState: 'listening',
+    tasksActive: true,
+    attentionPending: true,
+  }
+  assert.equal(resolveOrbVisualState(everything), 'hidden')
+  assert.equal(
+    resolveOrbVisualState({ ...everything, lifecycle: 'waking' }),
+    'waking',
+  )
+  assert.equal(
+    resolveOrbVisualState({ ...everything, lifecycle: 'active' }),
+    'error',
+  )
+  // 对话态优先于所有后台态。
+  for (const voiceState of ['listening', 'thinking', 'speaking']) {
+    assert.equal(resolveOrbVisualState({
+      ...everything,
+      lifecycle: 'active',
+      connectionError: false,
+      voiceState,
+    }), voiceState)
+  }
+  // 后台态优先级：attention > working > occupied > connecting > idle。
+  const background = {
+    lifecycle: 'active',
+    connectionError: false,
+    connecting: true,
+    ownershipBusy: true,
+    voiceState: 'idle',
+    tasksActive: true,
+    attentionPending: true,
+  }
+  assert.equal(resolveOrbVisualState(background), 'attention')
+  assert.equal(
+    resolveOrbVisualState({ ...background, attentionPending: false }),
+    'working',
+  )
+  assert.equal(resolveOrbVisualState({
+    ...background,
+    attentionPending: false,
+    tasksActive: false,
+  }), 'occupied')
+  assert.equal(resolveOrbVisualState({
+    ...background,
+    attentionPending: false,
+    tasksActive: false,
+    ownershipBusy: false,
+  }), 'connecting')
+  assert.equal(resolveOrbVisualState({
+    ...background,
+    attentionPending: false,
+    tasksActive: false,
+    ownershipBusy: false,
+    connecting: false,
+  }), 'idle')
+  // 无入参与未知语音态透传。
+  assert.equal(resolveOrbVisualState(), 'idle')
+  assert.equal(resolveOrbVisualState({ voiceState: 'custom' }), 'custom')
 })

--- a/web/test/sprite-orb.test.mjs
+++ b/web/test/sprite-orb.test.mjs
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  defaultAnimations,
+  frameAtElapsed,
+  frameRect,
+  resolveAnimations,
+  spriteAnimationForOrbState,
+  spriteGeometry,
+} from '../src/sprite-orb.js'
+
+test('maps every orb visual state to a pet animation track', () => {
+  const cases = {
+    idle: 'idle',
+    listening: 'waiting',
+    connecting: 'waiting',
+    thinking: 'review',
+    occupied: 'running',
+    working: 'working',
+    attention: 'attention',
+    speaking: 'waving',
+    waking: 'waving',
+    error: 'failed',
+    hidden: 'idle',
+    unknown: 'idle',
+  }
+  const animations = defaultAnimations()
+  for (const [state, expected] of Object.entries(cases)) {
+    assert.equal(spriteAnimationForOrbState({ state }), expected)
+    assert.ok(animations[expected], `track ${expected} must exist`)
+  }
+  // 拖拽修饰优先于语音状态。
+  assert.equal(
+    spriteAnimationForOrbState({ state: 'speaking', dragging: true }),
+    'running-right',
+  )
+})
+
+test('default tracks repeat three times then settle into the idle loop', () => {
+  const animations = defaultAnimations()
+  const idle = animations.idle
+  assert.equal(idle.frames.length, 6)
+  assert.deepEqual(
+    idle.frames.map(frame => frame.durationMs),
+    [1680, 660, 660, 840, 840, 1920],
+  )
+  assert.equal(idle.loopStart, 0)
+
+  const waving = animations.waving
+  // waving 行 4 帧重复 3 遍 + idle 6 帧沉降段。
+  assert.equal(waving.frames.length, 4 * 3 + 6)
+  assert.equal(waving.loopStart, 12)
+  assert.equal(waving.fallback, 'idle')
+  // 行内帧索引：第 3 行起始 spriteIndex = 24，末帧时长加长。
+  assert.equal(waving.frames[0].spriteIndex, 24)
+  assert.equal(waving.frames[3].durationMs, 280)
+  // 沉降段引用 idle 行帧。
+  assert.equal(waving.frames[12].spriteIndex, 0)
+
+  for (const name of [
+    'idle',
+    'running-right',
+    'running-left',
+    'waving',
+    'jumping',
+    'failed',
+    'waiting',
+    'running',
+    'review',
+    'working',
+    'attention',
+  ]) {
+    assert.ok(animations[name], `default track ${name} must exist`)
+    assert.ok(animations[animations[name].fallback])
+  }
+})
+
+test('the working track loops the running-left row without settling', () => {
+  const working = defaultAnimations().working
+  // 仅含第 2 行的 8 帧，无 idle 沉降段，持续循环。
+  assert.equal(working.frames.length, 8)
+  assert.equal(working.loopStart, 0)
+  assert.equal(working.fallback, 'idle')
+  assert.equal(working.frames[0].spriteIndex, 16)
+  assert.equal(working.frames[7].spriteIndex, 23)
+  assert.equal(working.frames[7].durationMs, 220)
+})
+
+test('the attention track loops the jumping row to demand a decision', () => {
+  const attention = defaultAnimations().attention
+  // 仅含第 4 行（jumping）的 5 帧，持续循环不沉降。
+  assert.equal(attention.frames.length, 5)
+  assert.equal(attention.loopStart, 0)
+  assert.equal(attention.fallback, 'idle')
+  assert.equal(attention.frames[0].spriteIndex, 32)
+  assert.equal(attention.frames[4].spriteIndex, 36)
+  assert.equal(attention.frames[4].durationMs, 280)
+})
+
+test('resolves elapsed time to frames across intro, loop, and one-shot tracks', () => {
+  const looping = {
+    frames: [
+      { spriteIndex: 10, durationMs: 100 },
+      { spriteIndex: 11, durationMs: 100 },
+      { spriteIndex: 12, durationMs: 200 },
+    ],
+    loopStart: 1,
+    fallback: 'idle',
+  }
+  assert.deepEqual(frameAtElapsed(looping, 0), {
+    spriteIndex: 10,
+    remainingMs: 100,
+  })
+  assert.deepEqual(frameAtElapsed(looping, 150), {
+    spriteIndex: 11,
+    remainingMs: 50,
+  })
+  // 播完整段后从 loopStart 段循环：总长 400，循环段 300。
+  assert.deepEqual(frameAtElapsed(looping, 400), {
+    spriteIndex: 11,
+    remainingMs: 100,
+  })
+  // 850 → 循环内位置 100 + (450 % 300) = 250，落在第三帧。
+  assert.deepEqual(frameAtElapsed(looping, 850), {
+    spriteIndex: 12,
+    remainingMs: 150,
+  })
+
+  const oneShot = {
+    frames: [{ spriteIndex: 0, durationMs: 100 }],
+    loopStart: null,
+    fallback: 'idle',
+  }
+  assert.deepEqual(frameAtElapsed(oneShot, 50), {
+    spriteIndex: 0,
+    remainingMs: 50,
+  })
+  // one-shot 播完返回 null，由调用方交棒 fallback。
+  assert.equal(frameAtElapsed(oneShot, 100), null)
+})
+
+test('merges pet.json animation overrides and validates them', () => {
+  const merged = resolveAnimations({
+    animations: {
+      'waving': { frames: [1, 2], fps: 10, loop: false, fallback: 'waiting' },
+    },
+  }, 72)
+  assert.deepEqual(merged.waving.frames, [
+    { spriteIndex: 1, durationMs: 100 },
+    { spriteIndex: 2, durationMs: 100 },
+  ])
+  assert.equal(merged.waving.loopStart, null)
+  assert.equal(merged.waving.fallback, 'waiting')
+  // 未覆盖的轨道保持默认。
+  assert.equal(merged.idle.frames.length, 6)
+
+  assert.throws(() => resolveAnimations({
+    animations: { 'spin': { frames: [] } },
+  }, 72), /至少要包含一帧/)
+  assert.throws(() => resolveAnimations({
+    animations: { 'spin': { frames: [0], fps: 0 } },
+  }, 72), /fps 非法/)
+  assert.throws(() => resolveAnimations({
+    animations: { 'spin': { frames: [0], fallback: 'nope' } },
+  }, 72), /fallback 不存在/)
+  // 默认轨道引用超出小网格帧数时同样失败（与 Codex 行为一致）。
+  assert.throws(() => resolveAnimations({}, 8), /越界的帧索引/)
+})
+
+test('derives sprite geometry from the frame spec with v1/v2 defaults', () => {
+  assert.deepEqual(spriteGeometry({}), {
+    width: 192,
+    height: 208,
+    columns: 8,
+    rows: 9,
+    frameCount: 72,
+  })
+  assert.equal(spriteGeometry({ spriteVersionNumber: 2 }).rows, 11)
+  assert.deepEqual(spriteGeometry({
+    frame: { width: 64, height: 64, columns: 4, rows: 2 },
+  }), {
+    width: 64,
+    height: 64,
+    columns: 4,
+    rows: 2,
+    frameCount: 8,
+  })
+  assert.equal(spriteGeometry({ frame: { width: 0 } }), null)
+
+  const geometry = spriteGeometry({})
+  assert.deepEqual(frameRect(geometry, 0), {
+    x: 0,
+    y: 0,
+    width: 192,
+    height: 208,
+  })
+  // 第 3 行（waving）第 0 帧：spriteIndex 24。
+  assert.deepEqual(frameRect(geometry, 24), {
+    x: 0,
+    y: 3 * 208,
+    width: 192,
+    height: 208,
+  })
+  assert.deepEqual(frameRect(geometry, 26).x, 2 * 192)
+})


### PR DESCRIPTION
桌面版悬浮球皮肤系统（v1.7.0 主功能）。

## 改动

- **`shared/orb-skin-catalog.mjs`**：皮肤身份的单源真理，主进程与 web 渲染层共用；内置 theme 皮肤（流光声波球 fluid、液态渐变球 goo）与导入 sprite 皮肤共用同一选择链，旧 `orbStyle` 配置只读兼容
- **`desktop/src/skin-store.mjs`**：皮肤存储与导入（Codex pet 包格式：pet.json + 精灵图），尺寸上限、id 校验、zip 解压经注入的系统工具执行
- **设置页**：皮肤选择器 + 导入/删除管理
- **web 渲染层**：新增 `DesktopSpriteOrb` 精灵渲染，与既有 CSS theme orb 并存；renderer-server/security 经受控本地通道暴露皮肤资源
- 双语文档同步更新

## 测试

- 752/752 全量通过（含皮肤功能新增 24 个用例：skin-store、orb-skin-catalog、sprite-orb、renderer-server/security/settings 扩展）
- 依赖审计、verify-package 通过
- 已 rebase 至最新 main（含 #112）

合并后紧接 release/1.7.0 发版 PR。
