### PR TITLE
refactor: project Task events at the Gateway boundary

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -61,6 +61,7 @@ is unsupported and breaks without notice.
 | `qwen-audio-agent/gateway-process` | `GatewayProcess`, `createGatewayProcess`, `GATEWAY_READY_MESSAGE`, `DEFAULT_GATEWAY_ENTRY`, `validateGatewayOrigin`, `portInUse` |
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`, `findRunningGateway`, `acquireGatewayLease` |
 | `qwen-audio-agent/realtime-events` | `GatewayClientEvent`, `GatewayServerEvent`, `GatewayTaskEvent` |
+| `qwen-audio-agent/gateway-events` | Gateway event Zod schemas and parsers |
 | `qwen-audio-agent/settings` | `createSettingsStore` |
 | `qwen-audio-agent/skin-store` | `importSkin`, `listSkins`, `removeSkin`, `effectiveOrbSkin`, `skinsDirectory`, `validateSkinPackage` |
 | `qwen-audio-agent/orb/main` | `bindOrbShell`, `configureOrbWindow`, `ORB_CHANNELS` |

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -54,6 +54,7 @@
 | `qwen-audio-agent/gateway-process` | `GatewayProcess`、`createGatewayProcess`、`GATEWAY_READY_MESSAGE`、`DEFAULT_GATEWAY_ENTRY`、`validateGatewayOrigin`、`portInUse` |
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`、`findRunningGateway`、`acquireGatewayLease` |
 | `qwen-audio-agent/realtime-events` | `GatewayClientEvent`、`GatewayServerEvent`、`GatewayTaskEvent` |
+| `qwen-audio-agent/gateway-events` | Gateway 事件 Zod Schema 与解析函数 |
 | `qwen-audio-agent/settings` | `createSettingsStore` |
 | `qwen-audio-agent/skin-store` | `importSkin`、`listSkins`、`removeSkin`、`effectiveOrbSkin`、`skinsDirectory`、`validateSkinPackage` |
 | `qwen-audio-agent/orb/main` | `bindOrbShell`、`configureOrbWindow`、`ORB_CHANNELS` |

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -37,6 +37,10 @@ import {
 import { ReminderScheduler } from '../task/reminder-scheduler.mjs'
 import { webDistributionPath } from '../core/install-paths.mjs'
 import { installOfflineNotifications } from './offline-notifications.mjs'
+import {
+  projectGatewayTaskEvent,
+  projectGatewayTaskSnapshot,
+} from '../transport/gateway-task-event-projector.mjs'
 
 export function createGatewayApplication({
   config = defaultConfig,
@@ -409,10 +413,11 @@ app.get('/api/tasks/:id/events', (req, res) => {
   res.setHeader('Connection', 'keep-alive')
   res.flushHeaders()
   const write = event => res.write(`data: ${JSON.stringify(event)}\n\n`)
-  write({ type: 'task.snapshot', task })
+  write(projectGatewayTaskSnapshot(task))
   const unsubscribe = taskManager.subscribe(event => {
     if (event.ownerId === req.identity.ownerId && event.task.id === req.params.id) {
-      write({ type: event.type, task: event.task })
+      const publicEvent = projectGatewayTaskEvent(event)
+      if (publicEvent) write(publicEvent)
     }
   })
   res.on('close', unsubscribe)

--- a/server/src/app/offline-notifications.mjs
+++ b/server/src/app/offline-notifications.mjs
@@ -1,3 +1,5 @@
+import { TaskDomainEvent } from '../task/task-events.mjs'
+
 export function installOfflineNotifications({
   taskManager,
   parentPort,
@@ -6,15 +8,15 @@ export function installOfflineNotifications({
 } = {}) {
   return taskManager.subscribe(event => {
     if (![
-      'task.progress.check',
-      'task.notification.pending',
+      TaskDomainEvent.PROGRESS_CHECK,
+      TaskDomainEvent.NOTIFICATION_PENDING,
     ].includes(event.type)) return
     const timer = setTimer(() => {
       const current = taskManager.get(event.task.id, {
         ownerId: event.ownerId,
       })
       if (!current) return
-      if (event.type === 'task.progress.check') {
+      if (event.type === TaskDomainEvent.PROGRESS_CHECK) {
         if (current.workState !== 'active') return
         parentPort?.postMessage({
           type: 'qwen-audio-agent:offline-notification',

--- a/server/src/task/reminder-scheduler.mjs
+++ b/server/src/task/reminder-scheduler.mjs
@@ -1,3 +1,5 @@
+import { TaskDomainEvent } from './task-events.mjs'
+
 /**
  * ReminderScheduler — setTimeout-driven scheduler for scheduled tasks.
  *
@@ -24,7 +26,10 @@ export class ReminderScheduler {
 
     // Re-arm whenever a new scheduled task is created or cancelled.
     this.unsubscribe = this.taskManager.subscribe(event => {
-      if (event.type === 'task.scheduled' || event.type === 'task.cancelled') {
+      if (
+        event.type === TaskDomainEvent.SCHEDULED
+        || event.type === TaskDomainEvent.CANCELLED
+      ) {
         this.reschedule()
       }
     })
@@ -64,7 +69,7 @@ export class ReminderScheduler {
       const timer = setTimeout(() => {
         if (task.status !== 'scheduled') return
         task.status = 'queued'
-        this.taskManager.emit('task.scheduled.fired', task)
+        this.taskManager.emit(TaskDomainEvent.SCHEDULED_FIRED, task)
         this.taskManager.persistDeferred()
         this.taskManager.drain()
       }, delay)

--- a/server/src/task/task-events.mjs
+++ b/server/src/task/task-events.mjs
@@ -1,0 +1,22 @@
+export const TaskDomainEvent = Object.freeze({
+  ACCEPTED: 'task.accepted',
+  SCHEDULED: 'task.scheduled',
+  SCHEDULED_FIRED: 'task.scheduled.fired',
+  RUNNING: 'task.running',
+  DELEGATED: 'task.delegated',
+  FINALIZING: 'task.finalizing',
+  CANCELLING: 'task.cancelling',
+  PROGRESS: 'task.progress',
+  PROGRESS_CHECK: 'task.progress.check',
+  COMPLETED: 'task.completed',
+  FAILED: 'task.failed',
+  CANCELLED: 'task.cancelled',
+  PERMISSION_REQUESTED: 'task.permission.requested',
+  PERMISSION_RESOLVED: 'task.permission.resolved',
+  NOTIFICATION_PENDING: 'task.notification.pending',
+  NOTIFICATION_DELIVERED: 'task.notification.delivered',
+})
+
+export const TASK_DOMAIN_EVENT_TYPES = new Set(
+  Object.values(TaskDomainEvent),
+)

--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { config } from '../core/config.mjs'
 import { TaskScheduler } from './task-scheduler.mjs'
 import { TaskStore } from './task-store.mjs'
+import { TaskDomainEvent } from './task-events.mjs'
 import { logger } from '../core/logger.mjs'
 
 const ACTIVE = new Set([
@@ -273,8 +274,8 @@ export class TaskManager {
         task.notificationStatus = 'pending'
         task.promise = Promise.resolve(publicTask(task))
         task.resolve = null
-        this.emit('task.failed', task)
-        this.emit('task.notification.pending', task)
+        this.emit(TaskDomainEvent.FAILED, task)
+        this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
         continue
       }
       task.runner = (_objective, context) => runner(snapshot, context)
@@ -319,15 +320,15 @@ export class TaskManager {
       ...details,
     }
     const log = [
-      'task.scheduled',
+      TaskDomainEvent.SCHEDULED,
       'task.created',
-      'task.running',
-      'task.delegated',
-      'task.permission.requested',
-      'task.permission.resolved',
-      'task.completed',
-      'task.failed',
-      'task.cancelled',
+      TaskDomainEvent.RUNNING,
+      TaskDomainEvent.DELEGATED,
+      TaskDomainEvent.PERMISSION_REQUESTED,
+      TaskDomainEvent.PERMISSION_RESOLVED,
+      TaskDomainEvent.COMPLETED,
+      TaskDomainEvent.FAILED,
+      TaskDomainEvent.CANCELLED,
     ].includes(type) ? this.logger?.info : this.logger?.debug
     log?.(type, {
       taskId: task.id,
@@ -414,7 +415,7 @@ export class TaskManager {
       task.resolve = resolve
     })
     this.tasks.set(task.id, task)
-    this.emit('task.accepted', task)
+    this.emit(TaskDomainEvent.ACCEPTED, task)
     queueMicrotask(() => this.drain())
     return { ...publicTask(task), reused: false }
   }
@@ -476,7 +477,7 @@ export class TaskManager {
       task.resolve = resolve
     })
     this.tasks.set(task.id, task)
-    this.emit('task.scheduled', task)
+    this.emit(TaskDomainEvent.SCHEDULED, task)
     // Do not call drain() — scheduled tasks wait for their timer.
     return { ...publicTask(task), reused: false }
   }
@@ -500,24 +501,24 @@ export class TaskManager {
     task.abortController = new AbortController()
     this.scheduler.acquire(task)
     task.schedulerHeld = true
-    this.emit('task.running', task)
+    this.emit(TaskDomainEvent.RUNNING, task)
     task.progressTimer = setInterval(() => {
       if (ACTIVE.has(task.status)) {
-        this.emit('task.progress', task, { persist: false })
+        this.emit(TaskDomainEvent.PROGRESS, task, { persist: false })
       }
     }, 1000)
     task.progressTimer.unref?.()
     const onEvent = event => {
       if (event?.type === 'backend.permission.requested' && event.permission) {
         task.authorization = { ...event.permission }
-        this.emit('task.permission.requested', task)
+        this.emit(TaskDomainEvent.PERMISSION_REQUESTED, task)
         return
       }
       if (event?.type === 'backend.permission.resolved' && event.permission) {
         if (task.authorization?.id === event.permission.id) {
           task.authorization = null
         }
-        this.emit('task.permission.resolved', task, {
+        this.emit(TaskDomainEvent.PERMISSION_RESOLVED, task, {
           permission: { ...event.permission },
         })
         return
@@ -530,7 +531,7 @@ export class TaskManager {
           this.scheduler.release(task)
           task.schedulerHeld = false
         }
-        this.emit('task.delegated', task)
+        this.emit(TaskDomainEvent.DELEGATED, task)
         this.drain()
         return
       }
@@ -540,7 +541,7 @@ export class TaskManager {
       ) {
         task.status = 'finalizing'
         task.delegation = { ...event.delegation, status: 'completed' }
-        this.emit('task.finalizing', task)
+        this.emit(TaskDomainEvent.FINALIZING, task)
         return
       }
       if (event?.type !== 'backend.activity' || !event.activity) return
@@ -551,7 +552,7 @@ export class TaskManager {
       if (index >= 0) task.activity[index] = activity
       else task.activity.push(activity)
       task.activity = task.activity.slice(-20)
-      this.emit('task.progress', task, { persist: false })
+      this.emit(TaskDomainEvent.PROGRESS, task, { persist: false })
       this.persistDeferred()
     }
     // Fallback runner for restored scheduled tasks whose runner was lost
@@ -588,8 +589,8 @@ export class TaskManager {
             this.scheduler.release(task)
             task.schedulerHeld = false
           }
-          this.emit('task.failed', task)
-          this.emit('task.notification.pending', task)
+          this.emit(TaskDomainEvent.FAILED, task)
+          this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
           this.persistDeferred()
           this.drain()
         }, 5000)
@@ -628,7 +629,7 @@ export class TaskManager {
           message = `任务"${task.objective.slice(0, 80)}"`
             + `已运行 ${elapsedMin} 分钟，正在处理中`
         }
-        this.emit('task.progress.check', task, {
+        this.emit(TaskDomainEvent.PROGRESS_CHECK, task, {
           persist: false,
           message,
           delegated: task.status === 'delegated',
@@ -691,10 +692,12 @@ export class TaskManager {
           task.schedulerHeld = false
         }
         this.emit(
-          task.status === 'completed' ? 'task.completed' : 'task.failed',
+          task.status === 'completed'
+            ? TaskDomainEvent.COMPLETED
+            : TaskDomainEvent.FAILED,
           task,
         )
-        this.emit('task.notification.pending', task)
+        this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
         task.resolve?.(publicTask(task))
         this.prune()
         this.drain()
@@ -717,7 +720,7 @@ export class TaskManager {
     }
     task.status = 'cancelling'
     task.authorization = null
-    this.emit('task.cancelling', task)
+    this.emit(TaskDomainEvent.CANCELLING, task)
     task.cancelPromise = Promise.resolve()
       .then(async () => {
         if (task.canceler) {
@@ -758,8 +761,8 @@ export class TaskManager {
           this.scheduler.release(task)
           task.schedulerHeld = false
         }
-        this.emit('task.failed', task)
-        this.emit('task.notification.pending', task)
+        this.emit(TaskDomainEvent.FAILED, task)
+        this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
         task.resolve?.(publicTask(task))
         this.prune()
         this.drain()
@@ -787,7 +790,7 @@ export class TaskManager {
       this.scheduler.release(task)
       task.schedulerHeld = false
     }
-    this.emit('task.cancelled', task)
+    this.emit(TaskDomainEvent.CANCELLED, task)
     task.resolve?.(publicTask(task))
     this.prune()
     this.drain()
@@ -881,7 +884,9 @@ export class TaskManager {
       task.notificationClaimedAt = null
       task.notificationDeliveredAt = Date.now()
       delivered += 1
-      this.emit('task.notification.delivered', task, { persist: false })
+      this.emit(TaskDomainEvent.NOTIFICATION_DELIVERED, task, {
+        persist: false,
+      })
     }
     if (delivered) this.persist()
     return delivered

--- a/server/src/transport/gateway-task-event-projector.mjs
+++ b/server/src/transport/gateway-task-event-projector.mjs
@@ -1,0 +1,70 @@
+import {
+  GatewayTaskEventMessageSchema,
+} from '../../../shared/protocol/gateway-events.mjs'
+import { GatewayTaskEvent } from '../../../shared/realtime-events.mjs'
+import { TaskDomainEvent } from '../task/task-events.mjs'
+
+const PUBLIC_EVENT_TYPE = new Map([
+  [TaskDomainEvent.ACCEPTED, GatewayTaskEvent.ACCEPTED],
+  [TaskDomainEvent.SCHEDULED, GatewayTaskEvent.SCHEDULED],
+  [TaskDomainEvent.SCHEDULED_FIRED, GatewayTaskEvent.SCHEDULED_FIRED],
+  [TaskDomainEvent.RUNNING, GatewayTaskEvent.RUNNING],
+  [TaskDomainEvent.DELEGATED, GatewayTaskEvent.DELEGATED],
+  [TaskDomainEvent.FINALIZING, GatewayTaskEvent.FINALIZING],
+  [TaskDomainEvent.CANCELLING, GatewayTaskEvent.CANCELLING],
+  [TaskDomainEvent.PROGRESS, GatewayTaskEvent.PROGRESS],
+  [TaskDomainEvent.PROGRESS_CHECK, GatewayTaskEvent.PROGRESS_CHECK],
+  [TaskDomainEvent.COMPLETED, GatewayTaskEvent.COMPLETED],
+  [TaskDomainEvent.FAILED, GatewayTaskEvent.FAILED],
+  [TaskDomainEvent.CANCELLED, GatewayTaskEvent.CANCELLED],
+  [
+    TaskDomainEvent.PERMISSION_REQUESTED,
+    GatewayTaskEvent.PERMISSION_REQUESTED,
+  ],
+  [
+    TaskDomainEvent.PERMISSION_RESOLVED,
+    GatewayTaskEvent.PERMISSION_RESOLVED,
+  ],
+  [
+    TaskDomainEvent.NOTIFICATION_PENDING,
+    GatewayTaskEvent.NOTIFICATION_PENDING,
+  ],
+  [
+    TaskDomainEvent.NOTIFICATION_DELIVERED,
+    GatewayTaskEvent.NOTIFICATION_DELIVERED,
+  ],
+])
+
+function publicDetails(event) {
+  return {
+    ...(
+      event.permission && typeof event.permission === 'object'
+        ? { permission: event.permission }
+        : {}
+    ),
+    ...(
+      typeof event.message === 'string'
+        ? { message: event.message }
+        : {}
+    ),
+  }
+}
+
+export function projectGatewayTaskEvent(event) {
+  if (!event || typeof event !== 'object') return null
+  const type = PUBLIC_EVENT_TYPE.get(event.type)
+  if (!type || !event.task || typeof event.task !== 'object') return null
+  return GatewayTaskEventMessageSchema.parse({
+    type,
+    task: event.task,
+    ...publicDetails(event),
+  })
+}
+
+export function projectGatewayTaskSnapshot(task) {
+  if (!task || typeof task !== 'object') return null
+  return GatewayTaskEventMessageSchema.parse({
+    type: GatewayTaskEvent.SNAPSHOT,
+    task,
+  })
+}

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -19,7 +19,9 @@ import {
 } from './realtime-provider.mjs'
 import { isAllowedOrigin } from '../core/request-security.mjs'
 import { taskManager } from '../task/task-manager.mjs'
+import { TaskDomainEvent } from '../task/task-events.mjs'
 import { recordTaskResult } from '../conversation/task-result-projector.mjs'
+import { projectGatewayTaskEvent } from '../transport/gateway-task-event-projector.mjs'
 import { ToolCallHandler } from './tools/tool-call-handler.mjs'
 import { TurnTranscripts } from './tools/turn-transcripts.mjs'
 import { TurnCorrelation } from './turn-correlation.mjs'
@@ -842,7 +844,7 @@ export function attachRealtimeGateway(server, {
     const unsubscribeTasks = taskManager.subscribe(event => {
       const task = event.task
       if (event.ownerId !== ownerId) return
-      if (event.type === 'task.progress.check') {
+      if (event.type === TaskDomainEvent.PROGRESS_CHECK) {
         if (task.sessionId !== sessionId) return
         if (!outputEnabled || !frontend?.ready) return
         const progressContext = {
@@ -872,7 +874,7 @@ export function attachRealtimeGateway(server, {
         })
         return
       }
-      if (event.type === 'task.notification.pending') {
+      if (event.type === TaskDomainEvent.NOTIFICATION_PENDING) {
         if (sleeping) {
           wakeFromSleep()
           return
@@ -883,19 +885,16 @@ export function attachRealtimeGateway(server, {
         return
       }
       if (task.sessionId !== sessionId) return
-      send(ws, {
-        type: event.type,
-        task,
-        ...(event.permission ? { permission: event.permission } : {}),
-      })
-      if (event.type === 'task.permission.requested') {
+      const publicEvent = projectGatewayTaskEvent(event)
+      if (publicEvent) send(ws, publicEvent)
+      if (event.type === TaskDomainEvent.PERMISSION_REQUESTED) {
         if (sleeping) {
           wakeFromSleep()
           return
         }
         announcePermission(task)
       }
-      if (event.type === 'task.permission.resolved') {
+      if (event.type === TaskDomainEvent.PERMISSION_RESOLVED) {
         const authorizationId = event.permission?.id
         if (authorizationId) {
           // 已进入对话的权限询问被其它通道（如 WebUI 按钮）处理后，把结果
@@ -926,7 +925,7 @@ export function attachRealtimeGateway(server, {
           }
         }
       }
-      if (event.type === 'task.delegated') {
+      if (event.type === TaskDomainEvent.DELEGATED) {
         const presentation = task.delegation?.presentation
         if (presentation?.inline?.content) {
           send(ws, {
@@ -940,7 +939,10 @@ export function attachRealtimeGateway(server, {
           })
         }
       }
-      if (['task.completed', 'task.failed'].includes(event.type)) {
+      if ([
+        TaskDomainEvent.COMPLETED,
+        TaskDomainEvent.FAILED,
+      ].includes(event.type)) {
         recordResult(task)
         const inline = task.resultMetadata?.presentation?.inline
         if (inline?.content) {

--- a/server/test/dependency-boundaries.test.mjs
+++ b/server/test/dependency-boundaries.test.mjs
@@ -8,13 +8,29 @@ const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../src')
 const projectRoot = resolve(sourceRoot, '../..')
 const sharedRoot = resolve(sourceRoot, '../../shared')
 const allowedDependencies = {
-  app: new Set(['agent', 'app', 'conversation', 'core', 'task', 'voice']),
+  app: new Set([
+    'agent',
+    'app',
+    'conversation',
+    'core',
+    'task',
+    'transport',
+    'voice',
+  ]),
   process: new Set(['process', 'shared']),
   core: new Set(['core', 'shared']),
   agent: new Set(['agent', 'core', 'shared']),
   conversation: new Set(['conversation', 'core', 'shared']),
   task: new Set(['agent', 'core', 'task']),
-  voice: new Set(['conversation', 'core', 'shared', 'task', 'voice']),
+  transport: new Set(['shared', 'task', 'transport']),
+  voice: new Set([
+    'conversation',
+    'core',
+    'shared',
+    'task',
+    'transport',
+    'voice',
+  ]),
 }
 
 function sourceFiles(directory) {

--- a/server/test/gateway-task-event-projector.test.mjs
+++ b/server/test/gateway-task-event-projector.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { GatewayTaskEvent } from '../../shared/realtime-events.mjs'
+import { TaskDomainEvent } from '../src/task/task-events.mjs'
+import {
+  projectGatewayTaskEvent,
+  projectGatewayTaskSnapshot,
+} from '../src/transport/gateway-task-event-projector.mjs'
+
+function task(overrides = {}) {
+  return {
+    id: 'work_1',
+    workId: 'work_1',
+    jobId: 'job_1',
+    workState: 'active',
+    status: 'running',
+    kind: 'work',
+    objective: 'inspect the system',
+    createdAt: 1,
+    elapsedMs: 0,
+    result: null,
+    error: null,
+    ...overrides,
+  }
+}
+
+test('projects every Task domain event into an explicit public event', () => {
+  for (const type of Object.values(TaskDomainEvent)) {
+    const projected = projectGatewayTaskEvent({
+      type,
+      ownerId: 'internal-owner-routing-key',
+      task: task(),
+    })
+    assert.ok(projected, `missing public projection for ${type}`)
+    assert.equal(projected.type, type)
+    assert.equal('ownerId' in projected, false)
+  }
+})
+
+test('keeps public details and strips undeclared Task fields', () => {
+  const projected = projectGatewayTaskEvent({
+    type: TaskDomainEvent.PERMISSION_REQUESTED,
+    task: task({ internalSchedulerLane: 'coordinator:owner' }),
+    permission: { id: 'permission_1', summary: 'run command' },
+    message: 'public progress',
+    privateReason: 'adapter-only',
+  })
+
+  assert.deepEqual(projected.permission, {
+    id: 'permission_1',
+    summary: 'run command',
+  })
+  assert.equal(projected.message, 'public progress')
+  assert.equal('internalSchedulerLane' in projected.task, false)
+  assert.equal('privateReason' in projected, false)
+})
+
+test('projects a reconnect snapshot through the same Task schema', () => {
+  const projected = projectGatewayTaskSnapshot(task({
+    status: 'queued',
+    privateStoreVersion: 2,
+  }))
+
+  assert.equal(projected.type, GatewayTaskEvent.SNAPSHOT)
+  assert.equal(projected.task.status, 'queued')
+  assert.equal('privateStoreVersion' in projected.task, false)
+})
+
+test('does not expose malformed or unrelated internal events', () => {
+  assert.equal(projectGatewayTaskEvent(null), null)
+  assert.equal(projectGatewayTaskEvent({ type: 'backend.activity' }), null)
+  assert.equal(projectGatewayTaskSnapshot(null), null)
+})

--- a/shared/protocol/gateway-events.mjs
+++ b/shared/protocol/gateway-events.mjs
@@ -15,6 +15,35 @@ export const GatewayEventEnvelopeSchema = z.object({
   type: z.string().min(1),
 }).passthrough()
 
+export const GatewayTaskSchema = z.object({
+  id: z.string().min(1),
+  workId: z.string().min(1),
+  jobId: z.string().min(1),
+  workState: z.string().min(1),
+  status: z.string().min(1),
+  kind: z.string().min(1),
+  parentWorkId: z.string().nullable().optional(),
+  objective: z.string(),
+  ownerId: z.string().optional(),
+  sessionId: z.string().optional(),
+  turnId: z.string().nullable().optional(),
+  createdAt: z.number(),
+  startedAt: z.number().nullable().optional(),
+  completedAt: z.number().nullable().optional(),
+  elapsedMs: z.number(),
+  result: z.string().nullable().optional(),
+  error: z.string().nullable().optional(),
+  resultMetadata: z.unknown().optional(),
+  activity: z.array(z.unknown()).optional(),
+  delegation: z.unknown().optional(),
+  authorization: z.unknown().optional(),
+  notificationStatus: z.string().optional(),
+  notificationDeliveredAt: z.number().nullable().optional(),
+  schedule: z.unknown().optional(),
+  timeoutMs: z.number().nullable().optional(),
+  progressCheckMs: z.number().nullable().optional(),
+})
+
 export const GatewayClientEventTypeSchema = z.enum(GATEWAY_CLIENT_EVENT_NAMES)
 export const GatewayServerEventTypeSchema = z.enum(GATEWAY_SERVER_EVENT_NAMES)
 export const GatewayTaskEventTypeSchema = z.enum(GATEWAY_TASK_EVENT_NAMES)
@@ -27,12 +56,21 @@ export const GatewayClientMessageSchema = GatewayEventEnvelopeSchema.extend({
   type: GatewayClientEventTypeSchema,
 })
 
-export const GatewayServerMessageSchema = GatewayEventEnvelopeSchema.extend({
-  type: z.union([
-    GatewayServerEventTypeSchema,
-    GatewayTaskEventTypeSchema,
-  ]),
+export const GatewayVoiceMessageSchema = GatewayEventEnvelopeSchema.extend({
+  type: GatewayServerEventTypeSchema,
 })
+
+export const GatewayTaskEventMessageSchema = GatewayEventEnvelopeSchema.extend({
+  type: GatewayTaskEventTypeSchema,
+  task: GatewayTaskSchema,
+  permission: z.record(z.string(), z.unknown()).optional(),
+  message: z.string().optional(),
+})
+
+export const GatewayServerMessageSchema = z.union([
+  GatewayVoiceMessageSchema,
+  GatewayTaskEventMessageSchema,
+])
 
 export function parseGatewayClientMessage(value) {
   return GatewayClientMessageSchema.parse(value)

--- a/shared/realtime-events.mjs
+++ b/shared/realtime-events.mjs
@@ -50,6 +50,7 @@ export const GatewayServerEvent = Object.freeze({
 })
 
 export const GatewayTaskEvent = Object.freeze({
+  SNAPSHOT: 'task.snapshot',
   ACCEPTED: 'task.accepted',
   SCHEDULED: 'task.scheduled',
   SCHEDULED_FIRED: 'task.scheduled.fired',
@@ -64,6 +65,8 @@ export const GatewayTaskEvent = Object.freeze({
   CANCELLED: 'task.cancelled',
   PERMISSION_REQUESTED: 'task.permission.requested',
   PERMISSION_RESOLVED: 'task.permission.resolved',
+  NOTIFICATION_PENDING: 'task.notification.pending',
+  NOTIFICATION_DELIVERED: 'task.notification.delivered',
   NOTIFICATION_OFFLINE: 'task.notification.offline',
 })
 

--- a/test/gateway-event-schema.test.mjs
+++ b/test/gateway-event-schema.test.mjs
@@ -7,6 +7,21 @@ import {
   parseGatewayServerMessage,
 } from '../shared/protocol/gateway-events.mjs'
 
+function task(overrides = {}) {
+  return {
+    id: 'work_1',
+    workId: 'work_1',
+    jobId: 'job_1',
+    workState: 'active',
+    status: 'running',
+    kind: 'work',
+    objective: 'test work',
+    createdAt: 1,
+    elapsedMs: 0,
+    ...overrides,
+  }
+}
+
 test('validates client event envelopes and preserves extension fields', () => {
   assert.deepEqual(parseGatewayClientMessage({
     type: 'connect',
@@ -39,9 +54,16 @@ test('validates voice and task messages in the server direction', () => {
   assert.equal(
     GatewayServerMessageSchema.safeParse({
       type: 'task.accepted',
-      task: { id: 'work_1' },
+      task: task(),
     }).success,
     true,
+  )
+  assert.equal(
+    GatewayServerMessageSchema.safeParse({
+      type: 'task.accepted',
+      task: { id: 'work_1' },
+    }).success,
+    false,
   )
   assert.equal(
     GatewayServerMessageSchema.safeParse({ type: 'connect' }).success,

--- a/test/realtime-events.test.mjs
+++ b/test/realtime-events.test.mjs
@@ -53,8 +53,20 @@ test('defines the shared sleep wake lifecycle', () => {
 })
 
 test('defines every task event consumed by Gateway clients', () => {
-  assert.equal(GatewayTaskEvent.ACCEPTED, 'task.accepted')
-  assert.equal(GATEWAY_SERVER_EVENT_TYPES.has('task.accepted'), true)
+  assert.deepEqual([
+    GatewayTaskEvent.SNAPSHOT,
+    GatewayTaskEvent.ACCEPTED,
+    GatewayTaskEvent.NOTIFICATION_PENDING,
+    GatewayTaskEvent.NOTIFICATION_DELIVERED,
+  ], [
+    'task.snapshot',
+    'task.accepted',
+    'task.notification.pending',
+    'task.notification.delivered',
+  ])
+  for (const event of Object.values(GatewayTaskEvent)) {
+    assert.equal(GATEWAY_SERVER_EVENT_TYPES.has(event), true)
+  }
 })
 
 test('recognizes event direction without throwing on malformed input', () => {


### PR DESCRIPTION
## Summary

- define the complete internal `TaskDomainEvent` registry
- project Task domain events into the public Gateway protocol instead of forwarding internal event objects
- validate and sanitize the public Task payload with Zod while preserving every current client field
- route both realtime WebSocket events and task SSE snapshots through the projector
- register previously implicit snapshot and notification lifecycle events
- document the public `qwen-audio-agent/gateway-events` entry point

Part of #185 (R1: protocol and client state).

## Compatibility

- existing public `task.*` event names are unchanged
- WebUI, TUI, Desktop, and task SSE continue to receive the current Task fields
- internal routing/detail fields are no longer able to leak into the client protocol accidentally
- `task.progress.check` and pending-notification behavior in the realtime voice path is unchanged

## Verification

- lint passed
- root: 64 tests (63 passed, 1 skipped)
- server: 538 passed
- WebUI, TUI, Desktop, and CLI workspace suites passed
- WebUI production build passed
- npm package verification passed (226 files)
