### PR TITLE
fix(tasks): report progress for interactive background work

### DIFF
--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -445,8 +445,9 @@ export const config = {
     1_800_000,
     { min: 60_000 },
   ),
-  scheduledTaskProgressCheckMs: numberSetting(
-    process.env.QWEN_AUDIO_AGENT_SCHEDULED_TASK_PROGRESS_CHECK_MS,
+  backgroundTaskProgressCheckMs: numberSetting(
+    process.env.QWEN_AUDIO_AGENT_BACKGROUND_TASK_PROGRESS_CHECK_MS
+      || process.env.QWEN_AUDIO_AGENT_SCHEDULED_TASK_PROGRESS_CHECK_MS,
     300_000,
     { min: 30_000 },
   ),

--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -95,6 +95,7 @@ export class TaskManager {
     pendingNotificationTtlMs = 604_800_000,
     notificationClaimTtlMs = 60_000,
     maxTerminalTasksPerOwner = 100,
+    progressCheckMs = config.backgroundTaskProgressCheckMs,
     logger: taskLogger = null,
   } = {}) {
     this.runner = runner
@@ -107,6 +108,7 @@ export class TaskManager {
     this.pendingNotificationTtlMs = pendingNotificationTtlMs
     this.notificationClaimTtlMs = notificationClaimTtlMs
     this.maxTerminalTasksPerOwner = maxTerminalTasksPerOwner
+    this.progressCheckMs = Math.max(0, Number(progressCheckMs) || 0)
     this.logger = taskLogger
     this.tasks = new Map()
     this.listeners = new Set()
@@ -370,6 +372,9 @@ export class TaskManager {
       terminalHandled: false,
       abortController: null,
       schedulerHeld: false,
+      progressCheckMs: String(kind || 'work') === 'work'
+        ? this.progressCheckMs
+        : null,
     }
     task.promise = new Promise(resolve => {
       task.resolve = resolve
@@ -388,7 +393,6 @@ export class TaskManager {
     schedule: { at, recurrence = 'once' } = {},
     type = 'reminder',
     timeoutMs = null,
-    progressCheckMs = null,
     runner = null,
   }) {
     const kind = type === 'task' ? 'scheduled_task' : 'reminder'
@@ -406,9 +410,7 @@ export class TaskManager {
       timeoutMs: type === 'task'
         ? Number(timeoutMs) || config.scheduledTaskTimeoutMs
         : null,
-      progressCheckMs: type === 'task'
-        ? Number(progressCheckMs) || config.scheduledTaskProgressCheckMs
-        : null,
+      progressCheckMs: null,
       createdAt: Date.now(),
       startedAt: null,
       completedAt: null,
@@ -560,9 +562,9 @@ export class TaskManager {
       }, task.timeoutMs)
       task.timeoutTimer.unref?.()
     }
-    // Progress check timer: periodically read real ACP activity data and
-    // emit task.progress.check so the voice gateway can announce it.
-    if (task.kind === 'scheduled_task' && task.progressCheckMs) {
+    // Interactive background work reports long-running progress. Scheduled
+    // work stays quiet until it completes, fails, or needs permission.
+    if (task.kind === 'work' && task.progressCheckMs) {
       task.progressCheckTimer = setInterval(() => {
         if (!ACTIVE.has(task.status)) {
           clearInterval(task.progressCheckTimer)

--- a/server/test/progress-check.test.mjs
+++ b/server/test/progress-check.test.mjs
@@ -25,49 +25,35 @@ function blockingRunner() {
   return runner
 }
 
-function createScheduledTask(manager, opts = {}) {
+function createWorkTask(manager, opts = {}) {
   const {
-    at,
     objective = 'test',
     ownerId = 'owner',
-    type = 'task',
     runner = null,
-    progressCheckMs = 30,
-    timeoutMs = 5_000,
   } = opts
-  return manager.createScheduled({
+  return manager.create({
     objective,
     ownerId,
     sessionId: 'voice',
     turnId: 'turn-1',
-    schedule: { at, recurrence: 'once' },
-    type,
     runner: runner || blockingRunner(),
-    progressCheckMs,
-    timeoutMs,
   })
 }
 
 test('progress check timer emits task.progress.check with activity-based message', async () => {
-  const manager = new TaskManager()
+  const manager = new TaskManager({ progressCheckMs: 30 })
   const progressEvents = []
   manager.subscribe(event => {
     if (event.type === 'task.progress.check') progressEvents.push(event)
   })
 
   const runner = blockingRunner()
-  const now = Date.now()
-  const task = createScheduledTask(manager, {
-    at: now - 1000,
+  const task = createWorkTask(manager, {
     objective: '测试进度任务',
-    progressCheckMs: 30,
     runner,
   })
 
   const internal = manager.tasks.get(task.id)
-  internal.status = 'queued'
-  manager.drain()
-
   await new Promise(resolve => setImmediate(resolve))
   assert.equal(manager.get(task.id).status, 'running')
 
@@ -86,13 +72,12 @@ test('progress check timer emits task.progress.check with activity-based message
 
   // Clean up
   runner.resolve({ content: 'done' })
-  if (internal.timeoutTimer) clearTimeout(internal.timeoutTimer)
   if (internal.progressCheckTimer) clearInterval(internal.progressCheckTimer)
   if (internal.progressTimer) clearInterval(internal.progressTimer)
 })
 
 test('progress check handles no activity gracefully', async () => {
-  const manager = new TaskManager()
+  const manager = new TaskManager({ progressCheckMs: 30 })
   const progressEvents = []
   manager.subscribe(event => {
     if (event.type === 'task.progress.check') progressEvents.push(event)
@@ -102,18 +87,12 @@ test('progress check handles no activity gracefully', async () => {
   let resolveRunner
   const noActivityRunner = async () => new Promise(r => { resolveRunner = r })
 
-  const now = Date.now()
-  const task = createScheduledTask(manager, {
-    at: now - 1000,
+  const task = createWorkTask(manager, {
     objective: '无活动任务',
-    progressCheckMs: 30,
     runner: noActivityRunner,
   })
 
   const internal = manager.tasks.get(task.id)
-  internal.status = 'queued'
-  manager.drain()
-
   await new Promise(resolve => setImmediate(resolve))
   assert.equal(manager.get(task.id).status, 'running')
   assert.equal(internal.activity.length, 0)
@@ -125,13 +104,12 @@ test('progress check handles no activity gracefully', async () => {
   assert.ok(event.message.includes('正在处理中'))
 
   resolveRunner({ content: 'done' })
-  if (internal.timeoutTimer) clearTimeout(internal.timeoutTimer)
   if (internal.progressCheckTimer) clearInterval(internal.progressCheckTimer)
   if (internal.progressTimer) clearInterval(internal.progressTimer)
 })
 
 test('delegated task progress check queries coordinator', async () => {
-  const manager = new TaskManager()
+  const manager = new TaskManager({ progressCheckMs: 30 })
   let queryCalled = false
   manager.configureCoordinatorQuery((_workId, _question, _options) => {
     queryCalled = true
@@ -147,18 +125,12 @@ test('delegated task progress check queries coordinator', async () => {
   let resolveRunner
   const blockingRunner = async () => new Promise(r => { resolveRunner = r })
 
-  const now = Date.now()
-  const task = createScheduledTask(manager, {
-    at: now - 1000,
+  const task = createWorkTask(manager, {
     objective: '委托任务',
-    progressCheckMs: 30,
     runner: blockingRunner,
   })
 
   const internal = manager.tasks.get(task.id)
-  internal.status = 'queued'
-  manager.drain()
-
   await new Promise(resolve => setImmediate(resolve))
   assert.equal(manager.get(task.id).status, 'running')
 
@@ -180,33 +152,26 @@ test('delegated task progress check queries coordinator', async () => {
   assert.ok(event.message.includes('第三层'))
 
   resolveRunner({ content: 'done' })
-  if (internal.timeoutTimer) clearTimeout(internal.timeoutTimer)
   if (internal.progressCheckTimer) clearInterval(internal.progressCheckTimer)
   if (internal.progressTimer) clearInterval(internal.progressTimer)
 })
 
 test('progress check timer stops after task completes', async () => {
-  const manager = new TaskManager()
+  const manager = new TaskManager({ progressCheckMs: 30 })
   const progressEvents = []
   manager.subscribe(event => {
     if (event.type === 'task.progress.check') progressEvents.push(event)
   })
 
   let resolveRunner
-  const now = Date.now()
-  const task = createScheduledTask(manager, {
-    at: now - 1000,
+  const task = createWorkTask(manager, {
     objective: '完成后停止进度检查',
     runner: () => new Promise(resolve => {
       resolveRunner = resolve
     }),
-    progressCheckMs: 30,
   })
 
   const internal = manager.tasks.get(task.id)
-  internal.status = 'queued'
-  manager.drain()
-
   await new Promise(resolve => setImmediate(resolve))
   assert.equal(manager.get(task.id).status, 'running')
 
@@ -223,6 +188,39 @@ test('progress check timer stops after task completes', async () => {
   await new Promise(resolve => setTimeout(resolve, 80))
   assert.equal(progressEvents.length, countBefore)
 
+  if (internal.progressTimer) clearInterval(internal.progressTimer)
+})
+
+test('scheduled tasks stay quiet while they run', async () => {
+  const manager = new TaskManager({ progressCheckMs: 30 })
+  const progressEvents = []
+  manager.subscribe(event => {
+    if (event.type === 'task.progress.check') progressEvents.push(event)
+  })
+
+  const runner = blockingRunner()
+  const task = manager.createScheduled({
+    objective: '安静执行的定时任务',
+    ownerId: 'owner',
+    sessionId: 'voice',
+    turnId: 'turn-1',
+    schedule: { at: Date.now() - 1000, recurrence: 'once' },
+    type: 'task',
+    runner,
+  })
+  const internal = manager.tasks.get(task.id)
+  internal.status = 'queued'
+  manager.drain()
+
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(manager.get(task.id).status, 'running')
+  assert.equal(manager.get(task.id).progressCheckMs, null)
+
+  await new Promise(resolve => setTimeout(resolve, 60))
+  assert.equal(progressEvents.length, 0)
+  assert.equal(internal.progressCheckTimer, null)
+
+  runner.resolve({ content: 'done' })
   if (internal.timeoutTimer) clearTimeout(internal.timeoutTimer)
   if (internal.progressTimer) clearInterval(internal.progressTimer)
 })

--- a/server/test/task-manager-scheduled.test.mjs
+++ b/server/test/task-manager-scheduled.test.mjs
@@ -62,7 +62,7 @@ test('createScheduled creates a task with status scheduled and correct kind', ()
   assert.equal(reminder.reused, false)
 })
 
-test('createScheduled with type=task sets timeoutMs and progressCheckMs', () => {
+test('createScheduled with type=task sets timeout without progress checks', () => {
   const manager = new TaskManager()
   const future = Date.now() + 60_000
 
@@ -79,7 +79,7 @@ test('createScheduled with type=task sets timeoutMs and progressCheckMs', () => 
   assert.equal(task.status, 'scheduled')
   assert.equal(task.kind, 'scheduled_task')
   assert.ok(task.timeoutMs > 0)
-  assert.ok(task.progressCheckMs > 0)
+  assert.equal(task.progressCheckMs, null)
 })
 
 test('createScheduled emits task.scheduled event', () => {

--- a/server/test/tool-call-handler-schedule.test.mjs
+++ b/server/test/tool-call-handler-schedule.test.mjs
@@ -102,7 +102,7 @@ test('handleScheduleReminder with type=task creates scheduled_task kind', async 
   const task = manager.get(output.reminder_id, { ownerId: 'owner' })
   assert.equal(task.kind, 'scheduled_task')
   assert.ok(task.timeoutMs > 0)
-  assert.ok(task.progressCheckMs > 0)
+  assert.equal(task.progressCheckMs, null)
 })
 
 test('handleScheduleReminder defaults type to reminder when not specified', async () => {


### PR DESCRIPTION
## Summary

- enable periodic progress checks for ordinary interactive background work
- keep scheduled tasks and reminders quiet until completion, failure, cancellation, or permission requests
- preserve delegated progress queries through the coordinator
- leave frontend tools and prompts unchanged

## Verification

- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`