### PR TITLE
refactor: extract realtime presentation runtime

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -170,7 +170,8 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 - [ ] Extract realtime session, turn, input, playback, and presentation logic.
   - [x] Centralize per-connection turn generation, correlation, and interruption boundaries.
   - [x] Extract provider audio/transcription and manual-input lifecycles.
-  - [ ] Extract playback/presentation and realtime session lifecycles.
+  - [x] Extract response correlation, playback, and presentation lifecycles.
+  - [ ] Extract the realtime provider session lifecycle.
 - [x] Add Frontend Tool Registry, Policy, and Executor.
   - [x] Extract the declarative Registry and visibility Policy.
   - [x] Route execution through the Registry-owned Executor.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -218,7 +218,8 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 - [ ] 提取 Realtime Session、Turn、Input、Playback 和 Presentation。
   - [x] 集中管理单连接内的 Turn 代次、关联与打断边界。
   - [x] 提取 Provider 音频/转写与手动输入生命周期。
-  - [ ] 继续提取 Playback/Presentation 与 Realtime Session 生命周期。
+  - [x] 提取响应关联、Playback 与 Presentation 生命周期。
+  - [ ] 继续提取 Realtime Provider Session 生命周期。
 - [x] 建立 Frontend Tool Registry、Policy 和 Executor。
   - [x] 提取声明式 Registry 与可见性 Policy。
   - [x] 通过 Registry 管理的 Executor 统一执行入口。

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -25,12 +25,12 @@ import { projectGatewayTaskEvent } from '../transport/gateway-task-event-project
 import { ToolCallHandler } from './tools/tool-call-handler.mjs'
 import { TurnTranscripts } from './tools/turn-transcripts.mjs'
 import { RealtimeInputRuntime } from './realtime-input-runtime.mjs'
-import { RealtimeTurnState } from './realtime-turn-state.mjs'
 import {
-  ensureResponseContext,
-  mergeResponseContext,
-  responseActivityContextPatch,
-} from './response-context.mjs'
+  acceptsPlaybackReceipt,
+  confirmsTaskNotificationOnPlaybackStart,
+  RealtimePresentationRuntime,
+} from './realtime-presentation-runtime.mjs'
+import { RealtimeTurnState } from './realtime-turn-state.mjs'
 import {
   ActiveVoiceClients,
   clientVoiceCapabilities,
@@ -39,10 +39,6 @@ import { ReconnectBackoff } from './reconnect-backoff.mjs'
 import { realtimeConnectionStatus } from './realtime-connection-status.mjs'
 import { SleepController } from './sleep-controller.mjs'
 import { createSherpaWakeWordDetector } from './wake-word/sherpa-detector.mjs'
-import {
-  evaluateResponseGuards,
-  isResponseGuardTurnCurrent,
-} from './response-guards/index.mjs'
 import {
   isResponseActivityEvent,
   realtimeResponseId,
@@ -78,22 +74,9 @@ export function isSleepActivityEvent(event = {}) {
   ].includes(event.type)
 }
 
-export function confirmsTaskNotificationOnPlaybackStart(context) {
-  return Boolean(
-    context
-    && (
-      context.origin === 'announcement'
-      || context.consumesTaskNotification
-    ),
-  )
-}
-
-export function acceptsPlaybackReceipt({
-  outputEnabled,
-  active,
-  responseKnown,
-}) {
-  return outputEnabled === true && active === true && responseKnown === true
+export {
+  acceptsPlaybackReceipt,
+  confirmsTaskNotificationOnPlaybackStart,
 }
 
 function clientDescriptor(event = {}) {
@@ -205,10 +188,8 @@ export function attachRealtimeGateway(server, {
     let sleepController
     const realtimeReconnectBackoff = new ReconnectBackoff()
     const announcementWindow = new AnnouncementWindow()
-    const playbackTurns = new Map()
     const notificationClaimantId = `voice_${randomUUID()}`
     let clientContext = normalizeClientContext()
-    const responseContexts = new Map()
     const turns = new RealtimeTurnState()
     const transcripts = new TurnTranscripts()
     const announcedPermissions = new Set()
@@ -553,6 +534,24 @@ export function attachRealtimeGateway(server, {
       reportFrontendError,
     })
 
+    const presentationRuntime = new RealtimePresentationRuntime({
+      ownerId,
+      sessionId,
+      turns,
+      conversationSync,
+      announcementWindow,
+      announcements,
+      toolCalls,
+      send: event => send(ws, event),
+      getFrontend: () => frontend,
+      getOutputEnabled: () => outputEnabled,
+      getNonVoiceClient: () => nonVoiceClient,
+      getResponseTurnCandidate: () => responseTurnCandidate,
+      clearResponseCandidate,
+      announcementQuietMs: config.announcementQuietMs,
+      responseContextCleanupMs: RESPONSE_CONTEXT_CLEANUP_MS,
+    })
+
     const queueNotification = task => {
       if (task.status === 'completed') {
         announcements.completed(task)
@@ -566,249 +565,6 @@ export function attachRealtimeGateway(server, {
       sessionId,
       task,
     })
-
-    const contextTaskIds = context => (
-      context?.taskIds?.length ? context.taskIds : [context?.taskId].filter(Boolean)
-    )
-
-    const publicResponseContext = context => ({
-      turnId: context.turnId,
-      taskId: context.taskId,
-      taskIds: context.taskIds,
-      turnIds: context.turnIds,
-      origin: context.origin,
-      turnGeneration: context.turnGeneration,
-      deliverySequence: context.deliverySequence,
-    })
-
-    const fallbackResponseContext = () => ({
-      turnId: turns.committedTurnId || turns.turnId,
-      taskId: null,
-      origin: 'model',
-      turnGeneration: turns.committedTurnId
-        ? turns.committedTurnGeneration
-        : turns.turnGeneration,
-    })
-
-    const emitAssistantTranscript = ({
-      id,
-      context,
-      content,
-      final,
-    }) => {
-      if (final) {
-        conversationSync.record({
-          ownerId,
-          sessionId,
-          id: `voice:assistant:${id}`,
-          role: 'assistant',
-          content,
-          source: context.origin === 'model' ? 'realtime-direct' : 'agent-presentation',
-          ...context,
-        })
-      }
-      send(ws, {
-        type: final ? 'transcript.final' : 'transcript.delta',
-        role: 'assistant',
-        content: content || '',
-        responseId: id,
-        ...publicResponseContext(context),
-      })
-    }
-
-    const flushPendingTranscripts = (id, context) => {
-      for (const transcript of context?.pendingTranscripts || []) {
-        emitAssistantTranscript({
-          id,
-          context,
-          content: transcript.content,
-          final: transcript.final,
-        })
-      }
-      if (context) context.pendingTranscripts = []
-    }
-
-    const finishResponseContextIfComplete = (id, context) => {
-      if (
-        context
-        && context.playbackEnded
-        && context.responseDone
-        && context.transcriptDone
-      ) {
-        responseContexts.delete(id)
-      }
-    }
-
-    const scheduleResponseContextCleanup = (id, context) => {
-      const timer = setTimeout(() => {
-        if (responseContexts.get(id) !== context) return
-        responseContexts.delete(id)
-        playbackTurns.delete(id)
-        announcementWindow.finishPlayback(id, {
-          hasFunctionCall: Boolean(context?.hasFunctionCall),
-        })
-      }, RESPONSE_CONTEXT_CLEANUP_MS)
-      timer.unref?.()
-    }
-
-    const startPlayback = id => {
-      const context = responseContexts.get(id)
-      // A cancelled response remains as a short-lived tombstone so late
-      // provider audio and client receipts cannot resurrect it.
-      if (context?.suppressed) return
-      announcementWindow.startPlayback(id)
-      const playbackTurnId = context?.turnId || playbackTurns.get(id) || turns.turnId
-      send(ws, {
-        type: 'voice.state',
-        state: 'speaking',
-        turnId: playbackTurnId,
-        origin: context?.origin || 'model',
-      })
-      if (!context || context.playbackStarted) return
-      context.playbackStarted = true
-      if (confirmsTaskNotificationOnPlaybackStart(context)) {
-        announcements.confirmMany(contextTaskIds(context))
-      }
-      flushPendingTranscripts(id, context)
-    }
-
-    const cancelQueuedPlayback = (id, { reason = '' } = {}) => {
-      const context = responseContexts.get(id)
-      announcementWindow.finishPlayback(id, {
-        hasFunctionCall: Boolean(context?.hasFunctionCall),
-      })
-      const playbackTurnId = playbackTurns.get(id) || turns.turnId
-      playbackTurns.delete(id)
-      if (context?.origin === 'announcement') {
-        if (reason === 'user_interruption') {
-          announcements.confirmMany(contextTaskIds(context))
-        } else {
-          announcements.retryMany(contextTaskIds(context))
-        }
-      }
-      if (context?.playbackStarted && reason === 'user_interruption') {
-        send(ws, {
-          type: 'response.interrupted',
-          responseId: id,
-          ...publicResponseContext(context),
-        })
-      }
-      if (context) {
-        context.suppressed = true
-        context.playbackEnded = true
-        context.pendingTranscripts = []
-        scheduleResponseContextCleanup(id, context)
-      }
-      send(ws, {
-        type: 'voice.state',
-        state: turns.userSpeaking ? 'listening' : 'idle',
-        turnId: turns.userSpeaking ? turns.turnId : playbackTurnId,
-        origin: context?.origin || 'model',
-      })
-      const timer = setTimeout(
-        () => announcements.flush(),
-        config.announcementQuietMs,
-      )
-      timer.unref?.()
-    }
-
-    const beginResponseLifecycle = event => {
-      const id = realtimeResponseId(event)
-      if (!id) return null
-      const existing = responseContexts.get(id)
-      const automaticResponse = (
-        !existing
-        && (event.__voiceOrigin || 'model') === 'model'
-        && !event.__voiceContext?.turnId
-      )
-      const automaticTurn = automaticResponse
-        ? responseTurnCandidate
-        : null
-      const fallback = {
-        turnId: event.__voiceContext?.turnId
-          || automaticTurn?.turnId
-          || turns.committedTurnId
-          || turns.turnId,
-        taskId: event.__voiceContext?.taskId || null,
-        origin: event.__voiceOrigin || 'model',
-        authorizationId: event.__voiceContext?.authorizationId || null,
-        turnGeneration: Number.isInteger(event.__voiceContext?.turnGeneration)
-          ? event.__voiceContext.turnGeneration
-          : automaticTurn?.turnGeneration
-            ?? (turns.committedTurnId
-              ? turns.committedTurnGeneration
-              : turns.turnGeneration),
-      }
-      const context = mergeResponseContext(
-        responseContexts,
-        id,
-        responseActivityContextPatch({ existing, event, fallback }),
-      )
-      if (
-        turns.manualInputGeneration !== null
-        && !automaticResponse
-        && context.turnGeneration === turns.manualInputGeneration
-        && context.origin === 'model'
-      ) {
-        turns.finishManualResponse(context)
-      }
-      // Compatible Realtime servers may omit response.created and reveal the
-      // correlation only on response.done. If audio already reached the
-      // client, confirm the newly identified task notification immediately.
-      if (
-        context.playbackStarted
-        && confirmsTaskNotificationOnPlaybackStart(context)
-      ) {
-        announcements.confirmMany(contextTaskIds(context))
-      }
-      if (automaticTurn) {
-        // Some OpenAI-compatible servers start an implicit server-VAD response
-        // with transcript or audio output and omit response.created. Any valid
-        // response output proves that turn detection accepted this turn.
-        turns.commit(automaticTurn)
-        clearResponseCandidate()
-      }
-      if (!context.responseStarted) {
-        context.responseStarted = true
-        send(ws, {
-          type: 'response.started',
-          responseId: id,
-          ...publicResponseContext(context),
-        })
-      }
-      return context
-    }
-
-    const finishPlayback = id => {
-      const playbackTurnId = playbackTurns.get(id) || turns.turnId
-      const context = responseContexts.get(id)
-      if (context?.suppressed) {
-        playbackTurns.delete(id)
-        return
-      }
-      announcementWindow.finishPlayback(id, {
-        hasFunctionCall: Boolean(context?.hasFunctionCall),
-      })
-      playbackTurns.delete(id)
-      if (context) {
-        context.playbackEnded = true
-        finishResponseContextIfComplete(id, context)
-        if (responseContexts.get(id) === context) {
-          scheduleResponseContextCleanup(id, context)
-        }
-      }
-      send(ws, {
-        type: 'voice.state',
-        state: turns.userSpeaking ? 'listening' : 'idle',
-        turnId: turns.userSpeaking ? turns.turnId : playbackTurnId,
-        origin: context?.origin || 'model',
-      })
-      const timer = setTimeout(
-        () => announcements.flush(),
-        config.announcementQuietMs,
-      )
-      timer.unref?.()
-    }
 
     const claimPendingNotifications = (
       taskIds,
@@ -899,17 +655,7 @@ export function attachRealtimeGateway(server, {
             origin === 'permission'
             && context?.authorizationId === authorizationId
           ))
-          for (const [responseId, context] of responseContexts) {
-            if (
-              context.origin === 'permission'
-              && context.authorizationId === authorizationId
-              && !context.suppressed
-            ) {
-              cancelQueuedPlayback(responseId, {
-                reason: 'permission_resolved',
-              })
-            }
-          }
+          presentationRuntime.cancelPermission(authorizationId)
         }
       }
       if (event.type === TaskDomainEvent.DELEGATED) {
@@ -949,14 +695,11 @@ export function attachRealtimeGateway(server, {
 
     const handleEvent = event => {
       if (isSleepActivityEvent(event)) sleepController?.recordActivity()
-      if (isResponseActivityEvent(event)) beginResponseLifecycle(event)
+      if (isResponseActivityEvent(event)) presentationRuntime.begin(event)
       if (inputs.handleProviderEvent(event)) return
-      if (event.type === 'response.created') {
-        // Lifecycle setup is handled before the event switch so providers that
-        // emit output before (or instead of) response.created follow this path.
-      } else if (event.type === 'response.function_call_arguments.done') {
+      if (event.type === 'response.function_call_arguments.done') {
         const id = realtimeResponseId(event)
-        const callContext = responseContexts.get(id)
+        const callContext = presentationRuntime.get(id)
           || { turnId: '', turnGeneration: -1 }
         logger.info('realtime.tool_call.received', {
           responseId: id,
@@ -964,239 +707,12 @@ export function attachRealtimeGateway(server, {
           toolName: event.name || event.item?.name || '',
           turnId: callContext.turnId || '',
         })
-        if (responseContexts.has(id)) {
-          responseContexts.get(id).hasFunctionCall = true
-        }
+        presentationRuntime.markFunctionCall(id)
         toolCalls.handle(event, { ...callContext, responseId: id }).catch(error => {
           send(ws, { type: 'error', message: error.message })
         })
-      } else if (
-        event.type === 'response.audio.delta'
-        || event.type === 'response.output_audio.delta'
-      ) {
-        const id = realtimeResponseId(event)
-        const responseContext = ensureResponseContext(
-          responseContexts,
-          id,
-          fallbackResponseContext(),
-        )
-        if (responseContext?.suppressed) return
-        const responseTurnId = responseContext.turnId || turns.turnId
-        if (id) {
-          responseContext.hasAudio = true
-          playbackTurns.set(id, responseTurnId)
-          announcementWindow.queueAudio(id, {
-            turnId: responseTurnId,
-            origin: responseContext.origin || 'model',
-          })
-        }
-        send(ws, {
-          type: 'audio.delta',
-          audio: event.delta,
-          sampleRate: Number(event.sampleRate)
-            || frontend.provider.outputSampleRate,
-          responseId: id,
-          turnId: responseTurnId,
-        })
-      } else if (
-        event.type === 'response.audio_transcript.delta'
-        || event.type === 'response.output_audio_transcript.delta'
-      ) {
-        const id = realtimeResponseId(event)
-        const context = ensureResponseContext(
-          responseContexts,
-          id,
-          fallbackResponseContext(),
-        )
-        if (context.suppressed) return
-        if (!context.playbackStarted) {
-          context.pendingTranscripts.push({
-            content: event.delta || '',
-            final: false,
-          })
-        } else {
-          emitAssistantTranscript({
-            id,
-            context,
-            content: event.delta || '',
-            final: false,
-          })
-        }
-      } else if (
-        event.type === 'response.audio_transcript.done'
-        || event.type === 'response.output_audio_transcript.done'
-      ) {
-        const id = realtimeResponseId(event)
-        const context = ensureResponseContext(
-          responseContexts,
-          id,
-          fallbackResponseContext(),
-        )
-        if (context.suppressed) return
-        context.transcriptDone = true
-        context.assistantTranscript = event.transcript || ''
-        if (!context.playbackStarted) {
-          context.pendingTranscripts.push({
-            content: event.transcript || '',
-            final: true,
-          })
-        } else {
-          emitAssistantTranscript({
-            id,
-            context,
-            content: event.transcript || '',
-            final: true,
-          })
-        }
-        finishResponseContextIfComplete(id, context)
-      } else if (event.type === 'response.text.delta') {
-        const id = realtimeResponseId(event)
-        const context = ensureResponseContext(
-          responseContexts,
-          id,
-          fallbackResponseContext(),
-        )
-        if (context.suppressed) return
-        emitAssistantTranscript({
-          id,
-          context,
-          content: event.delta || '',
-          final: false,
-        })
-      } else if (event.type === 'response.text.done') {
-        const id = realtimeResponseId(event)
-        const context = ensureResponseContext(
-          responseContexts,
-          id,
-          fallbackResponseContext(),
-        )
-        if (context.suppressed) return
-        context.transcriptDone = true
-        context.assistantTranscript = event.text || ''
-        emitAssistantTranscript({
-          id,
-          context,
-          content: event.text || '',
-          final: true,
-        })
-      } else if (event.type === 'response.done') {
-        const id = realtimeResponseId(event)
-        const responseContext = responseContexts.get(id)
-        const terminalToolResponse = toolCalls.consumeTerminalToolResponse(id)
-        const responseTurnId = responseContext?.turnId || turns.turnId
-        const responseStatus = event.response?.status
-        const responseFailed = ['failed', 'cancelled', 'incomplete'].includes(
-          responseStatus,
-        )
-        toolCalls.finishToolResponse(id, {
-          suppressResponse: responseFailed
-            || Boolean(responseContext?.suppressed)
-            || Boolean(responseContext?.hasAudio)
-            || Boolean(responseContext?.assistantTranscript?.trim()),
-        }).catch(error => {
-          send(ws, { type: 'error', message: error.message })
-        })
-        // Guards run before the context is retired below, which drops the
-        // transcript they inspect. They can only ask the model to reconsider;
-        // they never execute tools or mutate task state directly.
-        const responseGuardDecision = evaluateResponseGuards({
-          origin: responseContext?.origin || 'model',
-          hasFunctionCall: Boolean(responseContext?.hasFunctionCall),
-          failed: responseFailed,
-          suppressed: Boolean(responseContext?.suppressed),
-          transcript: responseContext?.assistantTranscript || '',
-        })
-        if (!responseContext?.suppressed) {
-          send(ws, { type: 'audio.done', responseId: id, turnId: responseTurnId })
-          if (!responseContext?.hasAudio) {
-            send(ws, {
-              type: 'voice.state',
-              state: 'idle',
-              turnId: responseTurnId,
-              origin: responseContext?.origin || 'model',
-            })
-          }
-        }
-        if (responseContext?.hasAudio && !responseFailed) {
-          responseContext.responseDone = true
-          finishResponseContextIfComplete(id, responseContext)
-        } else {
-          const completedNonVoiceAnnouncement = (
-            responseContext?.origin === 'announcement'
-            && nonVoiceClient
-            && !responseFailed
-          )
-          const completedNonVoiceTaskNotification = (
-            responseContext?.consumesTaskNotification
-            && nonVoiceClient
-            && !responseFailed
-          )
-          if (
-            responseContext
-            && !responseFailed
-            && (
-              responseContext.origin !== 'announcement'
-              || completedNonVoiceAnnouncement
-            )
-          ) {
-            flushPendingTranscripts(id, responseContext)
-          }
-          if (responseContext?.origin === 'announcement') {
-            if (completedNonVoiceAnnouncement) {
-              announcements.confirmMany(contextTaskIds(responseContext))
-            } else {
-              announcements.retryMany(contextTaskIds(responseContext))
-            }
-          } else if (completedNonVoiceTaskNotification) {
-            announcements.confirmMany(contextTaskIds(responseContext))
-          }
-          responseContexts.delete(id)
-        }
-        if (responseFailed && id) {
-          playbackTurns.delete(id)
-          announcementWindow.finishPlayback(id, {
-            hasFunctionCall: Boolean(responseContext?.hasFunctionCall),
-          })
-        }
-        announcementWindow.responseDone({
-          turnId: responseTurnId,
-          origin: responseContext?.origin || 'model',
-          hasAudio: Boolean(responseContext?.hasAudio),
-          hasFunctionCall: Boolean(responseContext?.hasFunctionCall),
-          suppressed: Boolean(responseContext?.suppressed) || terminalToolResponse,
-          failed: responseFailed,
-        })
-        if (
-          responseGuardDecision
-          && outputEnabled
-          && frontend?.ready
-          && frontend.capabilities.perResponseInstructions
-        ) {
-          const correctionFrontend = frontend
-          const correctionGeneration = responseContext?.turnGeneration
-          correctionFrontend.ensureResponse({
-            turnId: responseTurnId,
-            turnGeneration: correctionGeneration,
-          }, {
-            shouldCreate: () => isResponseGuardTurnCurrent({
-              sameFrontend: frontend === correctionFrontend,
-              outputEnabled,
-              userSpeaking: turns.userSpeaking,
-              responseTurnId,
-              responseTurnGeneration: correctionGeneration,
-              committedTurnId: turns.committedTurnId,
-              committedTurnGeneration: turns.committedTurnGeneration,
-            }),
-            response: {
-              instructions: responseGuardDecision.instructions,
-            },
-          }).catch(error => send(ws, { type: 'error', message: error.message }))
-        }
-        const timer = setTimeout(
-          () => announcements.flush(),
-          config.announcementQuietMs,
-        )
-        timer.unref?.()
+      } else if (presentationRuntime.handle(event)) {
+        return
       } else if (event.type === 'error') {
         // A response refused by a busy single-slot provider is retried by the
         // frontend transparently; nothing user-facing happened.
@@ -1240,41 +756,7 @@ export function attachRealtimeGateway(server, {
             message: errorMessage,
           })
         }
-        const id = realtimeResponseId(event)
-        const context = responseContexts.get(id)
-        if (context?.origin === 'announcement') {
-          send(ws, { type: 'playback.clear' })
-          announcementWindow.finishPlayback(id)
-          playbackTurns.delete(id)
-          responseContexts.delete(id)
-          announcements.retryMany(contextTaskIds(context))
-        } else {
-          if (id && context?.hasAudio) {
-            send(ws, {
-              type: 'audio.done',
-              responseId: id,
-              turnId: context.turnId || turns.turnId,
-            })
-          }
-          if (id && context?.hasAudio) {
-            scheduleResponseContextCleanup(id, context)
-          } else if (id) {
-            responseContexts.delete(id)
-            playbackTurns.delete(id)
-          }
-          announcementWindow.responseDone({
-            turnId: context?.turnId || turns.turnId,
-            origin: context?.origin || 'model',
-            hasAudio: Boolean(context?.hasAudio),
-            hasFunctionCall: Boolean(context?.hasFunctionCall),
-            failed: true,
-          })
-        }
-        const timer = setTimeout(
-          () => announcements.flush(),
-          config.announcementQuietMs,
-        )
-        timer.unref?.()
+        presentationRuntime.failResponse(event)
         // A provider may close an inactive response scope while a delegated
         // backend task is still running. The task remains healthy, and any
         // pending announcement has already returned to the retry queue, so this
@@ -1839,23 +1321,23 @@ export function attachRealtimeGateway(server, {
         if (acceptsPlaybackReceipt({
           outputEnabled,
           active: activeVoiceClients.isActive(ownerId, voiceClient),
-          responseKnown: responseContexts.has(id),
-        })) startPlayback(id)
+          responseKnown: presentationRuntime.has(id),
+        })) presentationRuntime.startPlayback(id)
       } else if (event.type === GatewayClientEvent.PLAYBACK_ENDED) {
         const id = String(event.responseId || '')
         if (acceptsPlaybackReceipt({
           outputEnabled,
           active: activeVoiceClients.isActive(ownerId, voiceClient),
-          responseKnown: responseContexts.has(id),
-        })) finishPlayback(id)
+          responseKnown: presentationRuntime.has(id),
+        })) presentationRuntime.finishPlayback(id)
       } else if (event.type === GatewayClientEvent.PLAYBACK_CANCELLED) {
         const id = String(event.responseId || '')
         if (acceptsPlaybackReceipt({
           outputEnabled,
           active: activeVoiceClients.isActive(ownerId, voiceClient),
-          responseKnown: responseContexts.has(id),
+          responseKnown: presentationRuntime.has(id),
         })) {
-          cancelQueuedPlayback(id, {
+          presentationRuntime.cancelPlayback(id, {
             reason: String(event.reason || ''),
           })
         }
@@ -1902,7 +1384,7 @@ export function attachRealtimeGateway(server, {
       turns.close()
       transcripts.close()
       announcementWindow.reset()
-      playbackTurns.clear()
+      presentationRuntime.clear()
       announcements.close()
       clearTimeout(permissionRetryTimer)
       permissionRetryTimer = null

--- a/server/src/voice/realtime-presentation-runtime.mjs
+++ b/server/src/voice/realtime-presentation-runtime.mjs
@@ -1,0 +1,640 @@
+import { GatewayServerEvent } from '../../../shared/realtime-events.mjs'
+import {
+  ensureResponseContext,
+  mergeResponseContext,
+  responseActivityContextPatch,
+} from './response-context.mjs'
+import {
+  evaluateResponseGuards,
+  isResponseGuardTurnCurrent,
+} from './response-guards/index.mjs'
+import { realtimeResponseId } from './response-lifecycle.mjs'
+
+const PRESENTATION_RESPONSE_EVENTS = new Set([
+  'response.created',
+  'response.audio.delta',
+  'response.output_audio.delta',
+  'response.audio_transcript.delta',
+  'response.output_audio_transcript.delta',
+  'response.audio_transcript.done',
+  'response.output_audio_transcript.done',
+  'response.text.delta',
+  'response.text.done',
+  'response.done',
+])
+
+export function confirmsTaskNotificationOnPlaybackStart(context) {
+  return Boolean(
+    context
+    && (
+      context.origin === 'announcement'
+      || context.consumesTaskNotification
+    ),
+  )
+}
+
+export function acceptsPlaybackReceipt({
+  outputEnabled,
+  active,
+  responseKnown,
+}) {
+  return outputEnabled === true && active === true && responseKnown === true
+}
+
+function contextTaskIds(context) {
+  return context?.taskIds?.length
+    ? context.taskIds
+    : [context?.taskId].filter(Boolean)
+}
+
+/**
+ * Owns response correlation and user-visible presentation for one realtime
+ * connection. Audio/text provider events and client playback receipts meet at
+ * this boundary so a response is acknowledged, retried and recorded once.
+ */
+export class RealtimePresentationRuntime {
+  constructor({
+    ownerId,
+    sessionId,
+    turns,
+    conversationSync,
+    announcementWindow,
+    announcements,
+    toolCalls,
+    send,
+    getFrontend,
+    getOutputEnabled,
+    getNonVoiceClient,
+    getResponseTurnCandidate,
+    clearResponseCandidate,
+    announcementQuietMs,
+    responseContextCleanupMs,
+  }) {
+    this.ownerId = ownerId
+    this.sessionId = sessionId
+    this.turns = turns
+    this.conversationSync = conversationSync
+    this.announcementWindow = announcementWindow
+    this.announcements = announcements
+    this.toolCalls = toolCalls
+    this.send = send
+    this.getFrontend = getFrontend
+    this.getOutputEnabled = getOutputEnabled
+    this.getNonVoiceClient = getNonVoiceClient
+    this.getResponseTurnCandidate = getResponseTurnCandidate
+    this.clearResponseCandidate = clearResponseCandidate
+    this.announcementQuietMs = announcementQuietMs
+    this.responseContextCleanupMs = responseContextCleanupMs
+    this.contexts = new Map()
+    this.playbackTurns = new Map()
+  }
+
+  has(id) {
+    return this.contexts.has(id)
+  }
+
+  get(id) {
+    return this.contexts.get(id)
+  }
+
+  entries() {
+    return this.contexts.entries()
+  }
+
+  markFunctionCall(id) {
+    const context = this.contexts.get(id)
+    if (context) context.hasFunctionCall = true
+    return context
+  }
+
+  publicContext(context = {}) {
+    return {
+      turnId: context.turnId,
+      taskId: context.taskId,
+      taskIds: context.taskIds,
+      turnIds: context.turnIds,
+      origin: context.origin,
+      turnGeneration: context.turnGeneration,
+      deliverySequence: context.deliverySequence,
+    }
+  }
+
+  fallbackContext() {
+    return {
+      turnId: this.turns.committedTurnId || this.turns.turnId,
+      taskId: null,
+      origin: 'model',
+      turnGeneration: this.turns.committedTurnId
+        ? this.turns.committedTurnGeneration
+        : this.turns.turnGeneration,
+    }
+  }
+
+  begin(event) {
+    const id = realtimeResponseId(event)
+    if (!id) return null
+    const existing = this.contexts.get(id)
+    const automaticResponse = (
+      !existing
+      && (event.__voiceOrigin || 'model') === 'model'
+      && !event.__voiceContext?.turnId
+    )
+    const automaticTurn = automaticResponse
+      ? this.getResponseTurnCandidate()
+      : null
+    const fallback = {
+      turnId: event.__voiceContext?.turnId
+        || automaticTurn?.turnId
+        || this.turns.committedTurnId
+        || this.turns.turnId,
+      taskId: event.__voiceContext?.taskId || null,
+      origin: event.__voiceOrigin || 'model',
+      authorizationId: event.__voiceContext?.authorizationId || null,
+      turnGeneration: Number.isInteger(event.__voiceContext?.turnGeneration)
+        ? event.__voiceContext.turnGeneration
+        : automaticTurn?.turnGeneration
+          ?? (this.turns.committedTurnId
+            ? this.turns.committedTurnGeneration
+            : this.turns.turnGeneration),
+    }
+    const context = mergeResponseContext(
+      this.contexts,
+      id,
+      responseActivityContextPatch({ existing, event, fallback }),
+    )
+    if (
+      this.turns.manualInputGeneration !== null
+      && !automaticResponse
+      && context.turnGeneration === this.turns.manualInputGeneration
+      && context.origin === 'model'
+    ) {
+      this.turns.finishManualResponse(context)
+    }
+    if (
+      context.playbackStarted
+      && confirmsTaskNotificationOnPlaybackStart(context)
+    ) {
+      this.announcements.confirmMany(contextTaskIds(context))
+    }
+    if (automaticTurn) {
+      this.turns.commit(automaticTurn)
+      this.clearResponseCandidate()
+    }
+    if (!context.responseStarted) {
+      context.responseStarted = true
+      this.send({
+        type: GatewayServerEvent.RESPONSE_STARTED,
+        responseId: id,
+        ...this.publicContext(context),
+      })
+    }
+    return context
+  }
+
+  handle(event) {
+    if (!PRESENTATION_RESPONSE_EVENTS.has(event?.type)) return false
+    if (event.type === 'response.created') return true
+    if (
+      event.type === 'response.audio.delta'
+      || event.type === 'response.output_audio.delta'
+    ) {
+      this.#audioDelta(event)
+    } else if (
+      event.type === 'response.audio_transcript.delta'
+      || event.type === 'response.output_audio_transcript.delta'
+    ) {
+      this.#audioTranscriptDelta(event)
+    } else if (
+      event.type === 'response.audio_transcript.done'
+      || event.type === 'response.output_audio_transcript.done'
+    ) {
+      this.#audioTranscriptDone(event)
+    } else if (event.type === 'response.text.delta') {
+      this.#textDelta(event)
+    } else if (event.type === 'response.text.done') {
+      this.#textDone(event)
+    } else if (event.type === 'response.done') {
+      this.#responseDone(event)
+    }
+    return true
+  }
+
+  #contextFor(event) {
+    return ensureResponseContext(
+      this.contexts,
+      realtimeResponseId(event),
+      this.fallbackContext(),
+    )
+  }
+
+  #audioDelta(event) {
+    const id = realtimeResponseId(event)
+    const context = this.#contextFor(event)
+    if (context?.suppressed) return
+    const responseTurnId = context.turnId || this.turns.turnId
+    if (id) {
+      context.hasAudio = true
+      this.playbackTurns.set(id, responseTurnId)
+      this.announcementWindow.queueAudio(id, {
+        turnId: responseTurnId,
+        origin: context.origin || 'model',
+      })
+    }
+    this.send({
+      type: GatewayServerEvent.AUDIO_DELTA,
+      audio: event.delta,
+      sampleRate: Number(event.sampleRate)
+        || this.getFrontend().provider.outputSampleRate,
+      responseId: id,
+      turnId: responseTurnId,
+    })
+  }
+
+  #audioTranscriptDelta(event) {
+    const id = realtimeResponseId(event)
+    const context = this.#contextFor(event)
+    if (context.suppressed) return
+    if (!context.playbackStarted) {
+      context.pendingTranscripts.push({
+        content: event.delta || '',
+        final: false,
+      })
+      return
+    }
+    this.#emitTranscript({
+      id,
+      context,
+      content: event.delta || '',
+      final: false,
+    })
+  }
+
+  #audioTranscriptDone(event) {
+    const id = realtimeResponseId(event)
+    const context = this.#contextFor(event)
+    if (context.suppressed) return
+    context.transcriptDone = true
+    context.assistantTranscript = event.transcript || ''
+    if (!context.playbackStarted) {
+      context.pendingTranscripts.push({
+        content: event.transcript || '',
+        final: true,
+      })
+    } else {
+      this.#emitTranscript({
+        id,
+        context,
+        content: event.transcript || '',
+        final: true,
+      })
+    }
+    this.#finishContextIfComplete(id, context)
+  }
+
+  #textDelta(event) {
+    const id = realtimeResponseId(event)
+    const context = this.#contextFor(event)
+    if (context.suppressed) return
+    this.#emitTranscript({
+      id,
+      context,
+      content: event.delta || '',
+      final: false,
+    })
+  }
+
+  #textDone(event) {
+    const id = realtimeResponseId(event)
+    const context = this.#contextFor(event)
+    if (context.suppressed) return
+    context.transcriptDone = true
+    context.assistantTranscript = event.text || ''
+    this.#emitTranscript({
+      id,
+      context,
+      content: event.text || '',
+      final: true,
+    })
+  }
+
+  #responseDone(event) {
+    const id = realtimeResponseId(event)
+    const context = this.contexts.get(id)
+    const terminalToolResponse = this.toolCalls.consumeTerminalToolResponse(id)
+    const responseTurnId = context?.turnId || this.turns.turnId
+    const responseStatus = event.response?.status
+    const failed = ['failed', 'cancelled', 'incomplete'].includes(responseStatus)
+    this.toolCalls.finishToolResponse(id, {
+      suppressResponse: failed
+        || Boolean(context?.suppressed)
+        || Boolean(context?.hasAudio)
+        || Boolean(context?.assistantTranscript?.trim()),
+    }).catch(error => this.send({
+      type: GatewayServerEvent.ERROR,
+      message: error.message,
+    }))
+    const guardDecision = evaluateResponseGuards({
+      origin: context?.origin || 'model',
+      hasFunctionCall: Boolean(context?.hasFunctionCall),
+      failed,
+      suppressed: Boolean(context?.suppressed),
+      transcript: context?.assistantTranscript || '',
+    })
+    if (!context?.suppressed) {
+      this.send({
+        type: GatewayServerEvent.AUDIO_DONE,
+        responseId: id,
+        turnId: responseTurnId,
+      })
+      if (!context?.hasAudio) {
+        this.send({
+          type: GatewayServerEvent.VOICE_STATE,
+          state: 'idle',
+          turnId: responseTurnId,
+          origin: context?.origin || 'model',
+        })
+      }
+    }
+    if (context?.hasAudio && !failed) {
+      context.responseDone = true
+      this.#finishContextIfComplete(id, context)
+    } else {
+      const nonVoiceClient = this.getNonVoiceClient()
+      const completedNonVoiceAnnouncement = (
+        context?.origin === 'announcement'
+        && nonVoiceClient
+        && !failed
+      )
+      const completedNonVoiceTaskNotification = (
+        context?.consumesTaskNotification
+        && nonVoiceClient
+        && !failed
+      )
+      if (
+        context
+        && !failed
+        && (
+          context.origin !== 'announcement'
+          || completedNonVoiceAnnouncement
+        )
+      ) {
+        this.#flushPendingTranscripts(id, context)
+      }
+      if (context?.origin === 'announcement') {
+        if (completedNonVoiceAnnouncement) {
+          this.announcements.confirmMany(contextTaskIds(context))
+        } else {
+          this.announcements.retryMany(contextTaskIds(context))
+        }
+      } else if (completedNonVoiceTaskNotification) {
+        this.announcements.confirmMany(contextTaskIds(context))
+      }
+      this.contexts.delete(id)
+    }
+    if (failed && id) {
+      this.playbackTurns.delete(id)
+      this.announcementWindow.finishPlayback(id, {
+        hasFunctionCall: Boolean(context?.hasFunctionCall),
+      })
+    }
+    this.announcementWindow.responseDone({
+      turnId: responseTurnId,
+      origin: context?.origin || 'model',
+      hasAudio: Boolean(context?.hasAudio),
+      hasFunctionCall: Boolean(context?.hasFunctionCall),
+      suppressed: Boolean(context?.suppressed) || terminalToolResponse,
+      failed,
+    })
+    if (guardDecision) this.#requestGuardCorrection(guardDecision, context, responseTurnId)
+    this.#flushAnnouncementsSoon()
+  }
+
+  #requestGuardCorrection(decision, context, responseTurnId) {
+    const frontend = this.getFrontend()
+    if (
+      !this.getOutputEnabled()
+      || !frontend?.ready
+      || !frontend.capabilities.perResponseInstructions
+    ) return
+    const generation = context?.turnGeneration
+    frontend.ensureResponse({
+      turnId: responseTurnId,
+      turnGeneration: generation,
+    }, {
+      shouldCreate: () => isResponseGuardTurnCurrent({
+        sameFrontend: this.getFrontend() === frontend,
+        outputEnabled: this.getOutputEnabled(),
+        userSpeaking: this.turns.userSpeaking,
+        responseTurnId,
+        responseTurnGeneration: generation,
+        committedTurnId: this.turns.committedTurnId,
+        committedTurnGeneration: this.turns.committedTurnGeneration,
+      }),
+      response: { instructions: decision.instructions },
+    }).catch(error => this.send({
+      type: GatewayServerEvent.ERROR,
+      message: error.message,
+    }))
+  }
+
+  #emitTranscript({ id, context, content, final }) {
+    if (final) {
+      this.conversationSync.record({
+        ownerId: this.ownerId,
+        sessionId: this.sessionId,
+        id: `voice:assistant:${id}`,
+        role: 'assistant',
+        content,
+        source: context.origin === 'model'
+          ? 'realtime-direct'
+          : 'agent-presentation',
+        ...context,
+      })
+    }
+    this.send({
+      type: final
+        ? GatewayServerEvent.TRANSCRIPT_FINAL
+        : GatewayServerEvent.TRANSCRIPT_DELTA,
+      role: 'assistant',
+      content: content || '',
+      responseId: id,
+      ...this.publicContext(context),
+    })
+  }
+
+  #flushPendingTranscripts(id, context) {
+    for (const transcript of context?.pendingTranscripts || []) {
+      this.#emitTranscript({
+        id,
+        context,
+        content: transcript.content,
+        final: transcript.final,
+      })
+    }
+    if (context) context.pendingTranscripts = []
+  }
+
+  #finishContextIfComplete(id, context) {
+    if (
+      context
+      && context.playbackEnded
+      && context.responseDone
+      && context.transcriptDone
+    ) {
+      this.contexts.delete(id)
+    }
+  }
+
+  #scheduleContextCleanup(id, context) {
+    const timer = setTimeout(() => {
+      if (this.contexts.get(id) !== context) return
+      this.contexts.delete(id)
+      this.playbackTurns.delete(id)
+      this.announcementWindow.finishPlayback(id, {
+        hasFunctionCall: Boolean(context?.hasFunctionCall),
+      })
+    }, this.responseContextCleanupMs)
+    timer.unref?.()
+  }
+
+  #flushAnnouncementsSoon() {
+    const timer = setTimeout(
+      () => this.announcements.flush(),
+      this.announcementQuietMs,
+    )
+    timer.unref?.()
+  }
+
+  startPlayback(id) {
+    const context = this.contexts.get(id)
+    if (context?.suppressed) return
+    this.announcementWindow.startPlayback(id)
+    const playbackTurnId = context?.turnId
+      || this.playbackTurns.get(id)
+      || this.turns.turnId
+    this.send({
+      type: GatewayServerEvent.VOICE_STATE,
+      state: 'speaking',
+      turnId: playbackTurnId,
+      origin: context?.origin || 'model',
+    })
+    if (!context || context.playbackStarted) return
+    context.playbackStarted = true
+    if (confirmsTaskNotificationOnPlaybackStart(context)) {
+      this.announcements.confirmMany(contextTaskIds(context))
+    }
+    this.#flushPendingTranscripts(id, context)
+  }
+
+  finishPlayback(id) {
+    const playbackTurnId = this.playbackTurns.get(id) || this.turns.turnId
+    const context = this.contexts.get(id)
+    if (context?.suppressed) {
+      this.playbackTurns.delete(id)
+      return
+    }
+    this.announcementWindow.finishPlayback(id, {
+      hasFunctionCall: Boolean(context?.hasFunctionCall),
+    })
+    this.playbackTurns.delete(id)
+    if (context) {
+      context.playbackEnded = true
+      this.#finishContextIfComplete(id, context)
+      if (this.contexts.get(id) === context) {
+        this.#scheduleContextCleanup(id, context)
+      }
+    }
+    this.send({
+      type: GatewayServerEvent.VOICE_STATE,
+      state: this.turns.userSpeaking ? 'listening' : 'idle',
+      turnId: this.turns.userSpeaking ? this.turns.turnId : playbackTurnId,
+      origin: context?.origin || 'model',
+    })
+    this.#flushAnnouncementsSoon()
+  }
+
+  cancelPlayback(id, { reason = '' } = {}) {
+    const context = this.contexts.get(id)
+    this.announcementWindow.finishPlayback(id, {
+      hasFunctionCall: Boolean(context?.hasFunctionCall),
+    })
+    const playbackTurnId = this.playbackTurns.get(id) || this.turns.turnId
+    this.playbackTurns.delete(id)
+    if (context?.origin === 'announcement') {
+      if (reason === 'user_interruption') {
+        this.announcements.confirmMany(contextTaskIds(context))
+      } else {
+        this.announcements.retryMany(contextTaskIds(context))
+      }
+    }
+    if (context?.playbackStarted && reason === 'user_interruption') {
+      this.send({
+        type: GatewayServerEvent.RESPONSE_INTERRUPTED,
+        responseId: id,
+        ...this.publicContext(context),
+      })
+    }
+    if (context) {
+      context.suppressed = true
+      context.playbackEnded = true
+      context.pendingTranscripts = []
+      this.#scheduleContextCleanup(id, context)
+    }
+    this.send({
+      type: GatewayServerEvent.VOICE_STATE,
+      state: this.turns.userSpeaking ? 'listening' : 'idle',
+      turnId: this.turns.userSpeaking ? this.turns.turnId : playbackTurnId,
+      origin: context?.origin || 'model',
+    })
+    this.#flushAnnouncementsSoon()
+  }
+
+  cancelPermission(authorizationId) {
+    for (const [responseId, context] of this.contexts) {
+      if (
+        context.origin === 'permission'
+        && context.authorizationId === authorizationId
+        && !context.suppressed
+      ) {
+        this.cancelPlayback(responseId, { reason: 'permission_resolved' })
+      }
+    }
+  }
+
+  failResponse(event) {
+    const id = realtimeResponseId(event)
+    const context = this.contexts.get(id)
+    if (context?.origin === 'announcement') {
+      this.send({ type: GatewayServerEvent.PLAYBACK_CLEAR })
+      this.announcementWindow.finishPlayback(id)
+      this.playbackTurns.delete(id)
+      this.contexts.delete(id)
+      this.announcements.retryMany(contextTaskIds(context))
+    } else {
+      if (id && context?.hasAudio) {
+        this.send({
+          type: GatewayServerEvent.AUDIO_DONE,
+          responseId: id,
+          turnId: context.turnId || this.turns.turnId,
+        })
+        this.#scheduleContextCleanup(id, context)
+      } else if (id) {
+        this.contexts.delete(id)
+        this.playbackTurns.delete(id)
+      }
+      this.announcementWindow.responseDone({
+        turnId: context?.turnId || this.turns.turnId,
+        origin: context?.origin || 'model',
+        hasAudio: Boolean(context?.hasAudio),
+        hasFunctionCall: Boolean(context?.hasFunctionCall),
+        failed: true,
+      })
+    }
+    this.#flushAnnouncementsSoon()
+  }
+
+  clear() {
+    this.contexts.clear()
+    this.playbackTurns.clear()
+  }
+}

--- a/server/test/realtime-presentation-runtime.test.mjs
+++ b/server/test/realtime-presentation-runtime.test.mjs
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { RealtimePresentationRuntime } from '../src/voice/realtime-presentation-runtime.mjs'
+import { RealtimeTurnState } from '../src/voice/realtime-turn-state.mjs'
+
+function harness({ nonVoiceClient = false } = {}) {
+  const events = []
+  const records = []
+  const calls = []
+  const turns = new RealtimeTurnState({
+    createVoiceTurnId: generation => `voice-${generation}`,
+  })
+  let responseTurnCandidate = null
+  const frontend = {
+    ready: true,
+    provider: { outputSampleRate: 24000 },
+    capabilities: { perResponseInstructions: false },
+  }
+  const runtime = new RealtimePresentationRuntime({
+    ownerId: 'owner-1',
+    sessionId: 'session-1',
+    turns,
+    conversationSync: { record: value => records.push(value) },
+    announcementWindow: {
+      queueAudio: (...args) => calls.push(['queueAudio', ...args]),
+      startPlayback: (...args) => calls.push(['startPlayback', ...args]),
+      finishPlayback: (...args) => calls.push(['finishPlayback', ...args]),
+      responseDone: (...args) => calls.push(['responseDone', ...args]),
+    },
+    announcements: {
+      confirmMany: ids => calls.push(['confirmMany', ids]),
+      retryMany: ids => calls.push(['retryMany', ids]),
+      flush: () => calls.push(['flush']),
+    },
+    toolCalls: {
+      consumeTerminalToolResponse: id => {
+        calls.push(['consumeTerminalToolResponse', id])
+        return false
+      },
+      finishToolResponse: async (...args) => calls.push([
+        'finishToolResponse',
+        ...args,
+      ]),
+    },
+    send: event => events.push(event),
+    getFrontend: () => frontend,
+    getOutputEnabled: () => true,
+    getNonVoiceClient: () => nonVoiceClient,
+    getResponseTurnCandidate: () => responseTurnCandidate,
+    clearResponseCandidate: () => {
+      responseTurnCandidate = null
+      calls.push(['clearResponseCandidate'])
+    },
+    announcementQuietMs: 60_000,
+    responseContextCleanupMs: 60_000,
+  })
+  return {
+    runtime,
+    turns,
+    events,
+    records,
+    calls,
+    setResponseTurnCandidate(value) {
+      responseTurnCandidate = value
+    },
+  }
+}
+
+function deliver(runtime, event) {
+  runtime.begin(event)
+  runtime.handle(event)
+}
+
+test('correlates an implicit provider response with the pending voice turn', () => {
+  const setup = harness()
+  const candidate = setup.turns.beginVoice('item-1').context
+  setup.turns.endSpeech()
+  setup.setResponseTurnCandidate(candidate)
+
+  deliver(setup.runtime, {
+    type: 'response.audio.delta',
+    response_id: 'response-1',
+    delta: 'audio',
+  })
+
+  assert.deepEqual(setup.turns.committed(), candidate)
+  assert.equal(setup.events[0].type, 'response.started')
+  assert.equal(setup.events[1].type, 'audio.delta')
+  assert.equal(setup.events[1].sampleRate, 24000)
+  assert.equal(
+    setup.calls.some(([name]) => name === 'clearResponseCandidate'),
+    true,
+  )
+})
+
+test('holds audio transcripts until playback starts and records them once', () => {
+  const { runtime, events, records, calls } = harness()
+  const context = {
+    turnId: 'turn-1',
+    turnGeneration: 1,
+    taskIds: ['work-1'],
+    consumesTaskNotification: true,
+  }
+
+  deliver(runtime, {
+    type: 'response.audio.delta',
+    response_id: 'response-1',
+    delta: 'audio',
+    __voiceContext: context,
+  })
+  deliver(runtime, {
+    type: 'response.audio_transcript.delta',
+    response_id: 'response-1',
+    delta: '后台任务',
+  })
+  deliver(runtime, {
+    type: 'response.audio_transcript.done',
+    response_id: 'response-1',
+    transcript: '后台任务完成了',
+  })
+  assert.equal(events.some(event => event.type === 'transcript.final'), false)
+
+  runtime.startPlayback('response-1')
+
+  assert.deepEqual(
+    events.filter(event => event.type.startsWith('transcript.')).map(event => ({
+      type: event.type,
+      content: event.content,
+    })),
+    [
+      { type: 'transcript.delta', content: '后台任务' },
+      { type: 'transcript.final', content: '后台任务完成了' },
+    ],
+  )
+  assert.equal(records.length, 1)
+  assert.equal(records[0].source, 'realtime-direct')
+  assert.equal(
+    calls.filter(([name]) => name === 'confirmMany').length,
+    1,
+  )
+})
+
+test('retires an audio response only after response, transcript and playback end', () => {
+  const { runtime } = harness()
+
+  deliver(runtime, {
+    type: 'response.audio.delta',
+    response_id: 'response-1',
+    delta: 'audio',
+    __voiceContext: { turnId: 'turn-1', turnGeneration: 1 },
+  })
+  runtime.startPlayback('response-1')
+  deliver(runtime, {
+    type: 'response.audio_transcript.done',
+    response_id: 'response-1',
+    transcript: '完成',
+  })
+  deliver(runtime, {
+    type: 'response.done',
+    response: { id: 'response-1', status: 'completed' },
+  })
+  assert.equal(runtime.has('response-1'), true)
+
+  runtime.finishPlayback('response-1')
+
+  assert.equal(runtime.has('response-1'), false)
+})
+
+test('user interruption confirms an announcement and suppresses late output', () => {
+  const { runtime, events, calls } = harness()
+
+  deliver(runtime, {
+    type: 'response.audio.delta',
+    response_id: 'response-1',
+    delta: 'audio',
+    __voiceOrigin: 'announcement',
+    __voiceContext: {
+      turnId: 'turn-1',
+      turnGeneration: 1,
+      taskIds: ['work-1'],
+    },
+  })
+  runtime.startPlayback('response-1')
+  runtime.cancelPlayback('response-1', { reason: 'user_interruption' })
+  deliver(runtime, {
+    type: 'response.audio_transcript.done',
+    response_id: 'response-1',
+    transcript: '不应出现',
+  })
+
+  assert.equal(
+    events.filter(event => event.type === 'transcript.final').length,
+    0,
+  )
+  assert.equal(
+    events.filter(event => event.type === 'response.interrupted').length,
+    1,
+  )
+  assert.equal(
+    calls.filter(([name]) => name === 'confirmMany').length,
+    3,
+  )
+  assert.equal(calls.some(([name]) => name === 'retryMany'), false)
+})
+
+test('a provider failure retries an undelivered announcement', () => {
+  const { runtime, calls } = harness()
+  runtime.begin({
+    type: 'response.created',
+    response: { id: 'response-1' },
+    __voiceOrigin: 'announcement',
+    __voiceContext: {
+      turnId: 'turn-1',
+      turnGeneration: 1,
+      taskIds: ['work-1'],
+    },
+  })
+
+  runtime.failResponse({ type: 'error', response_id: 'response-1' })
+
+  assert.equal(runtime.has('response-1'), false)
+  assert.deepEqual(
+    calls.find(([name]) => name === 'retryMany'),
+    ['retryMany', ['work-1']],
+  )
+})


### PR DESCRIPTION
## Summary
- centralize realtime response correlation, audio/text projection, and playback receipts
- keep task notification confirmation/retry and response tombstones inside one presentation boundary
- preserve tool-response completion and response-guard behavior
- update bilingual R2 progress and add focused lifecycle coverage

## Validation
- `node --test server/test/realtime-presentation-runtime.test.mjs server/test/realtime-input-runtime.test.mjs server/test/realtime-turn-state.test.mjs server/test/realtime-provider.test.mjs server/test/input-suspend-protocol.test.mjs server/test/desktop-sleep-tool-registration.test.mjs` (82 passed)
- `npm run lint`
- `npm run build`
- full Server suite reached 570/571 with `--test-force-exit`; only the unrelated OpenClaw child test was SIGKILLed by force-exit and passes alone

Roadmap: #185