### PR TITLE
fix(tui): ship pcm-audio.mjs in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "tui/native/",
     "tui/src/index.mjs",
     "tui/src/macos-voice-io.mjs",
+    "tui/src/pcm-audio.mjs",
     "tui/src/portaudio-voice-io.mjs",
     "tui/package.json",
     "web/dist/",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -132,6 +132,9 @@ if (isMain) {
     'server/src/index.mjs',
     'shared/runtime-environment.mjs',
     'tui/src/index.mjs',
+    'tui/src/macos-voice-io.mjs',
+    'tui/src/pcm-audio.mjs',
+    'tui/src/portaudio-voice-io.mjs',
     'web/dist/index.html',
   ]
   const missing = required.filter(file => !files.has(file))


### PR DESCRIPTION
## 问题

Fixes #127 — 1.8.0 npm 包缺少 `tui/src/pcm-audio.mjs`，TUI 启动即报 `ERR_MODULE_NOT_FOUND`。

## 根因

`tui/src/index.mjs` 启动时导入 `./pcm-audio.mjs`，但根 `package.json` 的 `files` 白名单从未包含它；`verify-package.mjs` 的 required 清单只检查 `tui/src/index.mjs`，发布自检也拦不住。

## 改动

- `package.json`：`files` 白名单补上 `tui/src/pcm-audio.mjs`
- `scripts/verify-package.mjs`：required 清单补齐全部 tui 运行时模块（macos-voice-io / pcm-audio / portaudio-voice-io），后续再漏任何一个都会让 release-check 直接失败

## 验证

- `node scripts/verify-package.mjs` 通过（167 个文件）
- `npm pack --dry-run` 确认 `tui/src/pcm-audio.mjs` 进包
- `test/verify-package.test.mjs` 全过

## 备注

issue 评论区 @YUHAO-corn 的诊断正确，感谢。修复后建议尽快发 1.8.1 补丁版，1.8.0 的 TUI 对 npm 用户完全不可用。