### PR TITLE
feat: 桌面版与 CLI 资产共享 + 运行态隔离（消除记忆/配置/工作区分叉）

### DIFF
--- a/cli/test/runtime-environment.test.mjs
+++ b/cli/test/runtime-environment.test.mjs
@@ -501,3 +501,54 @@ test('does not require a DashScope credential for speech-to-speech', () => {
     /不支持的 Realtime 前台/,
   )
 })
+
+test('splits assets into QWAUDIO_DATA_DIR while runtime state stays put', () => {
+  const target = fixture()
+  const runtimeDir = resolve(target.base, 'desktop-runtime')
+  const dataDir = resolve(target.homeDirectory, '.config/qwaudio')
+  const env = {
+    QWAUDIO_CONFIG_DIR: runtimeDir,
+    QWAUDIO_DATA_DIR: dataDir,
+  }
+  const result = loadRuntimeEnvironment({
+    root: target.root,
+    homeDirectory: target.homeDirectory,
+    env,
+  })
+  assert.equal(result.configDirectory, runtimeDir)
+  assert.equal(result.dataDirectory, dataDir)
+  // 资产（配置、身份、记忆、清单、workspace）落共享资产目录。
+  assert.equal(result.configPath, resolve(dataDir, 'config.env'))
+  assert.equal(result.userModelPath, resolve(dataDir, 'USER.md'))
+  assert.equal(result.frontendMemoryPath, resolve(dataDir, 'MEMORY.md'))
+  assert.equal(result.frontendNotesPath, resolve(dataDir, 'frontend-notes.json'))
+  assert.equal(result.sharedWorkspace, resolve(dataDir, 'workspace'))
+  assert.equal(result.statePath, resolve(dataDir, 'state.env'))
+  // 运行时状态留在各形态自己的目录，双实例互不干扰。
+  assert.equal(result.taskStatePath, resolve(runtimeDir, 'tasks.json'))
+  assert.equal(
+    result.openClawStateDirectory,
+    resolve(runtimeDir, 'backends/openclaw/state'),
+  )
+  assertPrivateMode(result.configPath)
+  assertPrivateMode(result.statePath)
+})
+
+test('keeps assets beside runtime state without QWAUDIO_DATA_DIR', () => {
+  const target = fixture()
+  const env = {}
+  const result = loadRuntimeEnvironment({
+    root: target.root,
+    homeDirectory: target.homeDirectory,
+    env,
+  })
+  assert.equal(result.dataDirectory, result.configDirectory)
+  assert.equal(
+    result.configPath,
+    resolve(result.configDirectory, 'config.env'),
+  )
+  assert.equal(
+    result.taskStatePath,
+    resolve(result.configDirectory, 'tasks.json'),
+  )
+})

--- a/desktop/src/config-migration.mjs
+++ b/desktop/src/config-migration.mjs
@@ -1,15 +1,18 @@
 import {
   copyFileSync,
+  chmodSync,
   existsSync,
   mkdirSync,
+  statSync,
   writeFileSync,
 } from 'node:fs'
 import { resolve } from 'node:path'
 
-// 桌面版与 CLI（~/.config/qwaudio）使用相互独立的数据目录。桌面版默认
-// 使用 Electron 应用数据目录；仅以下文件会在首次启动时从旧目录复制过来，
-// 运行时状态（gateway.lock、state/、logs/ 等）各自重建、互不共享。
-const MIGRATED_FILES = [
+// 桌面版与 CLI 共享同一份资产（配置、身份、记忆、清单，QWAUDIO_DATA_DIR
+// 指向 CLI 的 ~/.config/qwaudio）；运行时状态（gateway.lock、tasks.json、
+// state/、logs/、皮肤等）仍留在桌面版自己的 Electron 数据目录，互不干扰。
+// tasks.json 属运行时状态，不参与共享与回填。
+const SHARED_ASSET_FILES = [
   'config.env',
   'state.env',
   'ASSISTANT.md',
@@ -17,42 +20,62 @@ const MIGRATED_FILES = [
   'MEMORY.md',
   'frontend-memory.json',
   'frontend-notes.json',
-  'tasks.json',
 ]
-const MIGRATION_MARKER = 'migrated-from.json'
+const BACKFILL_MARKER = 'shared-assets-backfill.json'
 
 export function resolveDesktopConfigDirectory({ env, userDataDirectory }) {
   if (env.QWAUDIO_CONFIG_DIR) return resolve(env.QWAUDIO_CONFIG_DIR)
   return resolve(userDataDirectory)
 }
 
-export function migrateLegacyConfig({ legacyDir, targetDir }) {
-  if (!legacyDir || !targetDir) return { migrated: false, reason: 'missing-directories' }
-  const legacy = resolve(legacyDir)
-  const target = resolve(targetDir)
-  if (legacy === target) return { migrated: false, reason: 'same-directory' }
-  if (!existsSync(resolve(legacy, 'config.env'))) {
-    return { migrated: false, reason: 'no-legacy-config' }
+// 旧版本桌面版曾把资产复制到自己的目录并各自演化。切换到共享资产层时，
+// 把桌面侧仍较新的资产一次性回填到共享目录：被覆盖的共享侧文件先备份为
+// <名称>.pre-merge.bak；state.env 是本地身份，共享侧已存在时保留（桌面侧
+// 的签名作废，重新签发即可）。幂等：桌面目录写入回填标记后不再执行。
+export function backfillSharedAssets({ desktopDir, dataDir }) {
+  if (!desktopDir || !dataDir) {
+    return { backfilled: false, reason: 'missing-directories' }
   }
-  if (existsSync(resolve(target, 'config.env'))) {
-    return { migrated: false, reason: 'target-configured' }
+  const source = resolve(desktopDir)
+  const target = resolve(dataDir)
+  if (source === target) return { backfilled: false, reason: 'same-directory' }
+  const markerPath = resolve(source, BACKFILL_MARKER)
+  if (existsSync(markerPath)) {
+    return { backfilled: false, reason: 'already-backfilled' }
   }
   mkdirSync(target, { recursive: true, mode: 0o700 })
   const copied = []
-  for (const name of MIGRATED_FILES) {
-    const source = resolve(legacy, name)
-    if (!existsSync(source)) continue
-    copyFileSync(source, resolve(target, name))
+  const skipped = []
+  for (const name of SHARED_ASSET_FILES) {
+    const from = resolve(source, name)
+    if (!existsSync(from)) continue
+    const to = resolve(target, name)
+    if (existsSync(to)) {
+      if (name === 'state.env') {
+        skipped.push(name)
+        continue
+      }
+      if (statSync(to).mtimeMs >= statSync(from).mtimeMs) {
+        skipped.push(name)
+        continue
+      }
+      copyFileSync(to, `${to}.pre-merge.bak`)
+      chmodSync(`${to}.pre-merge.bak`, 0o600)
+    }
+    copyFileSync(from, to)
+    chmodSync(to, 0o600)
     copied.push(name)
   }
+  mkdirSync(source, { recursive: true, mode: 0o700 })
   writeFileSync(
-    resolve(target, MIGRATION_MARKER),
+    markerPath,
     `${JSON.stringify({
-      legacyDir: legacy,
-      migratedAt: new Date().toISOString(),
-      files: copied,
+      dataDir: target,
+      backfilledAt: new Date().toISOString(),
+      copied,
+      skipped,
     }, null, 2)}\n`,
     'utf8',
   )
-  return { migrated: true, copied, legacyDir: legacy }
+  return { backfilled: copied.length > 0, copied, skipped }
 }

--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -95,7 +95,7 @@ import {
   expandProcessPath,
 } from './process-path.mjs'
 import {
-  migrateLegacyConfig,
+  backfillSharedAssets,
   resolveDesktopConfigDirectory,
 } from './config-migration.mjs'
 import {
@@ -109,9 +109,10 @@ import { DesktopPresence } from './desktop-presence.mjs'
 // 检测能找到通过 Homebrew、nvm 或官方脚本安装的 Agent 命令。
 expandProcessPath()
 
-// 桌面版与 CLI（~/.config/qwaudio）使用相互独立的数据目录：桌面版默认走
-// Electron 应用数据目录，两者的 Gateway、锁、日志与设置互不干扰；
-// QWAUDIO_CONFIG_DIR 仍优先（高级用户 / Profile 场景）。
+// 桌面版与 CLI 的运行时状态（Gateway、锁、日志、皮肤）互相独立：桌面版
+// 默认走 Electron 应用数据目录；QWAUDIO_CONFIG_DIR 仍优先（高级用户 /
+// Profile 场景）。资产层（配置、身份、记忆、清单、workspace）则共享 CLI
+// 的用户数据目录（QWAUDIO_DATA_DIR），两种形态是同一个助手。
 // 统一应用名，让开发模式与打包版共用同一个 userData 目录（打包版
 // 的 productName 与单实例锁都基于它；开发模式默认会落到包名目录）。
 app.setName('Qwen Audio Agent')
@@ -120,9 +121,15 @@ process.env.QWAUDIO_CONFIG_DIR = resolveDesktopConfigDirectory({
   env: process.env,
   userDataDirectory: app.getPath('userData'),
 })
-const configMigration = migrateLegacyConfig({
-  legacyDir: legacyConfigDirectory,
-  targetDir: process.env.QWAUDIO_CONFIG_DIR,
+if (!process.env.QWAUDIO_DATA_DIR) {
+  // legacyConfigDirectory 在覆写 QWAUDIO_CONFIG_DIR 之前解析，显式配置的
+  // 目录（Profile 场景）会让资产与运行时落在同一处，保持完全隔离。
+  process.env.QWAUDIO_DATA_DIR = legacyConfigDirectory
+}
+// 旧版本桌面版持有各自演化的资产副本，切到共享资产层前先一次性回填。
+const assetBackfill = backfillSharedAssets({
+  desktopDir: process.env.QWAUDIO_CONFIG_DIR,
+  dataDir: process.env.QWAUDIO_DATA_DIR,
 })
 
 const here = dirname(fileURLToPath(import.meta.url))
@@ -131,7 +138,7 @@ const runtimeRoot = app.isPackaged
   ? resolve(process.resourcesPath, 'runtime')
   : sourceRoot
 const expectedConfigPath = resolve(
-  userConfigDirectory(process.env),
+  process.env.QWAUDIO_DATA_DIR,
   'config.env',
 )
 const configExistedAtLaunch = existsSync(expectedConfigPath)
@@ -145,10 +152,11 @@ const logger = createLogger({
   fileName: 'desktop.log',
 })
 const skinsRoot = skinsDirectory(runtimeEnvironment.configDirectory)
-// 悬浮球摆位：记住用户拖到的位置，重启后回到原位；显示器变化时夹取
-// 到仍然存在的屏幕。状态经 settings-store 存进配置目录的 ui-state.json。
+// 设置表单读写共享资产层的 config.env（与 CLI 同一份）；悬浮球摆位等
+// 窗口状态是桌面专属，经 ui-state.json 留在桌面版自己的数据目录。
 const desktopSettingsStore = createSettingsStore({
-  configDir: runtimeEnvironment.configDirectory,
+  configDir: runtimeEnvironment.dataDirectory,
+  uiStateDir: runtimeEnvironment.configDirectory,
 })
 const orbPlacement = createOrbPlacement({
   getDisplays: () => screen.getAllDisplays(),
@@ -167,10 +175,11 @@ logger.info('desktop.starting', {
   platform: process.platform,
   arch: process.arch,
 })
-if (configMigration.migrated) {
-  logger.info('desktop.config_migrated', {
-    legacyDir: configMigration.legacyDir,
-    files: configMigration.copied,
+if (assetBackfill.backfilled) {
+  logger.info('desktop.assets_backfilled', {
+    dataDir: process.env.QWAUDIO_DATA_DIR,
+    files: assetBackfill.copied,
+    skipped: assetBackfill.skipped,
   })
 }
 const fallbackPage = resolve(here, 'orb-unavailable.html')

--- a/desktop/src/settings-store.mjs
+++ b/desktop/src/settings-store.mjs
@@ -61,6 +61,10 @@ function writePrivateFile(path, content) {
  *
  * @param {object} options
  * @param {string} options.configDir Required. The instance data directory.
+ * @param {string} [options.uiStateDir=options.configDir] Directory for
+ *   ui-state.json. The desktop app shares config.env with the CLI's asset
+ *   directory while window state stays in its own runtime directory; an
+ *   embedding host keeps the default single directory.
  * @param {object} [options.env=process.env] Environment consulted for values
  *   the stored configuration leaves unset, and updated on save so an
  *   in-process restart observes what was just written.
@@ -75,10 +79,15 @@ function writePrivateFile(path, content) {
  *   orbPosition: { load: () => object|null, save: (state: object) => object },
  * }}
  */
-export function createSettingsStore({ configDir, env = process.env } = {}) {
+export function createSettingsStore({
+  configDir,
+  uiStateDir = configDir,
+  env = process.env,
+} = {}) {
   const directory = requiredConfigDirectory(configDir)
+  const uiStateDirectory = requiredConfigDirectory(uiStateDir)
   const settingsPath = resolve(directory, SETTINGS_FILE)
-  const uiStatePath = resolve(directory, UI_STATE_FILE)
+  const uiStatePath = resolve(uiStateDirectory, UI_STATE_FILE)
 
   // Reading must never create anything: the startup gate runs before a host
   // has decided to start, and answering "not configured yet" is not a reason
@@ -111,7 +120,10 @@ export function createSettingsStore({ configDir, env = process.env } = {}) {
   }
 
   const saveUiState = patch => {
-    ensureDirectory()
+    mkdirSync(uiStateDirectory, {
+      recursive: true,
+      mode: PRIVATE_DIRECTORY_MODE,
+    })
     const next = { ...loadUiState(), ...patch }
     writePrivateFile(uiStatePath, `${JSON.stringify(next, null, 2)}\n`)
     return next

--- a/desktop/test/config-migration.test.mjs
+++ b/desktop/test/config-migration.test.mjs
@@ -1,32 +1,38 @@
 import assert from 'node:assert/strict'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import test from 'node:test'
 import {
-  migrateLegacyConfig,
+  backfillSharedAssets,
   resolveDesktopConfigDirectory,
 } from '../src/config-migration.mjs'
 
 function withDirectories(fn) {
   const root = mkdtempSync(join(tmpdir(), 'qwaudio-config-migration-'))
-  const legacyDir = join(root, 'legacy')
-  const targetDir = join(root, 'target')
+  const desktopDir = join(root, 'desktop')
+  const dataDir = join(root, 'shared')
   try {
-    return fn({ legacyDir, targetDir })
+    return fn({ desktopDir, dataDir })
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
 }
 
-function seedLegacy(legacyDir) {
-  mkdirSync(legacyDir, { recursive: true })
-  writeFileSync(join(legacyDir, 'config.env'), 'DASHSCOPE_API_KEY=sk-legacy\n', 'utf8')
-  writeFileSync(join(legacyDir, 'state.env'), 'QWEN_AUDIO_AGENT_AUTH_SECRET=secret\n', 'utf8')
-  writeFileSync(join(legacyDir, 'ASSISTANT.md'), '# ASSISTANT\n\n你叫小舟。\n', 'utf8')
-  writeFileSync(join(legacyDir, 'USER.md'), '# USER\n', 'utf8')
-  writeFileSync(join(legacyDir, 'MEMORY.md'), '# MEMORY\n', 'utf8')
-  writeFileSync(join(legacyDir, 'gateway.lock'), '{}\n', 'utf8')
+function seed(directory, name, content, epochSeconds) {
+  mkdirSync(directory, { recursive: true })
+  const path = join(directory, name)
+  writeFileSync(path, content, 'utf8')
+  utimesSync(path, epochSeconds, epochSeconds)
+  return path
 }
 
 test('prefers QWAUDIO_CONFIG_DIR over the Electron userData directory', () => {
@@ -50,64 +56,87 @@ test('falls back to the Electron userData directory without override', () => {
   )
 })
 
-test('copies user config files from the legacy CLI directory once', () => {
-  withDirectories(({ legacyDir, targetDir }) => {
-    seedLegacy(legacyDir)
-    const result = migrateLegacyConfig({ legacyDir, targetDir })
-    assert.equal(result.migrated, true)
-    assert.deepEqual(result.copied, [
-      'config.env',
-      'state.env',
-      'ASSISTANT.md',
-      'USER.md',
-      'MEMORY.md',
-    ])
-    for (const name of [
-      'config.env',
-      'state.env',
-      'ASSISTANT.md',
-      'USER.md',
-      'MEMORY.md',
-    ]) {
-      assert.ok(existsSync(join(targetDir, name)))
-    }
-    // 运行时状态不迁移，CLI 侧原件保留
-    assert.equal(existsSync(join(targetDir, 'gateway.lock')), false)
-    assert.ok(existsSync(join(legacyDir, 'config.env')))
+test('backfills newer desktop assets and keeps a backup of the shared copy', () => {
+  withDirectories(({ desktopDir, dataDir }) => {
+    seed(desktopDir, 'MEMORY.md', '# MEMORY desktop\n', 2000)
+    seed(dataDir, 'MEMORY.md', '# MEMORY cli\n', 1000)
+    const result = backfillSharedAssets({ desktopDir, dataDir })
+    assert.equal(result.backfilled, true)
+    assert.deepEqual(result.copied, ['MEMORY.md'])
     assert.equal(
-      readFileSync(join(targetDir, 'config.env'), 'utf8'),
-      'DASHSCOPE_API_KEY=sk-legacy\n',
+      readFileSync(join(dataDir, 'MEMORY.md'), 'utf8'),
+      '# MEMORY desktop\n',
     )
-    const marker = JSON.parse(readFileSync(join(targetDir, 'migrated-from.json'), 'utf8'))
-    assert.equal(marker.legacyDir, resolve(legacyDir))
-    assert.deepEqual(marker.files, [
-      'config.env',
-      'state.env',
-      'ASSISTANT.md',
-      'USER.md',
-      'MEMORY.md',
-    ])
-    // 重复执行保持幂等，不覆盖已有配置
-    const again = migrateLegacyConfig({ legacyDir, targetDir })
-    assert.equal(again.migrated, false)
-    assert.equal(again.reason, 'target-configured')
+    assert.equal(
+      readFileSync(join(dataDir, 'MEMORY.md.pre-merge.bak'), 'utf8'),
+      '# MEMORY cli\n',
+    )
   })
 })
 
-test('skips migration when no legacy config exists', () => {
-  withDirectories(({ legacyDir, targetDir }) => {
-    const missing = migrateLegacyConfig({ legacyDir, targetDir })
-    assert.equal(missing.migrated, false)
-    assert.equal(missing.reason, 'no-legacy-config')
-    assert.equal(existsSync(join(targetDir, 'migrated-from.json')), false)
+test('leaves shared assets that are newer than the desktop copies', () => {
+  withDirectories(({ desktopDir, dataDir }) => {
+    seed(desktopDir, 'config.env', 'DASHSCOPE_API_KEY=sk-desktop\n', 1000)
+    seed(dataDir, 'config.env', 'DASHSCOPE_API_KEY=sk-cli\n', 2000)
+    const result = backfillSharedAssets({ desktopDir, dataDir })
+    assert.equal(result.backfilled, false)
+    assert.deepEqual(result.skipped, ['config.env'])
+    assert.equal(
+      readFileSync(join(dataDir, 'config.env'), 'utf8'),
+      'DASHSCOPE_API_KEY=sk-cli\n',
+    )
+    assert.equal(existsSync(join(dataDir, 'config.env.pre-merge.bak')), false)
   })
 })
 
-test('skips migration when legacy and target are the same directory', () => {
-  withDirectories(({ legacyDir }) => {
-    seedLegacy(legacyDir)
-    const result = migrateLegacyConfig({ legacyDir, targetDir: legacyDir })
-    assert.equal(result.migrated, false)
+test('never overwrites an existing shared state.env identity', () => {
+  withDirectories(({ desktopDir, dataDir }) => {
+    seed(desktopDir, 'state.env', 'QWEN_AUDIO_AGENT_AUTH_SECRET=desktop\n', 2000)
+    seed(dataDir, 'state.env', 'QWEN_AUDIO_AGENT_AUTH_SECRET=cli\n', 1000)
+    const result = backfillSharedAssets({ desktopDir, dataDir })
+    assert.deepEqual(result.skipped, ['state.env'])
+    assert.equal(
+      readFileSync(join(dataDir, 'state.env'), 'utf8'),
+      'QWEN_AUDIO_AGENT_AUTH_SECRET=cli\n',
+    )
+  })
+})
+
+test('copies desktop assets missing from the shared directory', () => {
+  withDirectories(({ desktopDir, dataDir }) => {
+    seed(desktopDir, 'USER.md', '# USER desktop\n', 2000)
+    seed(desktopDir, 'tasks.json', '{"version":1}\n', 2000)
+    const result = backfillSharedAssets({ desktopDir, dataDir })
+    assert.deepEqual(result.copied, ['USER.md'])
+    assert.equal(
+      readFileSync(join(dataDir, 'USER.md'), 'utf8'),
+      '# USER desktop\n',
+    )
+    // tasks.json 是运行时状态，永不参与共享回填。
+    assert.equal(existsSync(join(dataDir, 'tasks.json')), false)
+  })
+})
+
+test('runs exactly once per desktop directory', () => {
+  withDirectories(({ desktopDir, dataDir }) => {
+    seed(desktopDir, 'MEMORY.md', '# MEMORY desktop\n', 2000)
+    const first = backfillSharedAssets({ desktopDir, dataDir })
+    assert.equal(first.backfilled, true)
+    seed(desktopDir, 'USER.md', '# USER late\n', 3000)
+    const again = backfillSharedAssets({ desktopDir, dataDir })
+    assert.equal(again.backfilled, false)
+    assert.equal(again.reason, 'already-backfilled')
+    assert.equal(existsSync(join(dataDir, 'USER.md')), false)
+  })
+})
+
+test('skips when the desktop and shared directories are the same', () => {
+  withDirectories(({ desktopDir }) => {
+    const result = backfillSharedAssets({
+      desktopDir,
+      dataDir: desktopDir,
+    })
+    assert.equal(result.backfilled, false)
     assert.equal(result.reason, 'same-directory')
   })
 })

--- a/desktop/test/settings-store.test.mjs
+++ b/desktop/test/settings-store.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -90,4 +90,22 @@ test('orbPosition matches the placement storage contract', t => {
   store.saveUiState({ theme: 'dark' })
   store.orbPosition.save({ x: 56, y: 78, displayId: 2 })
   assert.equal(store.loadUiState().theme, 'dark')
+})
+
+test('splits ui state into its own directory when uiStateDir is given', t => {
+  const root = temporaryRoot(t)
+  const store = createSettingsStore({
+    configDir: join(root, 'shared'),
+    uiStateDir: join(root, 'runtime'),
+    env: {},
+  })
+  // 设置留在共享资产目录，窗口状态留在桌面运行时目录。
+  assert.equal(store.path, join(root, 'shared', 'config.env'))
+  assert.equal(store.uiStatePath, join(root, 'runtime', 'ui-state.json'))
+  store.save({ dashscopeApiKey: 'sk-test' })
+  store.saveUiState({ theme: 'dark' })
+  assert.ok(existsSync(join(root, 'shared', 'config.env')))
+  assert.ok(existsSync(join(root, 'runtime', 'ui-state.json')))
+  assert.equal(existsSync(join(root, 'shared', 'ui-state.json')), false)
+  assert.equal(existsSync(join(root, 'runtime', 'config.env')), false)
 })

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,14 +10,21 @@ Setting `QWAUDIO_CONFIG_DIR` or `XDG_CONFIG_HOME` can change the configuration d
 `.env.local` and `.env` files in the development repository are still supported and take priority
 over the user configuration file.
 
-The desktop edition and CLI use mutually independent data directories: the CLI uses
-`~/.config/qwaudio`, while the desktop edition uses the system standard application data directory
-(`~/Library/Application Support/Qwen Audio Agent` on macOS, `~/.config/Qwen Audio Agent` on Linux,
-and `%APPDATA%\Qwen Audio Agent` on Windows). Their Gateways, locks, logs, and settings do not
-interfere with each other and can run simultaneously. On first launch, the desktop edition copies
-user configuration files such as `config.env` from the CLI directory (the CLI retains the
-originals); runtime states such as `gateway.lock` are rebuilt independently. When
-`QWAUDIO_CONFIG_DIR` is explicitly set, the desktop edition also respects this override.
+The desktop edition and CLI share one asset layer and keep their runtime state apart, mirroring how
+Qoder's IDE and CLI coexist. The shared assets — `config.env`, the local identity (`state.env`),
+memory documents (`USER.md`, `MEMORY.md`, `ASSISTANT.md`), frontend notes, and the shared agent
+`workspace/` — live in the CLI's user data directory (`~/.config/qwaudio`, overridable via
+`QWAUDIO_DATA_DIR`), so both editions act as the same assistant with one memory and one
+configuration. Runtime state — `gateway.lock`, `tasks.json`, ACP session state, logs, and desktop
+skins — stays in each edition's own directory: `~/.config/qwaudio` for the CLI and the system
+application data directory for the desktop edition (`~/Library/Application Support/Qwen Audio
+Agent` on macOS, `~/.config/Qwen Audio Agent` on Linux, `%APPDATA%\Qwen Audio Agent` on Windows).
+Both editions can therefore run simultaneously without interfering, though this is rarely needed
+in practice. Desktop installations upgrading from older versions backfill any assets that are
+newer in the desktop directory into the shared layer once (the replaced shared file is kept as
+`<name>.pre-merge.bak`; an existing shared `state.env` identity is never overwritten). When
+`QWAUDIO_CONFIG_DIR` is explicitly set, the desktop edition respects it and keeps assets and
+runtime state together in that directory, preserving full isolation for profile scenarios.
 
 The configuration priority is fixed as:
 

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -9,12 +9,19 @@
 设置 `QWAUDIO_CONFIG_DIR` 或 `XDG_CONFIG_HOME` 可以更改配置目录。开发仓库中的
 `.env.local` 和 `.env` 仍然支持，并优先于用户配置文件。
 
-桌面版与 CLI 使用相互独立的数据目录：CLI 使用 `~/.config/qwaudio`，桌面版使用
-系统标准应用数据目录（macOS 为 `~/Library/Application Support/Qwen Audio Agent`，
-Linux 为 `~/.config/Qwen Audio Agent`，Windows 为 `%APPDATA%\Qwen Audio Agent`）。
-两者的 Gateway、锁、日志与设置互不干扰，可以同时运行。桌面版首次启动时会从 CLI
-目录复制 `config.env` 等用户配置（CLI 保留原件）；`gateway.lock` 等运行时状态各自
-重建。显式设置 `QWAUDIO_CONFIG_DIR` 时桌面版也遵循该覆盖。
+桌面版与 CLI 共享同一个资产层、各自保留运行时状态（参照 Qoder IDE 与 qodercli
+的目录分层）。共享的资产——`config.env`、本地身份（`state.env`）、记忆文档
+（`USER.md`、`MEMORY.md`、`ASSISTANT.md`）、前台清单以及 Agent 共享 `workspace/`——
+统一放在 CLI 的用户数据目录（`~/.config/qwaudio`，可用 `QWAUDIO_DATA_DIR` 覆盖），
+两种形态是同一个助手：一份记忆、一份配置。运行时状态——`gateway.lock`、
+`tasks.json`、ACP 会话状态、日志与桌面皮肤——留在各自目录：CLI 为
+`~/.config/qwaudio`，桌面版为系统标准应用数据目录（macOS 为
+`~/Library/Application Support/Qwen Audio Agent`，Linux 为
+`~/.config/Qwen Audio Agent`，Windows 为 `%APPDATA%\Qwen Audio Agent`）。因此两者
+可以同时运行、互不干扰（实际上很少需要）。从旧版本升级的桌面安装会把桌面目录中
+较新的资产一次性回填到共享层（被替换的共享文件保留为 `<名称>.pre-merge.bak`；
+共享层已有的 `state.env` 身份永不覆盖）。显式设置 `QWAUDIO_CONFIG_DIR` 时桌面版
+遵循该覆盖，资产与运行时状态落在同一目录，为 Profile 场景保留完全隔离。
 
 配置优先级固定为：
 

--- a/server/src/conversation/frontend-notes.mjs
+++ b/server/src/conversation/frontend-notes.mjs
@@ -2,6 +2,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  statSync,
   writeFileSync,
 } from 'node:fs'
 import { createHash } from 'node:crypto'
@@ -94,10 +95,32 @@ export class FrontendNotesStore {
     this.ownerAccess = new Map()
     this.warning = null
     this.persistenceDisabled = false
+    this.loadedMtimeMs = 0
     if (filePath) this.load()
   }
 
+  fileMtimeMs() {
+    try {
+      return statSync(this.filePath).mtimeMs
+    } catch (error) {
+      if (error.code === 'ENOENT') return 0
+      throw error
+    }
+  }
+
+  // 桌面版与 CLI 共享同一份清单文件，两个 Gateway 极少同时运行，但一旦
+  // 并发，各自的内存缓存会把对方的写入整份冲掉。读写入口先对比磁盘
+  // mtime，被其它实例更新过就重载，把覆盖窗口缩到单次读改写之内。
+  refreshIfChanged() {
+    if (!this.filePath || this.persistenceDisabled) return
+    if (this.fileMtimeMs() === this.loadedMtimeMs) return
+    this.users = new Map()
+    this.ownerAccess = new Map()
+    this.load()
+  }
+
   load() {
+    this.loadedMtimeMs = this.fileMtimeMs()
     let parsed
     try {
       parsed = JSON.parse(readFileSync(this.filePath, 'utf8'))
@@ -246,6 +269,7 @@ export class FrontendNotesStore {
         mode: 0o600,
       })
       renameSync(temporary, this.filePath)
+      this.loadedMtimeMs = this.fileMtimeMs()
       return true
     } catch (error) {
       this.disablePersistence(`无法保存前台清单文件：${error.message}`)
@@ -254,6 +278,7 @@ export class FrontendNotesStore {
   }
 
   lists(ownerId) {
+    this.refreshIfChanged()
     this.pruneOwners()
     const safeOwnerId = String(ownerId)
     this.touch(safeOwnerId)
@@ -263,6 +288,7 @@ export class FrontendNotesStore {
   }
 
   show(ownerId, name) {
+    this.refreshIfChanged()
     this.touch(String(ownerId))
     const resolution = resolveList(this.users.get(String(ownerId)) || new Map(), name)
     if (!resolution.found || !name) {
@@ -278,6 +304,7 @@ export class FrontendNotesStore {
   }
 
   add(ownerId, { list, items = [] } = {}) {
+    this.refreshIfChanged()
     this.pruneOwners()
     const safeOwnerId = String(ownerId)
     const safeName = clean(list, MAX_LIST_NAME_CHARS)
@@ -349,6 +376,7 @@ export class FrontendNotesStore {
   }
 
   remove(ownerId, { list, items = [] } = {}) {
+    this.refreshIfChanged()
     this.pruneOwners()
     const safeOwnerId = String(ownerId)
     const safeItems = items
@@ -407,6 +435,7 @@ export class FrontendNotesStore {
   }
 
   clear(ownerId, list) {
+    this.refreshIfChanged()
     this.pruneOwners()
     const safeOwnerId = String(ownerId)
     const lists = this.users.get(safeOwnerId) || new Map()
@@ -433,6 +462,7 @@ export class FrontendNotesStore {
   }
 
   drop(ownerId, list) {
+    this.refreshIfChanged()
     this.pruneOwners()
     const safeOwnerId = String(ownerId)
     const lists = this.users.get(safeOwnerId) || new Map()

--- a/server/src/conversation/frontend-notes.mjs
+++ b/server/src/conversation/frontend-notes.mjs
@@ -96,6 +96,7 @@ export class FrontendNotesStore {
     this.warning = null
     this.persistenceDisabled = false
     this.loadedMtimeMs = 0
+    this.loadedContentHash = ''
     if (filePath) this.load()
   }
 
@@ -111,16 +112,30 @@ export class FrontendNotesStore {
   // 桌面版与 CLI 共享同一份清单文件，两个 Gateway 极少同时运行，但一旦
   // 并发，各自的内存缓存会把对方的写入整份冲掉。读写入口先对比磁盘
   // mtime，被其它实例更新过就重载，把覆盖窗口缩到单次读改写之内。
+  // mtime 相等不代表内容相等：部分文件系统（NTFS）与快速连续写入可能
+  // 落在同一时间刻度，所以 mtime 命中时再以内容哈希兜底确认。
   refreshIfChanged() {
     if (!this.filePath || this.persistenceDisabled) return
-    if (this.fileMtimeMs() === this.loadedMtimeMs) return
+    const mtimeMs = this.fileMtimeMs()
+    if (mtimeMs === this.loadedMtimeMs && this.fileContentHash() === this.loadedContentHash) return
     this.users = new Map()
     this.ownerAccess = new Map()
     this.load()
   }
 
+  fileContentHash() {
+    try {
+      return createHash('sha1').update(readFileSync(this.filePath)).digest('hex')
+    } catch {
+      // 读不到的文件（不存在、是目录等）视为空内容；真正的读取错误由
+      // load()/persist() 的既有错误路径处理。
+      return ''
+    }
+  }
+
   load() {
     this.loadedMtimeMs = this.fileMtimeMs()
+    this.loadedContentHash = this.fileContentHash()
     let parsed
     try {
       parsed = JSON.parse(readFileSync(this.filePath, 'utf8'))
@@ -270,6 +285,7 @@ export class FrontendNotesStore {
       })
       renameSync(temporary, this.filePath)
       this.loadedMtimeMs = this.fileMtimeMs()
+      this.loadedContentHash = this.fileContentHash()
       return true
     } catch (error) {
       this.disablePersistence(`无法保存前台清单文件：${error.message}`)

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -34,7 +34,7 @@ export function numberSetting(value, fallback, {
 export function resolveBackendWorkspace(
   protocol,
   env = process.env,
-  configDirectory = runtimeEnvironment.configDirectory,
+  configDirectory = runtimeEnvironment.dataDirectory,
 ) {
   const definition = backendDefinition(protocol)
   if (!definition?.workspaceEnvironment) {
@@ -160,6 +160,7 @@ const realtimeFrontend = resolveRealtimeFrontendConfiguration(process.env)
 export const config = {
   root,
   configDirectory: runtimeEnvironment.configDirectory,
+  dataDirectory: runtimeEnvironment.dataDirectory,
   host: process.env.HOST || '127.0.0.1',
   // PORT=0 lets an embedded host (e.g. the desktop app) fall back to a
   // random loopback port and learn it from the child process report.

--- a/server/test/frontend-notes.test.mjs
+++ b/server/test/frontend-notes.test.mjs
@@ -145,3 +145,21 @@ test('rolls back additions when persistence is unavailable', t => {
   assert.deepEqual(store.lists('owner-a'), [])
   assert.equal(store.health().persistenceEnabled, false)
 })
+
+test('reloads from disk when another instance updated the shared file', t => {
+  const root = mkdtempSync(join(tmpdir(), 'frontend-notes-shared-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  const filePath = join(root, 'frontend-notes.json')
+  // 桌面版与 CLI 双开时是两个进程各持一个 store 实例读写同一文件。
+  const cli = new FrontendNotesStore({ filePath })
+  const desktop = new FrontendNotesStore({ filePath })
+  cli.add('owner-a', { list: '购物清单', items: ['牛奶'] })
+  // 另一实例写入后，本实例的下一次读写要先看到磁盘上的最新内容，
+  // 而不是用自己的旧缓存整份覆盖回去。
+  desktop.add('owner-a', { list: '购物清单', items: ['面包'] })
+  const merged = cli.show('owner-a', '购物清单')
+  assert.deepEqual(merged.items.map(item => item.text), ['牛奶', '面包'])
+  cli.add('owner-a', { list: '购物清单', items: ['鸡蛋'] })
+  const final = desktop.show('owner-a', '购物清单')
+  assert.deepEqual(final.items.map(item => item.text), ['牛奶', '面包', '鸡蛋'])
+})

--- a/shared/runtime-environment.mjs
+++ b/shared/runtime-environment.mjs
@@ -99,6 +99,18 @@ export function userConfigDirectory(
   return resolve(base, 'qwaudio')
 }
 
+// 资产目录：配置、身份、记忆、清单与共享 workspace 等"用户资产"的归属地。
+// 默认与运行时目录（configDirectory）相同；桌面版把它指向 CLI 的用户目录，
+// 让两种形态共享同一份资产，而 tasks/logs/锁等运行时状态仍按形态隔离
+// （参照 Qoder IDE 与 qodercli 的目录分层）。
+export function userDataDirectory(
+  env = process.env,
+  homeDirectory = homedir(),
+) {
+  if (env.QWAUDIO_DATA_DIR) return resolve(env.QWAUDIO_DATA_DIR)
+  return userConfigDirectory(env, homeDirectory)
+}
+
 function ensureGeneratedSecret(env, configDirectory) {
   if (env[SECRET_KEY]) return { generated: false, statePath: null }
   const statePath = resolve(configDirectory, 'state.env')
@@ -452,39 +464,45 @@ export function loadRuntimeEnvironment({
 } = {}) {
   if (!root) throw new Error('loadRuntimeEnvironment requires root')
   const configDirectory = userConfigDirectory(env, homeDirectory)
+  // 资产（配置/身份/记忆/清单/workspace）从资产目录读写；tasks、logs、
+  // 实例锁等运行时状态留在 configDirectory。两者默认相同，桌面版分离。
+  const dataDirectory = userDataDirectory(env, homeDirectory)
   const candidates = [
     resolve(root, '.env.local'),
     resolve(root, '.env'),
-    resolve(configDirectory, 'config.env'),
+    resolve(dataDirectory, 'config.env'),
   ]
   const loadedFiles = candidates.filter(path => loadFile(path, env))
   if (!readOnly) {
     mkdirSync(configDirectory, { recursive: true, mode: 0o700 })
+    if (dataDirectory !== configDirectory) {
+      mkdirSync(dataDirectory, { recursive: true, mode: 0o700 })
+    }
   }
   const configPath = readOnly
-    ? resolve(configDirectory, 'config.env')
-    : ensureUserConfig(configDirectory)
+    ? resolve(dataDirectory, 'config.env')
+    : ensureUserConfig(dataDirectory)
   const userModelPath = readOnly
-    ? resolve(configDirectory, 'USER.md')
-    : ensureUserModel(configDirectory)
+    ? resolve(dataDirectory, 'USER.md')
+    : ensureUserModel(dataDirectory)
   const assistantProfilePath = readOnly
-    ? resolve(configDirectory, 'ASSISTANT.md')
+    ? resolve(dataDirectory, 'ASSISTANT.md')
     : ensureAssistantProfile(
-        configDirectory,
+        dataDirectory,
         resolve(root, 'config/frontend-agent/ASSISTANT.md'),
       )
   const frontendMemoryPath = readOnly
-    ? resolve(configDirectory, 'MEMORY.md')
-    : ensureLongTermMemory(configDirectory)
-  const legacyFrontendMemoryPath = resolve(configDirectory, 'frontend-memory.json')
-  const frontendNotesPath = resolve(configDirectory, 'frontend-notes.json')
+    ? resolve(dataDirectory, 'MEMORY.md')
+    : ensureLongTermMemory(dataDirectory)
+  const legacyFrontendMemoryPath = resolve(dataDirectory, 'frontend-memory.json')
+  const frontendNotesPath = resolve(dataDirectory, 'frontend-notes.json')
   const taskStatePath = resolve(configDirectory, 'tasks.json')
   const backendWorkspaces = resolveBackendWorkspaces(
     env,
     root,
-    configDirectory,
+    dataDirectory,
   )
-  const sharedWorkspace = defaultBackendWorkspace(configDirectory)
+  const sharedWorkspace = defaultBackendWorkspace(dataDirectory)
   const workspace = id => backendWorkspaces[id]?.directory || ''
   const openCodeWorkspace = workspace('opencode')
   const openClawWorkspace = workspace('openclaw')
@@ -511,7 +529,7 @@ export function loadRuntimeEnvironment({
       memoryPath: frontendMemoryPath,
       userModelPath,
       ownerId: env.QWEN_AUDIO_AGENT_PERSONAL_OWNER_ID || 'user_personal',
-      configDirectory,
+      configDirectory: dataDirectory,
     })) {
       migratedFiles.push(frontendMemoryPath, userModelPath)
     }
@@ -521,10 +539,12 @@ export function loadRuntimeEnvironment({
       }
       env[entry.environment] = entry.directory
     }
-    legacyWorkspaceNotices = collectLegacyWorkspaceNotices(
-      configDirectory,
-      sharedWorkspace,
-    )
+    // 旧的按后台隔离目录可能分别留在运行时目录与资产目录（桌面版分离后）。
+    legacyWorkspaceNotices = [...new Set([configDirectory, dataDirectory])]
+      .flatMap(directory => collectLegacyWorkspaceNotices(
+        directory,
+        sharedWorkspace,
+      ))
     if (backendWorkspaces.codebuddy?.managed) {
       ensureCodeBuddyTemplate(
         resolve(root, 'config/codebuddy/workspace/.codebuddy/models.json'),
@@ -541,10 +561,11 @@ export function loadRuntimeEnvironment({
     )).map(([, targetPath]) => targetPath))
   }
   const secret = generateSecret && !readOnly
-    ? ensureGeneratedSecret(env, configDirectory)
+    ? ensureGeneratedSecret(env, dataDirectory)
     : { generated: false, statePath: null }
   return {
     configDirectory,
+    dataDirectory,
     configPath,
     assistantProfilePath,
     userModelPath,


### PR DESCRIPTION
## 变更说明

桌面版与 CLI 从"数据目录完全隔离"演进为**资产共享 + 运行态隔离**（参照 Qoder IDE 与 qodercli 的目录分层），消除两种形态间配置、记忆、workspace 的分叉——两边是同一个助手：一份记忆、一份配置、一份工作区。

**目录分层**：
- 共享资产层 `~/.config/qwaudio`（`QWAUDIO_DATA_DIR` 可覆盖）：config.env、state.env（本地身份）、USER/MEMORY/ASSISTANT.md、前台清单、共享 `workspace/`
- 运行时层（按形态隔离）：tasks.json、ACP 会话状态、日志、实例锁、桌面皮肤与窗口状态——CLI 仍在 `~/.config/qwaudio`（**CLI 零行为变化**），桌面版留在 Application Support

**关键设计**：
- 双实例可并存：唯一的真实碰撞面（frontend-notes 内存缓存整写）加 mtime 变化重载防护；MEMORY.md 本为"读盘-原子写"模式天然安全，保持整文档格式
- 升级迁移：桌面版首启动把桌面侧较新的资产一次性回填共享层（被替换文件备份 `<名称>.pre-merge.bak`），**共享侧 state.env 身份永不覆盖**；marker 幂等
- Profile 场景不破坏：显式 `QWAUDIO_CONFIG_DIR` 时资产与运行态同目录，保持完全隔离；嵌入宿主契约不变（`createSettingsStore` 的 `uiStateDir` 为可选参数）

## 验证

- [x] `npm test`（六 workspace 1022 项全绿：56/500/81/55/193/137）
- [x] `npm run lint`
- [x] `npm run build`（不涉及 web 构建产物变化）
- [x] 行为变化已补充测试：双目录路径断言、回填七场景（较新回填+备份/较旧跳过/身份保护/缺失拷贝/tasks 排除/幂等/同目录）、ui-state 分离、双实例交替写清单不互相覆盖
- [x] 真机端到端：沙箱冒烟（回填→双目录加载→CLI 行为不变）+ 本机桌面版实际启动验证（回填 marker、.pre-merge.bak 备份、state.env 未动均符合预期）

## 兼容性与安全

- [x] 未提交密钥、用户数据、日志或内部地址
- [x] 配置、用户可见行为和依赖变化已同步更新文档（docs/configuration.md 与 configuration.zh.md 数据目录章节重写）
- [x] 影响说明：持久化布局变化——桌面版资产读写位置迁移至共享目录，附一次性回填（备份保留、身份保护、幂等）；CLI 存量用户零变化；无网络、权限模型或发布流程影响
