### PR TITLE
refactor: migrate TUI to shared Gateway client state

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -151,8 +151,8 @@ spells them by hand is on its own.
 ### Shared client state
 
 `qwen-audio-agent/gateway-client-state` folds public Gateway events into the
-side-effect-free client state fields `connectionState`, `voiceState`,
-`wakeWordActive`, `ownership`, and `currentTurnId`.
+side-effect-free client state fields `connectionState`, `voiceReady`,
+`voiceState`, `wakeWordActive`, `ownership`, and `currentTurnId`.
 `reduceGatewayClientState(state, event)` preserves object identity for unknown
 events and consistently ignores direct-model `voice.state` updates from stale
 turns. Clients still own playback, microphone, and UI side effects; they should

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -141,8 +141,9 @@ await orb.load()
 ### 共享客户端状态
 
 `qwen-audio-agent/gateway-client-state` 将公开 Gateway 事件归并为无副作用的客户端
-状态：`connectionState`、`voiceState`、`wakeWordActive`、`ownership` 与
-`currentTurnId`。`reduceGatewayClientState(state, event)` 对未知事件保持原对象不变，
+状态：`connectionState`、`voiceReady`、`voiceState`、`wakeWordActive`、
+`ownership` 与 `currentTurnId`。`reduceGatewayClientState(state, event)` 对未知事件
+保持原对象不变，
 并统一忽略来自旧轮次的直连模型 `voice.state`；客户端仍自行处理音频播放、麦克风和
 界面副作用，不应再复制这部分协议状态判断。锁定测试：
 `test/gateway-client-state.test.mjs`。

--- a/shared/gateway-client-state.mjs
+++ b/shared/gateway-client-state.mjs
@@ -10,6 +10,7 @@ export function createGatewayClientState({
 } = {}) {
   return {
     connectionState,
+    voiceReady: false,
     voiceState: 'idle',
     wakeWordActive: false,
     ownership: { ...DEFAULT_OWNERSHIP },
@@ -34,24 +35,31 @@ export function reduceGatewayClientState(current, event) {
       return {
         ...state,
         connectionState: 'connecting',
+        voiceReady: false,
       }
 
     case GatewayServerEvent.GATEWAY_DISCONNECTED:
       return {
         ...state,
         connectionState: 'unavailable',
+        voiceReady: false,
         voiceState: 'idle',
       }
 
     case GatewayServerEvent.VOICE_READY:
       return event.inputSampleRate
-        ? { ...state, connectionState: 'connected' }
+        ? {
+            ...state,
+            connectionState: 'connected',
+            voiceReady: true,
+          }
         : state
 
     case GatewayServerEvent.VOICE_CONNECTION:
       return {
         ...state,
         connectionState: event.state || 'connecting',
+        voiceReady: event.state === 'connected' ? state.voiceReady : false,
       }
 
     case GatewayServerEvent.TURN_STARTED:

--- a/test/gateway-client-state.test.mjs
+++ b/test/gateway-client-state.test.mjs
@@ -13,6 +13,7 @@ function reduce(events, initial = createGatewayClientState()) {
 test('creates one stable client-state vocabulary', () => {
   assert.deepEqual(createGatewayClientState(), {
     connectionState: 'connecting',
+    voiceReady: false,
     voiceState: 'idle',
     wakeWordActive: false,
     ownership: {
@@ -28,23 +29,33 @@ test('creates one stable client-state vocabulary', () => {
 })
 
 test('projects Gateway and Realtime connection events', () => {
+  const handshaken = reduceGatewayClientState(createGatewayClientState(), {
+    type: 'voice.connection',
+    state: 'connected',
+  })
+  assert.equal(handshaken.connectionState, 'connected')
+  assert.equal(handshaken.voiceReady, false)
+
   const connected = reduce([
     { type: 'gateway.connected' },
     { type: 'voice.ready', inputSampleRate: 16_000 },
   ])
   assert.equal(connected.connectionState, 'connected')
+  assert.equal(connected.voiceReady, true)
 
   const retrying = reduceGatewayClientState(connected, {
     type: 'voice.connection',
     state: 'unavailable',
   })
   assert.equal(retrying.connectionState, 'unavailable')
+  assert.equal(retrying.voiceReady, false)
 
   const disconnected = reduceGatewayClientState({
     ...retrying,
     voiceState: 'speaking',
   }, { type: 'gateway.disconnected' })
   assert.equal(disconnected.connectionState, 'unavailable')
+  assert.equal(disconnected.voiceReady, false)
   assert.equal(disconnected.voiceState, 'idle')
 })
 

--- a/tui/src/index.mjs
+++ b/tui/src/index.mjs
@@ -6,6 +6,10 @@ import {
   GatewayServerEvent,
 } from '../../shared/realtime-events.mjs'
 import {
+  createGatewayClientState,
+  reduceGatewayClientState,
+} from '../../shared/gateway-client-state.mjs'
+import {
   displayInputText,
   inputFileParts,
   inputText,
@@ -269,6 +273,23 @@ export function canSendMicrophoneAudio({
   captureEnabled,
 }) {
   return Boolean(connected && !muted && captureEnabled)
+}
+
+export function canStartTuiCapture({
+  clientState,
+  muted,
+  closed,
+  bridgeExited,
+  socketOpen,
+}) {
+  return Boolean(
+    !muted
+    && clientState?.voiceReady
+    && clientState?.ownership?.state === 'active'
+    && !closed
+    && !bridgeExited
+    && socketOpen,
+  )
 }
 
 export function performManualInterrupt({
@@ -1083,8 +1104,7 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
   let reconnectTimer = null
   let reconnectDelay = 500
   let connectedOnce = false
-  let frontendReady = false
-  let ownsVoice = false
+  let gatewayClientState = createGatewayClientState()
   let everOwnedVoice = false
   let captureEnabled = false
   let captureStateSent = false
@@ -1279,14 +1299,13 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
   })
 
   const startMicrophone = () => {
-    if (
-      muted
-      || !frontendReady
-      || !ownsVoice
-      || closed
-      || bridgeExited
-      || socket?.readyState !== WebSocket.OPEN
-    ) return
+    if (!canStartTuiCapture({
+      clientState: gatewayClientState,
+      muted,
+      closed,
+      bridgeExited,
+      socketOpen: socket?.readyState === WebSocket.OPEN,
+    })) return
     if (setCaptureEnabled(true)) {
       setStatus(`已连接 · 麦克风已开启 · ${audioMode.shortLabel}`)
       print(`[麦克风已开启 · ${inputSampleRate} Hz · ${audioMode.shortLabel}]`)
@@ -1344,8 +1363,8 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
     } catch {
       return
     }
+    gatewayClientState = reduceGatewayClientState(gatewayClientState, event)
     if (event.type === GatewayServerEvent.VOICE_READY) {
-      frontendReady = true
       const nextRate = Number(event.inputSampleRate) || inputSampleRate
       if (nextRate !== inputSampleRate) {
         print(`${style('[音频配置错误]', 'red')} Gateway 要求 ${nextRate} Hz，`
@@ -1353,23 +1372,20 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
         close()
         return
       }
-      if (ownsVoice) startMicrophone()
+      if (gatewayClientState.ownership.state === 'active') startMicrophone()
     }
     if (
       event.type === GatewayServerEvent.VOICE_CONNECTION
       && event.state === 'unavailable'
     ) {
-      frontendReady = false
       setCaptureEnabled(false)
       print(`${style('[语音前台连接失败]', 'red')} ${event.message || '请检查前台服务配置'}`)
     }
     if (event.type === GatewayServerEvent.VOICE_OWNERSHIP) {
       if (event.state === 'active') {
-        ownsVoice = true
         everOwnedVoice = true
         startMicrophone()
       } else if (event.state === 'busy') {
-        ownsVoice = false
         setCaptureEnabled(false)
         playback.clear()
         const holder = frontendLabel(event.holder)
@@ -1386,7 +1402,6 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
       }
     }
     if (event.type === GatewayServerEvent.VOICE_DEACTIVATED) {
-      ownsVoice = false
       muted = true
       setCaptureEnabled(false)
       playback.clear()
@@ -1505,6 +1520,9 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
     nextSocket.on('open', () => {
       if (socket !== nextSocket || closed) return
       reconnectDelay = 500
+      gatewayClientState = reduceGatewayClientState(gatewayClientState, {
+        type: GatewayServerEvent.GATEWAY_CONNECTED,
+      })
       setStatus('Gateway 已连接 · 语音服务准备中')
       nextSocket.send(JSON.stringify(connectMessage({
         voiceEnabled: true,
@@ -1535,8 +1553,9 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
     nextSocket.on('close', () => {
       if (socket !== nextSocket) return
       socket = null
-      frontendReady = false
-      ownsVoice = false
+      gatewayClientState = reduceGatewayClientState(gatewayClientState, {
+        type: GatewayServerEvent.GATEWAY_DISCONNECTED,
+      })
       setCaptureEnabled(false)
       playback.clear()
       transcriptDisplay.reset()

--- a/tui/test/index.test.mjs
+++ b/tui/test/index.test.mjs
@@ -5,6 +5,7 @@ import {
   assertInteractiveTerminal,
   audioModeForPlatform,
   canSendMicrophoneAudio,
+  canStartTuiCapture,
   completeTranscript,
   connectMessage,
   createPlayback,
@@ -57,6 +58,40 @@ test('microphone command controls input without disabling voice output', () => {
     type: 'input.unmute',
     takeover: false,
   })
+})
+
+test('waits for voice.ready and active ownership before starting capture', () => {
+  const connected = {
+    connectionState: 'connected',
+    voiceReady: false,
+    ownership: { state: 'active', holder: null },
+  }
+  assert.equal(canStartTuiCapture({
+    clientState: connected,
+    muted: false,
+    closed: false,
+    bridgeExited: false,
+    socketOpen: true,
+  }), false)
+
+  assert.equal(canStartTuiCapture({
+    clientState: { ...connected, voiceReady: true },
+    muted: false,
+    closed: false,
+    bridgeExited: false,
+    socketOpen: true,
+  }), true)
+  assert.equal(canStartTuiCapture({
+    clientState: {
+      ...connected,
+      voiceReady: true,
+      ownership: { state: 'busy', holder: { type: 'desktop' } },
+    },
+    muted: false,
+    closed: false,
+    bridgeExited: false,
+    socketOpen: true,
+  }), false)
 })
 
 test('shows a permission operation without duplicating the spoken question', () => {


### PR DESCRIPTION
## Summary

- migrate TUI connection and ownership state to the shared Gateway client reducer
- add `voiceReady` so a connected Realtime handshake remains distinct from validated audio readiness
- gate microphone capture on `voice.ready`, active ownership, socket availability, and existing local audio conditions
- preserve TUI-specific terminal, playback, reconnect, and takeover behavior

## Validation

- `npm run lint`
- root tests: 69 passed, 1 skipped
- WebUI: 88 passed
- TUI: 56 passed
- Desktop: 208 passed
- CLI: 144 passed
- `npm run build`
- `node scripts/verify-package.mjs`

Local Server execution is interrupted by the managed macOS environment when importing the existing OpenClaw adapter (SIGKILL); GitHub CI is the clean-environment verification for that unchanged path.

Roadmap: #185