### PR TITLE
feat(skills): 技能管理透传 skills.sh + 启动补装；权限与消息排序修复

### DIFF
--- a/cli/src/arguments.mjs
+++ b/cli/src/arguments.mjs
@@ -13,6 +13,7 @@ const COMMANDS = new Set([
   'config',
   'setup',
   'install',
+  'skill',
 ])
 const GATEWAY_ACTIONS = new Set([
   'run',
@@ -25,6 +26,7 @@ const GATEWAY_ACTIONS = new Set([
 ])
 const BACKEND_PERMISSION_MODES = new Set(['native', 'full'])
 const TUI_AUDIO_MODES = new Set(['half', 'full'])
+const SKILL_ACTIONS = new Set(['install', 'list', 'remove', 'update'])
 
 export function createVoiceSessionId() {
   return `voice-${randomUUID().replaceAll('-', '')}`
@@ -72,6 +74,26 @@ export function parseArguments(argv, env = process.env) {
     && !args[0].startsWith('-')
     ? args.shift()
     : ''
+  const skillAction = command === 'skill' && args[0] && !args[0].startsWith('-')
+    ? args.shift()
+    : ''
+  if (command === 'skill' && !SKILL_ACTIONS.has(skillAction)) {
+    throw new Error(
+      `skill 需要子命令（可选：${[...SKILL_ACTIONS].join('、')}）`,
+    )
+  }
+  const skillTarget = command === 'skill'
+    && ['install', 'remove'].includes(skillAction)
+    && args[0]
+    && !args[0].startsWith('-')
+    ? args.shift()
+    : ''
+  if (command === 'skill' && skillAction === 'install' && !skillTarget) {
+    throw new Error('skill install 需要技能来源（本地目录或 git URL）')
+  }
+  if (command === 'skill' && skillAction === 'remove' && !skillTarget) {
+    throw new Error('skill remove 需要技能名称')
+  }
 
   const options = {
     command,
@@ -93,6 +115,10 @@ export function parseArguments(argv, env = process.env) {
     backendUrl: '',
     backendUrlSpecified: false,
     installTarget: '',
+    skillAction,
+    skillTarget,
+    skillNames: [],
+    skillList: false,
     openBrowser: true,
     takeover: false,
     json: false,
@@ -135,6 +161,9 @@ export function parseArguments(argv, env = process.env) {
       options.audioMode = nextValue(args, index++, '--audio-mode').toLowerCase()
       audioModeSpecified = true
     } else if (argument === '--no-open') options.openBrowser = false
+    else if (argument === '--skill') {
+      options.skillNames.push(nextValue(args, index++, '--skill'))
+    } else if (argument === '--list') options.skillList = true
     else if (argument === '--takeover') options.takeover = true
     else if (argument === '--json') options.json = true
     else if (argument === '--yes' || argument === '-y') options.yes = true
@@ -167,10 +196,20 @@ export function parseArguments(argv, env = process.env) {
     )
   }
   if (options.installTarget === 'acp') {
-    throw new Error('通用 ACP 后台请自行安装，并通过 ACP_COMMAND 配置')
+    throw new Error('通用 ACP 接入的 Agent 请自行安装，并通过 ACP_COMMAND 配置')
   }
   if (command !== 'install' && options.yes) {
     throw new Error('--yes 只适用于 install')
+  }
+  const skillInstall = command === 'skill' && skillAction === 'install'
+  if (options.skillNames.length && !skillInstall) {
+    throw new Error('--skill 只适用于 skill install')
+  }
+  if (options.skillList && !skillInstall) {
+    throw new Error('--list 只适用于 skill install')
+  }
+  if (options.skillList && options.skillNames.length) {
+    throw new Error('--list 与 --skill 不能同时使用')
   }
 
   const definition = options.backend
@@ -259,6 +298,11 @@ export function helpText() {
     '  qwenaudio config set --realtime-model ID  更新 Realtime 模型',
     '  qwenaudio setup [选项]       只读检查后台 Agent 接入准备情况',
     '  qwenaudio install NAME        一键安装后台 Agent（含所需 ACP 适配器）',
+    '  qwenaudio skill install SRC --skill NAME  安装技能到所有后台（经 skills.sh）',
+    '  qwenaudio skill install SRC --list         列出来源中可安装的技能',
+    '  qwenaudio skill list          查看已安装技能',
+    '  qwenaudio skill remove NAME   移除技能',
+    '  qwenaudio skill update        更新已安装技能',
     '',
     'Gateway 选项：',
     '  --url URL              Gateway 地址（默认 http://127.0.0.1:3101）',
@@ -274,6 +318,11 @@ export function helpText() {
     'Install 选项：',
     `  NAME                   可选：${backendNames().filter(name => name !== 'acp').join('、')}；不含通用 acp（需自行安装）`,
     '  --yes, -y              脚本类安装步骤不再逐个确认（谨慎使用）',
+    '',
+    'Skill 选项（底层由 skills.sh 完成，自动覆盖全部后台 Agent）：',
+    '  SRC                    来源：owner/repo、git URL、GitHub tree URL 或技能页 URL',
+    '  --skill NAME           指定要安装的技能（可多次）',
+    '  --list                 只列出来源内可安装的技能，不安装',
     '',
     '界面选项：',
     '  --session ID           复用指定语音会话',

--- a/cli/src/launcher.mjs
+++ b/cli/src/launcher.mjs
@@ -4,13 +4,23 @@ import readline from 'node:readline'
 import { loadRuntimeEnvironment } from '../../shared/runtime-environment.mjs'
 import {
   backendDefinition,
+  backendNames,
+  normalizeBackendProtocol,
   resolveBackendOwnership,
 } from '../../shared/backend-catalog.mjs'
 import {
+  findExecutable,
   formatBackendSetup,
   inspectBackendSetups,
 } from '../../shared/backend-setup.mjs'
 import { installBackend } from '../../shared/backend-install.mjs'
+import {
+  addSkills,
+  listSkills,
+  presentInstallerAgents,
+  removeSkill,
+  updateSkills,
+} from '../../shared/skill-library.mjs'
 import { helpText, parseArguments } from './arguments.mjs'
 import {
   ensureRuntime,
@@ -143,6 +153,21 @@ export async function main(argv, {
     env,
     ...installerOptions,
   }),
+  skillTools = {
+    addSkills,
+    listSkills,
+    removeSkill,
+    updateSkills,
+    // 安装目标：本机实际存在的后台（CLI 可执行即算）∪ 当前配置后台；
+    // 不为从未使用的后台预建目录，新后台由网关启动补装自动补齐。
+    presentAgents: () => presentInstallerAgents({
+      readyBackends: backendNames().filter(id => {
+        const command = backendDefinition(id)?.setup?.command
+        return Boolean(command && findExecutable(command, { env }))
+      }),
+      currentProtocol: normalizeBackendProtocol(env.AGENT_PROTOCOL),
+    }),
+  },
   runMinimalTui = runMinimal,
   prepareRuntime = options => ensureRuntime(options, { root, env }),
   inspectGateway = url => readGatewayHealth(url),
@@ -196,6 +221,35 @@ export async function main(argv, {
     const selected = report.backends.find(item => item.selected)
       || (options.backendSpecified ? report.backends[0] : null)
     return selected && !selected.ready ? 1 : 0
+  }
+  if (options.command === 'skill') {
+    // qwenaudio skill 是 skills.sh 的品牌化入口：参数组装后透传，输出原样展示。
+    if (options.skillAction === 'list') {
+      stdout.write(skillTools.listSkills().stdout)
+      return 0
+    }
+    if (options.skillAction === 'update') {
+      stdout.write(skillTools.updateSkills().stdout)
+      return 0
+    }
+    if (options.skillAction === 'install') {
+      const result = skillTools.addSkills(options.skillTarget, {
+        skills: options.skillNames,
+        list: options.skillList,
+        ...(options.skillList ? {} : { agents: skillTools.presentAgents() }),
+      })
+      stdout.write(result.stdout)
+      if (!options.skillList) {
+        // 各后台发现新技能的时机不同：部分热加载，部分仅在进程/会话启动时扫描。
+        stdout.write(
+          '技能已安装；若运行中的后台未发现新技能，'
+          + '执行 qwenaudio gateway restart 后即可生效\n',
+        )
+      }
+      return 0
+    }
+    stdout.write(skillTools.removeSkill(options.skillTarget).stdout)
+    return 0
   }
   if (options.command === 'install') {
     const label = backendDefinition(options.installTarget)?.label

--- a/cli/test/arguments.test.mjs
+++ b/cli/test/arguments.test.mjs
@@ -132,6 +132,72 @@ test('rejects invalid install targets and misplaced flags', () => {
   )
 })
 
+test('parses skill passthrough commands', () => {
+  const install = parseArguments(
+    ['skill', 'install', 'owner/repo', '--skill', 'pdf-tools', '--skill', 'review'],
+    {},
+  )
+  assert.equal(install.command, 'skill')
+  assert.equal(install.skillAction, 'install')
+  assert.equal(install.skillTarget, 'owner/repo')
+  assert.deepEqual(install.skillNames, ['pdf-tools', 'review'])
+  assert.equal(install.skillList, false)
+
+  const list = parseArguments(
+    ['skill', 'install', 'https://github.com/vercel-labs/skills', '--list'],
+    {},
+  )
+  assert.equal(list.skillTarget, 'https://github.com/vercel-labs/skills')
+  assert.equal(list.skillList, true)
+
+  const installed = parseArguments(['skill', 'list'], {})
+  assert.equal(installed.skillAction, 'list')
+  assert.equal(installed.skillTarget, '')
+
+  const remove = parseArguments(['skill', 'remove', 'pdf-tools'], {})
+  assert.equal(remove.skillAction, 'remove')
+  assert.equal(remove.skillTarget, 'pdf-tools')
+
+  const update = parseArguments(['skill', 'update'], {})
+  assert.equal(update.skillAction, 'update')
+})
+
+test('rejects incomplete or misplaced skill arguments', () => {
+  assert.throws(() => parseArguments(['skill'], {}), /skill 需要子命令/)
+  assert.throws(() => parseArguments(['skill', 'publish'], {}), /skill 需要子命令/)
+  assert.throws(
+    () => parseArguments(['skill', 'install'], {}),
+    /需要技能来源/,
+  )
+  assert.throws(
+    () => parseArguments(['skill', 'remove'], {}),
+    /需要技能名称/,
+  )
+  assert.throws(
+    () => parseArguments(['skill', 'install', 'owner/repo', '--skill'], {}),
+    /--skill 缺少参数/,
+  )
+  assert.throws(
+    () => parseArguments(['skill', 'list', '--skill', 'x'], {}),
+    /--skill 只适用于 skill install/,
+  )
+  assert.throws(
+    () => parseArguments(['skill', 'remove', 'x', '--list'], {}),
+    /--list 只适用于 skill install/,
+  )
+  assert.throws(
+    () => parseArguments(
+      ['skill', 'install', 'owner/repo', '--list', '--skill', 'x'],
+      {},
+    ),
+    /--list 与 --skill 不能同时使用/,
+  )
+  assert.throws(
+    () => parseArguments(['install', 'codex', '--skill', 'x'], {}),
+    /--skill 只适用于 skill install/,
+  )
+})
+
 test('rejects the removed backend mode option', () => {
   assert.throws(() => parseArguments([
     'gateway',

--- a/cli/test/launcher.test.mjs
+++ b/cli/test/launcher.test.mjs
@@ -97,6 +97,71 @@ test('starts the Gateway by default without acquiring a UI lock', async () => {
   ])
 })
 
+test('dispatches skill commands straight to the skills CLI', async () => {
+  const target = harness()
+  const skillCalls = []
+  target.dependencies.skillTools = {
+    addSkills: (source, options) => {
+      skillCalls.push(['add', source, options.skills, options.list, options.agents])
+      return { stdout: 'installed skill output\n' }
+    },
+    listSkills: () => {
+      skillCalls.push(['list'])
+      return { stdout: 'skill listing\n' }
+    },
+    removeSkill: name => {
+      skillCalls.push(['remove', name])
+      return { stdout: 'removed\n' }
+    },
+    updateSkills: () => {
+      skillCalls.push(['update'])
+      return { stdout: 'updated\n' }
+    },
+    presentAgents: () => ['claude-code', 'opencode'],
+  }
+  const output = () => target.calls
+    .filter(call => call[0] === 'stdout')
+    .map(call => call[1])
+    .join('')
+
+  assert.equal(
+    await main(
+      ['skill', 'install', 'owner/repo', '--skill', 'review'],
+      target.dependencies,
+    ),
+    0,
+  )
+  // 安装目标是“本机存在的后台 ∪ 当前后台”名单，而非全量。
+  assert.deepEqual(
+    skillCalls[0],
+    ['add', 'owner/repo', ['review'], false, ['claude-code', 'opencode']],
+  )
+  assert.match(output(), /installed skill output/)
+  assert.match(output(), /gateway restart/)
+
+  skillCalls.length = 0
+  target.calls.length = 0
+  assert.equal(
+    await main(['skill', 'install', 'owner/repo', '--list'], target.dependencies),
+    0,
+  )
+  assert.deepEqual(skillCalls[0], ['add', 'owner/repo', [], true, undefined])
+  // --list 只枚举，不输出安装后的生效提示。
+  assert.doesNotMatch(output(), /gateway restart/)
+
+  skillCalls.length = 0
+  assert.equal(await main(['skill', 'list'], target.dependencies), 0)
+  assert.deepEqual(skillCalls, [['list']])
+
+  skillCalls.length = 0
+  assert.equal(await main(['skill', 'remove', 'review'], target.dependencies), 0)
+  assert.deepEqual(skillCalls, [['remove', 'review']])
+
+  skillCalls.length = 0
+  assert.equal(await main(['skill', 'update'], target.dependencies), 0)
+  assert.deepEqual(skillCalls, [['update']])
+})
+
 test('marks only an explicitly addressed OpenClaw Gateway as external', async () => {
   const managed = harness()
   managed.dependencies.env = { AGENT_PROTOCOL: 'openclaw' }

--- a/cli/test/runtime-environment.test.mjs
+++ b/cli/test/runtime-environment.test.mjs
@@ -220,46 +220,25 @@ test('keeps managed backend data outside the installation directory', () => {
     generateSecret: false,
   })
 
+  // 所有后台默认共享同一个托管 workspace，均在安装目录之外。
   assert.equal(
+    result.sharedWorkspace,
+    resolve(result.configDirectory, 'workspace'),
+  )
+  for (const workspace of [
     result.openCodeWorkspace,
-    resolve(result.configDirectory, 'workspaces/opencode'),
-  )
-  assert.equal(
     result.openClawWorkspace,
-    resolve(result.configDirectory, 'workspaces/openclaw'),
-  )
-  assert.equal(
     result.qoderWorkspace,
-    resolve(result.configDirectory, 'workspaces/qoder'),
-  )
-  assert.equal(
     result.qwenCodeWorkspace,
-    resolve(result.configDirectory, 'workspaces/qwen'),
-  )
-  assert.equal(
     result.kimiWorkspace,
-    resolve(result.configDirectory, 'workspaces/kimi'),
-  )
-  assert.equal(
     result.hermesWorkspace,
-    resolve(result.configDirectory, 'workspaces/hermes'),
-  )
-  assert.equal(
     result.codeBuddyWorkspace,
-    resolve(result.configDirectory, 'workspaces/codebuddy'),
-  )
-  assert.equal(
     result.codexWorkspace,
-    resolve(result.configDirectory, 'workspaces/codex'),
-  )
-  assert.equal(
     result.claudeWorkspace,
-    resolve(result.configDirectory, 'workspaces/claude'),
-  )
-  assert.equal(
     result.acpWorkspace,
-    resolve(result.configDirectory, 'workspaces/acp'),
-  )
+  ]) {
+    assert.equal(workspace, result.sharedWorkspace)
+  }
   assert.equal(
     result.openClawStateDirectory,
     resolve(result.configDirectory, 'backends/openclaw/state'),
@@ -292,6 +271,31 @@ test('keeps managed backend data outside the installation directory', () => {
   assert.equal(
     existsSync(resolve(result.openCodeWorkspace, 'AGENTS.md')),
     false,
+  )
+})
+
+test('reports legacy per-backend workspaces without touching them', () => {
+  const target = fixture()
+  const configDirectory = resolve(target.homeDirectory, '.config/qwaudio')
+  const legacyDirectory = resolve(configDirectory, 'workspaces/qwen')
+  mkdirSync(legacyDirectory, { recursive: true })
+  writeFileSync(resolve(legacyDirectory, 'notes.md'), 'user data\n')
+
+  const result = loadRuntimeEnvironment({
+    root: target.root,
+    homeDirectory: target.homeDirectory,
+    env: {},
+    generateSecret: false,
+  })
+  assert.deepEqual(result.legacyWorkspaceNotices, [{
+    backend: 'qwen',
+    legacyDirectory,
+    sharedWorkspace: result.sharedWorkspace,
+  }])
+  // 只提示，不迁移不删除。
+  assert.equal(
+    readFileSync(resolve(legacyDirectory, 'notes.md'), 'utf8'),
+    'user data\n',
   )
 })
 

--- a/cli/test/skill-library.test.mjs
+++ b/cli/test/skill-library.test.mjs
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import {
+  addSkills,
+  ensureBackendSkills,
+  listSkills,
+  presentInstallerAgents,
+  readSkillLock,
+  removeSkill,
+  runSkillsCli,
+  skillsCliPackage,
+  updateSkills,
+} from '../../shared/skill-library.mjs'
+import {
+  backendDefinitions,
+  backendSkillsSpec,
+  skillsInstallerAgents,
+  validateBackendSkillsSpec,
+} from '../../shared/backend-catalog.mjs'
+
+function fakeSpawn({ status = 0, stdout = '', stderr = '', error } = {}) {
+  const calls = []
+  const spawn = args => {
+    calls.push(args)
+    return { status, stdout, stderr, error }
+  }
+  return { calls, spawn }
+}
+
+test('runs the pinned skills.sh package through npx argv', () => {
+  const target = fakeSpawn({ stdout: 'ok\n' })
+  const result = runSkillsCli(['list', '-g'], { spawn: target.spawn })
+  assert.deepEqual(target.calls, [['-y', skillsCliPackage(), 'list', '-g']])
+  assert.equal(result.stdout, 'ok\n')
+
+  // 版本可用环境变量覆盖（对齐 *_PACKAGE 惯例）。
+  assert.equal(
+    skillsCliPackage({ QWEN_AUDIO_AGENT_SKILLS_CLI_PACKAGE: 'skills@9.9.9' }),
+    'skills@9.9.9',
+  )
+  assert.match(skillsCliPackage({}), /^skills@\d/)
+})
+
+test('surfaces skills.sh failures with stderr detail', () => {
+  const failed = fakeSpawn({ status: 1, stderr: 'repository not found' })
+  assert.throws(
+    () => runSkillsCli(['add', 'missing/repo'], { spawn: failed.spawn }),
+    /repository not found/,
+  )
+  const broken = fakeSpawn({ error: new Error('spawn npx ENOENT') })
+  assert.throws(
+    () => runSkillsCli(['list'], { spawn: broken.spawn }),
+    /skills CLI 启动失败/,
+  )
+})
+
+test('installs to every backend installer agent explicitly', () => {
+  const target = fakeSpawn({ stdout: 'installed\n' })
+  addSkills('alirezarezvani/claude-skills', {
+    skills: ['skill-security-auditor', 'playwright-pro'],
+    spawn: target.spawn,
+  })
+  const args = target.calls[0]
+  assert.equal(args[2], 'add')
+  assert.equal(args[3], 'alirezarezvani/claude-skills')
+  // 技能多选。
+  assert.deepEqual(
+    args.filter((value, index) => args[index - 1] === '--skill'),
+    ['skill-security-auditor', 'playwright-pro'],
+  )
+  // 全局安装、拷贝模式（规避 symlink 兼容性问题）、非交互。
+  for (const flag of ['-g', '--copy', '-y']) {
+    assert.ok(args.includes(flag), `missing ${flag}`)
+  }
+  // 缺省回退 catalog installer 全名单。
+  const agents = args.filter((value, index) => args[index - 1] === '-a')
+  assert.deepEqual(agents.sort(), [...skillsInstallerAgents()].sort())
+  assert.ok(agents.includes('hermes-agent'))
+  assert.ok(agents.includes('openclaw'))
+  // deepseek 暂无 skills.sh 安装器（经 ~/.agents/skills 被动受益）。
+  assert.equal(agents.length, 9)
+
+  // 传入 agents 时只装给指定后台（“本机存在 ∪ 当前”名单）。
+  const narrowed = fakeSpawn({ stdout: 'installed\n' })
+  addSkills('owner/repo', {
+    skills: ['review'],
+    agents: ['claude-code'],
+    spawn: narrowed.spawn,
+  })
+  assert.deepEqual(
+    narrowed.calls[0].filter((value, index) => (
+      narrowed.calls[0][index - 1] === '-a'
+    )),
+    ['claude-code'],
+  )
+})
+
+test('lists remote skills without installing', () => {
+  const target = fakeSpawn({ stdout: 'skill-a\nskill-b\n' })
+  const result = addSkills('vercel-labs/skills', {
+    list: true,
+    spawn: target.spawn,
+  })
+  assert.deepEqual(
+    target.calls,
+    [['-y', skillsCliPackage(), 'add', 'vercel-labs/skills', '--list']],
+  )
+  assert.match(result.stdout, /skill-a/)
+})
+
+test('requires --skill for installs and a non-empty source', () => {
+  const target = fakeSpawn()
+  assert.throws(
+    () => addSkills('owner/repo', { spawn: target.spawn }),
+    /--skill/,
+  )
+  assert.throws(() => addSkills('', { spawn: target.spawn }), /来源/)
+  assert.equal(target.calls.length, 0)
+})
+
+test('passes list, remove and update straight through in global scope', () => {
+  const target = fakeSpawn({ stdout: 'done\n' })
+  listSkills({ spawn: target.spawn })
+  removeSkill('pdf-tools', { spawn: target.spawn })
+  updateSkills({ spawn: target.spawn })
+  assert.deepEqual(target.calls.map(args => args.slice(2)), [
+    ['list', '-g'],
+    ['remove', 'pdf-tools', '-g', '-y'],
+    ['update', '-g'],
+  ])
+  assert.throws(() => removeSkill('', { spawn: target.spawn }), /名称/)
+})
+
+test('every backend definition declares its skills contract', () => {
+  for (const definition of backendDefinitions()) {
+    assert.doesNotThrow(() => validateBackendSkillsSpec(definition))
+  }
+  // acp 是通用接入方式无技能约定；deepseek 暂无 skills.sh 安装器。
+  assert.equal(backendSkillsSpec('acp'), null)
+  assert.deepEqual(backendSkillsSpec('deepseek'), { installer: null })
+  assert.deepEqual(backendSkillsSpec('claude'), { installer: 'claude-code' })
+
+  assert.throws(
+    () => validateBackendSkillsSpec({ id: 'future' }),
+    /缺少 skills 声明/,
+  )
+  for (const installer of ['', 'Bad Name', 'UPPER', 'has space', '-lead', 'a--b']) {
+    assert.throws(
+      () => validateBackendSkillsSpec({ id: 'future', skills: { installer } }),
+      /installer 无效/,
+    )
+  }
+  assert.doesNotThrow(() => validateBackendSkillsSpec({
+    id: 'future',
+    skills: { installer: 'new-agent-cli' },
+  }))
+})
+
+function lockFixture(skills) {
+  const homeDirectory = mkdtempSync(join(tmpdir(), 'qwaudio-skill-home-'))
+  if (skills) {
+    mkdirSync(resolve(homeDirectory, '.agents'), { recursive: true })
+    writeFileSync(
+      resolve(homeDirectory, '.agents/.skill-lock.json'),
+      JSON.stringify({ version: 3, skills }),
+    )
+  }
+  return homeDirectory
+}
+
+function placeSkill(homeDirectory, directory, name) {
+  const skillDirectory = resolve(homeDirectory, directory, name)
+  mkdirSync(skillDirectory, { recursive: true })
+  writeFileSync(resolve(skillDirectory, 'SKILL.md'), '---\nname: x\n---\n')
+}
+
+test('reads the skills.sh lockfile defensively', () => {
+  const empty = lockFixture(null)
+  assert.deepEqual(readSkillLock({ homeDirectory: empty }), {})
+  const filled = lockFixture({ review: { source: 'owner/repo' } })
+  assert.deepEqual(
+    Object.keys(readSkillLock({ homeDirectory: filled })),
+    ['review'],
+  )
+})
+
+test('backfills missing skills for the active backend synchronously', () => {
+  const homeDirectory = lockFixture({
+    review: { source: 'owner/repo' },
+    'pdf-tools': { source: 'owner/repo' },
+    remote: { sourceUrl: 'https://github.com/o/r.git' },
+  })
+  // 当前后台（qwen → ~/.qwen/skills）已有 review，缺另外两个。
+  placeSkill(homeDirectory, '.qwen/skills', 'review')
+
+  const target = fakeSpawn({ stdout: 'ok\n' })
+  const result = ensureBackendSkills({
+    protocol: 'qwen',
+    homeDirectory,
+    spawn: target.spawn,
+  })
+  assert.equal(result.refreshed, true)
+  assert.equal(result.installer, 'qwen-code')
+  assert.deepEqual(result.installed.sort(), ['pdf-tools', 'remote'])
+  // 按来源分组：两个来源各一条命令，均只面向当前后台。
+  assert.equal(target.calls.length, 2)
+  for (const args of target.calls) {
+    assert.deepEqual(
+      args.filter((value, index) => args[index - 1] === '-a'),
+      ['qwen-code'],
+    )
+  }
+  assert.deepEqual(
+    target.calls[0].filter((value, index) => (
+      target.calls[0][index - 1] === '--skill'
+    )),
+    ['pdf-tools'],
+  )
+})
+
+test('isolates per-source backfill failures with cleanup guidance', () => {
+  const homeDirectory = lockFixture({
+    gone: { source: 'owner/stale-repo' },
+    review: { source: 'owner/live-repo' },
+  })
+  const calls = []
+  const spawn = args => {
+    calls.push(args)
+    // 旧源里的技能已被上游移除 → 该源失败；另一源正常。
+    return args.includes('owner/stale-repo')
+      ? { status: 1, stdout: '', stderr: 'No matching skills found' }
+      : { status: 0, stdout: 'ok\n', stderr: '' }
+  }
+  const result = ensureBackendSkills({ protocol: 'claude', homeDirectory, spawn })
+  assert.equal(result.refreshed, true)
+  assert.deepEqual(result.installed, ['review'])
+  assert.equal(result.failures.length, 1)
+  assert.deepEqual(result.failures[0].names, ['gone'])
+  assert.match(result.failures[0].hint, /skill remove/)
+  assert.equal(calls.length, 2)
+})
+
+test('skips backfill when nothing is missing or unsupported', () => {
+  const target = fakeSpawn()
+  // 无安装器（deepseek/纯前台）。
+  assert.equal(
+    ensureBackendSkills({ protocol: 'deepseek', spawn: target.spawn }).reason,
+    'no-installer',
+  )
+  assert.equal(
+    ensureBackendSkills({ protocol: '', spawn: target.spawn }).reason,
+    'no-installer',
+  )
+  // lock 为空。
+  const empty = lockFixture(null)
+  assert.equal(
+    ensureBackendSkills({
+      protocol: 'qwen',
+      homeDirectory: empty,
+      spawn: target.spawn,
+    }).reason,
+    'up-to-date',
+  )
+  // 技能齐全。
+  const ready = lockFixture({ review: { source: 'owner/repo' } })
+  placeSkill(ready, '.claude/skills', 'review')
+  assert.equal(
+    ensureBackendSkills({
+      protocol: 'claude',
+      homeDirectory: ready,
+      spawn: target.spawn,
+    }).reason,
+    'up-to-date',
+  )
+  assert.equal(target.calls.length, 0)
+})
+
+test('builds the present-backend installer list with fallback', () => {
+  // 检测到的后台 ∪ 当前后台，去重且排除无安装器后台。
+  assert.deepEqual(
+    presentInstallerAgents({
+      readyBackends: ['claude', 'opencode', 'deepseek', 'acp'],
+      currentProtocol: 'opencode',
+    }).sort(),
+    ['claude-code', 'opencode'],
+  )
+  // 当前后台未装 CLI 也必须在名单（openclaw npx 托管场景）。
+  assert.deepEqual(
+    presentInstallerAgents({ readyBackends: [], currentProtocol: 'openclaw' }),
+    ['openclaw'],
+  )
+  // 一个都没有时回退全名单。
+  assert.deepEqual(
+    presentInstallerAgents({ readyBackends: [], currentProtocol: '' }).sort(),
+    [...skillsInstallerAgents()].sort(),
+  )
+})

--- a/docs/backends/overview.md
+++ b/docs/backends/overview.md
@@ -4,19 +4,24 @@ The Backend Agent handles tasks that require tools, file operations, or sustaine
 
 ## Supported Agents
 
-| Backend Agent | Integration Method | Setup Requirements | Recommendation |
-| --- | --- | --- | --- |
-| None | N/A | Frontend-only mode, no configuration needed | ★★★★★ |
-| OpenCode | Native ACP | Supports one-click install and Bailian configuration | ★★★★★ |
-| OpenClaw | Built-in ACP bridge | Supports one-click install and Bailian configuration | ★★★★★ |
-| Qoder | Native ACP | Supports one-click install, requires user configuration | ★★★★★ |
-| Qwen Code | Native ACP | Supports one-click install, requires user configuration | ★★★★☆ |
-| Kimi Code | Native ACP | Supports one-click install, requires user configuration | ★★★★★ |
-| Hermes | Native ACP | Supports one-click install, requires user configuration | ★★★★☆ |
-| CodeBuddy | Native ACP | Supports one-click install, requires user configuration | ★★★★☆ |
-| Codex | External ACP adapter | Supports one-click install of both the core and adapter, requires user configuration | ★★★★☆ |
-| Claude Code | External ACP adapter | Supports one-click install of both the core and adapter, requires user configuration | ★★★★☆ |
-| DeepSeek | Native ACP (experimental) | Supports one-click install, requires a DeepSeek API key | ★★★★☆ |
+| Backend Agent | Integration Method | Setup Requirements | Skills | Recommendation |
+| --- | --- | --- | --- | --- |
+| None | N/A | Frontend-only mode, no configuration needed | — | ★★★★★ |
+| OpenCode | Native ACP | Supports one-click install and Bailian configuration | `~/.config/opencode/skills/` | ★★★★★ |
+| OpenClaw | Built-in ACP bridge | Supports one-click install and Bailian configuration | `~/.openclaw/skills/` | ★★★★★ |
+| Qoder | Native ACP | Supports one-click install, requires user configuration | `~/.qoder/skills/` | ★★★★★ |
+| Qwen Code | Native ACP | Supports one-click install, requires user configuration | `~/.qwen/skills/` | ★★★★☆ |
+| Kimi Code | Native ACP | Supports one-click install, requires user configuration | `~/.agents/skills/` | ★★★★★ |
+| Hermes | Native ACP | Supports one-click install, requires user configuration | `~/.hermes/skills/` | ★★★★☆ |
+| CodeBuddy | Native ACP | Supports one-click install, requires user configuration | `~/.codebuddy/skills/` | ★★★★☆ |
+| Codex | External ACP adapter | Supports one-click install of both the core and adapter, requires user configuration | `~/.codex/skills/` | ★★★★☆ |
+| Claude Code | External ACP adapter | Supports one-click install of both the core and adapter, requires user configuration | `~/.claude/skills/` | ★★★★☆ |
+| DeepSeek | Native ACP (experimental) | Supports one-click install, requires a DeepSeek API key | `~/.agents/skills/` | ★★★★☆ |
+
+Skills install once through `qwenaudio skill install` (a branded entry point
+for the standard skills.sh installer) and land in every backend's user-level
+directory above automatically. See
+[Skill Management](../configuration.md#skill-management).
 
 The recommendation rating reflects the current integration completeness, compatibility, and extent of real-world verification: five stars indicates a fully tested and recommended integration, while four stars indicates ongoing development or incomplete verification of the same scope.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,83 @@ DEEPSEEK_HARNESS_MODEL=deepseek-v4-pro
 
 `DEEPSEEK_API_KEY` may still be set as an explicit per-run override.
 
+## Skill Management
+
+Backend agents execute the actual tasks, so standard Agent Skills
+(`SKILL.md` folders in the open format) are installed for backends.
+`qwenaudio skill` is a branded entry point for the community-standard
+[skills.sh](https://skills.sh) installer (`npx skills`): every command is a
+1:1 passthrough, with one addition — installs target the backends that
+actually exist on this machine (CLI detected) plus the currently configured
+backend, instead of relying on skills.sh's own agent detection.
+
+```bash
+qwenaudio skill install <source> --skill <name>   # install to every backend
+qwenaudio skill install <source> --list           # list skills in a source
+qwenaudio skill list                              # list installed skills
+qwenaudio skill remove <name>                     # remove a skill
+qwenaudio skill update                            # update installed skills
+```
+
+Supported sources are whatever skills.sh supports:
+
+| Source form | Example |
+| --- | --- |
+| GitHub shorthand | `qwenaudio skill install vercel-labs/agent-skills --skill web-design-guidelines` |
+| Repository URL (GitHub/GitLab/any git) | `qwenaudio skill install https://github.com/alirezarezvani/claude-skills --skill skill-security-auditor` |
+| Tree URL (skill subdirectory) | `qwenaudio skill install https://github.com/o/r/tree/main/skills/x --skill x` |
+| Hub skill page URL | `qwenaudio skill install https://clawhub.ai/thcjp/skills/excel-formula-tool-free --skill excel-formula-tool-free` |
+| Local directory | `qwenaudio skill install ./my-skill --skill my-skill` |
+
+For multi-skill repositories `--skill` is required (repeat it to install
+several); run `--list` first to see what a source provides. Installing an
+entire large catalog at once is intentionally not supported — every skill
+description is injected into backend system prompts.
+
+Skills land in each backend CLI's own user-level directory
+(`~/.claude/skills/`, `~/.qwen/skills/`, `~/.openclaw/skills/`,
+`~/.agents/skills/`, …), so they also work when you use those CLIs directly,
+and the desktop app and CLI share the same skills.
+
+When you switch to — or newly install — a backend that is missing previously
+installed skills, the gateway backfills them synchronously at startup: a
+millisecond-level local check against the skills.sh lockfile
+(`~/.agents/.skill-lock.json`), and only when something is actually missing a
+one-off skills.sh run (a few seconds) before the backend process starts, so
+the backend always sees a complete skill set on its first scan. Failures
+(for example offline) are logged and never block the voice gateway.
+
+The pinned skills.sh version can be overridden with
+`QWEN_AUDIO_AGENT_SKILLS_CLI_PACKAGE` (for example `skills@latest`). If a
+newly added backend is not yet supported by skills.sh, contribute an agent
+definition to its `src/agents.ts` — that is the official extension point.
+
+### When skills take effect
+
+Files are synced immediately, but each backend discovers new skills on its
+own schedule:
+
+| Backend | Discovery | New skill visible |
+| --- | --- | --- |
+| Claude Code, Qwen Code, Hermes, DeepSeek | Hot reload (watcher or on-demand read) | Immediately, no action needed |
+| Qoder | On session start; `/skills reload` inside a native session | Next backend session |
+| OpenCode, OpenClaw, Kimi Code, CodeBuddy, Codex | Snapshot at process or session start | After the backend process restarts |
+
+If a newly installed skill is not picked up, `qwenaudio gateway restart`
+restarts the backend process and always resolves it.
+
+### Shared backend workspace
+
+All backends now share one default working directory,
+`<config-dir>/workspace`, so switching backends continues the same files
+seamlessly. Per-backend overrides (for example `OPENCODE_WORKSPACE`)
+still isolate a specific backend when set explicitly. Older versions used
+per-backend directories under `<config-dir>/workspaces/<backend>/`; if such a
+directory still contains files, the gateway logs a
+`workspace.legacy_directory` notice on startup. Files are never migrated or
+deleted automatically — move anything you still need into the shared
+workspace manually.
+
 ## Minimal Configuration
 
 The minimal configuration only requires real-time voice credentials:

--- a/server/src/agent/backends/registry.mjs
+++ b/server/src/agent/backends/registry.mjs
@@ -6,7 +6,7 @@ import { genericAcpBackendDriver } from './generic-acp.mjs'
 import { localAcpBackendDrivers } from './local-acp.mjs'
 import { openClawBackendDriver } from './openclaw.mjs'
 import { openCodeBackendDriver } from './opencode.mjs'
-import { backendDefinition } from '../../../../shared/backend-catalog.mjs'
+import { backendDefinition, validateBackendSkillsSpec } from '../../../../shared/backend-catalog.mjs'
 
 const CAPABILITY_FLAGS = [
   'delegation',
@@ -21,6 +21,8 @@ const CAPABILITY_FLAGS = [
 function validateBackendDriver(driver) {
   const definition = backendDefinition(driver?.id)
   if (!definition) throw new Error(`后台 Driver 未在目录注册：${driver?.id}`)
+  // skills 声明是接入协议的一部分，注册时强制校验。
+  validateBackendSkillsSpec(definition)
   if (driver.label !== definition.label) {
     throw new Error(`后台 Driver 标签不一致：${driver.id}`)
   }

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -1,6 +1,9 @@
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { loadRuntimeEnvironment } from '../../../shared/runtime-environment.mjs'
+import {
+  defaultBackendWorkspace,
+  loadRuntimeEnvironment,
+} from '../../../shared/runtime-environment.mjs'
 import {
   backendDefinition,
   backendNames,
@@ -40,7 +43,7 @@ export function resolveBackendWorkspace(
   const configured = env[definition.workspaceEnvironment]
   return configured
     ? resolve(root, configured)
-    : resolve(configDirectory, `workspaces/${definition.id}`)
+    : defaultBackendWorkspace(configDirectory)
 }
 
 export function resolveAcpArgs(value) {

--- a/server/src/index.mjs
+++ b/server/src/index.mjs
@@ -2,6 +2,7 @@ import { dirname, resolve } from 'node:path'
 import { once } from 'node:events'
 import { fileURLToPath } from 'node:url'
 import { loadRuntimeEnvironment } from '../../shared/runtime-environment.mjs'
+import { ensureBackendSkills } from '../../shared/skill-library.mjs'
 import { createLogger } from '../../shared/logger.mjs'
 import { acquireGatewayLease } from '../../shared/gateway-instance-lock.mjs'
 import { startManagedBackend } from './process/managed-backend.mjs'
@@ -53,6 +54,33 @@ try {
     owner: process.env.QWEN_AUDIO_GATEWAY_OWNER
       || (process.env.QWEN_AUDIO_AGENT_DESKTOP === '1' ? 'desktop' : 'cli'),
   })
+  // 旧版本按后台隔离的 workspace 目录不再作为默认工作区；只提示不迁移。
+  for (const notice of runtimeEnvironment.legacyWorkspaceNotices || []) {
+    logger.warn('workspace.legacy_directory', {
+      backend: notice.backend,
+      legacyDirectory: notice.legacyDirectory,
+      sharedWorkspace: notice.sharedWorkspace,
+      hint: '各后台已改为共享同一工作区；如需旧文件请手动移动到共享目录',
+    })
+  }
+  // 切换/新装后台后把已装技能补齐。日常是毫秒级本地 diff；仅确实
+  // 缺失时同步跑一次 skills.sh，保证后台首次扫描前技能已就位。
+  try {
+    const backfill = ensureBackendSkills({ protocol: process.env.AGENT_PROTOCOL })
+    if (backfill.refreshed) {
+      logger.info('skills.backfilled', {
+        backend: process.env.AGENT_PROTOCOL,
+        installer: backfill.installer,
+        installed: backfill.installed,
+      })
+    }
+    for (const failure of backfill.failures || []) {
+      logger.warn('skills.backfill_failed', failure)
+    }
+  } catch (error) {
+    // 离线等失败不阻塞语音网关启动；技能可下次启动再补。
+    logger.warn('skills.backfill_failed', { error })
+  }
   backendRuntime = await startManagedBackend({ root, logger })
   const managedBackend = backendRuntime.child
   const onManagedBackendExit = (code, signal) => {

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -844,6 +844,16 @@ export function attachRealtimeGateway(server, {
       if (event.type === 'task.permission.resolved') {
         const authorizationId = event.permission?.id
         if (authorizationId) {
+          // 已进入对话的权限询问被其它通道（如 WebUI 按钮）处理后，把结果
+          // 静默回注模型上下文：避免模型不知情而重复追问，或把用户随后的
+          // 口头确认误报为“请求已失效”。
+          if (announcedPermissions.has(authorizationId) && frontend?.ready) {
+            frontend.appendUserInputContext([{
+              type: 'text',
+              text: '（系统提示：刚才的后台权限请求已处理完毕，任务继续执行；'
+                + '无需再询问或回应该请求。）',
+            }]).catch(() => {})
+          }
           announcedPermissions.delete(authorizationId)
           frontend?.cancelResponses((context, origin) => (
             origin === 'permission'

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -698,7 +698,8 @@ export class ToolCallHandler {
         callId,
         failure(
           'permission_not_pending',
-          '这项权限请求已经失效或不属于当前任务。',
+          '这项权限请求已经处理过或不属于当前任务；若用户刚在界面上确认过，'
+          + '无需重复回应，直接继续即可。',
           { retryable: false },
         ),
         turnId,

--- a/server/test/acp-backend-adapter.test.mjs
+++ b/server/test/acp-backend-adapter.test.mjs
@@ -288,7 +288,13 @@ test('backs off repeated health spawns after any local ACP startup failure', asy
   const first = await adapter.health()
   const second = await adapter.health()
   assert.equal(first.ok, false)
-  assert.deepEqual(second, first)
+  // retryAfterMs 随真实时钟递减，两次调用跨毫秒边界时会差 1ms；
+  // 对它断言范围，其余字段保持严格相等。
+  assert.ok(second.retryAfterMs > 0 && second.retryAfterMs <= 30_000)
+  assert.deepEqual(
+    { ...second, retryAfterMs: 0 },
+    { ...first, retryAfterMs: 0 },
+  )
   assert.equal(starts, 1)
 
   adapter.lastHealthFailure.at -= 30_001

--- a/server/test/config.test.mjs
+++ b/server/test/config.test.mjs
@@ -25,11 +25,11 @@ test('preserves explicit zero numeric settings', () => {
   assert.equal(numberSetting(0, 120, { min: 0, max: 1000 }), 0)
 })
 
-test('uses the user data directory for the default OpenCode workspace', () => {
+test('uses the shared user data workspace for the default OpenCode workspace', () => {
   const directory = resolve('/home/user/.config/qwaudio')
   assert.equal(
     resolveBackendWorkspace('opencode', {}, directory),
-    resolve(directory, 'workspaces/opencode'),
+    resolve(directory, 'workspace'),
   )
 })
 
@@ -57,36 +57,22 @@ test('uses the default ACP Session mode unless a custom OpenCode Agent is explic
   }), 'shared-agent')
 })
 
-test('uses the user data directory for the default Qoder workspace', () => {
+test('uses the shared user data workspace for the default Qoder workspace', () => {
   const directory = resolve('/home/user/.config/qwaudio')
   assert.equal(
     resolveBackendWorkspace('qoder', {}, directory),
-    resolve(directory, 'workspaces/qoder'),
+    resolve(directory, 'workspace'),
   )
 })
 
-test('uses the user data directory for additional ACP backend workspaces', () => {
+test('shares one default workspace across additional ACP backends', () => {
   const directory = resolve('/home/user/.config/qwaudio')
-  assert.equal(
-    resolveBackendWorkspace('hermes', {}, directory),
-    resolve(directory, 'workspaces/hermes'),
-  )
-  assert.equal(
-    resolveBackendWorkspace('kimi', {}, directory),
-    resolve(directory, 'workspaces/kimi'),
-  )
-  assert.equal(
-    resolveBackendWorkspace('codebuddy', {}, directory),
-    resolve(directory, 'workspaces/codebuddy'),
-  )
-  assert.equal(
-    resolveBackendWorkspace('codex', {}, directory),
-    resolve(directory, 'workspaces/codex'),
-  )
-  assert.equal(
-    resolveBackendWorkspace('qwen', {}, directory),
-    resolve(directory, 'workspaces/qwen'),
-  )
+  for (const backend of ['hermes', 'kimi', 'codebuddy', 'codex', 'qwen']) {
+    assert.equal(
+      resolveBackendWorkspace(backend, {}, directory),
+      resolve(directory, 'workspace'),
+    )
+  }
 })
 
 test('maps one backend model name to each managed backend provider', () => {

--- a/shared/backend-catalog.mjs
+++ b/shared/backend-catalog.mjs
@@ -8,6 +8,7 @@ const definitions = new Map([
     id: 'opencode',
     label: 'OpenCode',
     workspaceEnvironment: 'OPENCODE_WORKSPACE',
+    skills: { installer: 'opencode' },
     setup: {
       command: 'opencode',
       executableEnvironment: 'OPENCODE_BIN',
@@ -39,6 +40,7 @@ const definitions = new Map([
     id: 'openclaw',
     label: 'OpenClaw',
     workspaceEnvironment: 'QWEN_AUDIO_AGENT_OPENCLAW_WORKSPACE',
+    skills: { installer: 'openclaw' },
     setup: {
       command: 'openclaw',
       executableEnvironment: 'OPENCLAW_BIN',
@@ -77,6 +79,7 @@ const definitions = new Map([
     id: 'qoder',
     label: 'Qoder',
     workspaceEnvironment: 'QODER_WORKSPACE',
+    skills: { installer: 'qoder' },
     setup: {
       command: 'qodercli',
       executableEnvironment: ['QODERCLI_PATH', 'QODER_CLI_PATH'],
@@ -98,6 +101,7 @@ const definitions = new Map([
     id: 'qwen',
     label: 'Qwen Code',
     workspaceEnvironment: 'QWEN_CODE_WORKSPACE',
+    skills: { installer: 'qwen-code' },
     setup: {
       command: 'qwen',
       executableEnvironment: 'QWEN_CODE_BIN',
@@ -122,6 +126,8 @@ const definitions = new Map([
     id: 'kimi',
     label: 'Kimi Code',
     workspaceEnvironment: 'KIMI_WORKSPACE',
+    // kimi 读开放标准通用目录 ~/.agents/skills（skills.sh 同名映射）。
+    skills: { installer: 'kimi-code-cli' },
     setup: {
       command: 'kimi',
       executableEnvironment: 'KIMI_CODE_BIN',
@@ -143,6 +149,8 @@ const definitions = new Map([
     id: 'hermes',
     label: 'Hermes',
     workspaceEnvironment: 'HERMES_WORKSPACE',
+    // Hermes 官方唯一技能目录在用户主目录，无项目级约定。
+    skills: { installer: 'hermes-agent' },
     setup: {
       command: 'hermes',
       executableEnvironment: 'HERMES_BIN',
@@ -168,6 +176,7 @@ const definitions = new Map([
     id: 'codebuddy',
     label: 'CodeBuddy',
     workspaceEnvironment: 'CODEBUDDY_WORKSPACE',
+    skills: { installer: 'codebuddy' },
     setup: {
       command: 'codebuddy',
       executableEnvironment: 'CODEBUDDY_BIN',
@@ -189,6 +198,7 @@ const definitions = new Map([
     id: 'codex',
     label: 'Codex',
     workspaceEnvironment: 'CODEX_WORKSPACE',
+    skills: { installer: 'codex' },
     setup: {
       command: 'codex',
       executableEnvironment: 'CODEX_PATH',
@@ -221,6 +231,7 @@ const definitions = new Map([
     id: 'claude',
     label: 'Claude Code',
     workspaceEnvironment: 'CLAUDE_WORKSPACE',
+    skills: { installer: 'claude-code' },
     setup: {
       command: 'claude',
       executableEnvironment: 'CLAUDE_CODE_EXECUTABLE',
@@ -252,6 +263,9 @@ const definitions = new Map([
     id: 'deepseek',
     label: 'DeepSeek',
     workspaceEnvironment: 'DEEPSEEK_HARNESS_WORKSPACE',
+    // skills.sh 暂无 dsh 专属安装器，将来支持后改为对应 installer 即可；
+    // 当前 dsh 读开放标准目录 ~/.agents/skills，已可被动受益。
+    skills: { installer: null },
     setup: {
       command: 'dsh',
       executableEnvironment: 'DEEPSEEK_HARNESS_BIN',
@@ -313,6 +327,8 @@ const definitions = new Map([
     id: 'acp',
     label: 'ACP Agent',
     workspaceEnvironment: 'ACP_WORKSPACE',
+    // 通用 ACP 接入的 agent 由用户自带，技能目录约定未知；显式声明无约定。
+    skills: null,
     setup: {
       commandEnvironment: 'ACP_COMMAND',
       integration: 'generic',
@@ -331,6 +347,45 @@ const definitions = new Map([
 
 export function backendDefinition(protocol) {
   return definitions.get(normalizeBackendProtocol(protocol)) || null
+}
+
+// skills.sh（npx skills）的 agent id 形态：kebab-case。限定字符集防止
+// installer 声明被拼接进命令参数时注入额外 flag。
+const SKILLS_INSTALLER_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+// skills 声明是后台接入协议的必填项：要么声明其在 skills.sh 的安装器
+// agent id（installer: null 表示经通用目录被动覆盖，无需专属安装），
+// 要么显式 skills: null 表示无技能约定。缺失即视为接入不完整，
+// 注册与测试直接失败，避免新后台遗漏 SKILL 支持决策。skills.sh
+// 未支持的新后台应按其官方扩展点（src/agents.ts）提 PR。
+export function validateBackendSkillsSpec(definition) {
+  if (definition?.skills === undefined) {
+    throw new Error(`后台 ${definition?.id} 缺少 skills 声明（声明 skills.sh 安装器，无约定时显式 null）`)
+  }
+  const spec = definition.skills
+  if (spec === null) return null
+  if (spec?.installer === null) return spec
+  if (
+    typeof spec?.installer !== 'string'
+    || !SKILLS_INSTALLER_PATTERN.test(spec.installer)
+  ) {
+    throw new Error(`后台 ${definition.id} 的 skills.installer 无效：${spec?.installer}`)
+  }
+  return spec
+}
+
+export function backendSkillsSpec(protocol) {
+  const definition = backendDefinition(protocol)
+  if (!definition) return null
+  return validateBackendSkillsSpec(definition)
+}
+
+// 供 skill install 透传时组装显式 -a 名单：不依赖 skills.sh 的本机检测
+//（检测基于特征目录存在性，hermes 未装 CLI、openclaw 被产品隔离时会漏）。
+export function skillsInstallerAgents() {
+  return [...new Set(backendDefinitions()
+    .map(definition => validateBackendSkillsSpec(definition)?.installer)
+    .filter(Boolean))]
 }
 
 export function backendNames() {

--- a/shared/backend-install.mjs
+++ b/shared/backend-install.mjs
@@ -123,7 +123,7 @@ export function installSupport(id, {
   if (!spec) {
     return {
       supported: false,
-      reason: '通用 ACP 后台需自行安装，并通过 ACP_COMMAND 配置',
+      reason: '通用 ACP 接入的 Agent 需自行安装，并通过 ACP_COMMAND 配置',
     }
   }
   if (!steps.length) {

--- a/shared/runtime-environment.mjs
+++ b/shared/runtime-environment.mjs
@@ -6,6 +6,7 @@ import {
   linkSync,
   lstatSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   unlinkSync,
   writeFileSync,
@@ -266,6 +267,13 @@ function migrateLegacyMemory({
   return Boolean(user.length || memory.length)
 }
 
+// 所有后台 Agent 共享同一个默认 workspace。历史上按后台隔离（workspaces/<id>）
+// 是为了各自的 AGENTS.md 指令模板，该机制已被 session 级指令注入取代；共享目录
+// 让用户切换后台时能无缝继续同一份工作，也让 SKILL 等资产只需同步到一处。
+export function defaultBackendWorkspace(configDirectory) {
+  return resolve(configDirectory, 'workspace')
+}
+
 function resolveBackendWorkspaces(env, root, configDirectory) {
   return Object.fromEntries(backendDefinitions()
     .filter(definition => definition.workspaceEnvironment)
@@ -274,11 +282,39 @@ function resolveBackendWorkspaces(env, root, configDirectory) {
       return [definition.id, {
         directory: configured
           ? resolve(root, configured)
-          : resolve(configDirectory, `workspaces/${definition.id}`),
+          : defaultBackendWorkspace(configDirectory),
         environment: definition.workspaceEnvironment,
         managed: !configured,
       }]
     }))
+}
+
+// 旧版本按后台隔离的 workspaces/<id>/ 目录里可能有用户文件。只提示位置，
+// 不自动迁移、不删除，由用户决定是否手动移动到共享 workspace。
+function collectLegacyWorkspaceNotices(configDirectory, sharedWorkspace) {
+  const notices = []
+  for (const definition of backendDefinitions()) {
+    if (!definition.workspaceEnvironment) continue
+    const legacyDirectory = resolve(
+      configDirectory,
+      `workspaces/${definition.id}`,
+    )
+    let entries
+    try {
+      entries = readdirSync(legacyDirectory)
+    } catch (error) {
+      if (error.code !== 'ENOENT' && error.code !== 'ENOTDIR') throw error
+      continue
+    }
+    if (entries.length) {
+      notices.push({
+        backend: definition.id,
+        legacyDirectory,
+        sharedWorkspace,
+      })
+    }
+  }
+  return notices
 }
 
 function codeBuddyModelName(env) {
@@ -448,6 +484,7 @@ export function loadRuntimeEnvironment({
     root,
     configDirectory,
   )
+  const sharedWorkspace = defaultBackendWorkspace(configDirectory)
   const workspace = id => backendWorkspaces[id]?.directory || ''
   const openCodeWorkspace = workspace('opencode')
   const openClawWorkspace = workspace('openclaw')
@@ -463,6 +500,7 @@ export function loadRuntimeEnvironment({
     ? resolve(root, env.QWEN_AUDIO_AGENT_OPENCLAW_STATE_DIR)
     : resolve(configDirectory, 'backends/openclaw/state')
   let migratedFiles = []
+  let legacyWorkspaceNotices = []
   if (prepareBackendRuntime && !readOnly) {
     migratePrivateFile(
       resolve(root, 'runtime/frontend-memory.json'),
@@ -483,6 +521,10 @@ export function loadRuntimeEnvironment({
       }
       env[entry.environment] = entry.directory
     }
+    legacyWorkspaceNotices = collectLegacyWorkspaceNotices(
+      configDirectory,
+      sharedWorkspace,
+    )
     if (backendWorkspaces.codebuddy?.managed) {
       ensureCodeBuddyTemplate(
         resolve(root, 'config/codebuddy/workspace/.codebuddy/models.json'),
@@ -509,6 +551,7 @@ export function loadRuntimeEnvironment({
     frontendMemoryPath,
     frontendNotesPath,
     taskStatePath,
+    sharedWorkspace,
     openCodeWorkspace,
     openClawWorkspace,
     qoderWorkspace,
@@ -521,6 +564,7 @@ export function loadRuntimeEnvironment({
     acpWorkspace,
     openClawStateDirectory,
     migratedFiles,
+    legacyWorkspaceNotices,
     loadedFiles,
     generatedSecret: secret.generated,
     statePath: secret.statePath,

--- a/shared/skill-library.mjs
+++ b/shared/skill-library.mjs
@@ -1,0 +1,203 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
+import {
+  backendSkillsSpec,
+  skillsInstallerAgents,
+} from './backend-catalog.mjs'
+
+// qwenaudio skill 是 skills.sh（npm 包 skills）的 1:1 品牌化入口：技能的
+// 下载、落盘、lockfile 一致性全部由 skills.sh 自管，这里只负责组装参数、
+// 透传输出。技能落点为各后台 CLI 的用户级全局目录（~/.claude/skills 等），
+// 产品内外、桌面版与 CLI 天然共享。
+const DEFAULT_SKILLS_CLI_PACKAGE = 'skills@1.5.22'
+
+function clean(value) {
+  return String(value || '').trim()
+}
+
+export function skillsCliPackage(env = process.env) {
+  return clean(env.QWEN_AUDIO_AGENT_SKILLS_CLI_PACKAGE)
+    || DEFAULT_SKILLS_CLI_PACKAGE
+}
+
+function defaultSpawn(args) {
+  return spawnSync('npx', args, {
+    encoding: 'utf8',
+    windowsHide: true,
+    // skills.sh 需要克隆仓库并按需下载，慢网络下留足时间。
+    timeout: 600_000,
+  })
+}
+
+export function runSkillsCli(args, {
+  spawn = defaultSpawn,
+  packageSpec = skillsCliPackage(),
+} = {}) {
+  const result = spawn(['-y', packageSpec, ...args])
+  if (result.error) {
+    throw new Error(`skills CLI 启动失败：${result.error.message}`)
+  }
+  if (result.status !== 0) {
+    const detail = clean(result.stderr) || clean(result.stdout)
+    throw new Error(`skills CLI 执行失败${detail ? `：\n${detail}` : ''}`)
+  }
+  return { stdout: String(result.stdout || ''), stderr: String(result.stderr || '') }
+}
+
+// 安装（或 --list 枚举）远程源里的技能。源形态与 skills.sh 完全对齐：
+// owner/repo、GitHub/GitLab/任意 git URL、tree URL、技能页 URL、本地目录。
+// agents 由调用方传入（通常为“已检测到的后台 ∪ 当前配置后台”），
+// 缺省回退全名单。
+export function addSkills(source, {
+  skills = [],
+  list = false,
+  agents = skillsInstallerAgents(),
+  spawn,
+  packageSpec,
+} = {}) {
+  const target = clean(source)
+  if (!target) throw new Error('请提供技能来源（owner/repo、git URL 或 hub 页面 URL）')
+  if (list) {
+    return runSkillsCli(['add', target, '--list'], { spawn, packageSpec })
+  }
+  if (!skills.length) {
+    throw new Error(
+      '请用 --skill 指定要安装的技能（可多次）；'
+      + '先运行 --list 查看该来源提供的技能清单',
+    )
+  }
+  return runSkillsCli([
+    'add',
+    target,
+    ...skills.flatMap(name => ['--skill', clean(name)]),
+    '-g',
+    '--copy',
+    '-y',
+    ...agents.flatMap(agent => ['-a', agent]),
+  ], { spawn, packageSpec })
+}
+
+export function listSkills({ spawn, packageSpec } = {}) {
+  // 安装用 -g（全局），管理命令保持同一作用域。
+  return runSkillsCli(['list', '-g'], { spawn, packageSpec })
+}
+
+export function removeSkill(name, { spawn, packageSpec } = {}) {
+  const skill = clean(name)
+  if (!skill) throw new Error('请提供要移除的技能名称')
+  return runSkillsCli(['remove', skill, '-g', '-y'], { spawn, packageSpec })
+}
+
+export function updateSkills({ spawn, packageSpec } = {}) {
+  return runSkillsCli(['update', '-g'], { spawn, packageSpec })
+}
+
+// skills.sh 的全局 lockfile：已装技能的唯一事实源（含来源仓库）。
+const SKILL_LOCK_PATH = '.agents/.skill-lock.json'
+
+// installer → 全局技能目录（相对用户主目录）。实测校准：codex/opencode/
+// kimi 属 skills.sh 的 universal 组，不论是否单独安装都合并落在开放标准
+// 目录 ~/.agents/skills（三家官方均声明读取该目录）。这是实现细节，
+// 不进 catalog 协议。
+const INSTALLER_SKILLS_DIRECTORIES = {
+  'claude-code': '.claude/skills',
+  codex: '.agents/skills',
+  opencode: '.agents/skills',
+  openclaw: '.openclaw/skills',
+  qoder: '.qoder/skills',
+  'qwen-code': '.qwen/skills',
+  'kimi-code-cli': '.agents/skills',
+  'hermes-agent': '.hermes/skills',
+  codebuddy: '.codebuddy/skills',
+}
+
+export function readSkillLock({ homeDirectory = homedir() } = {}) {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(resolve(homeDirectory, SKILL_LOCK_PATH), 'utf8'),
+    )
+    return parsed?.skills && typeof parsed.skills === 'object'
+      ? parsed.skills
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+// 网关启动时的同步补装：把 lock 里已装的技能补齐到当前后台。日常路径
+// 是纯本地 diff（毫秒级）；仅在确实缺失时才跑 skills.sh（秒级，一次性）。
+// 同步执行保证后台进程首次扫描时技能已就位，无时序问题。
+export function ensureBackendSkills({
+  protocol,
+  homeDirectory = homedir(),
+  spawn,
+  packageSpec,
+} = {}) {
+  const installer = backendSkillsSpec(protocol)?.installer
+  if (!installer) return { refreshed: false, reason: 'no-installer' }
+  const directory = INSTALLER_SKILLS_DIRECTORIES[installer]
+  if (!directory) return { refreshed: false, reason: 'no-directory' }
+  const locked = readSkillLock({ homeDirectory })
+  const missing = Object.entries(locked).filter(([name]) => (
+    !existsSync(resolve(homeDirectory, directory, name, 'SKILL.md'))
+  ))
+  if (!missing.length) return { refreshed: false, reason: 'up-to-date' }
+  // 按来源仓库分组，一组一条命令。
+  const bySource = new Map()
+  for (const [name, entry] of missing) {
+    const source = clean(entry?.source || entry?.sourceUrl)
+    if (!source) continue
+    if (!bySource.has(source)) bySource.set(source, [])
+    bySource.get(source).push(name)
+  }
+  const installed = []
+  const failures = []
+  for (const [source, names] of bySource) {
+    // 逐源容错：某个技能在上游已改名/删除（lock 过期）或网络失败时，
+    // 不影响其它来源的补装；失败项给出 remove 清理指引。
+    try {
+      runSkillsCli([
+        'add',
+        source,
+        ...names.flatMap(name => ['--skill', name]),
+        '-g',
+        '--copy',
+        '-y',
+        '-a',
+        installer,
+      ], { spawn, packageSpec })
+      installed.push(...names)
+    } catch (error) {
+      failures.push({
+        source,
+        names,
+        hint: '若技能已从来源移除，可执行 qwenaudio skill remove <名称> 清理，'
+          + '避免每次启动重试',
+        message: String(error?.message || error),
+      })
+    }
+  }
+  return {
+    refreshed: installed.length > 0,
+    installer,
+    installed,
+    failures,
+  }
+}
+
+// 供 launcher 拼“本地实际存在的后台 ∪ 当前配置后台”名单：避免为用户
+// 从未使用的后台预建目录；新后台出现后由启动补装自动补齐。
+export function presentInstallerAgents({
+  readyBackends = [],
+  currentProtocol = '',
+} = {}) {
+  const installers = new Set()
+  for (const id of [...readyBackends, currentProtocol]) {
+    const installer = id ? backendSkillsSpec(id)?.installer : null
+    if (installer) installers.add(installer)
+  }
+  // 一个都没有（纯前台模式且未装任何 CLI）时回退全名单，保持命令可用。
+  return installers.size ? [...installers] : skillsInstallerAgents()
+}

--- a/web/src/message-order.js
+++ b/web/src/message-order.js
@@ -34,8 +34,16 @@ export function insertByTurn(items, message) {
   if (matching.length) {
     insertAt = message.role === 'user' ? matching[0] : matching.at(-1) + 1
   } else {
+    // 只有语音 turn 自带可比较的时间戳；文字 turn（text_*）无法定时，
+    // 按到达顺序追加，且不参与时间比较——否则文字轮会被误判为
+    // “最晚”，导致后续语音消息全部插到列表顶部。
     const timestamp = turnTimestamp(message.turnId)
-    insertAt = items.findIndex(item => turnTimestamp(item.turnId) > timestamp)
+    insertAt = Number.isFinite(timestamp)
+      ? items.findIndex(item => {
+          const existing = turnTimestamp(item.turnId)
+          return Number.isFinite(existing) && existing > timestamp
+        })
+      : -1
     if (insertAt < 0) insertAt = items.length
   }
   const next = [...items]

--- a/web/test/message-order.test.js
+++ b/web/test/message-order.test.js
@@ -237,3 +237,36 @@ test('keeps asynchronous announcements as new live-tail turns', () => {
   assert.equal(turns[1].standalone, true)
   assert.equal(turns[1].messages[0].id, 'announcement')
 })
+
+test('appends voice messages after earlier text-turn history', () => {
+  // 文字轮的 turnId（text_*）没有时间戳；此前会被误判为"最晚"，
+  // 导致后续语音消息全部插到列表顶部而不可见。
+  const afterText = [
+    { id: 'user:text_a', role: 'user', turnId: 'text_a', content: '文字提问' },
+    { id: 'voice:r1', role: 'assistant', turnId: 'text_a', content: '文字回复' },
+  ]
+  const withVoiceUser = insertByTurn(afterText, {
+    id: 'user:voice-200-1',
+    role: 'user',
+    turnId: 'voice-200-1',
+    content: '语音提问',
+  })
+  assert.equal(withVoiceUser.at(-1).id, 'user:voice-200-1')
+
+  const withVoiceReply = insertByTurn(withVoiceUser, {
+    id: 'voice:r2',
+    role: 'assistant',
+    turnId: 'voice-200-1',
+    content: '语音回复',
+  })
+  assert.equal(withVoiceReply.at(-1).id, 'voice:r2')
+
+  // 反向：语音轮之后的文字消息同样追加在末尾。
+  const withText = insertByTurn(withVoiceReply, {
+    id: 'user:text_b',
+    role: 'user',
+    turnId: 'text_b',
+    content: '再发文字',
+  })
+  assert.equal(withText.at(-1).id, 'user:text_b')
+})


### PR DESCRIPTION
## 变更说明

三块独立工作（按 commit 分隔）：

**1. 技能管理完全透传 skills.sh（feat，主体）**
- `qwenaudio skill install/list/remove/update` 1:1 透传 [skills.sh](https://skills.sh)（pin `skills@1.5.22`，`-g --copy` 落各后台 CLI 用户级全局目录），技能产品内外、桌面版与 CLI 天然共享
- catalog 为每个后台声明 `skills.installer`（driver 注册时强制校验，kebab-case 防参数注入）；deepseek 暂无上游安装器，声明 `installer: null` 留注释待支持
- 按需安装：名单收窄为"本机实际存在的后台 ∪ 当前配置后台"；网关启动时按 skills.sh 全局 lockfile 同步补装缺失技能（日常为毫秒级本地 diff，仅缺失时跑一次 skills.sh，逐源容错不阻塞启动）
- 各后台默认 workspace 收敛为共享 `workspace/` 目录（技能资产与工作上下文只需一处）；旧 `workspaces/<id>` 仅日志提示，不迁移不删除

**2. 权限双通道同步（fix/server）**
WebUI 按钮批复权限后静默回注前台模型上下文，修复模型重复追问与"权限请求已失效"误报。

**3. WebUI 消息排序（fix/web）**
文字轮 turnId（`text_*`）无时间戳被误判为"最晚"，导致其后语音轮消息全部插到列表顶部；改为无法定时的消息按到达顺序追加。

## 验证

- [x] `npm test`（六 workspace 966 项全绿：45/486/81/55/164/135）
- [x] `npm run lint`
- [x] `npm run build`（web dist 重建并人工验证消息排序修复）
- [x] 行为变化已补充测试（skill-library 135 项、message-order 回归用例）；技能安装/补装/上游已删技能容错均做过真机端到端验证

## 兼容性与安全

- [x] 未提交密钥、用户数据、日志或内部地址
- [x] 配置、用户可见行为和依赖变化已同步更新文档（docs/configuration.md、docs/backends/overview.md：技能来源表、全局目录表、启动补装说明）
- [x] 影响说明：技能安装经 npx 拉取 skills.sh 并克隆技能仓库（网络）；技能写入用户主目录各 CLI 全局技能目录（持久化）；启动补装失败仅告警不阻塞网关；无权限模型与隐私变化
