### PR TITLE
docs: link Awesome Codex Pet gallery in v1.7.0 news entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ tells you:
 - **2026-08-09 · [v1.8.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.8.0)**
   🆕 Adds Qwen Code backend; 🔧 fixes known issues.
 - **2026-08-07 · [v1.7.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.7.0)**
-  🎨 The orb now supports skins, with custom look imports; 🪟 improved Windows backend Agent startup.
+  🎨 The orb opens up custom skins — import your own look, compatible with pet packs from the [Awesome Codex Pet](https://codexpet.top/) community gallery; 🪟 improved Windows backend Agent startup.
 - **2026-08-07 · [v1.6.1](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.6.1)**
   ⚡ Task delegation and permission decisions confirm instantly; 🖥️ built-in computer-use lets backend Agents operate the computer out of the box; 🎙️ more reliable wake; 📚 fully bilingual docs.
 - **2026-08-06 · [v1.6.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.6.0)**

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -23,7 +23,7 @@
 - **2026-08-09 · [v1.8.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.8.0)**
   🆕 新增 Qwen Code 后台；🔧 修复已知问题。
 - **2026-08-07 · [v1.7.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.7.0)**
-  🎨 悬浮球支持换肤，可导入自定义外观；🪟 优化 Windows 后台 Agent 启动。
+  🎨 悬浮球开放自定义外观，兼容 [Awesome Codex Pet](https://codexpet.top/) 社区画廊的宠物包；🪟 优化 Windows 后台 Agent 启动。
 - **2026-08-07 · [v1.6.1](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.6.1)**
   ⚡ 委派任务与权限确认即说即回；🖥️ 内置 computer-use，后台 Agent 开箱可操作电脑；🎙️ 唤醒更可靠；📚 文档全面双语化。
 - **2026-08-06 · [v1.6.0](https://github.com/QwenAudio/qwen-audio-agent/releases/tag/v1.6.0)**


### PR DESCRIPTION
The v1.7.0 orb skin system opens up custom looks, and its import format is compatible with pet packs from the Awesome Codex Pet community gallery (https://codexpet.top/). This links the gallery from the News entry in both README.md and README_ZH.md so users can find skins directly.

- EN: 'The orb opens up custom skins — import your own look, compatible with pet packs from the Awesome Codex Pet community gallery'
- ZH: '悬浮球开放自定义外观，兼容 Awesome Codex Pet 社区画廊的宠物包'

Docs-only change, two-line diff.