### PR TITLE
feat(web): add modular speech pipeline and browser TTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ DASHSCOPE_API_KEY=
 # QWEN_AUDIO_REALTIME_PROVIDER=speech-to-speech
 # SPEECH_TO_SPEECH_REALTIME_URL=ws://127.0.0.1:8765/v1/realtime
 
+# 可选：旧网页切换到“本地 VAD + 云端 ASR/LLM/TTS”模式时使用的 WebSocket 地址。
+# SPEECH_TO_SPEECH_VAD_WS_URL=ws://127.0.0.1:8765/v1/vad
+
 # 可选：选择后台 Agent；留空时仅使用前台实时语音聊天。
 # OpenCode/OpenClaw 支持自动安装和百炼配置。
 # 可选 openclaw、opencode、qoder、kimi、hermes、

--- a/cli/src/gateway-service.mjs
+++ b/cli/src/gateway-service.mjs
@@ -129,7 +129,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=${systemd(workingDirectory)}
+WorkingDirectory=${workingDirectory}
 ExecStart=${command.map(systemd).join(' ')}
 ${Object.entries(environment).map(([key, value]) => (
     `Environment=${systemd(`${key}=${value}`)}`

--- a/cli/test/gateway-service.test.mjs
+++ b/cli/test/gateway-service.test.mjs
@@ -101,7 +101,7 @@ test('installs a systemd user service with restart protection', async () => {
     const unit = readFileSync(installed.servicePath, 'utf8')
     assert.match(unit, /ExecStart="\/usr\/bin\/node"/)
     assert.match(unit, /"\/opt\/server\/index.mjs"/)
-    assert.match(unit, /WorkingDirectory="\/opt\/server"/)
+    assert.match(unit, /WorkingDirectory=\/opt\/server/)
     assert.match(unit, /Restart=on-failure/)
     assert.deepEqual(calls.at(-1), [
       'systemctl',

--- a/server/src/app/bootstrap.mjs
+++ b/server/src/app/bootstrap.mjs
@@ -14,6 +14,7 @@ import { ProfiledMemoryStore } from '../conversation/profiled-memory-store.mjs'
 import { UserProfile } from '../conversation/user-profile.mjs'
 import { enforceSameOrigin } from '../core/request-security.mjs'
 import { attachRealtimeGateway } from '../voice/realtime-gateway.mjs'
+import { attachSpeechToSpeechGateway } from '../voice/speech-to-speech-gateway.mjs'
 import { describeActiveRealtime } from '../voice/realtime-provider.mjs'
 import { SessionPermissionPolicy } from '../voice/session-permission-policy.mjs'
 import { taskManager, taskStore } from '../task/task-manager.mjs'
@@ -279,6 +280,7 @@ app.use((error, req, res, next) => {
 
 const server = createServer(app)
 export { server }
+attachSpeechToSpeechGateway(server, { identityManager })
 realtimeGateway = attachRealtimeGateway(server, {
   identityManager,
   memoryStore: frontendMemory,

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -220,6 +220,11 @@ export const config = {
   // connects to the endpoint and supplies the shared frontend instructions and
   // tools for each realtime Session.
   speechToSpeechRealtimeUrl: realtimeFrontend.speechToSpeechRealtimeUrl,
+  // Local modular VAD service used by the WebUI's alternate speech pipeline.
+  speechToSpeechVadWebSocketUrl: (
+    process.env.SPEECH_TO_SPEECH_VAD_WS_URL
+    || 'ws://127.0.0.1:8765/v1/vad'
+  ),
   // Do not advertise a local service merely because a default endpoint
   // exists. It becomes selectable when the user explicitly configures it or
   // chooses it as the active frontend.

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -117,6 +117,8 @@ export function attachRealtimeGateway(server, {
 
   server.on('upgrade', (request, socket, head) => {
     const url = new URL(request.url, 'http://localhost')
+    // The modular speech-to-speech bridge owns this separate WebSocket path.
+    if (url.pathname === '/api/speech-to-speech') return
     if (rejectUnsupportedRealtimeUpgrade(socket, url.pathname)) return
     if (!isAllowedOrigin(request)) {
       rejectUpgrade(socket, '403 Forbidden', 'origin not allowed')

--- a/server/src/voice/speech-to-speech-gateway.mjs
+++ b/server/src/voice/speech-to-speech-gateway.mjs
@@ -1,0 +1,100 @@
+import { WebSocket, WebSocketServer } from 'ws'
+import { config } from '../core/config.mjs'
+import { isAllowedOrigin } from '../core/request-security.mjs'
+import { logger } from '../core/logger.mjs'
+
+export const SPEECH_TO_SPEECH_PATH = '/api/speech-to-speech'
+
+function rejectUpgrade(socket, status, message) {
+  socket.write(
+    `HTTP/1.1 ${status}\r\nConnection: close\r\nContent-Type: text/plain\r\n\r\n${message}`,
+  )
+  socket.destroy()
+}
+
+/**
+ * Authenticated same-origin bridge from the public WebUI to the local VAD
+ * service. The cloud provider keys remain inside the Python service.
+ */
+export function attachSpeechToSpeechGateway(server, { identityManager }) {
+  const wss = new WebSocketServer({
+    noServer: true,
+    maxPayload: 8 * 1024 * 1024,
+  })
+
+  server.on('upgrade', (request, socket, head) => {
+    const url = new URL(request.url, 'http://localhost')
+    if (url.pathname !== SPEECH_TO_SPEECH_PATH) return
+    if (!isAllowedOrigin(request)) {
+      rejectUpgrade(socket, '403 Forbidden', 'origin not allowed')
+      return
+    }
+    const identity = identityManager.resolveUpgrade(request)
+    if (!identity) {
+      rejectUpgrade(socket, '401 Unauthorized', 'identity required')
+      return
+    }
+    wss.handleUpgrade(request, socket, head, ws => {
+      wss.emit('connection', ws, url, identity)
+    })
+  })
+
+  wss.on('connection', (client, url, identity) => {
+    const connectionLogger = logger.child({
+      subsystem: 'speech_to_speech_bridge',
+      ownerId: identity.ownerId,
+    })
+    const upstream = new WebSocket(config.speechToSpeechVadWebSocketUrl)
+    const pending = []
+    let closed = false
+
+    const closeBoth = (code = 1000, reason = '') => {
+      if (closed) return
+      closed = true
+      if (client.readyState === WebSocket.OPEN) client.close(code, reason)
+      if (
+        upstream.readyState === WebSocket.OPEN
+        || upstream.readyState === WebSocket.CONNECTING
+      ) upstream.close(code, reason)
+    }
+
+    client.on('message', (data, isBinary) => {
+      if (closed) return
+      if (upstream.readyState === WebSocket.OPEN) {
+        upstream.send(data, { binary: isBinary })
+        return
+      }
+      if (pending.length >= 100) {
+        closeBoth(1013, 'upstream is not ready')
+        return
+      }
+      pending.push({ data, isBinary })
+    })
+
+    upstream.on('open', () => {
+      for (const item of pending.splice(0)) {
+        upstream.send(item.data, { binary: item.isBinary })
+      }
+      connectionLogger.debug('bridge.connected')
+    })
+
+    upstream.on('message', (data, isBinary) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(data, { binary: isBinary })
+      }
+    })
+
+    client.on('close', () => closeBoth())
+    client.on('error', error => {
+      connectionLogger.debug('bridge.client_error', { error })
+      closeBoth(1011, 'client error')
+    })
+    upstream.on('close', () => closeBoth(1011, 'speech service closed'))
+    upstream.on('error', error => {
+      connectionLogger.warn('bridge.upstream_error', { error })
+      closeBoth(1011, 'speech service unavailable')
+    })
+  })
+
+  return { path: SPEECH_TO_SPEECH_PATH, wss }
+}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -29,6 +29,8 @@ import useRealtimeVoice, {
   retainedRealtimeProvider,
   shouldClaimReleasedVoice,
 } from './useRealtimeVoice.js'
+import useSpeechToSpeech from './useSpeechToSpeech.js'
+import { browserTtsSupported } from './browserTts.js'
 import { requestedSessionId } from './session.js'
 import { initialVoiceEnabled } from './voice-defaults.js'
 import {
@@ -125,6 +127,14 @@ export default function App() {
   const [realtimeProvider, setRealtimeProvider] = useState(
     () => localStorage.getItem('qwen-audio-agent.realtimeProvider') || '',
   )
+  const [voiceMode, setVoiceMode] = useState(
+    () => localStorage.getItem('qwen-audio-agent.voiceMode') || 'qwen',
+  )
+  const [speechTtsMode, setSpeechTtsMode] = useState(() => {
+    const saved = localStorage.getItem('qwen-audio-agent.speechTtsMode')
+    if (saved === 'server') return 'server'
+    return browserTtsSupported(window) ? 'browser' : 'server'
+  })
   const [backend, setBackend] = useState({ label: 'Agent', ready: false })
   const [agentTasks, setAgentTasks] = useState([])
   const [orbDragging, setOrbDragging] = useState(false)
@@ -133,6 +143,7 @@ export default function App() {
   const [workSettledAt, setWorkSettledAt] = useState(Date.now)
   const activeVoiceResponse = useRef('')
   const currentTurnId = useRef('')
+  const speechTurnId = useRef('')
   const responseTurnMap = useRef(new Map())
   const agentTurnIds = useRef(new Set())
   const taskDismissTimers = useRef(new Map())
@@ -634,9 +645,61 @@ export default function App() {
     waitingForVoice,
   ])
 
+  const onSpeechToSpeechEvent = useCallback(event => {
+    if (event.type === 'session.ready') {
+      const asrLabel = event.asr_provider === 'mimo'
+        ? 'MiMo ASR'
+        : event.asr_streaming ? 'Qwen 流式 ASR' : 'ASR'
+      setActivity(`本地 VAD + ${asrLabel} 已连接`)
+    }
+    if (event.type === 'vad.speech_started') {
+      setActivity('正在听你说')
+    }
+    if (event.type === 'asr.partial') {
+      const content = normalizeTranscript(event.text)
+      if (content) setActivity(`正在识别：${content}`)
+    }
+    if (event.type === 'asr.completed') {
+      const content = normalizeTranscript(event.text)
+      if (!content) return
+      const turnId = `speech-${Date.now()}-${crypto.randomUUID()}`
+      speechTurnId.current = turnId
+      setMessages(items => [...items, {
+        id: `speech:user:${turnId}`,
+        role: 'user',
+        content,
+        turnId,
+        voice: true,
+        origin: 'speech-to-speech',
+        final: true,
+      }])
+      setActivity('正在理解')
+    }
+    if (event.type === 'llm.completed') {
+      const content = normalizeTranscript(event.text)
+      if (!content) return
+      const turnId = speechTurnId.current || `speech-${Date.now()}-${crypto.randomUUID()}`
+      speechTurnId.current = turnId
+      setMessages(items => [...items, {
+        id: `speech:assistant:${turnId}`,
+        role: 'assistant',
+        content,
+        turnId,
+        origin: 'speech-to-speech',
+        final: true,
+      }])
+      setActivity('正在播放回复')
+    }
+    if (event.type === 'pipeline.error') {
+      setActivity('云端语音链路暂时不可用')
+    }
+  }, [])
+
+  const qwenVoiceEnabled = voiceMode === 'qwen' && voiceEnabled
+  const speechToSpeechEnabled = voiceMode === 'speech-to-speech' && voiceEnabled
   const voice = useRealtimeVoice({
     sessionId,
-    enabled: voiceEnabled,
+    enabled: desktopOrbMode ? voiceEnabled : qwenVoiceEnabled,
     suspended: desktopOrbMode && desktopLifecycle === 'sleeping',
     outputMuted: false,
     inputOnlyMute: desktopOrbMode,
@@ -651,23 +714,37 @@ export default function App() {
       setActivity(message)
     },
   })
+  const speechToSpeechVoice = useSpeechToSpeech({
+    sessionId,
+    enabled: speechToSpeechEnabled,
+    ttsMode: speechTtsMode,
+    onEvent: onSpeechToSpeechEvent,
+    onInputError: message => {
+      setVoiceEnabled(false)
+      setWaitingForVoice(false)
+      setActivity(message)
+    },
+  })
+  const activeVoice = voiceMode === 'speech-to-speech'
+    ? speechToSpeechVoice
+    : voice
   const lifecycleTransition = (
     desktopOrbMode && desktopLifecycle !== 'active'
   )
   const voiceConnectionError = (
-    !lifecycleTransition && voice.connectionState === 'unavailable'
+    !lifecycleTransition && activeVoice.connectionState === 'unavailable'
   )
   const visualVoiceState = desktopLifecycle === 'sleeping'
     ? 'sleeping'
     : desktopLifecycle === 'waking'
       ? 'waking'
-      : voice.ownership.state === 'busy'
+      : voiceMode === 'qwen' && voice.ownership.state === 'busy'
     ? 'occupied'
     : voiceConnectionError
       ? 'error'
-      : voiceEnabled && voice.connectionState === 'connecting'
+      : voiceEnabled && activeVoice.connectionState === 'connecting'
       ? 'connecting'
-      : voice.visualState || voice.state
+      : activeVoice.visualState || activeVoice.state
   const ownershipLabel = voice.ownership.holder
     ? frontendLabel(voice.ownership.holder)
     : ''
@@ -758,6 +835,18 @@ export default function App() {
     workSettled,
     workSettledAt,
   ])
+  const selectVoiceMode = value => {
+    if (!['qwen', 'speech-to-speech'].includes(value)) return
+    if (voiceEnabled) {
+      setVoiceEnabled(false)
+      setWaitingForVoice(false)
+    }
+    setVoiceMode(value)
+    localStorage.setItem('qwen-audio-agent.voiceMode', value)
+    setActivity(value === 'speech-to-speech'
+      ? '已切换到本地 VAD + 语音流水线'
+      : '已切换到 Qwen 实时模式')
+  }
 
   // Switching the front end reconnects on its own: realtimeProvider is part of
   // the realtime effect's dependencies, so changing it tears the current socket
@@ -769,6 +858,19 @@ export default function App() {
     } else {
       localStorage.removeItem('qwen-audio-agent.realtimeProvider')
     }
+  }
+
+  const selectSpeechTtsMode = value => {
+    if (!['browser', 'server'].includes(value)) return
+    if (value === 'browser' && !browserTtsSupported(window)) {
+      setActivity('当前浏览器不支持内置 TTS，请继续使用 MiMo TTS')
+      return
+    }
+    setSpeechTtsMode(value)
+    localStorage.setItem('qwen-audio-agent.speechTtsMode', value)
+    setActivity(value === 'browser'
+      ? '已切换到浏览器 TTS，回复将更快开始播放'
+      : '已切换到 MiMo TTS')
   }
 
   const resetSession = () => {
@@ -783,12 +885,17 @@ export default function App() {
     activeVoiceResponse.current = ''
     responseTurnMap.current.clear()
     agentTurnIds.current.clear()
+    speechTurnId.current = ''
     setActivity('已创建新会话')
   }
 
   const enableVoice = () => {
-    if (!voice.activateAudio()) return
-    if (voice.ownership.state === 'busy' && !takeoverRequested) {
+    if (!activeVoice.activateAudio()) return
+    if (
+      voiceMode === 'qwen'
+      && voice.ownership.state === 'busy'
+      && !takeoverRequested
+    ) {
       setWaitingForVoice(true)
       setActivity(`等待${ownershipLabel || '其他入口'}释放语音`)
       return
@@ -852,8 +959,8 @@ export default function App() {
       window.qwenAudioAgentDesktop?.wake()
       return
     }
-    if (voice.state === 'speaking') {
-      voice.interrupt()
+    if (activeVoice.state === 'speaking') {
+      activeVoice.interrupt()
       return
     }
     if (desktopOrbMode && (voiceEnabled || waitingForVoice)) {
@@ -1002,7 +1109,9 @@ export default function App() {
   >
     <label>{message.role === 'user'
       ? '你'
-      : message.companion ? resultLabel(message) : 'qwen-audio'}</label>
+      : message.origin === 'speech-to-speech'
+        ? 'MiMo 语音'
+        : message.companion ? resultLabel(message) : 'qwen-audio'}</label>
     <MessageContent
       role={message.role}
       content={message.content}
@@ -1024,7 +1133,27 @@ export default function App() {
         <i className={backend.ready ? 'ready' : ''} />
         {backend.label}
       </a>
-      {realtimeProviders.length > 1 && <select
+      <select
+        className="ghost voice-mode"
+        value={voiceMode}
+        onChange={event => selectVoiceMode(event.target.value)}
+        title="选择语音对话模式"
+        aria-label="选择语音对话模式"
+      >
+        <option value="qwen">模式：Qwen 实时</option>
+        <option value="speech-to-speech">模式：本地 VAD + 语音流水线</option>
+      </select>
+      {voiceMode === 'speech-to-speech' && <select
+        className="ghost voice-mode tts-mode"
+        value={speechTtsMode}
+        onChange={event => selectSpeechTtsMode(event.target.value)}
+        title="选择文字转语音引擎"
+        aria-label="选择文字转语音引擎"
+      >
+        <option value="browser">TTS：浏览器（更快）</option>
+        <option value="server">TTS：MiMo（音质更稳）</option>
+      </select>}
+      {voiceMode === 'qwen' && realtimeProviders.length > 1 && <select
         className="ghost frontend-provider"
         value={realtimeProvider}
         onChange={event => selectRealtimeProvider(event.target.value)}
@@ -1061,7 +1190,7 @@ export default function App() {
     <section className="workspace">
       <div className="hero">
         <button
-          ref={voice.levelElementRef}
+          ref={activeVoice.levelElementRef}
           className={`orb ${visualVoiceState}`}
           onClick={handleOrbClick}
           aria-label="语音交互"
@@ -1070,7 +1199,7 @@ export default function App() {
         </button>
         <p>VOICE FRONTEND</p>
         <h1>你说，我来调度。</h1>
-        <small>{voice.error || activity}</small>
+        <small>{activeVoice.error || activity}</small>
       </div>
 
       <div

--- a/web/src/browserTts.js
+++ b/web/src/browserTts.js
@@ -1,0 +1,17 @@
+export function browserTtsSupported(scope = globalThis) {
+  return Boolean(scope?.speechSynthesis && scope?.SpeechSynthesisUtterance)
+}
+
+export function preferredChineseVoice(voices = []) {
+  const scored = voices.map((voice, index) => {
+    const language = String(voice.lang || '').toLowerCase()
+    let score = 0
+    if (language === 'zh-cn' || language === 'zh-hans-cn') score += 40
+    else if (language.startsWith('zh')) score += 30
+    if (voice.localService) score += 4
+    if (voice.default) score += 2
+    return { voice, score, index }
+  })
+  scored.sort((left, right) => right.score - left.score || left.index - right.index)
+  return scored[0]?.voice || null
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -61,6 +61,16 @@ header {
 header button { padding: 9px 13px; border-radius: 10px; color: #ddd; border: 1px solid #ffffff18; background: #ffffff08; }
 header .voice.active { color: white; border-color: #785cf4; background: #785cf4; }
 header .voice.waiting { color: #ded5ff; border-color: #927cf480; }
+header select.voice-mode {
+  max-width: 172px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  color: #d8d4e2;
+  border: 1px solid #ffffff18;
+  background: #ffffff08;
+}
+header select.voice-mode:focus { outline: 1px solid #8e7ed0; }
+header select.tts-mode { max-width: 168px; }
 
 .workspace {
   width: min(760px, calc(100% - 32px));
@@ -780,6 +790,13 @@ article.user .message-body .inline-code { background: #5e44c9; color: #f0eaff; }
 @media (max-width: 600px) {
   header { padding: 0 14px; }
   .brand small, header .ghost, .backend { display: none; }
+  header select.voice-mode {
+    display: block;
+    max-width: 145px;
+    padding: 7px 8px;
+    font-size: 11px;
+  }
+  header select.tts-mode { max-width: 125px; }
   .workspace { padding: 24px 0 14px; }
   .orb:not(.desktop-orb) { width: 92px; height: 92px; }
   .hero p { margin-top: 14px; }

--- a/web/src/useSpeechToSpeech.js
+++ b/web/src/useSpeechToSpeech.js
@@ -1,0 +1,400 @@
+import { useEffect, useRef, useState } from 'react'
+import { decodePcm, pcmBase64, resample } from './audio.js'
+import { browserTtsSupported, preferredChineseVoice } from './browserTts.js'
+
+const INPUT_RATE = 16000
+const DEFAULT_OUTPUT_RATE = 24000
+
+function socketUrl() {
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const basePath = location.pathname.endsWith('/')
+    ? location.pathname
+    : location.pathname.replace(/[^/]*$/, '')
+  return `${protocol}//${location.host}${basePath}api/speech-to-speech`
+}
+
+function base64Bytes(value) {
+  const binary = atob(value)
+  const bytes = Uint8Array.from(binary, character => character.charCodeAt(0))
+  return bytes.buffer
+}
+
+function visualState(state, inputActive, enabled) {
+  return enabled && inputActive ? 'listening' : state
+}
+
+export default function useSpeechToSpeech({
+  sessionId,
+  enabled,
+  ttsMode = 'server',
+  onEvent,
+  onInputError,
+}) {
+  const [state, setState] = useState('idle')
+  const [inputActive, setInputActive] = useState(false)
+  const [error, setError] = useState('')
+  const [visualError, setVisualError] = useState(false)
+  const [connectionState, setConnectionState] = useState('idle')
+  const eventRef = useRef(onEvent)
+  const inputErrorRef = useRef(onInputError)
+  const socketRef = useRef(null)
+  const audioRef = useRef(null)
+  const levelElementRef = useRef(null)
+  const sessionReadyRef = useRef(false)
+  const enabledRef = useRef(enabled)
+  const inputReadyRef = useRef(false)
+  const playbackRef = useRef({ cursor: 0, sources: [] })
+  const browserSpeechRef = useRef(null)
+
+  eventRef.current = onEvent
+  inputErrorRef.current = onInputError
+  enabledRef.current = enabled
+
+  const setAudioLevel = value => {
+    levelElementRef.current?.style.setProperty('--level', String(value))
+  }
+
+  const activateAudio = () => {
+    const AudioContext = window.AudioContext || window.webkitAudioContext
+    if (!AudioContext) {
+      setError('当前浏览器不支持实时语音播放')
+      setVisualError(true)
+      return false
+    }
+    if (!audioRef.current || audioRef.current.state === 'closed') {
+      audioRef.current = new AudioContext()
+    }
+    audioRef.current.resume().catch(reason => {
+      setError(reason?.message || '语音播放没有成功启用，请再点一次开启语音')
+      setVisualError(true)
+    })
+    return true
+  }
+
+  const sendSocketEvent = event => {
+    const socket = socketRef.current
+    if (socket?.readyState !== WebSocket.OPEN) return false
+    socket.send(JSON.stringify(event))
+    return true
+  }
+
+  const stopPlayback = () => {
+    playbackRef.current.sources.forEach(source => {
+      try {
+        source.stop()
+      } catch {
+        // The source may already have ended.
+      }
+    })
+    playbackRef.current = { cursor: 0, sources: [] }
+    browserSpeechRef.current = null
+    if (browserTtsSupported(window)) window.speechSynthesis.cancel()
+    if (enabledRef.current) setState('idle')
+  }
+
+  const speakInBrowser = text => {
+    const content = String(text || '').trim()
+    if (!content) return
+    if (!browserTtsSupported(window)) {
+      setError('当前浏览器不支持内置语音合成，请切换到 MiMo TTS')
+      setVisualError(true)
+      return
+    }
+    stopPlayback()
+    const utterance = new window.SpeechSynthesisUtterance(content)
+    utterance.lang = 'zh-CN'
+    utterance.rate = 1
+    utterance.pitch = 1
+    utterance.volume = 1
+    const voice = preferredChineseVoice(window.speechSynthesis.getVoices())
+    if (voice) utterance.voice = voice
+    browserSpeechRef.current = utterance
+    utterance.onstart = () => {
+      if (browserSpeechRef.current === utterance && enabledRef.current) {
+        setState('speaking')
+      }
+    }
+    utterance.onend = () => {
+      if (browserSpeechRef.current === utterance) {
+        browserSpeechRef.current = null
+        if (enabledRef.current) setState('idle')
+      }
+    }
+    utterance.onerror = event => {
+      if (browserSpeechRef.current !== utterance) return
+      browserSpeechRef.current = null
+      setState('idle')
+      setError(event.error || '浏览器语音合成失败，请切换到 MiMo TTS')
+      setVisualError(true)
+    }
+    window.speechSynthesis.speak(utterance)
+  }
+
+  const failInput = (reason, media, processor, source, analyser) => {
+    const message = reason?.message || String(reason || '无法打开麦克风')
+    inputReadyRef.current = false
+    setAudioLevel(0)
+    setInputActive(false)
+    media?.getTracks().forEach(track => track.stop())
+    processor?.disconnect()
+    source?.disconnect()
+    analyser?.disconnect()
+    setError(message)
+    setVisualError(true)
+    inputErrorRef.current?.(message)
+  }
+
+  const playAudio = async event => {
+    const context = audioRef.current
+    if (!context || !event.audio) return
+    try {
+      if (context.state === 'suspended') await context.resume()
+      let buffer
+      if (event.format === 'pcm16' || event.format === 'pcm') {
+        const samples = decodePcm(event.audio)
+        buffer = context.createBuffer(
+          1,
+          samples.length,
+          Number(event.sample_rate) || DEFAULT_OUTPUT_RATE,
+        )
+        buffer.copyToChannel(samples, 0)
+      } else {
+        buffer = await context.decodeAudioData(base64Bytes(event.audio).slice(0))
+      }
+      if (!enabledRef.current) return
+      const source = context.createBufferSource()
+      source.buffer = buffer
+      source.connect(context.destination)
+      const playback = playbackRef.current
+      const start = Math.max(context.currentTime + 0.02, playback.cursor)
+      playback.cursor = start + buffer.duration
+      playback.sources.push(source)
+      setState('speaking')
+      source.onended = () => {
+        const current = playbackRef.current
+        current.sources = current.sources.filter(item => item !== source)
+        if (current.sources.length === 0 && enabledRef.current) setState('idle')
+      }
+      source.start(start)
+    } catch (reason) {
+      setError(reason?.message || '语音播放失败')
+      setVisualError(true)
+    }
+  }
+
+  useEffect(() => {
+    if (!enabled) {
+      sessionReadyRef.current = false
+      setConnectionState('idle')
+      setInputActive(false)
+      stopPlayback()
+      return undefined
+    }
+
+    let disposed = false
+    let reconnectTimer
+    let reconnectDelay = 500
+    const connect = () => {
+      if (disposed) return
+      const socket = new WebSocket(socketUrl())
+      socketRef.current = socket
+      sessionReadyRef.current = false
+      setConnectionState('connecting')
+      socket.onopen = () => {
+        reconnectDelay = 500
+        setError('')
+        setVisualError(false)
+      }
+      socket.onmessage = message => {
+        let event
+        try {
+          event = JSON.parse(message.data)
+        } catch {
+          return
+        }
+        if (event.type === 'server.ready') {
+          sendSocketEvent({
+            type: 'session.start',
+            sample_rate: INPUT_RATE,
+            tts_mode: ttsMode,
+          })
+        }
+        if (event.type === 'session.ready') {
+          sessionReadyRef.current = true
+          setConnectionState('connected')
+          setError('')
+          setVisualError(false)
+        }
+        if (event.type === 'vad.speech_started') {
+          stopPlayback()
+          setState('listening')
+        }
+        if (event.type === 'pipeline.error') {
+          setError('云端语音链路暂时不可用')
+          setVisualError(true)
+        }
+        if (event.type === 'tts.started') {
+          stopPlayback()
+        }
+        if (event.type === 'tts.chunk' || event.type === 'tts.completed') {
+          if (ttsMode === 'server') void playAudio(event)
+        }
+        if (event.type === 'llm.completed' && ttsMode === 'browser') {
+          speakInBrowser(event.text)
+        }
+        eventRef.current?.(event)
+      }
+      socket.onerror = () => {
+        if (!disposed) {
+          setConnectionState('unavailable')
+          setError('语音服务连接中断，正在重连')
+          setVisualError(true)
+        }
+      }
+      socket.onclose = () => {
+        if (socketRef.current === socket) socketRef.current = null
+        sessionReadyRef.current = false
+        if (disposed) return
+        setConnectionState('unavailable')
+        setState('idle')
+        setError('语音服务连接中断，正在重连')
+        setVisualError(true)
+        reconnectTimer = setTimeout(connect, reconnectDelay)
+        reconnectDelay = Math.min(5000, reconnectDelay * 2)
+      }
+    }
+    connect()
+    return () => {
+      disposed = true
+      clearTimeout(reconnectTimer)
+      sessionReadyRef.current = false
+      if (socketRef.current?.readyState === WebSocket.OPEN) {
+        socketRef.current.close()
+      }
+      socketRef.current = null
+      stopPlayback()
+    }
+  }, [enabled, sessionId, ttsMode])
+
+  useEffect(() => {
+    if (!enabled) {
+      inputReadyRef.current = false
+      setAudioLevel(0)
+      setInputActive(false)
+      return undefined
+    }
+
+    let disposed = false
+    let media
+    let source
+    let processor
+    let analyser
+    let animation
+    let visualInputActive = false
+    let lastVoiceAt = 0
+    inputReadyRef.current = false
+
+    const startAudio = async () => {
+      try {
+        if (!activateAudio()) {
+          failInput('当前浏览器不支持实时语音播放', media, processor, source, analyser)
+          return
+        }
+        const context = audioRef.current
+        if (!context) {
+          failInput('无法初始化实时语音播放', media, processor, source, analyser)
+          return
+        }
+        if (context.state === 'suspended') await context.resume()
+        media = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            // Automatic gain often lifts fans, distant voices and playback
+            // leakage enough to look like foreground speech to a VAD.
+            autoGainControl: false,
+          },
+        })
+        if (disposed) {
+          media.getTracks().forEach(track => track.stop())
+          return
+        }
+        setVisualError(false)
+        source = context.createMediaStreamSource(media)
+        analyser = context.createAnalyser()
+        analyser.fftSize = 512
+        source.connect(analyser)
+        processor = context.createScriptProcessor(2048, 1, 1)
+        processor.onaudioprocess = event => {
+          const socket = socketRef.current
+          if (
+            socket?.readyState !== WebSocket.OPEN
+            || !sessionReadyRef.current
+          ) return
+          const audio = resample(
+            event.inputBuffer.getChannelData(0),
+            context.sampleRate,
+            INPUT_RATE,
+          )
+          socket.send(JSON.stringify({
+            type: 'audio.append',
+            audio: pcmBase64(audio),
+          }))
+        }
+        source.connect(processor)
+        processor.connect(context.destination)
+        inputReadyRef.current = true
+        const samples = new Float32Array(analyser.fftSize)
+        const tick = () => {
+          analyser.getFloatTimeDomainData(samples)
+          const power = samples.reduce((sum, value) => sum + value * value, 0)
+          const level = Math.min(1, Math.sqrt(power / samples.length) / 0.18)
+          setAudioLevel(level)
+          const now = performance.now()
+          if (level >= 0.075) {
+            lastVoiceAt = now
+            if (!visualInputActive) {
+              visualInputActive = true
+              setInputActive(true)
+            }
+          } else if (visualInputActive && now - lastVoiceAt >= 140) {
+            visualInputActive = false
+            setInputActive(false)
+          }
+          animation = requestAnimationFrame(tick)
+        }
+        tick()
+      } catch (reason) {
+        if (!disposed) failInput(reason, media, processor, source, analyser)
+      }
+    }
+    startAudio()
+
+    return () => {
+      disposed = true
+      inputReadyRef.current = false
+      cancelAnimationFrame(animation)
+      setInputActive(false)
+      media?.getTracks().forEach(track => track.stop())
+      processor?.disconnect()
+      source?.disconnect()
+      analyser?.disconnect()
+    }
+  }, [enabled, sessionId])
+
+  useEffect(() => () => {
+    audioRef.current?.close()
+    audioRef.current = null
+  }, [])
+
+  return {
+    state,
+    visualState: visualState(state, inputActive, enabled),
+    error,
+    visualError,
+    connectionState,
+    levelElementRef,
+    activateAudio,
+    interrupt: stopPlayback,
+  }
+}

--- a/web/test/browser-tts.test.mjs
+++ b/web/test/browser-tts.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { browserTtsSupported, preferredChineseVoice } from '../src/browserTts.js'
+
+test('browserTtsSupported requires both browser speech APIs', () => {
+  assert.equal(browserTtsSupported({}), false)
+  assert.equal(browserTtsSupported({
+    speechSynthesis: {},
+    SpeechSynthesisUtterance: function Utterance() {},
+  }), true)
+})
+
+test('preferredChineseVoice favors local mainland Chinese voice', () => {
+  const voices = [
+    { name: 'English', lang: 'en-US', localService: true },
+    { name: 'Cloud Chinese', lang: 'zh-TW', localService: false },
+    { name: 'Local Chinese', lang: 'zh-CN', localService: true },
+  ]
+
+  assert.equal(preferredChineseVoice(voices).name, 'Local Chinese')
+})


### PR DESCRIPTION
## What changed

- add an authenticated same-origin WebSocket bridge for the modular VAD speech service
- add a WebUI mode for local VAD with replaceable ASR, LLM, and TTS providers
- add browser-native SpeechSynthesis as a low-latency TTS option with MiMo server TTS fallback
- preserve microphone noise suppression, playback interruption, reconnect handling, and persisted mode selection
- fix systemd Gateway units so an already escaped working directory is not quoted twice

## Why

The existing realtime frontend cannot expose the separately deployed VAD → ASR → LLM → TTS pipeline. The bridge keeps provider credentials in the local speech service while browser TTS avoids waiting for a complete server-side audio response.

## Validation

- npm test
- npm run build
- live local WebSocket session using browser TTS mode
- end-to-end VAD → MiMo ASR → Qwen LLM → TTS latency probe

## Deployment note

The Python speech-to-speech service is deployed separately and is not part of this repository. Set SPEECH_TO_SPEECH_VAD_WS_URL to its WebSocket endpoint.