### PR TITLE
feat: add AG-UI task event projection

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -18,7 +18,9 @@ a feature then degrades instead of failing.
 Versioning follows SemVer: the minor rises for an additive capability, the
 major for a breaking change to any endpoint or event named below.
 
-The current version is `2.0.0`. It succeeds the `1.x` line of the
+The current version is `2.1.0`. The `2.1` line adds the optional AG-UI Task
+event projection; it succeeds the `2.0` contract without changing its default
+event stream. The `2.x` line succeeds the `1.x` line of the
 `feat/embedded-gateway-host-contract` fork (which ended at `1.7.0`): the major
 bump records that capabilities that line advertised — such as
 `gateway.embedded-lifecycle` and `desktop.settings-window` — are not part of
@@ -38,6 +40,7 @@ below instead of assuming the old list.
 | `input.suspend-clears-playback` | Suspending also clears playback so host recording stays clean | `server/test/input-suspend-protocol.test.mjs` |
 | `input.suspend-ttl` | A suspension expires on its own when the holder never resumes | `server/test/input-arbitration.test.mjs` |
 | `input.suspend-ack` | Clients confirm a suspension with `input.suspend.ack` (status display only — never wait for it) | `server/test/input-suspend-protocol.test.mjs` |
+| `tasks.ag-ui-event-stream` | `GET /api/tasks/:id/events?format=ag-ui` projects the existing Task stream into AG-UI `ACTIVITY_SNAPSHOT` events; omitting `format` preserves the native stream | `server/test/agui-event-projector.test.mjs` |
 | `desktop.orb-shell` | The orb form's main-process contract ships: `bindOrbShell` answers the channels the shipped preload sends | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` owns the orb window recipe; its `destroy()` is the host's synchronous teardown path (renderer exit is what releases the microphone) | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` covers the default anchor, display clamping and drop persistence | `desktop/test/orb-placement.test.mjs` |
@@ -62,6 +65,7 @@ is unsupported and breaks without notice.
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`, `findRunningGateway`, `acquireGatewayLease` |
 | `qwen-audio-agent/realtime-events` | `GatewayClientEvent`, `GatewayServerEvent`, `GatewayTaskEvent` |
 | `qwen-audio-agent/gateway-events` | Gateway event Zod schemas and parsers |
+| `qwen-audio-agent/ag-ui-events` | Zod schema and parser for the supported AG-UI compatibility surface |
 | `qwen-audio-agent/gateway-client-state` | `createGatewayClientState`, `reduceGatewayClientState`, `acceptsGatewayVoiceState` |
 | `qwen-audio-agent/settings` | `createSettingsStore` |
 | `qwen-audio-agent/skin-store` | `importSkin`, `listSkins`, `removeSkin`, `effectiveOrbSkin`, `skinsDirectory`, `validateSkinPackage` |
@@ -126,12 +130,18 @@ await orb.load()
 | `POST /api/input/suspend` | Take the microphone: `{ owner, reason?, ttlMs? }`; default TTL 15 s, cap 300 s |
 | `POST /api/input/resume` | Release it: `{ owner }` |
 | `GET /api/input` | Current suspension status |
+| `GET /api/tasks/:id/events?format=ag-ui` | Opt-in AG-UI `ACTIVITY_SNAPSHOT` stream for one Task; capability: `tasks.ag-ui-event-stream` |
 
 Microphone suspension semantics: do not wait for the acknowledgement (a key
 press that starts recording is latency sensitive — send and start recording);
 idempotent per owner, a repeated suspend refreshes the deadline; multiple
 owners are reference counted; every hold expires, so a crashed holder can
 never silence the Gateway for good.
+
+The AG-UI endpoint is an event projection, not a complete AG-UI agent/run
+endpoint. Each Task keeps one stable `messageId`; every lifecycle update
+replaces its `qwen.audio.task` activity content. The native Task stream remains
+the default and existing clients receive no additional events.
 
 Endpoints not listed here (`/api/tasks`, `/api/timeline`, `/api/backend/ui`,
 `/api/permissions/:id`, `WS /api/realtime` payloads beyond the events below)

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -14,7 +14,8 @@
 版本号遵循 SemVer：新增能力升 minor；下文点名的任一端点或事件发生破坏性
 变更升 major。
 
-当前版本为 `2.0.0`，接替 `feat/embedded-gateway-host-contract` 分支的 `1.x`
+当前版本为 `2.1.0`。`2.1` 新增可选的 AG-UI Task 事件投射，默认事件流保持
+`2.0` 契约不变。`2.x` 接替 `feat/embedded-gateway-host-contract` 分支的 `1.x`
 版本线（止于 `1.7.0`）：升 major 记录的事实是——那条线宣告过的部分能力位
 （如 `gateway.embedded-lifecycle`、`desktop.settings-window`）不在本契约中。
 从该分支迁移的宿主应重新核对下方能力位表，而不是假设旧清单仍然成立。
@@ -32,6 +33,7 @@
 | `input.suspend-clears-playback` | 抢占同时清除播报，宿主录音不会录进 Gateway 自己的语音 | `server/test/input-suspend-protocol.test.mjs` |
 | `input.suspend-ttl` | 持有者不主动释放时抢占自行过期 | `server/test/input-arbitration.test.mjs` |
 | `input.suspend-ack` | 客户端以 `input.suspend.ack` 确认抢占生效（仅用于状态展示——不要等待它） | `server/test/input-suspend-protocol.test.mjs` |
+| `tasks.ag-ui-event-stream` | `GET /api/tasks/:id/events?format=ag-ui` 将现有 Task 事件流投射为 AG-UI `ACTIVITY_SNAPSHOT`；不传 `format` 时仍为原生事件流 | `server/test/agui-event-projector.test.mjs` |
 | `desktop.orb-shell` | 悬浮球形态的主进程契约随包发布：`bindOrbShell` 应答随包 preload 发出的全部通道 | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` 持有悬浮球窗口配方；其 `destroy()` 是宿主的同步销毁路径（渲染进程退出才能确定性释放麦克风） | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` 覆盖默认锚点、显示器夹取与拖放持久化 | `desktop/test/orb-placement.test.mjs` |
@@ -55,6 +57,7 @@
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`、`findRunningGateway`、`acquireGatewayLease` |
 | `qwen-audio-agent/realtime-events` | `GatewayClientEvent`、`GatewayServerEvent`、`GatewayTaskEvent` |
 | `qwen-audio-agent/gateway-events` | Gateway 事件 Zod Schema 与解析函数 |
+| `qwen-audio-agent/ag-ui-events` | 当前支持的 AG-UI 兼容事件 Zod Schema 与解析函数 |
 | `qwen-audio-agent/gateway-client-state` | `createGatewayClientState`、`reduceGatewayClientState`、`acceptsGatewayVoiceState` |
 | `qwen-audio-agent/settings` | `createSettingsStore` |
 | `qwen-audio-agent/skin-store` | `importSkin`、`listSkins`、`removeSkin`、`effectiveOrbSkin`、`skinsDirectory`、`validateSkinPackage` |
@@ -118,10 +121,15 @@ await orb.load()
 | `POST /api/input/suspend` | 抢占麦克风：`{ owner, reason?, ttlMs? }`，默认 15 秒，上限 300 秒 |
 | `POST /api/input/resume` | 释放抢占：`{ owner }` |
 | `GET /api/input` | 当前抢占状态 |
+| `GET /api/tasks/:id/events?format=ag-ui` | 单个 Task 的可选 AG-UI `ACTIVITY_SNAPSHOT` 事件流；能力位：`tasks.ag-ui-event-stream` |
 
 麦克风抢占的语义要点：**不要等回执**（按键到录音是延迟敏感路径，直接发送并
 立即开始录音）；按 owner 幂等，重复宣告只刷新截止时间；多 owner 引用计数；
 每个抢占都会过期，持有方崩溃或漏发 `resume` 也会自动恢复。
+
+该接口只是 AG-UI 事件投射，不是完整的 AG-UI Agent/Run 端点。每个 Task 使用
+稳定的 `messageId`，每次生命周期更新都会替换对应的 `qwen.audio.task` activity
+内容。原生 Task 事件流仍是默认格式，现有客户端不会收到任何新增事件。
 
 未在此列出的接口（`/api/tasks`、`/api/timeline`、`/api/backend/ui`、
 `/api/permissions/:id`，以及 `WS /api/realtime` 中除下文事件之外的负载）

--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -159,11 +159,11 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 
 ### R1 — Protocol and client state
 
-- [ ] Add Zod schemas for Gateway client, server, and task events.
-- [ ] Introduce domain events and public event projectors.
-- [ ] Add an AG-UI compatibility projector without removing current events.
-- [ ] Extract a shared Gateway client and state reducer.
-- [ ] Migrate WebUI, TUI, and Desktop one at a time.
+- [x] Add Zod schemas for Gateway client, server, and task events.
+- [x] Introduce domain events and public event projectors.
+- [x] Add an AG-UI compatibility projector without removing current events.
+- [x] Extract a shared Gateway client and state reducer.
+- [x] Migrate WebUI, TUI, and Desktop one at a time.
 
 ### R2 — Frontend Chatbot Runtime
 

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -205,11 +205,11 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 
 ### R1：协议与客户端状态
 
-- [ ] 为 Gateway Client/Server/Task 事件建立 Zod Schema。
-- [ ] 建立 Domain Event 与公开 Event Projector。
-- [ ] 增加 AG-UI 兼容投射层，不立即删除现有事件。
-- [ ] 提取共享 Gateway Client 和状态 Reducer。
-- [ ] 依次迁移 WebUI、TUI、Desktop。
+- [x] 为 Gateway Client/Server/Task 事件建立 Zod Schema。
+- [x] 建立 Domain Event 与公开 Event Projector。
+- [x] 增加 AG-UI 兼容投射层，不立即删除现有事件。
+- [x] 提取共享 Gateway Client 和状态 Reducer。
+- [x] 依次迁移 WebUI、TUI、Desktop。
 
 完成条件：三个客户端不再各自解释 Work 和 Voice 状态机。
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "./gateway-lease": "./shared/gateway-instance-lock.mjs",
     "./realtime-events": "./shared/realtime-events.mjs",
     "./gateway-events": "./shared/protocol/gateway-events.mjs",
+    "./ag-ui-events": "./shared/protocol/agui-events.mjs",
     "./gateway-client-state": "./shared/gateway-client-state.mjs",
     "./gateway-application": "./server/src/app/gateway-application.mjs",
     "./realtime-provider": "./server/src/voice/realtime-provider-extension.mjs",

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -41,6 +41,9 @@ import {
   projectGatewayTaskEvent,
   projectGatewayTaskSnapshot,
 } from '../transport/gateway-task-event-projector.mjs'
+import {
+  projectGatewayTaskEventForFormat,
+} from '../transport/agui-event-projector.mjs'
 
 export function createGatewayApplication({
   config = defaultConfig,
@@ -408,16 +411,20 @@ app.post('/api/permissions/:id', async (req, res, next) => {
 app.get('/api/tasks/:id/events', (req, res) => {
   const task = taskManager.get(req.params.id, { ownerId: req.identity.ownerId })
   if (!task) return res.status(404).json({ error: 'task not found' })
+  const projectEvent = event => projectGatewayTaskEventForFormat(
+    event,
+    req.query.format,
+  )
   res.setHeader('Content-Type', 'text/event-stream')
   res.setHeader('Cache-Control', 'no-cache')
   res.setHeader('Connection', 'keep-alive')
   res.flushHeaders()
   const write = event => res.write(`data: ${JSON.stringify(event)}\n\n`)
-  write(projectGatewayTaskSnapshot(task))
+  write(projectEvent(projectGatewayTaskSnapshot(task)))
   const unsubscribe = taskManager.subscribe(event => {
     if (event.ownerId === req.identity.ownerId && event.task.id === req.params.id) {
       const publicEvent = projectGatewayTaskEvent(event)
-      if (publicEvent) write(publicEvent)
+      if (publicEvent) write(projectEvent(publicEvent))
     }
   })
   res.on('close', unsubscribe)

--- a/server/src/core/gateway-protocol.mjs
+++ b/server/src/core/gateway-protocol.mjs
@@ -10,13 +10,14 @@
 // Every capability listed here is locked by a test (see docs/contract.md);
 // anything not listed is internal and may change in any release.
 //
+// 2.1.0 adds an opt-in AG-UI projection while preserving the native stream.
 // 2.0.0 succeeds the 1.x line of the feat/embedded-gateway-host-contract
 // fork (last 1.7.0). The major bump is semantic, not cosmetic: capabilities
 // that line advertised (gateway.embedded-lifecycle, gateway.self-terminate,
 // desktop.settings-window, …) are not part of this contract, and a removed
 // capability is a breaking change. Hosts migrating from the fork must branch
 // on the capability list below, never on the version number.
-export const GATEWAY_PROTOCOL_VERSION = '2.0.0'
+export const GATEWAY_PROTOCOL_VERSION = '2.1.0'
 
 export const GATEWAY_CAPABILITIES = Object.freeze([
   // The Gateway statically hosts web/dist at its own origin, so a client may
@@ -55,6 +56,10 @@ export const GATEWAY_CAPABILITIES = Object.freeze([
   'input.suspend-ttl',
   // Clients confirm a suspension with input.suspend.ack.
   'input.suspend-ack',
+  // GET /api/tasks/:id/events?format=ag-ui projects the existing public Task
+  // stream into AG-UI ACTIVITY_SNAPSHOT events. The default stream is
+  // unchanged.
+  'tasks.ag-ui-event-stream',
   // The orb shell contract ships: qwen-audio-agent/orb/preload plus
   // orb/main's bindOrbShell, so a host may run the floating orb form.
   'desktop.orb-shell',

--- a/server/src/transport/agui-event-projector.mjs
+++ b/server/src/transport/agui-event-projector.mjs
@@ -1,0 +1,42 @@
+import {
+  AguiActivitySnapshotEventSchema,
+  AguiEventType,
+} from '../../../shared/protocol/agui-events.mjs'
+import {
+  GatewayTaskEventMessageSchema,
+} from '../../../shared/protocol/gateway-events.mjs'
+
+export const AGUI_TASK_ACTIVITY_TYPE = 'qwen.audio.task'
+
+/**
+ * Projects one public Gateway Task event into an AG-UI activity snapshot.
+ *
+ * The input is validated at the public Gateway boundary first. The projector
+ * then copies only declared fields, so adapter-only routing data cannot leak
+ * through AG-UI even when a caller accidentally passes an enriched object.
+ */
+export function projectGatewayTaskEventToAgui(event) {
+  const parsed = GatewayTaskEventMessageSchema.safeParse(event)
+  if (!parsed.success) return null
+
+  const { type, task, permission, message } = parsed.data
+  return AguiActivitySnapshotEventSchema.parse({
+    type: AguiEventType.ACTIVITY_SNAPSHOT,
+    messageId: `${AGUI_TASK_ACTIVITY_TYPE}:${task.id}`,
+    activityType: AGUI_TASK_ACTIVITY_TYPE,
+    content: {
+      schema: 'qwen.audio.task/v1',
+      eventType: type,
+      task,
+      ...(permission ? { permission } : {}),
+      ...(message ? { message } : {}),
+    },
+    replace: true,
+  })
+}
+
+export function projectGatewayTaskEventForFormat(event, format) {
+  return format === 'ag-ui'
+    ? projectGatewayTaskEventToAgui(event)
+    : event
+}

--- a/server/test/agui-event-projector.test.mjs
+++ b/server/test/agui-event-projector.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  AguiEventType,
+  parseAguiGatewayEvent,
+} from '../../shared/protocol/agui-events.mjs'
+import { GatewayTaskEvent } from '../../shared/realtime-events.mjs'
+import {
+  AGUI_TASK_ACTIVITY_TYPE,
+  projectGatewayTaskEventForFormat,
+  projectGatewayTaskEventToAgui,
+} from '../src/transport/agui-event-projector.mjs'
+
+function task(overrides = {}) {
+  return {
+    id: 'work_1',
+    workId: 'work_1',
+    jobId: 'job_1',
+    workState: 'active',
+    status: 'running',
+    kind: 'work',
+    objective: 'inspect the system',
+    createdAt: 1,
+    elapsedMs: 0,
+    result: null,
+    error: null,
+    ...overrides,
+  }
+}
+
+test('projects every public Task event into one AG-UI activity snapshot', () => {
+  for (const eventType of Object.values(GatewayTaskEvent)) {
+    const projected = projectGatewayTaskEventToAgui({
+      type: eventType,
+      task: task(),
+    })
+
+    assert.equal(projected.type, AguiEventType.ACTIVITY_SNAPSHOT)
+    assert.equal(projected.messageId, `${AGUI_TASK_ACTIVITY_TYPE}:work_1`)
+    assert.equal(projected.activityType, AGUI_TASK_ACTIVITY_TYPE)
+    assert.equal(projected.replace, true)
+    assert.equal(projected.content.eventType, eventType)
+    assert.equal(projected.content.task.id, 'work_1')
+    assert.deepEqual(parseAguiGatewayEvent(projected), projected)
+  }
+})
+
+test('keeps one stable activity identity across a Task lifecycle', () => {
+  const running = projectGatewayTaskEventToAgui({
+    type: GatewayTaskEvent.RUNNING,
+    task: task(),
+  })
+  const completed = projectGatewayTaskEventToAgui({
+    type: GatewayTaskEvent.COMPLETED,
+    task: task({
+      workState: 'completed',
+      status: 'completed',
+      completedAt: 10,
+      result: '24 GB',
+    }),
+  })
+
+  assert.equal(completed.messageId, running.messageId)
+  assert.equal(completed.content.task.status, 'completed')
+  assert.equal(completed.content.task.result, '24 GB')
+})
+
+test('preserves public details without exposing undeclared fields', () => {
+  const projected = projectGatewayTaskEventToAgui({
+    type: GatewayTaskEvent.PERMISSION_REQUESTED,
+    task: task({ internalSchedulerLane: 'coordinator:owner' }),
+    permission: { id: 'permission_1', summary: 'run command' },
+    message: 'permission needed',
+    privateReason: 'adapter-only',
+  })
+
+  assert.deepEqual(projected.content.permission, {
+    id: 'permission_1',
+    summary: 'run command',
+  })
+  assert.equal(projected.content.message, 'permission needed')
+  assert.equal('internalSchedulerLane' in projected.content.task, false)
+  assert.equal('privateReason' in projected.content, false)
+})
+
+test('does not project malformed or unrelated events', () => {
+  assert.equal(projectGatewayTaskEventToAgui(null), null)
+  assert.equal(projectGatewayTaskEventToAgui({ type: 'voice.ready' }), null)
+})
+
+test('keeps native events by default and projects only on explicit opt-in', () => {
+  const event = {
+    type: GatewayTaskEvent.SNAPSHOT,
+    task: task(),
+  }
+
+  assert.equal(projectGatewayTaskEventForFormat(event), event)
+  assert.equal(projectGatewayTaskEventForFormat(event, 'native'), event)
+  assert.equal(
+    projectGatewayTaskEventForFormat(event, 'ag-ui').type,
+    AguiEventType.ACTIVITY_SNAPSHOT,
+  )
+})

--- a/shared/protocol/agui-events.mjs
+++ b/shared/protocol/agui-events.mjs
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+// This is the deliberately small AG-UI surface emitted by the Gateway today.
+// Keep the wire names identical to the upstream protocol while avoiding a
+// runtime dependency on the complete AG-UI SDK for one event type.
+export const AguiEventType = Object.freeze({
+  ACTIVITY_SNAPSHOT: 'ACTIVITY_SNAPSHOT',
+})
+
+export const AguiActivitySnapshotEventSchema = z.object({
+  type: z.literal(AguiEventType.ACTIVITY_SNAPSHOT),
+  messageId: z.string().min(1),
+  activityType: z.string().min(1),
+  content: z.record(z.string(), z.unknown()),
+  replace: z.boolean().optional().default(true),
+  timestamp: z.number().optional(),
+  rawEvent: z.unknown().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}).passthrough()
+
+export const AguiGatewayEventSchema = z.discriminatedUnion('type', [
+  AguiActivitySnapshotEventSchema,
+])
+
+export function parseAguiGatewayEvent(value) {
+  return AguiGatewayEventSchema.parse(value)
+}

--- a/test/gateway-event-schema.test.mjs
+++ b/test/gateway-event-schema.test.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  AguiEventType,
+  parseAguiGatewayEvent,
+} from '../shared/protocol/agui-events.mjs'
+import {
   GatewayClientMessageSchema,
   GatewayServerMessageSchema,
   parseGatewayClientMessage,
@@ -69,4 +73,16 @@ test('validates voice and task messages in the server direction', () => {
     GatewayServerMessageSchema.safeParse({ type: 'connect' }).success,
     false,
   )
+})
+
+test('validates the supported AG-UI activity event surface', () => {
+  const event = parseAguiGatewayEvent({
+    type: AguiEventType.ACTIVITY_SNAPSHOT,
+    messageId: 'qwen.audio.task:work_1',
+    activityType: 'qwen.audio.task',
+    content: { task: { status: 'running' } },
+  })
+
+  assert.equal(event.replace, true)
+  assert.equal(event.activityType, 'qwen.audio.task')
 })


### PR DESCRIPTION
## Summary
- add an opt-in AG-UI `ACTIVITY_SNAPSHOT` projection for public Task events
- preserve the existing native WebSocket and SSE event formats by default
- publish the supported schema, capability, protocol version, and bilingual contract docs
- mark the R1 protocol/client-state roadmap stage complete

## Validation
- `npm run lint`
- `npm run build`
- protocol/projector/contract tests (12 passing)
- full suite reached all root tests and 254 Server tests green locally; the existing Gateway application test worker remained open locally, so GitHub CI is the final full-suite gate