### PR TITLE
refactor: share Gateway client state reducer

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -62,6 +62,7 @@ is unsupported and breaks without notice.
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`, `findRunningGateway`, `acquireGatewayLease` |
 | `qwen-audio-agent/realtime-events` | `GatewayClientEvent`, `GatewayServerEvent`, `GatewayTaskEvent` |
 | `qwen-audio-agent/gateway-events` | Gateway event Zod schemas and parsers |
+| `qwen-audio-agent/gateway-client-state` | `createGatewayClientState`, `reduceGatewayClientState`, `acceptsGatewayVoiceState` |
 | `qwen-audio-agent/settings` | `createSettingsStore` |
 | `qwen-audio-agent/skin-store` | `importSkin`, `listSkins`, `removeSkin`, `effectiveOrbSkin`, `skinsDirectory`, `validateSkinPackage` |
 | `qwen-audio-agent/orb/main` | `bindOrbShell`, `configureOrbWindow`, `ORB_CHANNELS` |
@@ -146,6 +147,17 @@ spells them by hand is on its own.
 | server → client | `input.suspend` | Stop capturing outright (stronger than user-level mute: no capture, no wake word); carries `owner`, `reason`, `expiresAt` |
 | server → client | `input.resume` | Capture may resume |
 | client → server | `input.suspend.ack` | Confirms the suspension took effect on this client |
+
+### Shared client state
+
+`qwen-audio-agent/gateway-client-state` folds public Gateway events into the
+side-effect-free client state fields `connectionState`, `voiceState`,
+`wakeWordActive`, `ownership`, and `currentTurnId`.
+`reduceGatewayClientState(state, event)` preserves object identity for unknown
+events and consistently ignores direct-model `voice.state` updates from stale
+turns. Clients still own playback, microphone, and UI side effects; they should
+not duplicate this protocol-state interpretation. Locked by
+`test/gateway-client-state.test.mjs`.
 
 ## Instance lease
 

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -55,6 +55,7 @@
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`、`findRunningGateway`、`acquireGatewayLease` |
 | `qwen-audio-agent/realtime-events` | `GatewayClientEvent`、`GatewayServerEvent`、`GatewayTaskEvent` |
 | `qwen-audio-agent/gateway-events` | Gateway 事件 Zod Schema 与解析函数 |
+| `qwen-audio-agent/gateway-client-state` | `createGatewayClientState`、`reduceGatewayClientState`、`acceptsGatewayVoiceState` |
 | `qwen-audio-agent/settings` | `createSettingsStore` |
 | `qwen-audio-agent/skin-store` | `importSkin`、`listSkins`、`removeSkin`、`effectiveOrbSkin`、`skinsDirectory`、`validateSkinPackage` |
 | `qwen-audio-agent/orb/main` | `bindOrbShell`、`configureOrbWindow`、`ORB_CHANNELS` |
@@ -136,6 +137,15 @@ await orb.load()
 | 服务端 → 客户端 | `input.suspend` | 立即停止采集（比用户级静音更强：不采集、不做唤醒词检测）；携带 `owner`、`reason`、`expiresAt` |
 | 服务端 → 客户端 | `input.resume` | 可以恢复采集 |
 | 客户端 → 服务端 | `input.suspend.ack` | 确认抢占已在本客户端生效 |
+
+### 共享客户端状态
+
+`qwen-audio-agent/gateway-client-state` 将公开 Gateway 事件归并为无副作用的客户端
+状态：`connectionState`、`voiceState`、`wakeWordActive`、`ownership` 与
+`currentTurnId`。`reduceGatewayClientState(state, event)` 对未知事件保持原对象不变，
+并统一忽略来自旧轮次的直连模型 `voice.state`；客户端仍自行处理音频播放、麦克风和
+界面副作用，不应再复制这部分协议状态判断。锁定测试：
+`test/gateway-client-state.test.mjs`。
 
 ## 实例租约
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "./gateway-lease": "./shared/gateway-instance-lock.mjs",
     "./realtime-events": "./shared/realtime-events.mjs",
     "./gateway-events": "./shared/protocol/gateway-events.mjs",
+    "./gateway-client-state": "./shared/gateway-client-state.mjs",
     "./gateway-application": "./server/src/app/gateway-application.mjs",
     "./realtime-provider": "./server/src/voice/realtime-provider-extension.mjs",
     "./settings": "./desktop/src/settings-store.mjs",

--- a/shared/gateway-client-state.mjs
+++ b/shared/gateway-client-state.mjs
@@ -1,0 +1,98 @@
+import { GatewayServerEvent } from './realtime-events.mjs'
+
+const DEFAULT_OWNERSHIP = Object.freeze({
+  state: 'available',
+  holder: null,
+})
+
+export function createGatewayClientState({
+  connectionState = 'connecting',
+} = {}) {
+  return {
+    connectionState,
+    voiceState: 'idle',
+    wakeWordActive: false,
+    ownership: { ...DEFAULT_OWNERSHIP },
+    currentTurnId: '',
+  }
+}
+
+export function acceptsGatewayVoiceState(event, currentTurnId) {
+  return (
+    !event?.turnId
+    || event.turnId === currentTurnId
+    || event.origin !== 'model'
+  )
+}
+
+export function reduceGatewayClientState(current, event) {
+  const state = current || createGatewayClientState()
+  if (!event || typeof event !== 'object') return state
+
+  switch (event.type) {
+    case GatewayServerEvent.GATEWAY_CONNECTED:
+      return {
+        ...state,
+        connectionState: 'connecting',
+      }
+
+    case GatewayServerEvent.GATEWAY_DISCONNECTED:
+      return {
+        ...state,
+        connectionState: 'unavailable',
+        voiceState: 'idle',
+      }
+
+    case GatewayServerEvent.VOICE_READY:
+      return event.inputSampleRate
+        ? { ...state, connectionState: 'connected' }
+        : state
+
+    case GatewayServerEvent.VOICE_CONNECTION:
+      return {
+        ...state,
+        connectionState: event.state || 'connecting',
+      }
+
+    case GatewayServerEvent.TURN_STARTED:
+      return {
+        ...state,
+        currentTurnId: event.turnId || '',
+      }
+
+    case GatewayServerEvent.VOICE_STATE:
+      if (!acceptsGatewayVoiceState(event, state.currentTurnId)) return state
+      return {
+        ...state,
+        voiceState: event.state || state.voiceState,
+      }
+
+    case GatewayServerEvent.VOICE_SLEEP:
+      if (event.state !== 'enabled' && event.state !== 'disabled') return state
+      return {
+        ...state,
+        wakeWordActive: event.state === 'enabled',
+      }
+
+    case GatewayServerEvent.VOICE_OWNERSHIP:
+      return {
+        ...state,
+        ownership: {
+          state: event.state || 'available',
+          holder: event.holder || null,
+        },
+      }
+
+    case GatewayServerEvent.VOICE_DEACTIVATED:
+      return {
+        ...state,
+        ownership: {
+          state: 'busy',
+          holder: event.holder || null,
+        },
+      }
+
+    default:
+      return state
+  }
+}

--- a/test/gateway-client-state.test.mjs
+++ b/test/gateway-client-state.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  acceptsGatewayVoiceState,
+  createGatewayClientState,
+  reduceGatewayClientState,
+} from '../shared/gateway-client-state.mjs'
+
+function reduce(events, initial = createGatewayClientState()) {
+  return events.reduce(reduceGatewayClientState, initial)
+}
+
+test('creates one stable client-state vocabulary', () => {
+  assert.deepEqual(createGatewayClientState(), {
+    connectionState: 'connecting',
+    voiceState: 'idle',
+    wakeWordActive: false,
+    ownership: {
+      state: 'available',
+      holder: null,
+    },
+    currentTurnId: '',
+  })
+  assert.equal(
+    createGatewayClientState({ connectionState: 'hidden' }).connectionState,
+    'hidden',
+  )
+})
+
+test('projects Gateway and Realtime connection events', () => {
+  const connected = reduce([
+    { type: 'gateway.connected' },
+    { type: 'voice.ready', inputSampleRate: 16_000 },
+  ])
+  assert.equal(connected.connectionState, 'connected')
+
+  const retrying = reduceGatewayClientState(connected, {
+    type: 'voice.connection',
+    state: 'unavailable',
+  })
+  assert.equal(retrying.connectionState, 'unavailable')
+
+  const disconnected = reduceGatewayClientState({
+    ...retrying,
+    voiceState: 'speaking',
+  }, { type: 'gateway.disconnected' })
+  assert.equal(disconnected.connectionState, 'unavailable')
+  assert.equal(disconnected.voiceState, 'idle')
+})
+
+test('does not report ready from an incomplete voice.ready event', () => {
+  const state = createGatewayClientState()
+  assert.equal(
+    reduceGatewayClientState(state, { type: 'voice.ready' }),
+    state,
+  )
+})
+
+test('tracks the active turn and ignores stale direct-model voice state', () => {
+  const state = reduce([
+    { type: 'turn.started', turnId: 'voice-2' },
+    {
+      type: 'voice.state',
+      state: 'speaking',
+      turnId: 'voice-1',
+      origin: 'model',
+    },
+  ])
+  assert.equal(state.currentTurnId, 'voice-2')
+  assert.equal(state.voiceState, 'idle')
+
+  const announcement = reduceGatewayClientState(state, {
+    type: 'voice.state',
+    state: 'speaking',
+    turnId: 'voice-1',
+    origin: 'announcement',
+  })
+  assert.equal(announcement.voiceState, 'speaking')
+  assert.equal(acceptsGatewayVoiceState({
+    type: 'voice.state',
+    turnId: 'voice-1',
+    origin: 'model',
+  }, 'voice-2'), false)
+})
+
+test('projects sleep and voice ownership without client-specific inference', () => {
+  const active = reduce([
+    { type: 'voice.sleep', state: 'enabled' },
+    {
+      type: 'voice.ownership',
+      state: 'active',
+      holder: { type: 'desktop', label: 'Desktop' },
+    },
+  ])
+  assert.equal(active.wakeWordActive, true)
+  assert.deepEqual(active.ownership, {
+    state: 'active',
+    holder: { type: 'desktop', label: 'Desktop' },
+  })
+
+  const deactivated = reduceGatewayClientState(active, {
+    type: 'voice.deactivated',
+    holder: { type: 'tui', label: 'TUI' },
+  })
+  assert.deepEqual(deactivated.ownership, {
+    state: 'busy',
+    holder: { type: 'tui', label: 'TUI' },
+  })
+  assert.equal(reduceGatewayClientState(deactivated, {
+    type: 'voice.sleep',
+    state: 'detected',
+  }), deactivated)
+})
+
+test('preserves identity for events outside the client state projection', () => {
+  const state = createGatewayClientState()
+  assert.equal(reduceGatewayClientState(state, { type: 'audio.delta' }), state)
+  assert.equal(reduceGatewayClientState(state, null), state)
+})

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -1,8 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
 import {
   GatewayClientEvent,
   GatewayServerEvent,
 } from '../../shared/realtime-events.mjs'
+import {
+  acceptsGatewayVoiceState,
+  createGatewayClientState,
+  reduceGatewayClientState,
+} from '../../shared/gateway-client-state.mjs'
 import { clientInputCapabilities } from '../../shared/client-input-capabilities.mjs'
 import { decodePcm, pcmBase64, resample } from './audio.js'
 import { confirmTrackedPlaybackStart } from './playback-lifecycle.js'
@@ -20,11 +25,7 @@ function socketUrl(sessionId) {
 }
 
 export function acceptsVoiceState(event, currentTurnId) {
-  return (
-    !event.turnId
-    || event.turnId === currentTurnId
-    || event.origin !== 'model'
-  )
+  return acceptsGatewayVoiceState(event, currentTurnId)
 }
 
 export function visualVoiceState(state) {
@@ -212,21 +213,24 @@ export default function useRealtimeVoice({
   onEvent,
   onInputError,
 }) {
-  const [state, setState] = useState('idle')
+  const [clientState, dispatchClientState] = useReducer(
+    reduceGatewayClientState,
+    undefined,
+    createGatewayClientState,
+  )
   const [inputReady, setInputReady] = useState(false)
   const [error, setError] = useState('')
   const [visualError, setVisualError] = useState(false)
-  const [connectionState, setConnectionState] = useState('connecting')
-  const [wakeWordActive, setWakeWordActive] = useState(false)
-  const [ownership, setOwnership] = useState({
-    state: 'available',
-    holder: null,
-  })
+  const {
+    connectionState,
+    ownership,
+    voiceState: state,
+    wakeWordActive,
+  } = clientState
   const eventRef = useRef(onEvent)
   const inputErrorRef = useRef(onInputError)
   const wakeWordOnlyRef = useRef(wakeWordOnly)
   const socketRef = useRef(null)
-  const connectionStateRef = useRef('connecting')
   const hasConnectedRef = useRef(false)
   const pendingManualInputsRef = useRef([])
   const audioRef = useRef(null)
@@ -301,14 +305,7 @@ export default function useRealtimeVoice({
     }
   }, [])
 
-  const setRealtimeConnectionState = useCallback(next => {
-    connectionStateRef.current = next
-    if (next === 'connected') hasConnectedRef.current = true
-    setConnectionState(next)
-  }, [])
-
   const flushPendingManualInputs = useCallback(() => {
-    if (connectionStateRef.current !== 'connected') return
     const pending = pendingManualInputsRef.current
     if (pending.length) holdManualInputGuard()
     while (pending.length) {
@@ -497,11 +494,17 @@ export default function useRealtimeVoice({
 
   useEffect(() => {
     if (suspended) {
-      setState('idle')
+      dispatchClientState({
+        type: GatewayServerEvent.VOICE_STATE,
+        state: 'idle',
+      })
+      dispatchClientState({
+        type: GatewayServerEvent.VOICE_CONNECTION,
+        state: 'hidden',
+      })
       setInputReady(false)
       setError('')
       setVisualError(false)
-      setRealtimeConnectionState('hidden')
       return undefined
     }
     let disposed = false
@@ -516,8 +519,9 @@ export default function useRealtimeVoice({
         reconnectDelay = 500
         setError('')
         setVisualError(false)
-        setRealtimeConnectionState('connecting')
-        eventRef.current?.({ type: GatewayServerEvent.GATEWAY_CONNECTED })
+        const connectedEvent = { type: GatewayServerEvent.GATEWAY_CONNECTED }
+        dispatchClientState(connectedEvent)
+        eventRef.current?.(connectedEvent)
         const mode = realtimeClientMode({
           enabled: enabledRef.current,
           inputReady: inputReadyRef.current,
@@ -552,16 +556,17 @@ export default function useRealtimeVoice({
         } catch {
           return
         }
+        dispatchClientState(event)
         if (event.type === GatewayServerEvent.VOICE_READY && event.inputSampleRate) {
           inputSampleRate.current = event.inputSampleRate
-          setRealtimeConnectionState('connected')
+          hasConnectedRef.current = true
           setError('')
           setVisualError(false)
           flushPendingManualInputs()
         }
         if (event.type === GatewayServerEvent.VOICE_CONNECTION) {
-          setRealtimeConnectionState(event.state || 'connecting')
           if (event.state === 'connected') {
+            hasConnectedRef.current = true
             setError('')
             setVisualError(false)
             flushPendingManualInputs()
@@ -569,25 +574,6 @@ export default function useRealtimeVoice({
             setError(event.message || t('语音前台连接异常，正在重试'))
             setVisualError(true)
           }
-        }
-        if (event.type === GatewayServerEvent.VOICE_SLEEP) {
-          if (event.state === 'enabled') {
-            setWakeWordActive(true)
-          } else if (event.state === 'disabled') {
-            setWakeWordActive(false)
-          }
-        }
-        if (event.type === GatewayServerEvent.VOICE_OWNERSHIP) {
-          setOwnership({
-            state: event.state || 'available',
-            holder: event.holder || null,
-          })
-        }
-        if (event.type === GatewayServerEvent.VOICE_DEACTIVATED) {
-          setOwnership({
-            state: 'busy',
-            holder: event.holder || null,
-          })
         }
         if (event.type === GatewayServerEvent.TURN_STARTED) {
           currentTurnId.current = event.turnId || ''
@@ -603,7 +589,6 @@ export default function useRealtimeVoice({
         }
         if (event.type === GatewayServerEvent.VOICE_STATE) {
           if (acceptsVoiceState(event, currentTurnId.current)) {
-            setState(event.state)
             if (event.state === 'listening') {
               stopPlayback('user_interruption')
             }
@@ -631,7 +616,10 @@ export default function useRealtimeVoice({
       }
       socket.onerror = () => {
         if (!disposed) {
-          setRealtimeConnectionState('unavailable')
+          dispatchClientState({
+            type: GatewayServerEvent.VOICE_CONNECTION,
+            state: 'unavailable',
+          })
           setError(t('实时语音连接中断，正在重连'))
           setVisualError(true)
         }
@@ -641,17 +629,22 @@ export default function useRealtimeVoice({
         if (disposed) return
         releaseManualInputGuard()
         stopPlayback()
-        setState('idle')
-        setRealtimeConnectionState('unavailable')
+        const disconnectedEvent = {
+          type: GatewayServerEvent.GATEWAY_DISCONNECTED,
+        }
+        dispatchClientState(disconnectedEvent)
         setError(t('实时语音连接中断，正在重连'))
         setVisualError(true)
-        eventRef.current?.({ type: GatewayServerEvent.GATEWAY_DISCONNECTED })
+        eventRef.current?.(disconnectedEvent)
         reconnectTimer = setTimeout(connect, reconnectDelay)
         reconnectDelay = Math.min(5000, reconnectDelay * 2)
       }
     }
     setError('')
-    setRealtimeConnectionState('connecting')
+    dispatchClientState({
+      type: GatewayServerEvent.VOICE_CONNECTION,
+      state: 'connecting',
+    })
     connect()
 
     return () => {
@@ -678,7 +671,6 @@ export default function useRealtimeVoice({
     sessionId,
     stopPlayback,
     suspended,
-    setRealtimeConnectionState,
     takeover,
   ])
 


### PR DESCRIPTION
## Summary

- add a side-effect-free shared reducer for Gateway connection, voice, sleep, ownership, and active-turn state
- migrate WebUI state projection from parallel React states to the shared reducer without changing its public hook API
- publish and document `qwen-audio-agent/gateway-client-state` for the upcoming TUI and Desktop migrations

## Behavior

- keeps playback, microphone, reconnect, and localized error side effects in the WebUI hook
- preserves stale direct-model turn filtering and the existing sleep/ownership semantics
- preserves object identity for unrelated Gateway events

## Validation

- `npm run lint`
- root tests: 69 passed, 1 skipped
- WebUI: 88 passed
- TUI, Desktop, and CLI workspace suites passed
- `npm run build`
- package subpath import and `node scripts/verify-package.mjs` passed

Local Server execution is interrupted by the managed macOS environment when importing the existing OpenClaw adapter (SIGKILL); GitHub CI is the clean-environment verification for that unchanged path.

Roadmap: #185