### PR TITLE
fix: tolerate early realtime timeout wakeups

### DIFF
--- a/server/src/voice/realtime-provider.mjs
+++ b/server/src/voice/realtime-provider.mjs
@@ -585,10 +585,15 @@ export class RealtimeFrontend {
   armResponseInactivityTimeout(responseId, pending) {
     clearTimeout(pending.timer)
     pending.lastResponseActivityAt = Date.now()
-    pending.timer = setTimeout(() => {
+    const handleTimeout = () => {
       if (this.responseWaiters.get(responseId) !== pending) return
       const now = Date.now()
       const inactivityMs = now - pending.lastResponseActivityAt
+      const remainingMs = this.responseInactivityTimeoutMs - inactivityMs
+      if (remainingMs > 0) {
+        pending.timer = setTimeout(handleTimeout, remainingMs)
+        return
+      }
       try {
         this.onDiagnostic?.({
           event: 'realtime.response_timeout',
@@ -614,7 +619,8 @@ export class RealtimeFrontend {
         this.resolveIdle()
       }, 1000)
       recoveryTimer.unref?.()
-    }, this.responseInactivityTimeoutMs)
+    }
+    pending.timer = setTimeout(handleTimeout, this.responseInactivityTimeoutMs)
   }
 
   settlePending(pending, outcome) {


### PR DESCRIPTION
## Summary

- re-check elapsed inactivity when the watchdog wakes up
- re-arm it for the remaining interval when the platform timer fires slightly early
- prevent flaky timeout diagnostics and premature response cancellation

## Validation

- realtime provider test suite repeated 20 times
- `npm run test --workspace server`
- `npm run lint`

Follow-up to #142.