### PR TITLE
fix(desktop): clarify backend agent labels

### DIFF
--- a/desktop/src/settings.html
+++ b/desktop/src/settings.html
@@ -40,7 +40,7 @@
             <dd id="current-realtime">正在检查…</dd>
           </div>
           <div>
-            <dt>Agent</dt>
+            <dt>后台 Agent</dt>
             <dd id="current-backend" class="connection-status checking">正在检查…</dd>
           </div>
         </dl>
@@ -65,7 +65,7 @@
             aria-selected="false"
             aria-controls="backend-settings"
             data-settings-tab="backend"
-          >Agent</button>
+          >后台 Agent</button>
           <button
             id="app-tab"
             class="settings-tab"
@@ -205,7 +205,7 @@
           >
             <div class="settings-card backend-settings-card">
               <div class="setting-row backend-list-row">
-                <span class="setting-label" id="backend-list-label">Agent</span>
+                <span class="setting-label" id="backend-list-label">后台 Agent</span>
                 <div class="field-with-action backend-list-action">
                   <div class="backend-picker">
                     <button

--- a/desktop/test/settings-config.test.mjs
+++ b/desktop/test/settings-config.test.mjs
@@ -463,7 +463,7 @@ test('desktop settings expose external backend connection controls', () => {
   assert.match(html, /id="speech-to-speech-url"/)
   assert.match(html, /id="speech-to-speech-token"/)
   assert.match(html, />语音前台</)
-  assert.match(html, />Agent</)
+  assert.match(html, />后台 Agent</)
   assert.match(html, /for="backend-model">Model</)
   assert.match(html, />应用</)
   assert.match(html, /role="tablist"/)


### PR DESCRIPTION
## Summary
- label the desktop runtime field as 后台 Agent / Backend Agent
- label the settings tab and backend selector consistently
- update the desktop settings structure test

## Test
- node --test desktop/test/*.test.mjs