### PR TITLE
refactor: classify frontend tool execution modes

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -172,7 +172,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
   - [x] Extract the declarative Registry and visibility Policy.
   - [x] Route execution through the Registry-owned Executor.
 - [x] Migrate existing tools without renaming or changing behavior.
-- [ ] Make `spawn_thinking` a first-class background tool.
+- [x] Make `spawn_thinking` a first-class background tool.
 - [ ] Add a bounded short tool loop.
 
 ### R3 — Work Runtime

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -220,7 +220,7 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
   - [x] 提取声明式 Registry 与可见性 Policy。
   - [x] 通过 Registry 管理的 Executor 统一执行入口。
 - [x] 将现有工具逐个迁移，保持工具名与用户行为不变。
-- [ ] 将 `spawn_thinking` 固化为 background tool。
+- [x] 将 `spawn_thinking` 固化为 background tool。
 - [ ] 增加有界短工具循环。
 
 完成条件：增加新前台工具只需要定义、实现和测试，不修改 Realtime Gateway 主流程。

--- a/server/src/voice/frontend-tools.mjs
+++ b/server/src/voice/frontend-tools.mjs
@@ -231,17 +231,17 @@ const scheduleReminderTool = {
 }
 
 export const frontendToolRegistry = new FrontendToolRegistry([
-  { definition: spawnThinkingTool },
-  { definition: scheduleReminderTool },
-  { definition: cancelAgentTaskTool },
-  { definition: getAgentTaskStatusTool },
-  { definition: getCurrentTimeTool },
-  { definition: memoryTool },
-  { definition: notesTool },
-  { definition: respondAgentPermissionTool },
+  { definition: spawnThinkingTool, policy: { mode: 'background' } },
+  { definition: scheduleReminderTool, policy: { mode: 'inline' } },
+  { definition: cancelAgentTaskTool, policy: { mode: 'control' } },
+  { definition: getAgentTaskStatusTool, policy: { mode: 'control' } },
+  { definition: getCurrentTimeTool, policy: { mode: 'inline' } },
+  { definition: memoryTool, policy: { mode: 'inline' } },
+  { definition: notesTool, policy: { mode: 'inline' } },
+  { definition: respondAgentPermissionTool, policy: { mode: 'control' } },
   {
     definition: enterSleepTool,
-    policy: { requiredClientStates: ['sleeping'] },
+    policy: { mode: 'control', requiredClientStates: ['sleeping'] },
   },
 ])
 

--- a/server/src/voice/tools/frontend-tool-registry.mjs
+++ b/server/src/voice/tools/frontend-tool-registry.mjs
@@ -2,6 +2,14 @@ function toolName(entry) {
   return String(entry?.definition?.function?.name || '').trim()
 }
 
+export const FRONTEND_TOOL_MODES = Object.freeze([
+  'inline',
+  'background',
+  'control',
+])
+
+const FRONTEND_TOOL_MODE_SET = new Set(FRONTEND_TOOL_MODES)
+
 function clientStates(context) {
   return new Set(
     Array.isArray(context?.client?.states)
@@ -19,7 +27,13 @@ function policyAllows(policy = {}, context = {}) {
 }
 
 function normalizedPolicy(policy = {}) {
-  const normalized = { ...policy }
+  const mode = String(policy.mode || '').trim()
+  if (!FRONTEND_TOOL_MODE_SET.has(mode)) {
+    throw new Error(
+      `Frontend tool policy requires a valid mode: ${FRONTEND_TOOL_MODES.join(', ')}`,
+    )
+  }
+  const normalized = { ...policy, mode }
   if (Array.isArray(policy.requiredClientStates)) {
     normalized.requiredClientStates = Object.freeze([
       ...policy.requiredClientStates.map(String),
@@ -31,8 +45,9 @@ function normalizedPolicy(policy = {}) {
 /**
  * Declarative catalog for tools exposed to the realtime frontend model.
  *
- * Registry policy controls tool visibility only. Tool implementations still
- * validate permissions and current runtime state at execution time.
+ * Each entry declares its execution mode and optional visibility constraints.
+ * Visibility never replaces permission or current-state validation inside the
+ * tool implementation.
  */
 export class FrontendToolRegistry {
   #entriesByName
@@ -46,6 +61,7 @@ export class FrontendToolRegistry {
         throw new Error(`Duplicate frontend tool: ${name}`)
       }
       this.#entriesByName.set(name, Object.freeze({
+        name,
         definition: entry.definition,
         policy: normalizedPolicy(entry.policy),
       }))
@@ -88,12 +104,14 @@ export class FrontendToolRegistry {
  * tool has exactly one callable implementation and unknown tools stay closed.
  */
 export class FrontendToolExecutor {
+  #registry
   #handlersByName
 
   constructor({ registry, handlers = {} } = {}) {
     if (!(registry instanceof FrontendToolRegistry)) {
       throw new Error('FrontendToolExecutor requires a FrontendToolRegistry')
     }
+    this.#registry = registry
     this.#handlersByName = new Map()
     for (const [name, handler] of Object.entries(handlers)) {
       if (!registry.has(name)) {
@@ -110,9 +128,16 @@ export class FrontendToolExecutor {
     }
   }
 
-  async execute(name, context) {
-    const handler = this.#handlersByName.get(String(name || ''))
-    if (!handler) return { handled: false, value: undefined }
-    return { handled: true, value: await handler(context) }
+  async execute(name, context = {}) {
+    const entry = this.#registry.get(name)
+    const handler = this.#handlersByName.get(entry?.name)
+    if (!entry || !handler) {
+      return { handled: false, tool: null, value: undefined }
+    }
+    return {
+      handled: true,
+      tool: entry,
+      value: await handler({ ...context, tool: entry }),
+    }
   }
 }

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -846,7 +846,7 @@ export class ToolCallHandler {
         turnId,
       )
     }
-    return
+    return execution
   }
 
   async enterSleep(callId, turnId) {

--- a/server/test/frontend-tool-registry.test.mjs
+++ b/server/test/frontend-tool-registry.test.mjs
@@ -7,6 +7,7 @@ import {
   TOOLS,
 } from '../src/voice/frontend-tools.mjs'
 import {
+  FRONTEND_TOOL_MODES,
   FrontendToolRegistry,
 } from '../src/voice/tools/frontend-tool-registry.mjs'
 
@@ -54,9 +55,36 @@ test('exposes client-state tools only when the client advertises support', () =>
 
 test('keeps visibility policy separate from runtime execution checks', () => {
   const entry = frontendToolRegistry.get(ENTER_SLEEP_TOOL_NAME)
-  assert.deepEqual(entry.policy, { requiredClientStates: ['sleeping'] })
+  assert.deepEqual(entry.policy, {
+    mode: 'control',
+    requiredClientStates: ['sleeping'],
+  })
   assert.equal(Object.isFrozen(entry.policy), true)
   assert.equal(Object.isFrozen(entry.policy.requiredClientStates), true)
+})
+
+test('declares one background tool and classifies every other tool', () => {
+  assert.deepEqual(FRONTEND_TOOL_MODES, [
+    'inline',
+    'background',
+    'control',
+  ])
+  assert.deepEqual(Object.fromEntries(
+    frontendToolRegistry.names().map(name => [
+      name,
+      frontendToolRegistry.get(name).policy.mode,
+    ]),
+  ), {
+    spawn_thinking: 'background',
+    schedule_reminder: 'inline',
+    cancel_agent_task: 'control',
+    get_agent_task_status: 'control',
+    get_current_time: 'inline',
+    memory: 'inline',
+    notes: 'inline',
+    respond_agent_permission: 'control',
+    enter_sleep: 'control',
+  })
 })
 
 test('rejects unnamed and duplicate tool registrations', () => {
@@ -70,10 +98,20 @@ test('rejects unnamed and duplicate tool registrations', () => {
   }
   assert.throws(
     () => new FrontendToolRegistry([
-      { definition },
-      { definition },
+      { definition, policy: { mode: 'inline' } },
+      { definition, policy: { mode: 'inline' } },
     ]),
     /Duplicate frontend tool/,
+  )
+  assert.throws(
+    () => new FrontendToolRegistry([{ definition }]),
+    /requires a valid mode/,
+  )
+  assert.throws(
+    () => new FrontendToolRegistry([
+      { definition, policy: { mode: 'deferred' } },
+    ]),
+    /requires a valid mode/,
   )
 })
 
@@ -83,8 +121,8 @@ test('binds one executor per registered tool and rejects incomplete maps', async
     function: { name, parameters: { type: 'object' } },
   })
   const registry = new FrontendToolRegistry([
-    { definition: definition('first') },
-    { definition: definition('second') },
+    { definition: definition('first'), policy: { mode: 'background' } },
+    { definition: definition('second'), policy: { mode: 'inline' } },
   ])
 
   assert.throws(
@@ -104,12 +142,14 @@ test('binds one executor per registered tool and rejects incomplete maps', async
     first: async context => `first:${context.value}`,
     second: async () => 'second',
   })
-  assert.deepEqual(await executor.execute('first', { value: 1 }), {
-    handled: true,
-    value: 'first:1',
-  })
+  const execution = await executor.execute('first', { value: 1 })
+  assert.equal(execution.handled, true)
+  assert.equal(execution.tool.name, 'first')
+  assert.equal(execution.tool.policy.mode, 'background')
+  assert.equal(execution.value, 'first:1')
   assert.deepEqual(await executor.execute('unknown', {}), {
     handled: false,
+    tool: null,
     value: undefined,
   })
 })

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -166,12 +166,13 @@ test('submits one nonblocking coordinator work item with organized intent', asyn
     },
   })
   kit.transcripts.record('turn-one', '继续改刚才那个页面')
-  await kit.handler.handle({
+  const execution = await kit.handler.handle({
     call_id: 'call-one',
     name: 'spawn_thinking',
     arguments: JSON.stringify({ objective: '继续修改此前讨论的页面' }),
   }, { turnId: 'turn-one', turnGeneration: 1 })
 
+  assert.equal(execution.tool.policy.mode, 'background')
   assert.equal(kit.outputs[0][1].status, 'accepted')
   assert.equal(
     kit.outputs[0][1].message,


### PR DESCRIPTION
## Summary
- require every frontend tool to declare an inline, background, or control execution mode
- classify `spawn_thinking` as the only background tool and expose tool metadata through the executor result
- preserve existing tool names, prompts, receipts, and scheduling behavior
- update the bilingual frontend runtime roadmap

## Verification
- `npm run lint`
- focused server tests: 119 passed
- `npm run build`