### PR TITLE
refactor: extract realtime input runtime

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -169,7 +169,8 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 
 - [ ] Extract realtime session, turn, input, playback, and presentation logic.
   - [x] Centralize per-connection turn generation, correlation, and interruption boundaries.
-  - [ ] Extract input, playback/presentation, and realtime session lifecycles.
+  - [x] Extract provider audio/transcription and manual-input lifecycles.
+  - [ ] Extract playback/presentation and realtime session lifecycles.
 - [x] Add Frontend Tool Registry, Policy, and Executor.
   - [x] Extract the declarative Registry and visibility Policy.
   - [x] Route execution through the Registry-owned Executor.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -217,7 +217,8 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 
 - [ ] 提取 Realtime Session、Turn、Input、Playback 和 Presentation。
   - [x] 集中管理单连接内的 Turn 代次、关联与打断边界。
-  - [ ] 继续提取 Input、Playback/Presentation 与 Realtime Session 生命周期。
+  - [x] 提取 Provider 音频/转写与手动输入生命周期。
+  - [ ] 继续提取 Playback/Presentation 与 Realtime Session 生命周期。
 - [x] 建立 Frontend Tool Registry、Policy 和 Executor。
   - [x] 提取声明式 Registry 与可见性 Policy。
   - [x] 通过 Registry 管理的 Executor 统一执行入口。

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -24,8 +24,8 @@ import { recordTaskResult } from '../conversation/task-result-projector.mjs'
 import { projectGatewayTaskEvent } from '../transport/gateway-task-event-projector.mjs'
 import { ToolCallHandler } from './tools/tool-call-handler.mjs'
 import { TurnTranscripts } from './tools/turn-transcripts.mjs'
+import { RealtimeInputRuntime } from './realtime-input-runtime.mjs'
 import { RealtimeTurnState } from './realtime-turn-state.mjs'
-import { streamingInputTranscript } from './input-transcript.mjs'
 import {
   ensureResponseContext,
   mergeResponseContext,
@@ -47,13 +47,6 @@ import {
   isResponseActivityEvent,
   realtimeResponseId,
 } from './response-lifecycle.mjs'
-import {
-  displayInputText,
-  inputFileParts,
-  inputText,
-  normalizeInputParts,
-  withAttachmentAnchors,
-} from '../../../shared/input-parts.mjs'
 
 const MAX_PENDING_AUDIO_CHUNKS = 30
 const RESPONSE_START_WATCHDOG_MS = 12000
@@ -541,6 +534,25 @@ export function attachRealtimeGateway(server, {
       responseStartWatchdog.unref?.()
     }
 
+    const inputs = new RealtimeInputRuntime({
+      ownerId,
+      sessionId,
+      turns,
+      transcripts,
+      inputAssets,
+      conversationSync,
+      announcementWindow,
+      announcements,
+      send: event => send(ws, event),
+      getFrontend: () => frontend,
+      ensureFrontend: () => ensureFrontend(),
+      clearResponseCandidate,
+      expectResponseFor,
+      shouldEnsurePermissionResponse: context => responseTurnCandidate === context,
+      ensurePermissionResponseFor,
+      reportFrontendError,
+    })
+
     const queueNotification = task => {
       if (task.status === 'completed') {
         announcements.completed(task)
@@ -938,146 +950,8 @@ export function attachRealtimeGateway(server, {
     const handleEvent = event => {
       if (isSleepActivityEvent(event)) sleepController?.recordActivity()
       if (isResponseActivityEvent(event)) beginResponseLifecycle(event)
-      if (event.type === 'input_audio_buffer.speech_started') {
-        // A discrete text/image submission owns the turn until its response
-        // starts. Provider-side VAD events caused by audio already in flight
-        // belong to the superseded voice turn and must not take ownership back.
-        const started = turns.beginVoice(event.item_id)
-        if (!started.accepted) return
-        clearResponseCandidate()
-        announcementWindow.beginTurn(started.context.turnId)
-        announcements.dismissActive()
-        send(ws, {
-          type: 'playback.clear',
-          reason: 'user_interruption',
-        })
-        send(ws, { type: 'turn.started', turnId: started.context.turnId })
-        send(ws, {
-          type: 'voice.state',
-          state: 'listening',
-          turnId: started.context.turnId,
-        })
-        frontend?.cancel()
-      } else if (event.type === 'input_audio_buffer.speech_stopped') {
-        const stoppedTurn = turns.resolveInput(event.item_id)
-        if (
-          turns.isInputInvalid(event.item_id)
-          || turns.isStale(stoppedTurn)
-        ) {
-          turns.invalidateInput(event.item_id)
-          return
-        }
-        turns.endSpeech()
-        announcementWindow.endSpeech()
-        if (event.reason === 'turn_invalid') {
-          if (event.item_id) {
-            turns.invalidateInput(event.item_id)
-          }
-          send(ws, {
-            type: 'transcript.discard',
-            role: 'user',
-            turnId: stoppedTurn.turnId,
-            reason: 'turn_invalid',
-          })
-          send(ws, {
-            type: 'voice.state',
-            state: 'idle',
-            turnId: stoppedTurn.turnId,
-            origin: 'model',
-          })
-        } else {
-          expectResponseFor(stoppedTurn)
-          send(ws, {
-            type: 'voice.state',
-            state: 'processing',
-            turnId: stoppedTurn.turnId,
-            origin: 'model',
-          })
-        }
-      } else if (event.type === 'input_audio_buffer.committed') {
-        const committedInputTurn = turns.resolveInput(event.item_id)
-        if (
-          turns.isInputInvalid(event.item_id)
-          || turns.isStale(committedInputTurn)
-        ) {
-          turns.invalidateInput(event.item_id)
-          return
-        }
-        turns.endSpeech()
-        announcementWindow.endSpeech()
-        if (!turns.isInputInvalid(event.item_id)) {
-          send(ws, {
-            type: 'voice.state',
-            state: 'processing',
-            turnId: committedInputTurn.turnId,
-            origin: 'model',
-          })
-        }
-      } else if (event.type === 'conversation.item.ambient_audio_transcription.completed') {
-        turns.completeInput(event.item_id)
-      } else if (
-        event.type === 'conversation.item.input_audio_transcription.delta'
-        || event.type === 'conversation.item.input_audio_transcription.text'
-      ) {
-        if (turns.isInputInvalid(event.item_id)) return
-        const transcriptTurn = turns.resolveInput(event.item_id)
-        if (turns.isStale(transcriptTurn)) return
-        const transcript = streamingInputTranscript(event)
-        if (!transcriptTurn?.turnId || !transcript) return
-        send(ws, {
-          type: 'transcript.delta',
-          role: 'user',
-          content: transcript,
-          turnId: transcriptTurn.turnId,
-          replace: true,
-        })
-      } else if (event.type === 'conversation.item.input_audio_transcription.completed') {
-        const completedInput = turns.completeInput(event.item_id)
-        const transcriptTurn = completedInput.context
-        if (
-          completedInput.invalid
-          || turns.isStale(transcriptTurn)
-        ) return
-        const transcript = String(event.transcript || '').trim()
-        if (!transcript) {
-          send(ws, {
-            type: 'transcript.discard',
-            role: 'user',
-            turnId: transcriptTurn.turnId,
-          })
-          return
-        }
-        turns.commit(transcriptTurn)
-        transcripts.record(transcriptTurn.turnId, transcript)
-        if (responseTurnCandidate === transcriptTurn) {
-          ensurePermissionResponseFor(transcriptTurn)
-        }
-        conversationSync.record({
-          ownerId,
-          sessionId,
-          id: `voice:user:${transcriptTurn.turnId}`,
-          role: 'user',
-          content: transcript,
-          source: 'voice-user',
-          turnId: transcriptTurn.turnId,
-          inputs: inputAssets.metadataForParts(
-            transcripts.parts(transcriptTurn.turnId),
-          ),
-        })
-        send(ws, {
-          type: 'transcript.final',
-          role: 'user',
-          content: transcript,
-          turnId: transcriptTurn.turnId,
-        })
-      } else if (event.type === 'conversation.item.input_audio_transcription.failed') {
-        const failedInput = turns.completeInput(event.item_id)
-        send(ws, {
-          type: 'transcript.discard',
-          role: 'user',
-          turnId: failedInput.context?.turnId,
-        })
-      } else if (event.type === 'response.created') {
+      if (inputs.handleProviderEvent(event)) return
+      if (event.type === 'response.created') {
         // Lifecycle setup is handled before the event switch so providers that
         // emit output before (or instead of) response.created follow this path.
       } else if (event.type === 'response.function_call_arguments.done') {
@@ -1730,87 +1604,6 @@ export function attachRealtimeGateway(server, {
       attemptWakeConnect(0)
     }
 
-    const submitInputMessage = event => {
-      let parts
-      try {
-        parts = withAttachmentAnchors(normalizeInputParts(
-          event.parts,
-          { fallbackText: event.text },
-        ))
-      } catch (error) {
-        send(ws, { type: GatewayServerEvent.ERROR, message: error.message })
-        return
-      }
-      const inputTurnId = `text_${randomUUID().replaceAll('-', '')}`
-      parts = inputAssets.registerParts({
-        ownerId,
-        sessionId,
-        turnId: inputTurnId,
-        parts,
-      })
-      const text = inputText(parts)
-      const display = displayInputText(parts)
-      const {
-        context: inputContext,
-        supersededVoiceTurn,
-      } = turns.beginManual(inputTurnId)
-      clearResponseCandidate()
-      // Text and attachment submissions are first-class user turns. They must
-      // close any result announcement still occupying the previous turn and
-      // block a newly completed task from speaking over the response now being
-      // generated, just like input_audio_buffer.speech_started does for voice.
-      announcementWindow.beginTurn(inputTurnId)
-      announcementWindow.endSpeech()
-      announcements.dismissActive()
-      send(ws, {
-        type: GatewayServerEvent.PLAYBACK_CLEAR,
-        reason: 'user_interruption',
-      })
-      if (supersededVoiceTurn?.turnId) {
-        send(ws, {
-          type: GatewayServerEvent.TRANSCRIPT_DISCARD,
-          role: 'user',
-          turnId: supersededVoiceTurn.turnId,
-          reason: 'superseded_by_manual_input',
-        })
-      }
-      send(ws, { type: GatewayServerEvent.TURN_STARTED, turnId: inputTurnId })
-      send(ws, {
-        type: GatewayServerEvent.VOICE_STATE,
-        state: 'processing',
-        turnId: inputTurnId,
-        origin: 'model',
-      })
-      frontend?.cancel()
-      transcripts.record(inputTurnId, text || display)
-      transcripts.recordParts(inputTurnId, inputFileParts(parts))
-      conversationSync.record({
-        ownerId,
-        sessionId,
-        id: `voice:user:${inputTurnId}`,
-        role: 'user',
-        content: display,
-        source: 'text-user',
-        turnId: inputTurnId,
-        inputs: inputAssets.metadataForParts(parts),
-      })
-      send(ws, {
-        type: GatewayServerEvent.TRANSCRIPT_FINAL,
-        role: 'user',
-        content: display,
-        turnId: inputTurnId,
-      })
-      ensureFrontend()
-        .then(() => frontend.sendUserInput(
-          parts,
-          inputContext,
-        ))
-        .catch(error => {
-          turns.failManualInput(inputContext)
-          reportFrontendError(error)
-        })
-    }
-
     const acceptSleepingAudio = audio => {
       try {
         const sampleRate = realtimeProviderRegistry.resolve(sessionProvider)
@@ -2034,7 +1827,7 @@ export function attachRealtimeGateway(server, {
           return
         }
         sleepController.recordActivity()
-        submitInputMessage(event)
+        inputs.submit(event)
       } else if (event.type === GatewayClientEvent.INTERRUPT) {
         sleepController.recordActivity()
         turns.advanceBoundary()

--- a/server/src/voice/realtime-input-runtime.mjs
+++ b/server/src/voice/realtime-input-runtime.mjs
@@ -1,0 +1,305 @@
+import { randomUUID } from 'node:crypto'
+import { GatewayServerEvent } from '../../../shared/realtime-events.mjs'
+import {
+  displayInputText,
+  inputFileParts,
+  inputText,
+  normalizeInputParts,
+  withAttachmentAnchors,
+} from '../../../shared/input-parts.mjs'
+import { streamingInputTranscript } from './input-transcript.mjs'
+
+const PROVIDER_INPUT_EVENTS = new Set([
+  'input_audio_buffer.speech_started',
+  'input_audio_buffer.speech_stopped',
+  'input_audio_buffer.committed',
+  'conversation.item.ambient_audio_transcription.completed',
+  'conversation.item.input_audio_transcription.delta',
+  'conversation.item.input_audio_transcription.text',
+  'conversation.item.input_audio_transcription.completed',
+  'conversation.item.input_audio_transcription.failed',
+])
+
+/**
+ * Owns user-input lifecycle semantics for one realtime connection.
+ *
+ * It translates provider VAD/transcription events and discrete text/file
+ * submissions into the same Gateway turn model. Response, playback, task and
+ * provider-connection lifecycles remain outside this boundary.
+ */
+export class RealtimeInputRuntime {
+  constructor({
+    ownerId,
+    sessionId,
+    turns,
+    transcripts,
+    inputAssets,
+    conversationSync,
+    announcementWindow,
+    announcements,
+    send,
+    getFrontend,
+    ensureFrontend,
+    clearResponseCandidate,
+    expectResponseFor,
+    shouldEnsurePermissionResponse,
+    ensurePermissionResponseFor,
+    reportFrontendError,
+    createInputTurnId = () => `text_${randomUUID().replaceAll('-', '')}`,
+  }) {
+    this.ownerId = ownerId
+    this.sessionId = sessionId
+    this.turns = turns
+    this.transcripts = transcripts
+    this.inputAssets = inputAssets
+    this.conversationSync = conversationSync
+    this.announcementWindow = announcementWindow
+    this.announcements = announcements
+    this.send = send
+    this.getFrontend = getFrontend
+    this.ensureFrontend = ensureFrontend
+    this.clearResponseCandidate = clearResponseCandidate
+    this.expectResponseFor = expectResponseFor
+    this.shouldEnsurePermissionResponse = shouldEnsurePermissionResponse
+    this.ensurePermissionResponseFor = ensurePermissionResponseFor
+    this.reportFrontendError = reportFrontendError
+    this.createInputTurnId = createInputTurnId
+  }
+
+  handles(event) {
+    return PROVIDER_INPUT_EVENTS.has(event?.type)
+  }
+
+  handleProviderEvent(event) {
+    if (!this.handles(event)) return false
+
+    if (event.type === 'input_audio_buffer.speech_started') {
+      this.#startSpeech(event)
+    } else if (event.type === 'input_audio_buffer.speech_stopped') {
+      this.#stopSpeech(event)
+    } else if (event.type === 'input_audio_buffer.committed') {
+      this.#commitAudio(event)
+    } else if (event.type === 'conversation.item.ambient_audio_transcription.completed') {
+      this.turns.completeInput(event.item_id)
+    } else if (
+      event.type === 'conversation.item.input_audio_transcription.delta'
+      || event.type === 'conversation.item.input_audio_transcription.text'
+    ) {
+      this.#streamTranscript(event)
+    } else if (event.type === 'conversation.item.input_audio_transcription.completed') {
+      this.#completeTranscript(event)
+    } else if (event.type === 'conversation.item.input_audio_transcription.failed') {
+      const failedInput = this.turns.completeInput(event.item_id)
+      this.send({
+        type: GatewayServerEvent.TRANSCRIPT_DISCARD,
+        role: 'user',
+        turnId: failedInput.context?.turnId,
+      })
+    }
+    return true
+  }
+
+  #startSpeech(event) {
+    const started = this.turns.beginVoice(event.item_id)
+    if (!started.accepted) return
+    this.clearResponseCandidate()
+    this.announcementWindow.beginTurn(started.context.turnId)
+    this.announcements.dismissActive()
+    this.send({
+      type: GatewayServerEvent.PLAYBACK_CLEAR,
+      reason: 'user_interruption',
+    })
+    this.send({
+      type: GatewayServerEvent.TURN_STARTED,
+      turnId: started.context.turnId,
+    })
+    this.send({
+      type: GatewayServerEvent.VOICE_STATE,
+      state: 'listening',
+      turnId: started.context.turnId,
+    })
+    this.getFrontend()?.cancel()
+  }
+
+  #stopSpeech(event) {
+    const stoppedTurn = this.turns.resolveInput(event.item_id)
+    if (
+      this.turns.isInputInvalid(event.item_id)
+      || this.turns.isStale(stoppedTurn)
+    ) {
+      this.turns.invalidateInput(event.item_id)
+      return
+    }
+    this.turns.endSpeech()
+    this.announcementWindow.endSpeech()
+    if (event.reason === 'turn_invalid') {
+      this.turns.invalidateInput(event.item_id)
+      this.send({
+        type: GatewayServerEvent.TRANSCRIPT_DISCARD,
+        role: 'user',
+        turnId: stoppedTurn.turnId,
+        reason: 'turn_invalid',
+      })
+      this.send({
+        type: GatewayServerEvent.VOICE_STATE,
+        state: 'idle',
+        turnId: stoppedTurn.turnId,
+        origin: 'model',
+      })
+      return
+    }
+    this.expectResponseFor(stoppedTurn)
+    this.send({
+      type: GatewayServerEvent.VOICE_STATE,
+      state: 'processing',
+      turnId: stoppedTurn.turnId,
+      origin: 'model',
+    })
+  }
+
+  #commitAudio(event) {
+    const committedInputTurn = this.turns.resolveInput(event.item_id)
+    if (
+      this.turns.isInputInvalid(event.item_id)
+      || this.turns.isStale(committedInputTurn)
+    ) {
+      this.turns.invalidateInput(event.item_id)
+      return
+    }
+    this.turns.endSpeech()
+    this.announcementWindow.endSpeech()
+    this.send({
+      type: GatewayServerEvent.VOICE_STATE,
+      state: 'processing',
+      turnId: committedInputTurn.turnId,
+      origin: 'model',
+    })
+  }
+
+  #streamTranscript(event) {
+    if (this.turns.isInputInvalid(event.item_id)) return
+    const transcriptTurn = this.turns.resolveInput(event.item_id)
+    if (this.turns.isStale(transcriptTurn)) return
+    const transcript = streamingInputTranscript(event)
+    if (!transcriptTurn?.turnId || !transcript) return
+    this.send({
+      type: GatewayServerEvent.TRANSCRIPT_DELTA,
+      role: 'user',
+      content: transcript,
+      turnId: transcriptTurn.turnId,
+      replace: true,
+    })
+  }
+
+  #completeTranscript(event) {
+    const completedInput = this.turns.completeInput(event.item_id)
+    const transcriptTurn = completedInput.context
+    if (completedInput.invalid || this.turns.isStale(transcriptTurn)) return
+    const transcript = String(event.transcript || '').trim()
+    if (!transcript) {
+      this.send({
+        type: GatewayServerEvent.TRANSCRIPT_DISCARD,
+        role: 'user',
+        turnId: transcriptTurn.turnId,
+      })
+      return
+    }
+    this.turns.commit(transcriptTurn)
+    this.transcripts.record(transcriptTurn.turnId, transcript)
+    if (this.shouldEnsurePermissionResponse(transcriptTurn)) {
+      this.ensurePermissionResponseFor(transcriptTurn)
+    }
+    this.conversationSync.record({
+      ownerId: this.ownerId,
+      sessionId: this.sessionId,
+      id: `voice:user:${transcriptTurn.turnId}`,
+      role: 'user',
+      content: transcript,
+      source: 'voice-user',
+      turnId: transcriptTurn.turnId,
+      inputs: this.inputAssets.metadataForParts(
+        this.transcripts.parts(transcriptTurn.turnId),
+      ),
+    })
+    this.send({
+      type: GatewayServerEvent.TRANSCRIPT_FINAL,
+      role: 'user',
+      content: transcript,
+      turnId: transcriptTurn.turnId,
+    })
+  }
+
+  submit(event) {
+    let parts
+    try {
+      parts = withAttachmentAnchors(normalizeInputParts(
+        event.parts,
+        { fallbackText: event.text },
+      ))
+    } catch (error) {
+      this.send({ type: GatewayServerEvent.ERROR, message: error.message })
+      return
+    }
+    const inputTurnId = this.createInputTurnId()
+    parts = this.inputAssets.registerParts({
+      ownerId: this.ownerId,
+      sessionId: this.sessionId,
+      turnId: inputTurnId,
+      parts,
+    })
+    const text = inputText(parts)
+    const display = displayInputText(parts)
+    const {
+      context: inputContext,
+      supersededVoiceTurn,
+    } = this.turns.beginManual(inputTurnId)
+    this.clearResponseCandidate()
+    this.announcementWindow.beginTurn(inputTurnId)
+    this.announcementWindow.endSpeech()
+    this.announcements.dismissActive()
+    this.send({
+      type: GatewayServerEvent.PLAYBACK_CLEAR,
+      reason: 'user_interruption',
+    })
+    if (supersededVoiceTurn?.turnId) {
+      this.send({
+        type: GatewayServerEvent.TRANSCRIPT_DISCARD,
+        role: 'user',
+        turnId: supersededVoiceTurn.turnId,
+        reason: 'superseded_by_manual_input',
+      })
+    }
+    this.send({ type: GatewayServerEvent.TURN_STARTED, turnId: inputTurnId })
+    this.send({
+      type: GatewayServerEvent.VOICE_STATE,
+      state: 'processing',
+      turnId: inputTurnId,
+      origin: 'model',
+    })
+    this.getFrontend()?.cancel()
+    this.transcripts.record(inputTurnId, text || display)
+    this.transcripts.recordParts(inputTurnId, inputFileParts(parts))
+    this.conversationSync.record({
+      ownerId: this.ownerId,
+      sessionId: this.sessionId,
+      id: `voice:user:${inputTurnId}`,
+      role: 'user',
+      content: display,
+      source: 'text-user',
+      turnId: inputTurnId,
+      inputs: this.inputAssets.metadataForParts(parts),
+    })
+    this.send({
+      type: GatewayServerEvent.TRANSCRIPT_FINAL,
+      role: 'user',
+      content: display,
+      turnId: inputTurnId,
+    })
+    this.ensureFrontend()
+      .then(() => this.getFrontend().sendUserInput(parts, inputContext))
+      .catch(error => {
+        this.turns.failManualInput(inputContext)
+        this.reportFrontendError(error)
+      })
+  }
+}

--- a/server/test/realtime-input-runtime.test.mjs
+++ b/server/test/realtime-input-runtime.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { InputAssetRegistry } from '../src/voice/input-asset-registry.mjs'
+import { RealtimeInputRuntime } from '../src/voice/realtime-input-runtime.mjs'
+import { RealtimeTurnState } from '../src/voice/realtime-turn-state.mjs'
+import { TurnTranscripts } from '../src/voice/tools/turn-transcripts.mjs'
+
+function harness() {
+  const events = []
+  const records = []
+  const calls = []
+  const frontend = {
+    cancel: () => calls.push(['cancel']),
+    sendUserInput: async (parts, context) => {
+      calls.push(['sendUserInput', parts, context])
+    },
+  }
+  const turns = new RealtimeTurnState({
+    createVoiceTurnId: generation => `voice-${generation}`,
+  })
+  let permissionCandidate = null
+  const runtime = new RealtimeInputRuntime({
+    ownerId: 'owner-1',
+    sessionId: 'session-1',
+    turns,
+    transcripts: new TurnTranscripts(),
+    inputAssets: new InputAssetRegistry(),
+    conversationSync: { record: value => records.push(value) },
+    announcementWindow: {
+      beginTurn: turnId => calls.push(['beginTurn', turnId]),
+      endSpeech: () => calls.push(['endSpeech']),
+    },
+    announcements: {
+      dismissActive: () => calls.push(['dismissActive']),
+    },
+    send: event => events.push(event),
+    getFrontend: () => frontend,
+    ensureFrontend: async () => {},
+    clearResponseCandidate: () => calls.push(['clearResponseCandidate']),
+    expectResponseFor: context => {
+      permissionCandidate = context
+      calls.push(['expectResponseFor', context])
+    },
+    shouldEnsurePermissionResponse: context => context === permissionCandidate,
+    ensurePermissionResponseFor: context => calls.push([
+      'ensurePermissionResponseFor',
+      context,
+    ]),
+    reportFrontendError: error => calls.push(['reportFrontendError', error]),
+    createInputTurnId: () => 'text-1',
+  })
+  return { runtime, turns, events, records, calls }
+}
+
+test('handles only provider input lifecycle events', () => {
+  const { runtime } = harness()
+
+  assert.equal(runtime.handleProviderEvent({ type: 'response.created' }), false)
+  assert.equal(runtime.handleProviderEvent({
+    type: 'conversation.item.ambient_audio_transcription.completed',
+    item_id: 'ambient-1',
+  }), true)
+})
+
+test('projects one voice turn from speech start through final transcript', () => {
+  const { runtime, turns, events, records, calls } = harness()
+
+  runtime.handleProviderEvent({
+    type: 'input_audio_buffer.speech_started',
+    item_id: 'item-1',
+  })
+  runtime.handleProviderEvent({
+    type: 'conversation.item.input_audio_transcription.delta',
+    item_id: 'item-1',
+    text: '你',
+  })
+  runtime.handleProviderEvent({
+    type: 'input_audio_buffer.speech_stopped',
+    item_id: 'item-1',
+  })
+  runtime.handleProviderEvent({
+    type: 'conversation.item.input_audio_transcription.completed',
+    item_id: 'item-1',
+    transcript: '你好',
+  })
+
+  assert.equal(turns.userSpeaking, false)
+  assert.deepEqual(turns.committed(), {
+    turnId: 'voice-1',
+    turnGeneration: 1,
+  })
+  assert.deepEqual(events.map(event => event.type), [
+    'playback.clear',
+    'turn.started',
+    'voice.state',
+    'transcript.delta',
+    'voice.state',
+    'transcript.final',
+  ])
+  assert.equal(records.length, 1)
+  assert.equal(records[0].content, '你好')
+  assert.equal(records[0].source, 'voice-user')
+  assert.equal(
+    calls.some(([name]) => name === 'ensurePermissionResponseFor'),
+    true,
+  )
+})
+
+test('manual text input supersedes speech and reaches the frontend once', async () => {
+  const { runtime, turns, events, records, calls } = harness()
+  runtime.handleProviderEvent({
+    type: 'input_audio_buffer.speech_started',
+    item_id: 'item-voice',
+  })
+  events.length = 0
+  calls.length = 0
+
+  runtime.submit({ text: '看一下这个问题' })
+  await Promise.resolve()
+  await Promise.resolve()
+
+  assert.deepEqual(turns.committed(), {
+    turnId: 'text-1',
+    turnGeneration: 2,
+  })
+  assert.deepEqual(events.map(event => event.type), [
+    'playback.clear',
+    'transcript.discard',
+    'turn.started',
+    'voice.state',
+    'transcript.final',
+  ])
+  assert.equal(records.at(-1).source, 'text-user')
+  const sent = calls.find(([name]) => name === 'sendUserInput')
+  assert.deepEqual(sent[1], [{ type: 'text', text: '看一下这个问题' }])
+  assert.deepEqual(sent[2], {
+    turnId: 'text-1',
+    turnGeneration: 2,
+  })
+})
+
+test('invalid manual input fails before changing the current turn', () => {
+  const { runtime, turns, events } = harness()
+
+  runtime.submit({ parts: [{ type: 'unknown' }] })
+
+  assert.deepEqual(turns.current(), { turnId: '', turnGeneration: 0 })
+  assert.equal(events.length, 1)
+  assert.equal(events[0].type, 'error')
+  assert.match(events[0].message, /不支持的输入片段类型/)
+})


### PR DESCRIPTION
## Summary
- extract provider VAD/transcription handling into a dedicated realtime input runtime
- route manual text and attachment submissions through the same input boundary
- preserve turn ownership, permission correlation, and conversation recording semantics
- update bilingual R2 progress and add focused coverage

## Validation
- `node --test server/test/realtime-input-runtime.test.mjs server/test/realtime-turn-state.test.mjs server/test/realtime-gateway.test.mjs`
- `node --test server/test/input-suspend-protocol.test.mjs server/test/desktop-sleep-tool-registration.test.mjs server/test/memory-extract-hook.test.mjs server/test/realtime-input-runtime.test.mjs`
- `npm run lint`
- `npm run build`

Roadmap: #185