### PR TITLE
feat: bound frontend tool loops

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -173,7 +173,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
   - [x] Route execution through the Registry-owned Executor.
 - [x] Migrate existing tools without renaming or changing behavior.
 - [x] Make `spawn_thinking` a first-class background tool.
-- [ ] Add a bounded short tool loop.
+- [x] Add a bounded short tool loop.
 
 ### R3 — Work Runtime
 

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -221,7 +221,7 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
   - [x] 通过 Registry 管理的 Executor 统一执行入口。
 - [x] 将现有工具逐个迁移，保持工具名与用户行为不变。
 - [x] 将 `spawn_thinking` 固化为 background tool。
-- [ ] 增加有界短工具循环。
+- [x] 增加有界短工具循环。
 
 完成条件：增加新前台工具只需要定义、实现和测试，不修改 Realtime Gateway 主流程。
 

--- a/server/src/voice/frontend-tools.mjs
+++ b/server/src/voice/frontend-tools.mjs
@@ -231,7 +231,10 @@ const scheduleReminderTool = {
 }
 
 export const frontendToolRegistry = new FrontendToolRegistry([
-  { definition: spawnThinkingTool, policy: { mode: 'background' } },
+  {
+    definition: spawnThinkingTool,
+    policy: { mode: 'background', repeatHandling: 'handler' },
+  },
   { definition: scheduleReminderTool, policy: { mode: 'inline' } },
   { definition: cancelAgentTaskTool, policy: { mode: 'control' } },
   { definition: getAgentTaskStatusTool, policy: { mode: 'control' } },

--- a/server/src/voice/tools/frontend-tool-loop.mjs
+++ b/server/src/voice/tools/frontend-tool-loop.mjs
@@ -1,0 +1,128 @@
+const DEFAULT_MAX_CALLS_PER_TURN = 12
+const DEFAULT_MAX_DURATION_MS = 30_000
+const DEFAULT_MAX_TRACKED_TURNS = 100
+export const DEFAULT_FRONTEND_TOOL_MAX_RESULT_BYTES = 64 * 1024
+
+function positiveInteger(value, fallback) {
+  const number = Number(value)
+  return Number.isInteger(number) && number > 0 ? number : fallback
+}
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue)
+  if (!value || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.keys(value).sort().map(key => [key, stableValue(value[key])]),
+  )
+}
+
+function callSignature(toolName, args) {
+  return `${toolName}:${JSON.stringify(stableValue(args))}`
+}
+
+export function boundFrontendToolResult(
+  value,
+  maxBytes = DEFAULT_FRONTEND_TOOL_MAX_RESULT_BYTES,
+) {
+  const limit = positiveInteger(
+    maxBytes,
+    DEFAULT_FRONTEND_TOOL_MAX_RESULT_BYTES,
+  )
+  try {
+    const bytes = Buffer.byteLength(JSON.stringify(value), 'utf8')
+    return bytes <= limit
+      ? { accepted: true, value, bytes, maxBytes: limit }
+      : { accepted: false, value: undefined, bytes, maxBytes: limit }
+  } catch {
+    return {
+      accepted: false,
+      value: undefined,
+      bytes: null,
+      maxBytes: limit,
+    }
+  }
+}
+
+/**
+ * Per-connection safety boundary for model-driven frontend tool loops.
+ *
+ * The guard is deliberately independent from tool behavior: it limits one
+ * correlated user turn by time and call count, and blocks an exact repeated
+ * call before a side effect can run. A new turn receives a fresh budget.
+ */
+export class FrontendToolLoop {
+  #maxCallsPerTurn
+  #maxDurationMs
+  #maxTrackedTurns
+  #now
+  #turns = new Map()
+
+  constructor({
+    maxCallsPerTurn = DEFAULT_MAX_CALLS_PER_TURN,
+    maxDurationMs = DEFAULT_MAX_DURATION_MS,
+    maxTrackedTurns = DEFAULT_MAX_TRACKED_TURNS,
+    now = Date.now,
+  } = {}) {
+    this.#maxCallsPerTurn = positiveInteger(
+      maxCallsPerTurn,
+      DEFAULT_MAX_CALLS_PER_TURN,
+    )
+    this.#maxDurationMs = positiveInteger(
+      maxDurationMs,
+      DEFAULT_MAX_DURATION_MS,
+    )
+    this.#maxTrackedTurns = positiveInteger(
+      maxTrackedTurns,
+      DEFAULT_MAX_TRACKED_TURNS,
+    )
+    this.#now = typeof now === 'function' ? now : Date.now
+  }
+
+  admit({ turnId, turnGeneration, tool, args = {} } = {}) {
+    const id = String(turnId || '').trim()
+    const name = String(tool?.name || '').trim()
+    if (!id || !name) return { admitted: true, reason: null }
+
+    const key = `${String(turnGeneration ?? '')}:${id}`
+    const now = this.#now()
+    let turn = this.#turns.get(key)
+    if (!turn) {
+      turn = { startedAt: now, calls: 0, signatures: new Set() }
+      if (this.#turns.size >= this.#maxTrackedTurns) {
+        this.#turns.delete(this.#turns.keys().next().value)
+      }
+      this.#turns.set(key, turn)
+    }
+
+    if (now - turn.startedAt > this.#maxDurationMs) {
+      return {
+        admitted: false,
+        reason: 'duration_limit',
+        calls: turn.calls,
+      }
+    }
+    if (turn.calls >= this.#maxCallsPerTurn) {
+      return {
+        admitted: false,
+        reason: 'call_limit',
+        calls: turn.calls,
+      }
+    }
+
+    const signature = callSignature(name, args)
+    if (
+      turn.signatures.has(signature)
+      && tool.policy?.repeatHandling !== 'handler'
+    ) {
+      return {
+        admitted: false,
+        reason: 'repeated_call',
+        calls: turn.calls,
+      }
+    }
+
+    turn.calls += 1
+    turn.signatures.add(signature)
+    return { admitted: true, reason: null, calls: turn.calls }
+  }
+}

--- a/server/src/voice/tools/frontend-tool-registry.mjs
+++ b/server/src/voice/tools/frontend-tool-registry.mjs
@@ -1,3 +1,5 @@
+import { FrontendToolLoop } from './frontend-tool-loop.mjs'
+
 function toolName(entry) {
   return String(entry?.definition?.function?.name || '').trim()
 }
@@ -33,6 +35,18 @@ function normalizedPolicy(policy = {}) {
       `Frontend tool policy requires a valid mode: ${FRONTEND_TOOL_MODES.join(', ')}`,
     )
   }
+  if (
+    policy.repeatHandling !== undefined
+    && policy.repeatHandling !== 'handler'
+  ) {
+    throw new Error('Frontend tool repeatHandling must be handler when set')
+  }
+  if (
+    policy.maxResultBytes !== undefined
+    && positivePolicyInteger(policy.maxResultBytes) === null
+  ) {
+    throw new Error('Frontend tool maxResultBytes must be a positive integer')
+  }
   const normalized = { ...policy, mode }
   if (Array.isArray(policy.requiredClientStates)) {
     normalized.requiredClientStates = Object.freeze([
@@ -40,6 +54,11 @@ function normalizedPolicy(policy = {}) {
     ])
   }
   return Object.freeze(normalized)
+}
+
+function positivePolicyInteger(value) {
+  const number = Number(value)
+  return Number.isInteger(number) && number > 0 ? number : null
 }
 
 /**
@@ -91,8 +110,8 @@ export class FrontendToolRegistry {
       .map(([, entry]) => entry.definition)
   }
 
-  createExecutor(handlers) {
-    return new FrontendToolExecutor({ registry: this, handlers })
+  createExecutor(handlers, options) {
+    return new FrontendToolExecutor({ registry: this, handlers, ...options })
   }
 }
 
@@ -106,12 +125,14 @@ export class FrontendToolRegistry {
 export class FrontendToolExecutor {
   #registry
   #handlersByName
+  #loop
 
-  constructor({ registry, handlers = {} } = {}) {
+  constructor({ registry, handlers = {}, loop = new FrontendToolLoop() } = {}) {
     if (!(registry instanceof FrontendToolRegistry)) {
       throw new Error('FrontendToolExecutor requires a FrontendToolRegistry')
     }
     this.#registry = registry
+    this.#loop = loop
     this.#handlersByName = new Map()
     for (const [name, handler] of Object.entries(handlers)) {
       if (!registry.has(name)) {
@@ -132,10 +153,26 @@ export class FrontendToolExecutor {
     const entry = this.#registry.get(name)
     const handler = this.#handlersByName.get(entry?.name)
     if (!entry || !handler) {
-      return { handled: false, tool: null, value: undefined }
+      return {
+        handled: false,
+        executed: false,
+        tool: null,
+        value: undefined,
+      }
+    }
+    const limit = this.#loop.admit({ ...context, tool: entry })
+    if (!limit.admitted) {
+      return {
+        handled: true,
+        executed: false,
+        tool: entry,
+        limit,
+        value: undefined,
+      }
     }
     return {
       handled: true,
+      executed: true,
       tool: entry,
       value: await handler({ ...context, tool: entry }),
     }

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -11,6 +11,9 @@ import {
   RESPOND_AGENT_PERMISSION_TOOL_NAME,
   frontendToolRegistry,
 } from '../frontend-tools.mjs'
+import {
+  boundFrontendToolResult,
+} from './frontend-tool-loop.mjs'
 import { currentTimeSnapshot } from '../../conversation/frontend-agent-context.mjs'
 import { canonicalScope, isMemoryDocument } from '../../core/memory-scopes.mjs'
 import { inputPartRef } from '../../../../shared/input-parts.mjs'
@@ -128,6 +131,7 @@ export class ToolCallHandler {
     this.requestClientState = requestClientState
     this.onAgentActivity = onAgentActivity
     this.inputAssets = inputAssets
+    this.activeToolEntries = new Map()
     this.toolExecutor = frontendToolRegistry.createExecutor({
       [SPAWN_THINKING_TOOL_NAME]: context => (
         this.executeSpawnThinkingToolCall(context)
@@ -192,9 +196,21 @@ export class ToolCallHandler {
       responseContext,
       ...frontendOptions
     } = options || {}
+    const tool = this.activeToolEntries.get(callId)
+    const bounded = boundFrontendToolResult(
+      output,
+      tool?.policy.maxResultBytes,
+    )
+    const safeOutput = bounded.accepted
+      ? bounded.value
+      : failure(
+          'tool_result_too_large',
+          '工具结果过大，无法在当前语音轮次中安全返回。',
+          { retryable: true },
+        )
     await this.getFrontend()?.sendFunctionOutput(
       callId,
-      output,
+      safeOutput,
       { turnId, taskId, ...(responseContext || {}) },
       frontendOptions,
     )
@@ -831,22 +847,51 @@ export class ToolCallHandler {
       return
     }
 
-    const execution = await this.toolExecutor.execute(toolName, {
-      callId,
-      turnId,
-      generation,
-      args,
-      event,
-      callContext,
-    })
-    if (!execution.handled) {
-      await this.sendOutput(
+    const tool = frontendToolRegistry.get(toolName)
+    if (tool) this.activeToolEntries.set(callId, tool)
+    try {
+      const execution = await this.toolExecutor.execute(toolName, {
         callId,
-        failure('unsupported_tool', '当前无法执行这个操作。'),
         turnId,
-      )
+        generation,
+        args,
+        event,
+        callContext,
+      })
+      if (execution.handled && !execution.executed) {
+        const responseId = String(
+          callContext.responseId || event.response_id || '',
+        ).trim()
+        this.markTerminalToolResponse(responseId)
+        await this.sendOutput(
+          callId,
+          execution.limit.reason === 'repeated_call'
+            ? {
+                status: 'duplicate',
+                message: '本轮相同操作已经处理，不再重复执行。',
+              }
+            : failure(
+                'tool_loop_limit',
+                '本轮工具调用已达到安全边界，已停止继续执行。',
+                { retryable: true },
+              ),
+          turnId,
+          null,
+          { createResponse: false },
+        )
+        return execution
+      }
+      if (!execution.handled) {
+        await this.sendOutput(
+          callId,
+          failure('unsupported_tool', '当前无法执行这个操作。'),
+          turnId,
+        )
+      }
+      return execution
+    } finally {
+      this.activeToolEntries.delete(callId)
     }
-    return execution
   }
 
   async enterSleep(callId, turnId) {

--- a/server/test/frontend-tool-loop.test.mjs
+++ b/server/test/frontend-tool-loop.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  boundFrontendToolResult,
+  FrontendToolLoop,
+} from '../src/voice/tools/frontend-tool-loop.mjs'
+
+const tool = { name: 'example' }
+
+test('admits distinct calls within one bounded turn', () => {
+  const loop = new FrontendToolLoop({ maxCallsPerTurn: 2 })
+
+  assert.equal(loop.admit({ turnId: 'turn', tool, args: { value: 1 } }).admitted, true)
+  assert.equal(loop.admit({ turnId: 'turn', tool, args: { value: 2 } }).admitted, true)
+  assert.equal(loop.admit({ turnId: 'turn', tool, args: { value: 3 } }).reason, 'call_limit')
+})
+
+test('blocks an exact repeated call before executing it again', () => {
+  const loop = new FrontendToolLoop()
+
+  assert.equal(loop.admit({
+    turnId: 'turn',
+    tool,
+    args: { second: 2, first: 1 },
+  }).admitted, true)
+  assert.equal(loop.admit({
+    turnId: 'turn',
+    tool,
+    args: { first: 1, second: 2 },
+  }).reason, 'repeated_call')
+})
+
+test('lets a tool with richer idempotency semantics handle its own repeats', () => {
+  const loop = new FrontendToolLoop()
+  const guardedTool = {
+    name: 'guarded',
+    policy: { repeatHandling: 'handler' },
+  }
+
+  assert.equal(loop.admit({
+    turnId: 'turn',
+    tool: guardedTool,
+    args: { value: 1 },
+  }).admitted, true)
+  assert.equal(loop.admit({
+    turnId: 'turn',
+    tool: guardedTool,
+    args: { value: 1 },
+  }).admitted, true)
+})
+
+test('starts a fresh budget for a new turn or generation', () => {
+  const loop = new FrontendToolLoop()
+  const input = { tool, args: { value: 1 } }
+
+  assert.equal(loop.admit({ ...input, turnId: 'one', turnGeneration: 1 }).admitted, true)
+  assert.equal(loop.admit({ ...input, turnId: 'two', turnGeneration: 1 }).admitted, true)
+  assert.equal(loop.admit({ ...input, turnId: 'one', turnGeneration: 2 }).admitted, true)
+})
+
+test('stops a tool loop after its total duration budget', () => {
+  let now = 1_000
+  const loop = new FrontendToolLoop({
+    maxDurationMs: 100,
+    now: () => now,
+  })
+
+  assert.equal(loop.admit({ turnId: 'turn', tool, args: { value: 1 } }).admitted, true)
+  now += 101
+  assert.equal(loop.admit({
+    turnId: 'turn',
+    tool,
+    args: { value: 2 },
+  }).reason, 'duration_limit')
+})
+
+test('bounds serialized tool results before they return to the model', () => {
+  const accepted = { status: 'ok', content: 'short' }
+  assert.deepEqual(boundFrontendToolResult(accepted, 100).value, accepted)
+
+  const rejected = boundFrontendToolResult({ content: 'x'.repeat(100) }, 20)
+  assert.equal(rejected.accepted, false)
+  assert.equal(rejected.bytes > rejected.maxBytes, true)
+
+  const circular = {}
+  circular.self = circular
+  assert.equal(boundFrontendToolResult(circular).accepted, false)
+})

--- a/server/test/frontend-tool-registry.test.mjs
+++ b/server/test/frontend-tool-registry.test.mjs
@@ -10,6 +10,7 @@ import {
   FRONTEND_TOOL_MODES,
   FrontendToolRegistry,
 } from '../src/voice/tools/frontend-tool-registry.mjs'
+import { FrontendToolLoop } from '../src/voice/tools/frontend-tool-loop.mjs'
 
 const DEFAULT_TOOL_NAMES = [
   'spawn_thinking',
@@ -113,6 +114,18 @@ test('rejects unnamed and duplicate tool registrations', () => {
     ]),
     /requires a valid mode/,
   )
+  assert.throws(
+    () => new FrontendToolRegistry([
+      { definition, policy: { mode: 'inline', repeatHandling: 'always' } },
+    ]),
+    /repeatHandling must be handler/,
+  )
+  assert.throws(
+    () => new FrontendToolRegistry([
+      { definition, policy: { mode: 'inline', maxResultBytes: 0 } },
+    ]),
+    /maxResultBytes must be a positive integer/,
+  )
 })
 
 test('binds one executor per registered tool and rejects incomplete maps', async () => {
@@ -144,12 +157,43 @@ test('binds one executor per registered tool and rejects incomplete maps', async
   })
   const execution = await executor.execute('first', { value: 1 })
   assert.equal(execution.handled, true)
+  assert.equal(execution.executed, true)
   assert.equal(execution.tool.name, 'first')
   assert.equal(execution.tool.policy.mode, 'background')
   assert.equal(execution.value, 'first:1')
   assert.deepEqual(await executor.execute('unknown', {}), {
     handled: false,
+    executed: false,
     tool: null,
     value: undefined,
   })
+})
+
+test('enforces the tool loop before invoking a registered handler', async () => {
+  const definition = {
+    type: 'function',
+    function: { name: 'bounded', parameters: { type: 'object' } },
+  }
+  const registry = new FrontendToolRegistry([
+    { definition, policy: { mode: 'inline' } },
+  ])
+  let calls = 0
+  const executor = registry.createExecutor({
+    bounded: async () => { calls += 1 },
+  }, {
+    loop: new FrontendToolLoop({ maxCallsPerTurn: 1 }),
+  })
+
+  const context = { turnId: 'turn', turnGeneration: 1 }
+  assert.equal((await executor.execute('bounded', {
+    ...context,
+    args: { value: 1 },
+  })).executed, true)
+  const limited = await executor.execute('bounded', {
+    ...context,
+    args: { value: 2 },
+  })
+  assert.equal(limited.executed, false)
+  assert.equal(limited.limit.reason, 'call_limit')
+  assert.equal(calls, 1)
 })

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -109,6 +109,26 @@ test('fails closed for tools absent from the frontend registry', async () => {
   assert.equal(kit.manager.list({ ownerId: 'owner' }).length, 0)
 })
 
+test('blocks an exact repeated inline tool call within one turn', async () => {
+  const kit = harness()
+  const context = { turnId: 'turn-one', turnGeneration: 1 }
+
+  await kit.handler.handle({
+    call_id: 'call-time-one',
+    name: 'get_current_time',
+    arguments: '{}',
+  }, context)
+  await kit.handler.handle({
+    call_id: 'call-time-two',
+    name: 'get_current_time',
+    arguments: '{}',
+  }, context)
+
+  assert.equal(kit.outputs[0][1].status, 'ok')
+  assert.equal(kit.outputs[1][1].status, 'duplicate')
+  assert.equal(kit.outputs[1][3].createResponse, false)
+})
+
 async function permissionHarness({
   answer,
   authorizationId = 'auth-one',
@@ -1346,6 +1366,26 @@ test('returns the latest document when an exact edit no longer matches', async (
   })
   assert.equal(kit.outputs.at(-1)[1].error_code, 'edit_not_found')
   assert.equal(kit.outputs.at(-1)[1].documents[0].revision, 'latest')
+})
+
+test('fails closed when a frontend tool result exceeds its size budget', async () => {
+  const kit = harness({
+    memoryStore: {
+      list: () => [{
+        scope: 'memory',
+        content: 'x'.repeat(70 * 1024),
+        revision: 'large',
+      }],
+    },
+  })
+
+  await kit.handler.handle({
+    call_id: 'memory-too-large',
+    name: 'memory',
+    arguments: JSON.stringify({ action: 'read', document: 'memory' }),
+  })
+
+  assert.equal(kit.outputs.at(-1)[1].error_code, 'tool_result_too_large')
 })
 
 test('rejects sensitive additions and incomplete atomic edits', async () => {


### PR DESCRIPTION
## Summary
- add a per-turn frontend tool loop guard with call-count, duration, and exact-repeat limits
- preserve `spawn_thinking`'s existing handler-owned idempotency while blocking repeated inline/control side effects
- bound serialized tool results before returning them to the realtime model
- fail closed without creating another response when a loop reaches its safety boundary
- update the bilingual frontend runtime roadmap

## Verification
- `npm run lint`
- focused server tests: 127 passed
- `npm run build`