### PR TITLE
fix: prevent active realtime responses from timing out

### DIFF
--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -1383,6 +1383,10 @@ export function attachRealtimeGateway(server, {
           recentMessages: conversationSync.frontendContext({ ownerId, sessionId }),
         },
         onEvent: handleEvent,
+        onDiagnostic: diagnostic => {
+          const { event, ...fields } = diagnostic
+          connectionLogger.warn(event, fields)
+        },
         onError: error => {
           const classification = createdFrontend.provider.classifyError(error.message)
           if (classification !== 'inactivity') {

--- a/server/src/voice/realtime-provider.mjs
+++ b/server/src/voice/realtime-provider.mjs
@@ -74,9 +74,11 @@ export class RealtimeFrontend {
     onEvent,
     onError,
     onClose,
+    onDiagnostic,
     agentContext = {},
     responseStartTimeoutMs,
-    responseCompletionTimeoutMs = 120000,
+    responseInactivityTimeoutMs,
+    responseCompletionTimeoutMs,
   } = {}) {
     this.provider = validateRealtimeProvider(provider)
     this.protocol = provider.protocol
@@ -87,6 +89,7 @@ export class RealtimeFrontend {
     this.onEvent = onEvent
     this.onError = onError
     this.onClose = onClose
+    this.onDiagnostic = onDiagnostic
     this.agentContext = agentContext
     this.ws = null
     this.ready = false
@@ -102,7 +105,12 @@ export class RealtimeFrontend {
     this.responseStartTimeoutMs = responseStartTimeoutMs
       ?? this.provider.responseStartTimeoutMs
       ?? 30000
-    this.responseCompletionTimeoutMs = responseCompletionTimeoutMs
+    // Keep the previous option as an internal compatibility alias. This is an
+    // inactivity watchdog, not an absolute response duration limit: long
+    // speech must remain valid while the provider keeps streaming output.
+    this.responseInactivityTimeoutMs = responseInactivityTimeoutMs
+      ?? responseCompletionTimeoutMs
+      ?? 120000
   }
 
   connect() {
@@ -477,7 +485,12 @@ export class RealtimeFrontend {
       return
     }
     if (isResponseActivityEvent(event)) {
-      this.activeResponses.add(realtimeResponseId(event))
+      const responseId = realtimeResponseId(event)
+      this.activeResponses.add(responseId)
+      const pending = this.responseWaiters.get(responseId)
+      if (pending && event.type !== 'response.done') {
+        this.armResponseInactivityTimeout(responseId, pending)
+      }
     }
     if (event.type === 'response.created') {
       const id = realtimeResponseId(event)
@@ -499,23 +512,9 @@ export class RealtimeFrontend {
       if (id) {
         this.activeResponses.add(id)
         if (pending) {
-          pending.timer = setTimeout(() => {
-            if (this.responseWaiters.get(id) !== pending) return
-            this.send(this.protocol.responseCancel())
-            this.settlePending(pending, {
-              timedOut: true,
-              phase: 'completion',
-              responseId: id,
-            })
-            const recoveryTimer = setTimeout(() => {
-              if (this.responseWaiters.get(id) !== pending) return
-              this.responseWaiters.delete(id)
-              this.activeResponses.delete(id)
-              this.resolveIdle()
-            }, 1000)
-            recoveryTimer.unref?.()
-          }, this.responseCompletionTimeoutMs)
           this.responseWaiters.set(id, pending)
+          pending.responseStartedAt = Date.now()
+          this.armResponseInactivityTimeout(id, pending)
         }
       }
     }
@@ -581,6 +580,41 @@ export class RealtimeFrontend {
         : { failed: true, responseId: id, status })
       this.resolveIdle()
     }
+  }
+
+  armResponseInactivityTimeout(responseId, pending) {
+    clearTimeout(pending.timer)
+    pending.lastResponseActivityAt = Date.now()
+    pending.timer = setTimeout(() => {
+      if (this.responseWaiters.get(responseId) !== pending) return
+      const now = Date.now()
+      const inactivityMs = now - pending.lastResponseActivityAt
+      try {
+        this.onDiagnostic?.({
+          event: 'realtime.response_timeout',
+          provider: this.provider.key,
+          responseId,
+          phase: 'inactivity',
+          inactivityMs,
+          elapsedMs: now - pending.responseStartedAt,
+        })
+      } catch {
+        // Diagnostics must never prevent response recovery.
+      }
+      this.send(this.protocol.responseCancel())
+      this.settlePending(pending, {
+        timedOut: true,
+        phase: 'inactivity',
+        responseId,
+      })
+      const recoveryTimer = setTimeout(() => {
+        if (this.responseWaiters.get(responseId) !== pending) return
+        this.responseWaiters.delete(responseId)
+        this.activeResponses.delete(responseId)
+        this.resolveIdle()
+      }, 1000)
+      recoveryTimer.unref?.()
+    }, this.responseInactivityTimeoutMs)
   }
 
   settlePending(pending, outcome) {

--- a/server/test/realtime-provider.test.mjs
+++ b/server/test/realtime-provider.test.mjs
@@ -119,6 +119,81 @@ test('only reports a queued announcement as completed after response.done', asyn
   })
 })
 
+test('keeps a long response alive while output activity continues', async () => {
+  const frontend = createQwenFrontend({
+    responseStartTimeoutMs: 100,
+    responseInactivityTimeoutMs: 80,
+  })
+  frontend.ready = true
+  const sent = []
+  frontend.send = event => sent.push(event)
+
+  const outcome = frontend.speak('一段持续时间较长的语音回复')
+  await new Promise(resolve => setImmediate(resolve))
+  frontend.handleLifecycle({
+    type: 'response.created',
+    response: { id: 'response-long' },
+  })
+  await new Promise(resolve => setTimeout(resolve, 50))
+  frontend.handleLifecycle({
+    type: 'response.audio.delta',
+    response_id: 'response-long',
+    delta: 'audio-one',
+  })
+  await new Promise(resolve => setTimeout(resolve, 50))
+  frontend.handleLifecycle({
+    type: 'response.audio_transcript.delta',
+    response_id: 'response-long',
+    delta: '仍在输出',
+  })
+  await new Promise(resolve => setTimeout(resolve, 50))
+  frontend.handleLifecycle({
+    type: 'response.done',
+    response: { id: 'response-long', status: 'completed' },
+  })
+
+  assert.deepEqual(await outcome, {
+    completed: true,
+    responseId: 'response-long',
+  })
+  assert.doesNotMatch(
+    sent.map(event => event.type).join(','),
+    /response\.cancel/,
+  )
+})
+
+test('cancels and diagnoses a response only after output becomes inactive', async () => {
+  const diagnostics = []
+  const frontend = createQwenFrontend({
+    responseStartTimeoutMs: 100,
+    responseInactivityTimeoutMs: 10,
+    onDiagnostic: diagnostic => diagnostics.push(diagnostic),
+  })
+  frontend.ready = true
+  const sent = []
+  frontend.send = event => sent.push(event)
+
+  const outcome = frontend.speak('这次响应会停止输出')
+  await new Promise(resolve => setImmediate(resolve))
+  frontend.handleLifecycle({
+    type: 'response.created',
+    response: { id: 'response-stalled' },
+  })
+
+  assert.deepEqual(await outcome, {
+    timedOut: true,
+    phase: 'inactivity',
+    responseId: 'response-stalled',
+  })
+  assert.equal(sent.at(-1).type, 'response.cancel')
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].event, 'realtime.response_timeout')
+  assert.equal(diagnostics[0].provider, 'dashscope')
+  assert.equal(diagnostics[0].responseId, 'response-stalled')
+  assert.equal(diagnostics[0].phase, 'inactivity')
+  assert.ok(diagnostics[0].inactivityMs >= 10)
+})
+
 test('skips a queued response when its late deduplication guard rejects it', async () => {
   const frontend = createQwenFrontend()
   frontend.ready = true


### PR DESCRIPTION
## Summary

- replace the fixed response-duration timeout with a sliding inactivity watchdog
- keep long speech responses alive while audio, text, or transcript output is streaming
- emit diagnostics when a genuinely stalled response is cancelled
- cover active long responses and inactive-response recovery with tests

## Validation

- `npm test`
- `npm run lint`
- `npm run test --workspace server`

Fixes #117