### PR TITLE
refactor: add frontend tool registry policy

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -169,6 +169,8 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 
 - [ ] Extract realtime session, turn, input, playback, and presentation logic.
 - [ ] Add Frontend Tool Registry, Policy, and Executor.
+  - [x] Extract the declarative Registry and visibility Policy.
+  - [ ] Route execution through the Registry-owned Executor.
 - [ ] Migrate existing tools without renaming or changing behavior.
 - [ ] Make `spawn_thinking` a first-class background tool.
 - [ ] Add a bounded short tool loop.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -217,6 +217,8 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 
 - [ ] 提取 Realtime Session、Turn、Input、Playback 和 Presentation。
 - [ ] 建立 Frontend Tool Registry、Policy 和 Executor。
+  - [x] 提取声明式 Registry 与可见性 Policy。
+  - [ ] 通过 Registry 管理的 Executor 统一执行入口。
 - [ ] 将现有工具逐个迁移，保持工具名与用户行为不变。
 - [ ] 将 `spawn_thinking` 固化为 background tool。
 - [ ] 增加有界短工具循环。

--- a/server/src/voice/frontend-tools.mjs
+++ b/server/src/voice/frontend-tools.mjs
@@ -4,6 +4,7 @@ import {
   loadAssistantProfile,
 } from '../conversation/frontend-agent-context.mjs'
 import { MEMORY_DOCUMENTS } from '../core/memory-scopes.mjs'
+import { FrontendToolRegistry } from './tools/frontend-tool-registry.mjs'
 
 export const SPAWN_THINKING_TOOL_NAME = 'spawn_thinking'
 export const SCHEDULE_REMINDER_TOOL_NAME = 'schedule_reminder'
@@ -229,24 +230,29 @@ const scheduleReminderTool = {
   },
 }
 
-export const TOOLS = [
-  spawnThinkingTool,
-  scheduleReminderTool,
-  cancelAgentTaskTool,
-  getAgentTaskStatusTool,
-  getCurrentTimeTool,
-  memoryTool,
-  notesTool,
-  respondAgentPermissionTool,
-]
+export const frontendToolRegistry = new FrontendToolRegistry([
+  { definition: spawnThinkingTool },
+  { definition: scheduleReminderTool },
+  { definition: cancelAgentTaskTool },
+  { definition: getAgentTaskStatusTool },
+  { definition: getCurrentTimeTool },
+  { definition: memoryTool },
+  { definition: notesTool },
+  { definition: respondAgentPermissionTool },
+  {
+    definition: enterSleepTool,
+    policy: { requiredClientStates: ['sleeping'] },
+  },
+])
+
+export const TOOLS = frontendToolRegistry.definitions()
 
 export function frontendTools(agentContext = {}) {
-  const states = Array.isArray(agentContext.client?.states)
-    ? agentContext.client.states
-    : []
-  return states.includes('sleeping')
-    ? [...TOOLS, enterSleepTool]
-    : TOOLS
+  const tools = frontendToolRegistry.definitions(agentContext)
+  return tools.length === TOOLS.length
+    && tools.every((tool, index) => tool === TOOLS[index])
+    ? TOOLS
+    : tools
 }
 
 export const resultResponseInstructions = [

--- a/server/src/voice/realtime-provider.mjs
+++ b/server/src/voice/realtime-provider.mjs
@@ -26,6 +26,7 @@ export {
   RESPOND_AGENT_PERMISSION_TOOL_NAME,
   ENTER_SLEEP_TOOL_NAME,
   TOOLS,
+  frontendToolRegistry,
   frontendTools,
   buildFrontendInstructions,
 } from './frontend-tools.mjs'

--- a/server/src/voice/tools/frontend-tool-registry.mjs
+++ b/server/src/voice/tools/frontend-tool-registry.mjs
@@ -1,0 +1,73 @@
+function toolName(entry) {
+  return String(entry?.definition?.function?.name || '').trim()
+}
+
+function clientStates(context) {
+  return new Set(
+    Array.isArray(context?.client?.states)
+      ? context.client.states.map(String)
+      : [],
+  )
+}
+
+function policyAllows(policy = {}, context = {}) {
+  const availableStates = clientStates(context)
+  const requiredStates = Array.isArray(policy.requiredClientStates)
+    ? policy.requiredClientStates
+    : []
+  return requiredStates.every(state => availableStates.has(state))
+}
+
+function normalizedPolicy(policy = {}) {
+  const normalized = { ...policy }
+  if (Array.isArray(policy.requiredClientStates)) {
+    normalized.requiredClientStates = Object.freeze([
+      ...policy.requiredClientStates.map(String),
+    ])
+  }
+  return Object.freeze(normalized)
+}
+
+/**
+ * Declarative catalog for tools exposed to the realtime frontend model.
+ *
+ * Registry policy controls tool visibility only. Tool implementations still
+ * validate permissions and current runtime state at execution time.
+ */
+export class FrontendToolRegistry {
+  #entriesByName
+
+  constructor(entries = []) {
+    this.#entriesByName = new Map()
+    for (const entry of entries) {
+      const name = toolName(entry)
+      if (!name) throw new Error('Frontend tool definition requires a name')
+      if (this.#entriesByName.has(name)) {
+        throw new Error(`Duplicate frontend tool: ${name}`)
+      }
+      this.#entriesByName.set(name, Object.freeze({
+        definition: entry.definition,
+        policy: normalizedPolicy(entry.policy),
+      }))
+    }
+  }
+
+  has(name) {
+    return this.#entriesByName.has(String(name || ''))
+  }
+
+  get(name) {
+    return this.#entriesByName.get(String(name || '')) || null
+  }
+
+  isEnabled(name, context = {}) {
+    const entry = this.get(name)
+    return Boolean(entry && policyAllows(entry.policy, context))
+  }
+
+  definitions(context = {}) {
+    return [...this.#entriesByName.entries()]
+      .filter(([name]) => this.isEnabled(name, context))
+      .map(([, entry]) => entry.definition)
+  }
+}

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -9,7 +9,7 @@ import {
   NOTES_TOOL_NAME,
   MEMORY_TOOL_NAME,
   RESPOND_AGENT_PERMISSION_TOOL_NAME,
-} from '../realtime-provider.mjs'
+} from '../frontend-tools.mjs'
 import { currentTimeSnapshot } from '../../conversation/frontend-agent-context.mjs'
 import { canonicalScope, isMemoryDocument } from '../../core/memory-scopes.mjs'
 import { inputPartRef } from '../../../../shared/input-parts.mjs'

--- a/server/test/frontend-tool-registry.test.mjs
+++ b/server/test/frontend-tool-registry.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  ENTER_SLEEP_TOOL_NAME,
+  frontendToolRegistry,
+  frontendTools,
+  TOOLS,
+} from '../src/voice/frontend-tools.mjs'
+import {
+  FrontendToolRegistry,
+} from '../src/voice/tools/frontend-tool-registry.mjs'
+
+const DEFAULT_TOOL_NAMES = [
+  'spawn_thinking',
+  'schedule_reminder',
+  'cancel_agent_task',
+  'get_agent_task_status',
+  'get_current_time',
+  'memory',
+  'notes',
+  'respond_agent_permission',
+]
+
+function names(tools) {
+  return tools.map(tool => tool.function.name)
+}
+
+test('registers every default frontend tool once in stable order', () => {
+  assert.deepEqual(names(TOOLS), DEFAULT_TOOL_NAMES)
+  assert.deepEqual(names(frontendTools()), DEFAULT_TOOL_NAMES)
+  assert.equal(frontendTools(), TOOLS)
+  for (const name of DEFAULT_TOOL_NAMES) {
+    assert.equal(frontendToolRegistry.has(name), true)
+  }
+})
+
+test('exposes client-state tools only when the client advertises support', () => {
+  assert.equal(frontendToolRegistry.isEnabled(ENTER_SLEEP_TOOL_NAME), false)
+  assert.equal(
+    frontendToolRegistry.isEnabled(ENTER_SLEEP_TOOL_NAME, {
+      client: { states: ['sleeping'] },
+    }),
+    true,
+  )
+  assert.deepEqual(
+    names(frontendTools({ client: { states: ['sleeping'] } })),
+    [...DEFAULT_TOOL_NAMES, ENTER_SLEEP_TOOL_NAME],
+  )
+  assert.deepEqual(
+    names(frontendTools({ client: { states: ['unknown'] } })),
+    DEFAULT_TOOL_NAMES,
+  )
+})
+
+test('keeps visibility policy separate from runtime execution checks', () => {
+  const entry = frontendToolRegistry.get(ENTER_SLEEP_TOOL_NAME)
+  assert.deepEqual(entry.policy, { requiredClientStates: ['sleeping'] })
+  assert.equal(Object.isFrozen(entry.policy), true)
+  assert.equal(Object.isFrozen(entry.policy.requiredClientStates), true)
+})
+
+test('rejects unnamed and duplicate tool registrations', () => {
+  assert.throws(
+    () => new FrontendToolRegistry([{ definition: {} }]),
+    /requires a name/,
+  )
+  const definition = {
+    type: 'function',
+    function: { name: 'duplicate', parameters: { type: 'object' } },
+  }
+  assert.throws(
+    () => new FrontendToolRegistry([
+      { definition },
+      { definition },
+    ]),
+    /Duplicate frontend tool/,
+  )
+})


### PR DESCRIPTION
## Summary
- add one declarative registry for all realtime frontend tool definitions
- express client capability visibility as policy instead of provider-side array assembly
- preserve every existing tool name, definition, order, and runtime execution check
- remove the ToolCallHandler dependency on the full Realtime Provider module
- record the incremental R2 progress in the bilingual roadmap

## Validation
- `npm run lint`
- `npm run build`
- 109 frontend tool, provider, handler, and desktop registration tests pass