### PR TITLE
refactor: route frontend tools through executor

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -168,10 +168,10 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 ### R2 — Frontend Chatbot Runtime
 
 - [ ] Extract realtime session, turn, input, playback, and presentation logic.
-- [ ] Add Frontend Tool Registry, Policy, and Executor.
+- [x] Add Frontend Tool Registry, Policy, and Executor.
   - [x] Extract the declarative Registry and visibility Policy.
-  - [ ] Route execution through the Registry-owned Executor.
-- [ ] Migrate existing tools without renaming or changing behavior.
+  - [x] Route execution through the Registry-owned Executor.
+- [x] Migrate existing tools without renaming or changing behavior.
 - [ ] Make `spawn_thinking` a first-class background tool.
 - [ ] Add a bounded short tool loop.
 

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -216,10 +216,10 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 ### R2：Frontend Chatbot Runtime
 
 - [ ] 提取 Realtime Session、Turn、Input、Playback 和 Presentation。
-- [ ] 建立 Frontend Tool Registry、Policy 和 Executor。
+- [x] 建立 Frontend Tool Registry、Policy 和 Executor。
   - [x] 提取声明式 Registry 与可见性 Policy。
-  - [ ] 通过 Registry 管理的 Executor 统一执行入口。
-- [ ] 将现有工具逐个迁移，保持工具名与用户行为不变。
+  - [x] 通过 Registry 管理的 Executor 统一执行入口。
+- [x] 将现有工具逐个迁移，保持工具名与用户行为不变。
 - [ ] 将 `spawn_thinking` 固化为 background tool。
 - [ ] 增加有界短工具循环。
 

--- a/server/src/voice/tools/frontend-tool-registry.mjs
+++ b/server/src/voice/tools/frontend-tool-registry.mjs
@@ -60,6 +60,10 @@ export class FrontendToolRegistry {
     return this.#entriesByName.get(String(name || '')) || null
   }
 
+  names() {
+    return [...this.#entriesByName.keys()]
+  }
+
   isEnabled(name, context = {}) {
     const entry = this.get(name)
     return Boolean(entry && policyAllows(entry.policy, context))
@@ -69,5 +73,46 @@ export class FrontendToolRegistry {
     return [...this.#entriesByName.entries()]
       .filter(([name]) => this.isEnabled(name, context))
       .map(([, entry]) => entry.definition)
+  }
+
+  createExecutor(handlers) {
+    return new FrontendToolExecutor({ registry: this, handlers })
+  }
+}
+
+/**
+ * Exact dispatcher for the tools declared by one registry.
+ *
+ * Argument parsing, turn correlation and tool-specific policy remain outside
+ * this generic boundary; the executor only guarantees that every registered
+ * tool has exactly one callable implementation and unknown tools stay closed.
+ */
+export class FrontendToolExecutor {
+  #handlersByName
+
+  constructor({ registry, handlers = {} } = {}) {
+    if (!(registry instanceof FrontendToolRegistry)) {
+      throw new Error('FrontendToolExecutor requires a FrontendToolRegistry')
+    }
+    this.#handlersByName = new Map()
+    for (const [name, handler] of Object.entries(handlers)) {
+      if (!registry.has(name)) {
+        throw new Error(`Executor handler is not registered: ${name}`)
+      }
+      if (typeof handler !== 'function') {
+        throw new Error(`Executor handler must be a function: ${name}`)
+      }
+      this.#handlersByName.set(name, handler)
+    }
+    const missing = registry.names().filter(name => !this.#handlersByName.has(name))
+    if (missing.length) {
+      throw new Error(`Frontend tools lack executors: ${missing.join(', ')}`)
+    }
+  }
+
+  async execute(name, context) {
+    const handler = this.#handlersByName.get(String(name || ''))
+    if (!handler) return { handled: false, value: undefined }
+    return { handled: true, value: await handler(context) }
   }
 }

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -9,6 +9,7 @@ import {
   NOTES_TOOL_NAME,
   MEMORY_TOOL_NAME,
   RESPOND_AGENT_PERMISSION_TOOL_NAME,
+  frontendToolRegistry,
 } from '../frontend-tools.mjs'
 import { currentTimeSnapshot } from '../../conversation/frontend-agent-context.mjs'
 import { canonicalScope, isMemoryDocument } from '../../core/memory-scopes.mjs'
@@ -127,6 +128,33 @@ export class ToolCallHandler {
     this.requestClientState = requestClientState
     this.onAgentActivity = onAgentActivity
     this.inputAssets = inputAssets
+    this.toolExecutor = frontendToolRegistry.createExecutor({
+      [SPAWN_THINKING_TOOL_NAME]: context => (
+        this.executeSpawnThinkingToolCall(context)
+      ),
+      [SCHEDULE_REMINDER_TOOL_NAME]: ({ callId, turnId, args }) => (
+        this.handleScheduleReminder(callId, turnId, args)
+      ),
+      [CANCEL_AGENT_TASK_TOOL_NAME]: context => (
+        this.executeCancelToolCall(context)
+      ),
+      [GET_AGENT_TASK_STATUS_TOOL_NAME]: context => (
+        this.executeStatusToolCall(context)
+      ),
+      [GET_CURRENT_TIME_TOOL_NAME]: ({ callId, turnId }) => (
+        this.getCurrentTime(callId, turnId)
+      ),
+      [MEMORY_TOOL_NAME]: context => this.executeMemoryToolCall(context),
+      [NOTES_TOOL_NAME]: ({ callId, turnId, args }) => (
+        this.notes(callId, turnId, args)
+      ),
+      [RESPOND_AGENT_PERMISSION_TOOL_NAME]: ({ callId, turnId, args }) => (
+        this.respondAgentPermission(callId, turnId, args)
+      ),
+      [ENTER_SLEEP_TOOL_NAME]: ({ callId, turnId }) => (
+        this.enterSleep(callId, turnId)
+      ),
+    })
     this.gatewayApprovedPermissions = new Set()
     this.processedCalls = new Set()
     this.spawnResponseByTurn = new Map()
@@ -415,166 +443,135 @@ export class ToolCallHandler {
     })
   }
 
-  async handle(event, callContext = {}) {
-    const callId = event.call_id || event.item?.call_id || ''
-    const toolName = event.name || event.item?.name || ''
-    if (!callId) throw new Error('Realtime 工具调用缺少 call_id')
-    if (this.processedCalls.has(callId)) return
-    this.processedCalls.add(callId)
-    if (this.processedCalls.size > 500) {
-      this.processedCalls.delete(this.processedCalls.values().next().value)
-    }
-
-    const turnId = callContext.turnId
-      || event.__voiceContext?.turnId
-      || this.getTurnId()
-    const generation = Number.isInteger(callContext.turnGeneration)
-      ? callContext.turnGeneration
-      : Number.isInteger(event.__voiceContext?.turnGeneration)
-        ? event.__voiceContext.turnGeneration
-        : this.getTurnGeneration()
-    let args = {}
+  async executeMemoryToolCall({
+    callId,
+    turnId,
+    generation,
+    args,
+    event,
+    callContext,
+  }) {
+    const responseId = callContext.responseId || event.response_id || ''
+    const deferred = this.beginDeferredToolResponse(responseId, {
+      turnId,
+      turnGeneration: generation,
+    })
     try {
-      args = JSON.parse(event.arguments || '{}')
-    } catch {
-      // Invalid arguments are handled as missing fields below.
+      await this.memory(callId, turnId, args, deferred
+        ? { createResponse: false }
+        : undefined)
+    } catch (error) {
+      await this.completeDeferredToolResponse(deferred, { failed: true })
+      throw error
     }
+    await this.completeDeferredToolResponse(deferred)
+  }
 
-    if (this.isStale(turnId, generation)) {
-      await this.closeStaleCall(callId, turnId)
+  async executeCancelToolCall({
+    callId,
+    turnId,
+    generation,
+    args,
+    event,
+    callContext,
+  }) {
+    const responseId = String(
+      callContext.responseId || event.response_id || '',
+    ).trim()
+    const firstCancelResponse = turnId
+      ? this.cancelResponseByTurn.get(turnId)
+      : null
+    if (responseId && firstCancelResponse
+      && firstCancelResponse !== responseId) {
+      this.markTerminalToolResponse(responseId)
+      await this.sendOutput(callId, {
+        status: 'duplicate',
+        message: '本轮取消操作已经处理，不再重复执行。',
+      }, turnId, null, { createResponse: false })
       return
     }
-
-    if (toolName === GET_CURRENT_TIME_TOOL_NAME) {
-      await this.getCurrentTime(callId, turnId)
-      return
-    }
-    if (toolName === MEMORY_TOOL_NAME) {
-      const responseId = callContext.responseId || event.response_id || ''
-      const deferred = this.beginDeferredToolResponse(responseId, {
-        turnId,
-        turnGeneration: generation,
-      })
-      try {
-        await this.memory(callId, turnId, args, deferred
-          ? { createResponse: false }
-          : undefined)
-      } catch (error) {
-        await this.completeDeferredToolResponse(deferred, { failed: true })
-        throw error
-      }
-      await this.completeDeferredToolResponse(deferred)
-      return
-    }
-    if (toolName === NOTES_TOOL_NAME) {
-      await this.notes(callId, turnId, args)
-      return
-    }
-    if (toolName === SCHEDULE_REMINDER_TOOL_NAME) {
-      await this.handleScheduleReminder(callId, turnId, args)
-      return
-    }
-    if (toolName === CANCEL_AGENT_TASK_TOOL_NAME) {
-      const responseId = String(
-        callContext.responseId || event.response_id || '',
-      ).trim()
-      const firstCancelResponse = turnId
-        ? this.cancelResponseByTurn.get(turnId)
-        : null
-      if (responseId && firstCancelResponse
-        && firstCancelResponse !== responseId) {
-        this.markTerminalToolResponse(responseId)
-        await this.sendOutput(callId, {
-          status: 'duplicate',
-          message: '本轮取消操作已经处理，不再重复执行。',
-        }, turnId, null, { createResponse: false })
-        return
-      }
-      if (responseId && turnId && !firstCancelResponse) {
-        this.cancelResponseByTurn.set(turnId, responseId)
-        if (this.cancelResponseByTurn.size > 100) {
-          this.cancelResponseByTurn.delete(
-            this.cancelResponseByTurn.keys().next().value,
-          )
-        }
-      }
-      const deferred = this.beginDeferredToolResponse(responseId, {
-        turnId,
-        turnGeneration: generation,
-      }, { instructions: CANCEL_RECEIPT_INSTRUCTIONS })
-      let outputFailed = false
-      try {
-        await this.cancelAgentTask(
-          callId,
-          turnId,
-          args,
-          deferred
-            ? { createResponse: false }
-            : { response: { instructions: CANCEL_RECEIPT_INSTRUCTIONS } },
+    if (responseId && turnId && !firstCancelResponse) {
+      this.cancelResponseByTurn.set(turnId, responseId)
+      if (this.cancelResponseByTurn.size > 100) {
+        this.cancelResponseByTurn.delete(
+          this.cancelResponseByTurn.keys().next().value,
         )
-      } catch (error) {
-        outputFailed = true
-        throw error
-      } finally {
-        await this.completeDeferredToolResponse(deferred, {
-          failed: outputFailed,
-        })
       }
-      return
     }
-    if (toolName === GET_AGENT_TASK_STATUS_TOOL_NAME) {
-      const responseId = String(
-        callContext.responseId || event.response_id || '',
-      ).trim()
-      const spawnResponse = turnId
-        ? this.spawnResponseByTurn.get(turnId)
-        : null
-      const firstStatusResponse = turnId
-        ? this.statusResponseByTurn.get(turnId)
-        : null
-      const followsSpawnReceipt = Boolean(
-        responseId && spawnResponse && responseId !== spawnResponse,
-      )
-      const repeatsStatusQuery = Boolean(
-        responseId && firstStatusResponse && responseId !== firstStatusResponse,
-      )
-      if (followsSpawnReceipt || repeatsStatusQuery) {
-        this.markTerminalToolResponse(responseId)
-        await this.sendOutput(callId, {
-          status: 'duplicate',
-          message: '本轮不需要再次查询工作状态。',
-        }, turnId, null, { createResponse: false })
-        return
-      }
-      if (responseId && turnId && !firstStatusResponse) {
-        this.statusResponseByTurn.set(turnId, responseId)
-        if (this.statusResponseByTurn.size > 100) {
-          this.statusResponseByTurn.delete(
-            this.statusResponseByTurn.keys().next().value,
-          )
-        }
-      }
-      this.onAgentActivity({ activity: 'query', turnId })
-      await this.getAgentTaskStatus(callId, turnId, args)
-      return
-    }
-    if (toolName === RESPOND_AGENT_PERMISSION_TOOL_NAME) {
-      await this.respondAgentPermission(callId, turnId, args)
-      return
-    }
-    if (toolName === ENTER_SLEEP_TOOL_NAME) {
-      await this.enterSleep(callId, turnId)
-      return
-    }
-    if (toolName !== SPAWN_THINKING_TOOL_NAME) {
-      await this.sendOutput(
+    const deferred = this.beginDeferredToolResponse(responseId, {
+      turnId,
+      turnGeneration: generation,
+    }, { instructions: CANCEL_RECEIPT_INSTRUCTIONS })
+    let outputFailed = false
+    try {
+      await this.cancelAgentTask(
         callId,
-        failure('unsupported_tool', '当前无法执行这个操作。'),
         turnId,
+        args,
+        deferred
+          ? { createResponse: false }
+          : { response: { instructions: CANCEL_RECEIPT_INSTRUCTIONS } },
       )
+    } catch (error) {
+      outputFailed = true
+      throw error
+    } finally {
+      await this.completeDeferredToolResponse(deferred, {
+        failed: outputFailed,
+      })
+    }
+  }
+
+  async executeStatusToolCall({
+    callId,
+    turnId,
+    args,
+    event,
+    callContext,
+  }) {
+    const responseId = String(
+      callContext.responseId || event.response_id || '',
+    ).trim()
+    const spawnResponse = turnId
+      ? this.spawnResponseByTurn.get(turnId)
+      : null
+    const firstStatusResponse = turnId
+      ? this.statusResponseByTurn.get(turnId)
+      : null
+    const followsSpawnReceipt = Boolean(
+      responseId && spawnResponse && responseId !== spawnResponse,
+    )
+    const repeatsStatusQuery = Boolean(
+      responseId && firstStatusResponse && responseId !== firstStatusResponse,
+    )
+    if (followsSpawnReceipt || repeatsStatusQuery) {
+      this.markTerminalToolResponse(responseId)
+      await this.sendOutput(callId, {
+        status: 'duplicate',
+        message: '本轮不需要再次查询工作状态。',
+      }, turnId, null, { createResponse: false })
       return
     }
+    if (responseId && turnId && !firstStatusResponse) {
+      this.statusResponseByTurn.set(turnId, responseId)
+      if (this.statusResponseByTurn.size > 100) {
+        this.statusResponseByTurn.delete(
+          this.statusResponseByTurn.keys().next().value,
+        )
+      }
+    }
+    this.onAgentActivity({ activity: 'query', turnId })
+    await this.getAgentTaskStatus(callId, turnId, args)
+  }
 
+  async executeSpawnThinkingToolCall({
+    callId,
+    turnId,
+    generation,
+    args,
+    event,
+    callContext,
+  }) {
     const pendingPermissionTask = this.taskManager.list({
       ownerId: this.ownerId,
       sessionId: this.sessionId,
@@ -802,6 +799,54 @@ export class ToolCallHandler {
         failed: outputFailed,
       })
     }
+  }
+
+  async handle(event, callContext = {}) {
+    const callId = event.call_id || event.item?.call_id || ''
+    const toolName = event.name || event.item?.name || ''
+    if (!callId) throw new Error('Realtime 工具调用缺少 call_id')
+    if (this.processedCalls.has(callId)) return
+    this.processedCalls.add(callId)
+    if (this.processedCalls.size > 500) {
+      this.processedCalls.delete(this.processedCalls.values().next().value)
+    }
+
+    const turnId = callContext.turnId
+      || event.__voiceContext?.turnId
+      || this.getTurnId()
+    const generation = Number.isInteger(callContext.turnGeneration)
+      ? callContext.turnGeneration
+      : Number.isInteger(event.__voiceContext?.turnGeneration)
+        ? event.__voiceContext.turnGeneration
+        : this.getTurnGeneration()
+    let args = {}
+    try {
+      args = JSON.parse(event.arguments || '{}')
+    } catch {
+      // Invalid arguments are handled as missing fields below.
+    }
+
+    if (this.isStale(turnId, generation)) {
+      await this.closeStaleCall(callId, turnId)
+      return
+    }
+
+    const execution = await this.toolExecutor.execute(toolName, {
+      callId,
+      turnId,
+      generation,
+      args,
+      event,
+      callContext,
+    })
+    if (!execution.handled) {
+      await this.sendOutput(
+        callId,
+        failure('unsupported_tool', '当前无法执行这个操作。'),
+        turnId,
+      )
+    }
+    return
   }
 
   async enterSleep(callId, turnId) {

--- a/server/test/frontend-tool-registry.test.mjs
+++ b/server/test/frontend-tool-registry.test.mjs
@@ -76,3 +76,40 @@ test('rejects unnamed and duplicate tool registrations', () => {
     /Duplicate frontend tool/,
   )
 })
+
+test('binds one executor per registered tool and rejects incomplete maps', async () => {
+  const definition = name => ({
+    type: 'function',
+    function: { name, parameters: { type: 'object' } },
+  })
+  const registry = new FrontendToolRegistry([
+    { definition: definition('first') },
+    { definition: definition('second') },
+  ])
+
+  assert.throws(
+    () => registry.createExecutor({ first: async () => 'first' }),
+    /lack executors: second/,
+  )
+  assert.throws(
+    () => registry.createExecutor({
+      first: async () => 'first',
+      second: async () => 'second',
+      unknown: async () => 'unknown',
+    }),
+    /not registered: unknown/,
+  )
+
+  const executor = registry.createExecutor({
+    first: async context => `first:${context.value}`,
+    second: async () => 'second',
+  })
+  assert.deepEqual(await executor.execute('first', { value: 1 }), {
+    handled: true,
+    value: 'first:1',
+  })
+  assert.deepEqual(await executor.execute('unknown', {}), {
+    handled: false,
+    value: undefined,
+  })
+})

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -96,6 +96,19 @@ test('rejects sleep when the client did not advertise that state', async () => {
   assert.equal(kit.outputs[0][1].error_code, 'unsupported_client_state')
 })
 
+test('fails closed for tools absent from the frontend registry', async () => {
+  const kit = harness()
+
+  await kit.handler.handle({
+    call_id: 'call-unknown',
+    name: 'unknown_tool',
+    arguments: '{}',
+  }, { turnId: 'turn-one', turnGeneration: 1 })
+
+  assert.equal(kit.outputs[0][1].error_code, 'unsupported_tool')
+  assert.equal(kit.manager.list({ ownerId: 'owner' }).length, 0)
+})
+
 async function permissionHarness({
   answer,
   authorizationId = 'auth-one',


### PR DESCRIPTION
## Summary
- add a Registry-owned Frontend Tool Executor with exact handler coverage
- migrate all existing frontend tools from conditional dispatch to the executor without changing names or behavior
- keep unknown tools fail-closed and update the bilingual runtime roadmap

## Verification
- `npm run lint`
- focused server tests: 118 passed
- Web, TUI, Desktop, and CLI workspace tests passed
- `npm run build`

Server full test output reached 259 passing tests but the local Node test process retained an existing open handle; GitHub CI is the final full-suite check.