### PR TITLE
fix(desktop): keep hidden voice client in wake-only mode

### DIFF
--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -181,6 +181,7 @@ export function attachRealtimeGateway(server, {
     let realtimeBlockedError = ''
     let sleeping = false
     let waking = false
+    let explicitSleepRequested = false
     let wakeDetector = null
     let wakeDetectorPromise = null
     let sleepController
@@ -1555,7 +1556,7 @@ export function attachRealtimeGateway(server, {
     }
 
     const enterSleep = () => {
-      if (sleeping || !frontend?.ready) return
+      if (sleeping) return
       sleeping = true
       waking = false
       pendingAudio = []
@@ -1624,6 +1625,26 @@ export function attachRealtimeGateway(server, {
       })
     }
 
+    // The desktop window and the realtime provider must enter sleep as one
+    // state transition. Waiting for the independent inactivity timer lets a
+    // hidden, muted orb continue forwarding wake-word audio to the realtime
+    // model, which can produce replies while no orb is visible.
+    const requestExplicitSleep = () => {
+      if (!config.wakeWordEnabled || textOnlySession) return false
+      explicitSleepRequested = true
+      inputEnabled = false
+      pendingAudio = []
+      prepareSleepMode()
+      const finish = () => {
+        if (!explicitSleepRequested || !wakeDetector) return false
+        enterSleep()
+        return sleeping
+      }
+      if (wakeDetector) return finish()
+      wakeDetectorPromise?.then(finish).catch(() => {})
+      return true
+    }
+
     const WAKE_CONNECT_MAX_ATTEMPTS = 3
     const WAKE_CONNECT_RETRY_BACKOFF_MS = 350
 
@@ -1670,6 +1691,7 @@ export function attachRealtimeGateway(server, {
 
     const wakeFromSleep = () => {
       if (!sleeping || waking) return
+      explicitSleepRequested = false
       sleeping = false
       waking = true
       sleepController.wake()
@@ -1790,11 +1812,14 @@ export function attachRealtimeGateway(server, {
           waking = true
           sleepController.wake()
         }
-        if (inputEnabled || outputEnabled) {
+        prepareSleepMode()
+        if (event.wakeWordOnly === true) {
+          requestExplicitSleep()
+        } else if (inputEnabled || outputEnabled) {
           ensureFrontend().catch(reportFrontendError)
         }
-        prepareSleepMode()
       } else if (event.type === GatewayClientEvent.UNMUTE) {
+        explicitSleepRequested = false
         if (textOnlySession) {
           inputEnabled = false
           outputEnabled = true
@@ -1811,6 +1836,7 @@ export function attachRealtimeGateway(server, {
           })
           .catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.INPUT_UNMUTE) {
+        explicitSleepRequested = false
         if (textOnlySession) return
         if (activeVoiceClients.isActive(ownerId, voiceClient)) {
           inputEnabled = true
@@ -1918,6 +1944,7 @@ export function attachRealtimeGateway(server, {
           })
         }
       } else if (event.type === GatewayClientEvent.MUTE) {
+        explicitSleepRequested = false
         releaseVoiceClient()
         sleeping = false
         waking = false
@@ -1931,9 +1958,12 @@ export function attachRealtimeGateway(server, {
       } else if (event.type === GatewayClientEvent.INPUT_MUTE) {
         inputEnabled = false
         pendingAudio = []
+      } else if (event.type === GatewayClientEvent.SLEEP) {
+        requestExplicitSleep()
       } else if (event.type === GatewayClientEvent.WAKE) {
         // 桌面快捷键/托盘唤起只恢复窗口可见性，休眠中的前台连接靠这个事件
         // 恢复，复用唤醒词检测之后同一套重连与退避路径。
+        explicitSleepRequested = false
         if (sleeping) wakeFromSleep()
         else sleepController.recordActivity()
       }

--- a/shared/realtime-events.mjs
+++ b/shared/realtime-events.mjs
@@ -7,6 +7,7 @@ export const GatewayClientEvent = Object.freeze({
   AUDIO_APPEND: 'audio.append',
   TEXT_MESSAGE: 'text.message',
   INTERRUPT: 'interrupt',
+  SLEEP: 'sleep',
   WAKE: 'wake',
   PLAYBACK_STARTED: 'playback.started',
   PLAYBACK_ENDED: 'playback.ended',

--- a/test/realtime-events.test.mjs
+++ b/test/realtime-events.test.mjs
@@ -36,13 +36,15 @@ test('defines the shared playback acknowledgement lifecycle', () => {
   ])
 })
 
-// 桌面快捷键/托盘唤起靠 wake 事件恢复休眠中的前台连接，
-// 服务端用 voice.sleep 回报唤醒进展。
+// 桌面隐藏用 sleep 显式进入仅唤醒词监听；快捷键/托盘唤起靠 wake
+// 恢复前台连接，服务端用 voice.sleep 回报唤醒进展。
 test('defines the shared sleep wake lifecycle', () => {
   assert.deepEqual([
+    GatewayClientEvent.SLEEP,
     GatewayClientEvent.WAKE,
     GatewayServerEvent.VOICE_SLEEP,
   ], [
+    'sleep',
     'wake',
     'voice.sleep',
   ])

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -674,6 +674,7 @@ export default function App() {
     suspended: desktopOrbMode && desktopLifecycle === 'hidden' && !wakeWordEnabled,
     outputMuted: false,
     inputOnlyMute: desktopOrbMode,
+    wakeWordOnly: voiceEnabledForWakeWord,
     clientType: desktopOrbMode ? 'desktop' : 'web',
     clientLabel: desktopOrbMode ? t('桌面端') : 'WebUI',
     clientStates: desktopOrbMode ? ['sleeping'] : [],

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -54,8 +54,10 @@ export function retainedRealtimeProvider(selected, providers) {
 export function microphoneControlEvent({
   enabled,
   inputOnlyMute = false,
+  wakeWordOnly = false,
   takeover = false,
 } = {}) {
+  if (wakeWordOnly) return { type: GatewayClientEvent.SLEEP }
   if (inputOnlyMute) {
     return enabled
       ? { type: GatewayClientEvent.INPUT_UNMUTE, takeover }
@@ -72,6 +74,7 @@ export default function useRealtimeVoice({
   suspended = false,
   outputMuted = false,
   inputOnlyMute = false,
+  wakeWordOnly = false,
   clientType = 'web',
   clientLabel = 'WebUI',
   clientStates = [],
@@ -93,6 +96,7 @@ export default function useRealtimeVoice({
   })
   const eventRef = useRef(onEvent)
   const inputErrorRef = useRef(onInputError)
+  const wakeWordOnlyRef = useRef(wakeWordOnly)
   const socketRef = useRef(null)
   const audioRef = useRef(null)
   const levelElementRef = useRef(null)
@@ -118,6 +122,7 @@ export default function useRealtimeVoice({
   })
   eventRef.current = onEvent
   inputErrorRef.current = onInputError
+  wakeWordOnlyRef.current = wakeWordOnly
   enabledRef.current = enabled
   outputMutedRef.current = outputMuted
 
@@ -355,7 +360,7 @@ export default function useRealtimeVoice({
         const inputEnabled = shouldAdvertiseVoice(
           enabledRef.current,
           inputReadyRef.current,
-        )
+        ) && !wakeWordOnlyRef.current
         const outputEnabled = inputOnlyMute || inputEnabled
         socket.send(JSON.stringify({
           type: GatewayClientEvent.CONNECT,
@@ -364,6 +369,7 @@ export default function useRealtimeVoice({
           voiceEnabled: outputEnabled,
           inputEnabled,
           outputEnabled,
+          wakeWordOnly: wakeWordOnlyRef.current,
           clientType,
           clientLabel,
           clientStates: clientStatesSignature
@@ -508,6 +514,7 @@ export default function useRealtimeVoice({
       sendSocketEvent(microphoneControlEvent({
         enabled: false,
         inputOnlyMute,
+        wakeWordOnly: false,
       }))
       setAudioLevel(0)
       setInputActive(false)
@@ -530,6 +537,7 @@ export default function useRealtimeVoice({
       sendSocketEvent(microphoneControlEvent({
         enabled: false,
         inputOnlyMute,
+        wakeWordOnly: false,
       }))
       setAudioLevel(0)
       setInputActive(false)
@@ -583,6 +591,7 @@ export default function useRealtimeVoice({
         sendSocketEvent(microphoneControlEvent({
           enabled: true,
           inputOnlyMute,
+          wakeWordOnly,
           takeover,
         }))
         const samples = new Float32Array(analyser.fftSize)
@@ -626,6 +635,7 @@ export default function useRealtimeVoice({
     activateAudio,
     enabled,
     inputOnlyMute,
+    wakeWordOnly,
     sendSocketEvent,
     sessionId,
     setAudioLevel,

--- a/web/test/voice-state.test.mjs
+++ b/web/test/voice-state.test.mjs
@@ -42,6 +42,16 @@ test('desktop microphone controls mute only input', () => {
   })
 })
 
+test('hidden desktop capture enters wake-word-only sleep instead of unmuting input', () => {
+  assert.deepEqual(microphoneControlEvent({
+    enabled: true,
+    inputOnlyMute: true,
+    wakeWordOnly: true,
+  }), {
+    type: 'sleep',
+  })
+})
+
 test('regular voice controls retain full mute behavior', () => {
   assert.deepEqual(microphoneControlEvent({ enabled: false }), {
     type: 'mute',


### PR DESCRIPTION
## Summary

- put an auto-hidden desktop client into an explicit Gateway wake-only state
- prevent hidden, muted clients from forwarding ordinary speech to the realtime model
- preserve mute state after wake while still restoring the orb immediately
- cover the shared sleep/wake event contract and hidden-client microphone behavior

## Verification

- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`