### PR TITLE
refactor: establish chatbot runtime roadmap and protocol boundary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,8 @@
 This document defines the product boundary. Changes that contradict these
 invariants are architecture changes, not local feature work.
 
-See [`roadmap/frontend-chatbot-runtime.md`](roadmap/frontend-chatbot-runtime.md)
+See the
+[Realtime Voice Chatbot Runtime Roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/frontend-chatbot-runtime.md)
 for the target boundary and staged refactor of the Realtime Voice Chatbot,
 asynchronous work bridge, and single user-configured backend agent. Until each
 roadmap stage lands, this document remains the tested description of current

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,12 @@
 This document defines the product boundary. Changes that contradict these
 invariants are architecture changes, not local feature work.
 
+See [`roadmap/frontend-chatbot-runtime.md`](roadmap/frontend-chatbot-runtime.md)
+for the target boundary and staged refactor of the Realtime Voice Chatbot,
+asynchronous work bridge, and single user-configured backend agent. Until each
+roadmap stage lands, this document remains the tested description of current
+runtime behavior.
+
 ## 1. User-visible model
 
 The user talks to one qwen-audio assistant. Internally there are two qwen-audio-agent

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -4,7 +4,7 @@
 
 前台 Realtime Voice Chatbot、异步 Work Bridge 与单一用户后台 Agent 的目标边界及
 分阶段重构计划见
-[`roadmap/frontend-chatbot-runtime.zh.md`](roadmap/frontend-chatbot-runtime.zh.md)。
+[Realtime Voice Chatbot Runtime Roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/frontend-chatbot-runtime.zh.md)。
 在 Roadmap 分阶段落地期间，本文继续描述当前已实现并受测试保护的运行时行为。
 
 ## 1. 用户可见模型

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -2,6 +2,11 @@
 
 本文档定义产品边界。违反这些不变性的变更属于架构变更，而非局部功能开发。
 
+前台 Realtime Voice Chatbot、异步 Work Bridge 与单一用户后台 Agent 的目标边界及
+分阶段重构计划见
+[`roadmap/frontend-chatbot-runtime.zh.md`](roadmap/frontend-chatbot-runtime.zh.md)。
+在 Roadmap 分阶段落地期间，本文继续描述当前已实现并受测试保护的运行时行为。
+
 ## 1. 用户可见模型
 
 用户与一个 qwen-audio 助手对话。内部存在两个 qwen-audio-agent 层：

--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -1,0 +1,255 @@
+# Realtime Voice Chatbot Runtime Roadmap
+
+> Status: Proposal
+>
+> GitHub tracking: [#185](https://github.com/QwenAudio/qwen-audio-agent/issues/185)
+>
+> Scope: while retaining one active backend agent, refactor qwen-audio-agent
+> into a clearly bounded, extensible, standards-oriented realtime voice
+> chatbot runtime that connects to the user's own action agent through an
+> asynchronous work bridge.
+
+## 1. Product definition
+
+qwen-audio-agent contains two decoupled runtimes that appear to the user as one
+assistant:
+
+1. The **Realtime Voice Chatbot** owns the conversation. It handles voice,
+   text, images, attachments, context, memory, search, knowledge/RAG, bounded
+   low-latency tools, and presentation.
+2. The **Backend Action Agent** accesses files, code, applications, devices,
+   and external systems. It performs long-running, multi-step, or privileged
+   work using its own model, configuration, tools, MCP servers, skills, and
+   sessions.
+
+`spawn_thinking` is the only model-visible work handoff between them. It sends
+the user's objective and input references; the frontend never selects backend
+sessions, execution modes, delegation strategies, tools, or sub-agents.
+
+Only one user-selected backend is active. Multi-backend routing is outside this
+roadmap.
+
+## 2. Architecture invariants
+
+1. With no backend configured, frontend chat, memory, search, and knowledge/RAG
+   continue to work.
+2. Backend queuing, execution, authorization, and failure never block the live
+   conversation.
+3. `spawn_thinking` waits only for intake, never for completion.
+4. The frontend presents each backend result naturally and exactly once.
+5. Frontend Runtime never depends on ACP or a backend product.
+6. Work Runtime contains no session, coordinator-MCP, or backend-topology
+   knowledge.
+7. Backend adapters emit standard work events and artifacts; they never send
+   client events directly.
+8. Realtime providers never call the backend or choose work strategy.
+9. Clients consume the public protocol and never infer internal state machines.
+10. RAG indexing and memory extraction are system jobs, not user backend work.
+
+## 3. Target boundaries
+
+```text
+Desktop / WebUI / TUI
+          │ AG-UI compatible events + qwen.audio extensions
+          ▼
+Gateway Transport
+          ▼
+Frontend Chatbot Runtime
+├── Realtime Session / Conversation Context
+├── Frontend Tool Runtime
+├── Search / Knowledge
+├── Memory / Notes / Reminder
+└── Presentation Runtime
+          │ WorkSubmissionPort
+          ▼
+Work Runtime
+├── State / Queue / Authorization
+├── Artifact / Notification / Recovery
+└── Scheduler
+          │ BackendPort
+          ▼
+Single Backend Runtime
+          ▼
+ACP / future A2A / custom Backend Adapter
+```
+
+Dependency direction is fixed:
+
+```text
+Transport → Application → Domain ← Adapter
+```
+
+## 4. Core contracts
+
+### RealtimeProviderPort
+
+Providers expose `connect`, `updateSession`, `sendAudio`, `sendInput`,
+`sendToolResult`, `createResponse`, `cancelResponse`, `close`, `capabilities`,
+and `subscribe`. DashScope, OpenAI-compatible, Speech-to-Speech, and private
+providers implement this port.
+
+### FrontendTool
+
+Each tool declares its name, description, input/output schemas, executor, and a
+policy:
+
+```text
+mode: inline | background | control
+readOnly / requiresApproval
+timeoutMs / maxResultBytes / maxCallsPerTurn
+```
+
+`inline` tools return within the turn; `background` tools return an intake
+receipt (`spawn_thinking`); `control` tools query or change existing work.
+
+### Work
+
+Work records carry internal and user-facing identity, owner, conversation,
+turn, original request, objective, multimodal inputs, state, activity,
+authorization, artifacts, presentation, and timestamps. Public states align
+with A2A Task semantics: `submitted`, `working`, `auth_required`, `completed`,
+`failed`, and `cancelled`. Gateway-specific phases remain internal.
+
+### BackendPort
+
+Backends implement `describe`, `start`, `health`, `submit`, `status`, `cancel`,
+`respondAuthorization`, `subscribe`, and `close`. ACP sessions, coordinator
+prompts, coordinator MCP, and native delegation stay inside the ACP adapter.
+
+### Artifact and Presentation
+
+Artifacts consist of MIME-typed parts. Presentation contains factual material
+and delivery policy for the frontend, not a script that must be spoken
+verbatim.
+
+## 5. Standards strategy
+
+| Boundary | Strategy |
+| --- | --- |
+| Client ↔ Gateway | Gradually project stable AG-UI events; use `qwen.*` extensions for audio, playback, ownership, and sleep |
+| Gateway ↔ realtime model | OpenAI Realtime-compatible provider port |
+| Model tools | Function Calling + JSON Schema |
+| External tools and data | MCP; OpenAPI adapter for REST services |
+| Gateway ↔ backend agent | ACP today; A2A-aligned internal semantics and a future A2A adapter |
+| Multimodal content | MIME type plus text, URI, binary, or structured-data parts |
+| Observability | Structured logs and progressively OpenTelemetry-aligned traces |
+
+External protocols enter through projectors and adapters; they do not become
+the internal domain model.
+
+## 6. Frontend capability boundary
+
+The frontend may run bounded short tool loops governed by total latency, call
+count, result size, and interruption policy. It owns multimodal conversation,
+history, preferences, memory, notes, reminders, web search, URL fetch,
+citations, full context, knowledge/RAG, work control, authorization relay, and
+natural result presentation.
+
+Filesystem and shell access, code projects, application/device/browser
+control, long-running or privileged work, sub-agents, sessions, plans,
+delegation strategy, and backend MCP/skills/models remain backend-private.
+
+## 7. Migration releases
+
+### R0 — Freeze the architecture
+
+- [ ] Merge this roadmap and the bilingual architecture RFC.
+- [ ] Enforce dependency direction.
+- [ ] Add characterization tests for current critical behavior.
+
+### R1 — Protocol and client state
+
+- [ ] Add Zod schemas for Gateway client, server, and task events.
+- [ ] Introduce domain events and public event projectors.
+- [ ] Add an AG-UI compatibility projector without removing current events.
+- [ ] Extract a shared Gateway client and state reducer.
+- [ ] Migrate WebUI, TUI, and Desktop one at a time.
+
+### R2 — Frontend Chatbot Runtime
+
+- [ ] Extract realtime session, turn, input, playback, and presentation logic.
+- [ ] Add Frontend Tool Registry, Policy, and Executor.
+- [ ] Migrate existing tools without renaming or changing behavior.
+- [ ] Make `spawn_thinking` a first-class background tool.
+- [ ] Add a bounded short tool loop.
+
+### R3 — Work Runtime
+
+- [ ] Extract state machine, scheduler, repository, and notification concerns.
+- [ ] Separate user work from system jobs.
+- [ ] Add artifact and authorization models.
+- [ ] Preserve restart, cancellation, and exactly-once delivery semantics.
+
+### R4 — Backend Runtime
+
+- [ ] Define and validate BackendPort.
+- [ ] Reduce AgentClient to the single-backend runtime.
+- [ ] Implement BackendPort in the ACP adapter.
+- [ ] Move coordinator and session tools into the ACP boundary.
+- [ ] Add a reusable backend-adapter conformance suite.
+
+### R5 — Complete the frontend
+
+- [ ] Web search provider, URL fetch, and citations.
+- [ ] Knowledge store, document extraction, and indexing system jobs.
+- [ ] Full context, retrieval provider, and RAG tools.
+- [ ] Routing, citation, interruption, duplicate-speech, and prompt-injection
+      evaluations.
+
+### R6 — Open the ecosystem
+
+- [ ] MCP client with per-tool policy and enablement.
+- [ ] OpenAPI tool adapter.
+- [ ] Lightweight frontend profiles; do not invent a public skill standard.
+- [ ] Backend adapter SDK and examples.
+- [ ] Optional A2A backend adapter.
+
+## 8. Target repository shape
+
+```text
+server/src/
+├── app/                  # composition root
+├── transport/            # HTTP / WebSocket / AG-UI projectors
+├── frontend/             # chatbot runtime
+├── work/                 # user work domain
+├── backend/              # backend port/runtime/adapters
+├── providers/realtime/   # realtime provider adapters
+└── platform/             # config/identity/persistence/logging/security
+
+shared/                   # migration-time protocol and client runtime
+packages/                 # protocol/client/backend-sdk after contracts settle
+```
+
+Directories move only with responsibility extraction and tests; the roadmap
+does not authorize a cosmetic mass rename.
+
+## 9. Enforced dependency rules
+
+```text
+frontend/        must not import backend/adapters/
+work/            must not import ACP, sessions, or backend products
+transport/       must not implement domain state machines
+providers/       must not call BackendPort
+backend/adapters must not emit client events directly
+clients          must not infer internal Gateway state
+shared/protocol  must not depend on server
+```
+
+## 10. Quality gates
+
+Every stage runs lint, the complete test suite, release checks, public-protocol
+compatibility tests, no-backend chat tests, non-blocking background-work tests,
+interruption tests, exactly-once presentation tests, and adapter/provider
+conformance suites.
+
+Refactor PRs do not change user behavior by default. Behavioral changes require
+their own commit, bilingual documentation, and end-to-end tests.
+
+## 11. Non-goals
+
+- Multiple concurrently active or automatically routed backend agents.
+- Turning the frontend into a coding agent or general long-running agent.
+- Migrating to Open WebUI, LiveKit, or another full platform.
+- Immediately replacing the existing Gateway protocol.
+- Inventing new MCP, A2A, or skill protocols.
+- Exposing backend sessions or private task topology for uniformity.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -1,0 +1,315 @@
+# Realtime Voice Chatbot Runtime Roadmap
+
+> 状态：提案
+>
+> GitHub 跟踪：[#185](https://github.com/QwenAudio/qwen-audio-agent/issues/185)
+>
+> 范围：在保持单一后台 Agent 的前提下，将 qwen-audio-agent 重构为边界清晰、
+> 可扩展、相对标准化的实时语音 Chatbot Runtime，并通过异步 Work Bridge 接入
+> 用户自己的办事 Agent。
+
+## 1. 产品定义
+
+qwen-audio-agent 由两个彼此解耦、对用户表现为一个助手的运行时组成：
+
+1. **Realtime Voice Chatbot** 始终拥有用户对话。它负责语音、文本、图片、附件、
+   对话上下文、记忆、Search、Knowledge/RAG、低延迟前台工具和结果表达。
+2. **Backend Action Agent** 负责访问文件、代码、应用、设备和外部系统，执行长耗时、
+   多步骤或需要权限的工作。它使用自己的模型、配置、工具、MCP、Skill 和 Session。
+
+`spawn_thinking` 是二者之间唯一的模型可见工作交接入口。它只提交用户目标和输入引用，
+不允许前台选择后台 Session、执行方式、委托策略、工具或子 Agent。
+
+当前版本只激活一个用户选择的后台。多后台路由不属于本 Roadmap。
+
+## 2. 架构不变量
+
+以下规则由文档、依赖检查和测试共同保证：
+
+1. 没有后台 Agent 时，前台仍能完成正常聊天、记忆、Search 和 Knowledge/RAG。
+2. 后台排队、运行、等待权限或失败，不阻塞前台继续对话。
+3. `spawn_thinking` 只等待受理回执，不等待后台工作完成。
+4. 后台结果由前台在安全的语音窗口自然表达，且只交付一次。
+5. Frontend Runtime 不依赖 ACP、OpenCode、OpenClaw 或任何具体后台实现。
+6. Work Runtime 不包含 Session、MCP 协调工具或后台拓扑知识。
+7. Backend Adapter 不直接向客户端发送事件，只产生标准 Work 事件和 Artifact。
+8. Realtime Provider 不调用后台，不解释 Work 执行策略。
+9. 客户端只消费公开协议，不自行推导 Gateway 内部状态机。
+10. RAG 索引、记忆提取等平台内部任务是 System Job，不是用户 Backend Work。
+
+## 3. 目标边界
+
+```text
+Desktop / WebUI / TUI
+          │ AG-UI compatible events + qwen.audio extensions
+          ▼
+Gateway Transport
+          ▼
+Frontend Chatbot Runtime
+├── Realtime Session / Conversation Context
+├── Frontend Tool Runtime
+├── Search / Knowledge
+├── Memory / Notes / Reminder
+└── Presentation Runtime
+          │ WorkSubmissionPort
+          ▼
+Work Runtime
+├── State / Queue / Authorization
+├── Artifact / Notification / Recovery
+└── Scheduler
+          │ BackendPort
+          ▼
+Single Backend Runtime
+          ▼
+ACP / future A2A / custom Backend Adapter
+```
+
+依赖方向固定为：
+
+```text
+Transport → Application → Domain ← Adapter
+```
+
+## 4. 核心契约
+
+### 4.1 RealtimeProviderPort
+
+Realtime Provider 只负责将供应商协议投射成统一的实时会话事件：
+
+```js
+{
+  connect,
+  updateSession,
+  sendAudio,
+  sendInput,
+  sendToolResult,
+  createResponse,
+  cancelResponse,
+  close,
+  capabilities,
+  subscribe,
+}
+```
+
+DashScope、OpenAI-compatible、Speech-to-Speech 和私有 Provider 都实现该 Port。
+
+### 4.2 FrontendTool
+
+```js
+{
+  name,
+  description,
+  inputSchema,
+  outputSchema,
+  policy: {
+    mode: 'inline' | 'background' | 'control',
+    readOnly,
+    requiresApproval,
+    timeoutMs,
+    maxResultBytes,
+    maxCallsPerTurn,
+  },
+  execute,
+}
+```
+
+- `inline`：在当前对话轮次中返回，例如 Search、RAG、Time、Memory。
+- `background`：只返回受理回执，当前只有 `spawn_thinking`。
+- `control`：查询、取消和权限等控制操作，不创建新 Work。
+
+### 4.3 Work
+
+Work 是 Gateway 管理的用户工作回执，不镜像后台内部任务图。它包含内部 UUID、用户可见
+job ID、owner、conversation、turn、用户原话、objective、多模态输入、状态、活动、权限、
+Artifact、Presentation 和时间戳。
+
+公共状态向 A2A Task 语义靠拢：
+
+```text
+submitted → working → completed
+                  ├→ auth_required
+                  ├→ failed
+                  └→ cancelled
+```
+
+`queued`、`delegated`、`finalizing` 和 `cancelling` 等仅作为 Gateway 内部 phase，
+不得成为 Backend Adapter 的前置假设。
+
+### 4.4 BackendPort
+
+```js
+{
+  describe,
+  start,
+  health,
+  submit,
+  status,
+  cancel,
+  respondAuthorization,
+  subscribe,
+  close,
+}
+```
+
+ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter 内部。
+
+### 4.5 Artifact 与 Presentation
+
+后台输出统一为包含 MIME 类型的 Artifact Parts。Presentation 只携带供前台表达的
+事实材料和投递策略，不携带必须逐字播报的脚本。
+
+## 5. 标准协议策略
+
+| 边界 | 策略 |
+| --- | --- |
+| Client ↔ Gateway | 逐步兼容 AG-UI 稳定事件；音频、播放、所有权和休眠使用 `qwen.*` 扩展 |
+| Gateway ↔ Realtime Model | OpenAI Realtime-compatible Provider Port |
+| 模型工具 | Function Calling + JSON Schema |
+| 外部工具与数据 | MCP；普通 REST 服务可通过 OpenAPI Adapter |
+| Gateway ↔ Backend Agent | 当前 ACP；内部 Work 语义向 A2A 对齐；未来增加 A2A Adapter |
+| 多模态内容 | MIME Type + text / URI / binary / structured data Part |
+| 可观测性 | 结构化日志；逐步接入 OpenTelemetry trace 语义 |
+
+标准协议通过边界 Projector 或 Adapter 接入，不直接成为内部 Domain Model，避免协议升级
+扩散到核心业务。
+
+## 6. 前台能力边界
+
+前台允许有界的短工具循环：总耗时、调用次数、结果大小均受 Tool Policy 限制，用户
+插话时可立即终止当前前台循环。前台负责：
+
+- 连续语音、文本和多模态对话；
+- 对话历史、用户偏好、长期记忆、Notes 和 Reminder；
+- Web Search、URL Fetch、引用；
+- Full Context 与 Knowledge/RAG；
+- 后台 Work 查询、取消和权限转述；
+- 后台最终结果的自然表达。
+
+后台私有能力包括：
+
+- 文件系统、Shell、代码工程和应用操作；
+- 手机、浏览器、桌面和硬件控制；
+- 长时间、多步骤或高风险工作；
+- Subagent、Session、执行计划和委托策略；
+- 后台自己的 MCP、Skill、模型和工具。
+
+## 7. 迁移阶段
+
+### R0：架构冻结
+
+- [ ] 合并本 Roadmap 与中英文架构 RFC。
+- [ ] 为依赖方向增加静态检查。
+- [ ] 为当前关键行为补齐 characterization tests。
+
+完成条件：后续 PR 都能明确归属到一个 Domain 和一个公开契约。
+
+### R1：协议与客户端状态
+
+- [ ] 为 Gateway Client/Server/Task 事件建立 Zod Schema。
+- [ ] 建立 Domain Event 与公开 Event Projector。
+- [ ] 增加 AG-UI 兼容投射层，不立即删除现有事件。
+- [ ] 提取共享 Gateway Client 和状态 Reducer。
+- [ ] 依次迁移 WebUI、TUI、Desktop。
+
+完成条件：三个客户端不再各自解释 Work 和 Voice 状态机。
+
+### R2：Frontend Chatbot Runtime
+
+- [ ] 提取 Realtime Session、Turn、Input、Playback 和 Presentation。
+- [ ] 建立 Frontend Tool Registry、Policy 和 Executor。
+- [ ] 将现有工具逐个迁移，保持工具名与用户行为不变。
+- [ ] 将 `spawn_thinking` 固化为 background tool。
+- [ ] 增加有界短工具循环。
+
+完成条件：增加新前台工具只需要定义、实现和测试，不修改 Realtime Gateway 主流程。
+
+### R3：Work Runtime
+
+- [ ] 从 TaskManager 提取 State Machine、Scheduler、Repository 和 Notification。
+- [ ] 区分 User Work 与 System Job。
+- [ ] 建立 Artifact 与统一 Authorization 模型。
+- [ ] 保持重启、取消和恰好一次结果投递语义。
+
+完成条件：Work Runtime 不包含任何 ACP 或后台产品名称。
+
+### R4：Backend Runtime
+
+- [ ] 定义并校验 BackendPort。
+- [ ] 将 AgentClient 收敛为 Single Backend Runtime。
+- [ ] 让 ACP Adapter 实现 BackendPort。
+- [ ] 将 Coordinator 和 Session 工具下沉到 ACP Adapter。
+- [ ] 为 Backend Adapter 建立 conformance test suite。
+
+完成条件：新增非 ACP Adapter 不修改 Frontend、Work 或客户端代码。
+
+### R5：完整前台能力
+
+- [ ] Web Search Provider、URL Fetch 和 Citation。
+- [ ] Knowledge Store、Document Extractor 和索引 System Job。
+- [ ] Full Context、Retrieval Provider 和 RAG 工具。
+- [ ] 路由、引用、打断、重复播报和 Prompt Injection 评测。
+
+完成条件：后台设置为 `none` 时，前台仍是完整的轻量 Chatbot。
+
+### R6：开放生态
+
+- [ ] MCP Client 与逐工具授权/启用策略。
+- [ ] OpenAPI Tool Adapter。
+- [ ] 轻量 Frontend Profile；暂不自创公开 Skill 标准。
+- [ ] Backend Adapter SDK 与示例。
+- [ ] 可选 A2A Backend Adapter。
+
+完成条件：外部扩展通过标准协议或公开 SDK 完成，不修改核心运行时。
+
+## 8. 仓库目标结构
+
+```text
+server/src/
+├── app/                  # composition root
+├── transport/            # HTTP / WebSocket / AG-UI projectors
+├── frontend/             # Chatbot runtime
+├── work/                 # user work domain
+├── backend/              # backend port/runtime/adapters
+├── providers/realtime/   # realtime provider adapters
+└── platform/             # config/identity/persistence/logging/security
+
+shared/                   # 迁移期公共协议与客户端运行时
+packages/                 # 接口稳定后再拆 protocol/client/backend-sdk workspace
+```
+
+不进行一次性目录搬迁。每次移动必须伴随职责提取和测试。
+
+## 9. 强制依赖规则
+
+```text
+frontend/        不得导入 backend/adapters/
+work/            不得导入 ACP、Session 或具体后台
+transport/       不得实现业务状态机
+providers/       不得调用 BackendPort
+backend/adapters 不得直接向客户端发事件
+clients          不得自行推导 Gateway 内部状态
+shared/protocol  不得依赖 server
+```
+
+## 10. 质量门禁
+
+- `npm run lint`
+- `npm test`
+- `npm run release:check`
+- 公共协议兼容测试
+- 无后台聊天测试
+- 后台工作不阻塞对话测试
+- 打断不取消已提交 Work 测试
+- 最终结果恰好一次播报测试
+- Adapter 和 Provider conformance tests
+
+重构 PR 默认不改变用户行为。行为变化必须独立提交、更新中英文文档并增加端到端测试。
+
+## 11. 非目标
+
+- 同时连接或自动路由多个后台 Agent；
+- 将前台建设成编程 Agent 或通用长任务 Agent；
+- 迁移到 Open WebUI、LiveKit 或其他完整平台；
+- 立即替换现有 Gateway 协议；
+- 自创新的 MCP、A2A 或 Skill 协议；
+- 为了统一而暴露后台 Session 和内部任务拓扑。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,4 +70,46 @@ export default [
       'react-hooks/exhaustive-deps': 'error',
     },
   },
+  // Architecture boundaries are executable constraints, not documentation
+  // conventions. During the staged runtime refactor these rules protect the
+  // dependencies that are already clean; new target directories will receive
+  // equivalent rules as they are introduced.
+  {
+    files: ['shared/**/*.{js,mjs,cjs}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['../server/**', '../../server/**', '../../../server/**'],
+          message: 'shared modules must not depend on the Gateway server',
+        }],
+      }],
+    },
+  },
+  {
+    files: ['server/src/task/**/*.{js,mjs,cjs}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [{
+          group: [
+            '../agent/**',
+            '../../agent/**',
+            '../voice/**',
+            '../../voice/**',
+          ],
+          message: 'the task domain must not depend on voice or backend adapters',
+        }],
+      }],
+    },
+  },
+  {
+    files: ['server/src/voice/**/*.{js,mjs,cjs}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['../agent/**', '../../agent/**', '../../../agent/**'],
+          message: 'the realtime frontend must use injected work/backend ports',
+        }],
+      }],
+    },
+  },
 ]

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "./gateway-process": "./shared/gateway-process.mjs",
     "./gateway-lease": "./shared/gateway-instance-lock.mjs",
     "./realtime-events": "./shared/realtime-events.mjs",
+    "./gateway-events": "./shared/protocol/gateway-events.mjs",
     "./gateway-application": "./server/src/app/gateway-application.mjs",
     "./realtime-provider": "./server/src/voice/realtime-provider-extension.mjs",
     "./settings": "./desktop/src/settings-store.mjs",

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import {
   GatewayClientEvent,
   GatewayServerEvent,
+  isGatewayClientEvent,
 } from '../../../shared/realtime-events.mjs'
 import { AnnouncementManager } from './announcement/announcement-manager.mjs'
 import { AnnouncementWindow } from './announcement/announcement-window.mjs'
@@ -1903,6 +1904,7 @@ export function attachRealtimeGateway(server, {
       } catch {
         return
       }
+      if (!isGatewayClientEvent(event)) return
       if (event.type === GatewayClientEvent.CONNECT) {
         descriptor = clientDescriptor(event)
         voiceClient.descriptor = descriptor

--- a/shared/protocol/gateway-events.mjs
+++ b/shared/protocol/gateway-events.mjs
@@ -1,0 +1,43 @@
+import { z } from 'zod'
+import {
+  GatewayClientEvent,
+  GatewayServerEvent,
+  GatewayTaskEvent,
+} from '../realtime-events.mjs'
+
+const values = object => Object.freeze(Object.values(object))
+
+export const GATEWAY_CLIENT_EVENT_NAMES = values(GatewayClientEvent)
+export const GATEWAY_SERVER_EVENT_NAMES = values(GatewayServerEvent)
+export const GATEWAY_TASK_EVENT_NAMES = values(GatewayTaskEvent)
+
+export const GatewayEventEnvelopeSchema = z.object({
+  type: z.string().min(1),
+}).passthrough()
+
+export const GatewayClientEventTypeSchema = z.enum(GATEWAY_CLIENT_EVENT_NAMES)
+export const GatewayServerEventTypeSchema = z.enum(GATEWAY_SERVER_EVENT_NAMES)
+export const GatewayTaskEventTypeSchema = z.enum(GATEWAY_TASK_EVENT_NAMES)
+
+// The first protocol boundary deliberately validates the stable envelope and
+// event namespace while preserving provider/client extension fields. Payload
+// schemas can now be tightened one event at a time without inventing a second
+// event registry or breaking compatible clients.
+export const GatewayClientMessageSchema = GatewayEventEnvelopeSchema.extend({
+  type: GatewayClientEventTypeSchema,
+})
+
+export const GatewayServerMessageSchema = GatewayEventEnvelopeSchema.extend({
+  type: z.union([
+    GatewayServerEventTypeSchema,
+    GatewayTaskEventTypeSchema,
+  ]),
+})
+
+export function parseGatewayClientMessage(value) {
+  return GatewayClientMessageSchema.parse(value)
+}
+
+export function parseGatewayServerMessage(value) {
+  return GatewayServerMessageSchema.parse(value)
+}

--- a/shared/realtime-events.mjs
+++ b/shared/realtime-events.mjs
@@ -50,6 +50,7 @@ export const GatewayServerEvent = Object.freeze({
 })
 
 export const GatewayTaskEvent = Object.freeze({
+  ACCEPTED: 'task.accepted',
   SCHEDULED: 'task.scheduled',
   SCHEDULED_FIRED: 'task.scheduled.fired',
   RUNNING: 'task.running',
@@ -74,3 +75,19 @@ export const GATEWAY_SERVER_EVENT_TYPES = new Set([
   ...Object.values(GatewayServerEvent),
   ...Object.values(GatewayTaskEvent),
 ])
+
+export function isGatewayClientEvent(value) {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && GATEWAY_CLIENT_EVENT_TYPES.has(value.type),
+  )
+}
+
+export function isGatewayServerEvent(value) {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && GATEWAY_SERVER_EVENT_TYPES.has(value.type),
+  )
+}

--- a/test/gateway-event-schema.test.mjs
+++ b/test/gateway-event-schema.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  GatewayClientMessageSchema,
+  GatewayServerMessageSchema,
+  parseGatewayClientMessage,
+  parseGatewayServerMessage,
+} from '../shared/protocol/gateway-events.mjs'
+
+test('validates client event envelopes and preserves extension fields', () => {
+  assert.deepEqual(parseGatewayClientMessage({
+    type: 'connect',
+    provider: 'dashscope',
+    clientExtension: { inputSampleRate: 16_000 },
+  }), {
+    type: 'connect',
+    provider: 'dashscope',
+    clientExtension: { inputSampleRate: 16_000 },
+  })
+
+  assert.equal(
+    GatewayClientMessageSchema.safeParse({ type: 'voice.ready' }).success,
+    false,
+  )
+  assert.equal(GatewayClientMessageSchema.safeParse(null).success, false)
+})
+
+test('validates voice and task messages in the server direction', () => {
+  assert.deepEqual(parseGatewayServerMessage({
+    type: 'voice.ready',
+    inputSampleRate: 16_000,
+    outputSampleRate: 24_000,
+  }), {
+    type: 'voice.ready',
+    inputSampleRate: 16_000,
+    outputSampleRate: 24_000,
+  })
+
+  assert.equal(
+    GatewayServerMessageSchema.safeParse({
+      type: 'task.accepted',
+      task: { id: 'work_1' },
+    }).success,
+    true,
+  )
+  assert.equal(
+    GatewayServerMessageSchema.safeParse({ type: 'connect' }).success,
+    false,
+  )
+})

--- a/test/realtime-events.test.mjs
+++ b/test/realtime-events.test.mjs
@@ -6,6 +6,8 @@ import {
   GatewayClientEvent,
   GatewayServerEvent,
   GatewayTaskEvent,
+  isGatewayClientEvent,
+  isGatewayServerEvent,
 } from '../shared/realtime-events.mjs'
 
 test('keeps Gateway realtime event names unique within each direction', () => {
@@ -48,4 +50,18 @@ test('defines the shared sleep wake lifecycle', () => {
     'wake',
     'voice.sleep',
   ])
+})
+
+test('defines every task event consumed by Gateway clients', () => {
+  assert.equal(GatewayTaskEvent.ACCEPTED, 'task.accepted')
+  assert.equal(GATEWAY_SERVER_EVENT_TYPES.has('task.accepted'), true)
+})
+
+test('recognizes event direction without throwing on malformed input', () => {
+  assert.equal(isGatewayClientEvent({ type: 'connect' }), true)
+  assert.equal(isGatewayClientEvent({ type: 'voice.ready' }), false)
+  assert.equal(isGatewayClientEvent(null), false)
+  assert.equal(isGatewayServerEvent({ type: 'voice.ready' }), true)
+  assert.equal(isGatewayServerEvent({ type: 'task.accepted' }), true)
+  assert.equal(isGatewayServerEvent('voice.ready'), false)
 })


### PR DESCRIPTION
## Summary

- define the bilingual roadmap for a Realtime Voice Chatbot Runtime connected to one user-configured Backend Action Agent
- freeze dependency direction with lint-enforced boundaries
- add a public, extensible Gateway event schema and safe client-event ingress guard
- register the previously implicit `task.accepted` event and cover the contract with tests

Tracks #185.

## Design constraints

- `spawn_thinking` remains the only model-visible frontend-to-backend handoff
- the frontend does not choose backend sessions, tools, or delegation strategy
- no current event names or user-visible behavior are removed
- provider and client extension fields remain forward-compatible

## Verification

- `npm run lint`
- root tests: 64 tests, 63 passed, 1 skipped
- server tests: 288 passed (`node --test --test-force-exit`; local environment retains an unrelated long-lived handle after completion)
- WebUI, TUI, Desktop, and CLI workspace tests passed
- `npm pack --dry-run --json`; `shared/protocol/gateway-events.mjs` is included
- package self-reference import for `qwen-audio-agent/gateway-events` passed
