### PR TITLE
fix(agent): disable session-level MCP for OpenClaw ACP bridge

### DIFF
--- a/server/src/agent/acp-backend-adapter.mjs
+++ b/server/src/agent/acp-backend-adapter.mjs
@@ -177,7 +177,9 @@ export class AcpBackendAdapter {
     this.sessionToolServer = sessionToolServer || new AcpSessionToolServer()
     // Baseline stdio MCP servers (e.g. open-computer-use) injected into every
     // Session; backends spawn and connect to them on their own.
-    this.builtinMcp = Array.isArray(builtinMcp) ? builtinMcp : []
+    this.builtinMcp = this.profile.sessionMcp === false
+      ? []
+      : (Array.isArray(builtinMcp) ? builtinMcp : [])
     this.pendingPermissions = new Map()
     this.resolvedPermissions = new Map()
     this.coordinatorSessions = new Map()

--- a/server/src/agent/backends/openclaw.mjs
+++ b/server/src/agent/backends/openclaw.mjs
@@ -66,6 +66,7 @@ export const openClawBackendDriver = {
           : {}),
       },
       externalMcp: false,
+      sessionMcp: false,
       nativeDelegation: true,
       backendUi: true,
       sanitizeProcessOutput,


### PR DESCRIPTION
## Summary

修复 OpenClaw 作为后台 Agent 时 `session/new` 请求失败的问题。OpenClaw 的 ACP 桥接模式不支持会话级 MCP 服务器，但当前代码无条件将 `builtinMcp`（open-computer-use）注入到每个 Session，导致 OpenClaw 拒绝请求并返回 `acp bridge mode does not support per session mcp service`。

## Root Cause

1. **OpenClaw profile 缺少 `sessionMcp: false`** — 已有 `externalMcp: false` 禁用外部 MCP 注册，但没有机制禁用内置 MCP 注入
2. **`AcpBackendAdapter` 无 `sessionMcp` 检查** — `builtinMcp` 无条件注入，即使 backend 明确不支持

## Changes

| File | Change |
|---|---|
| `server/src/agent/backends/openclaw.mjs` | 添加 `sessionMcp: false` 禁用会话级 MCP 注入 |
| `server/src/agent/acp-backend-adapter.mjs` | 当 `profile.sessionMcp === false` 时将 `builtinMcp` 置为空数组 |

## Test Plan

- [x] `acp-process-client.test.mjs` — 5/5 通过
- [x] `acp-backend-adapter.test.mjs` — 35/35 通过（含 `builtinMcp defaults keep sessions working when disabled`）
- [x] 手动验证：OpenClaw 后台 Agent 可正常创建 Session 并执行任务