### PR TITLE
refactor: extract realtime provider session

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -167,11 +167,11 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 
 ### R2 — Frontend Chatbot Runtime
 
-- [ ] Extract realtime session, turn, input, playback, and presentation logic.
+- [x] Extract realtime session, turn, input, playback, and presentation logic.
   - [x] Centralize per-connection turn generation, correlation, and interruption boundaries.
   - [x] Extract provider audio/transcription and manual-input lifecycles.
   - [x] Extract response correlation, playback, and presentation lifecycles.
-  - [ ] Extract the realtime provider session lifecycle.
+  - [x] Extract the realtime provider session lifecycle.
 - [x] Add Frontend Tool Registry, Policy, and Executor.
   - [x] Extract the declarative Registry and visibility Policy.
   - [x] Route execution through the Registry-owned Executor.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -215,11 +215,11 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 
 ### R2：Frontend Chatbot Runtime
 
-- [ ] 提取 Realtime Session、Turn、Input、Playback 和 Presentation。
+- [x] 提取 Realtime Session、Turn、Input、Playback 和 Presentation。
   - [x] 集中管理单连接内的 Turn 代次、关联与打断边界。
   - [x] 提取 Provider 音频/转写与手动输入生命周期。
   - [x] 提取响应关联、Playback 与 Presentation 生命周期。
-  - [ ] 继续提取 Realtime Provider Session 生命周期。
+  - [x] 提取 Realtime Provider Session 生命周期。
 - [x] 建立 Frontend Tool Registry、Policy 和 Executor。
   - [x] 提取声明式 Registry 与可见性 Policy。
   - [x] 通过 Registry 管理的 Executor 统一执行入口。

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -13,7 +13,6 @@ import { conversationSync } from '../conversation/conversation-sync.mjs'
 import { InputAssetRegistry } from './input-asset-registry.mjs'
 import { normalizeClientContext } from '../conversation/frontend-agent-context.mjs'
 import {
-  createRealtimeFrontend,
   defaultRealtimeProviderRegistry,
   realtimeEventErrorMessage,
 } from './realtime-provider.mjs'
@@ -35,8 +34,7 @@ import {
   ActiveVoiceClients,
   clientVoiceCapabilities,
 } from './active-voice-clients.mjs'
-import { ReconnectBackoff } from './reconnect-backoff.mjs'
-import { realtimeConnectionStatus } from './realtime-connection-status.mjs'
+import { RealtimeProviderSession } from './realtime-provider-session.mjs'
 import { SleepController } from './sleep-controller.mjs'
 import { createSherpaWakeWordDetector } from './wake-word/sherpa-detector.mjs'
 import {
@@ -160,9 +158,6 @@ export function attachRealtimeGateway(server, {
       sessionId,
     })
     connectionLogger.info('voice_client.connected')
-    let frontend
-    let connectPromise
-    let pendingAudio = []
     let inputEnabled = false
     let outputEnabled = false
     // Set only by host arbitration. Unlike inputEnabled (which the client
@@ -170,23 +165,16 @@ export function attachRealtimeGateway(server, {
     // capturing, so nothing here may re-enable audio on its own.
     let inputSuspended = inputArbitration?.suspended === true
     let nonVoiceClient = false
-    // Realtime front end for this session. Defaults to the configured provider
-    // and can be switched by the client through the connect event.
-    let sessionProvider = defaultRealtimeProvider
     let descriptor = clientDescriptor()
     let responseTurnCandidate = null
     let responseStartWatchdog = null
     let permissionResponseTimer = null
-    let scheduledRealtimeReconnect = null
-    let realtimeConnectedAt = 0
-    let realtimeBlockedError = ''
     let sleeping = false
     let waking = false
     let explicitSleepRequested = false
     let wakeDetector = null
     let wakeDetectorPromise = null
     let sleepController
-    const realtimeReconnectBackoff = new ReconnectBackoff()
     const announcementWindow = new AnnouncementWindow()
     const notificationClaimantId = `voice_${randomUUID()}`
     let clientContext = normalizeClientContext()
@@ -194,13 +182,14 @@ export function attachRealtimeGateway(server, {
     const transcripts = new TurnTranscripts()
     const announcedPermissions = new Set()
     let permissionRetryTimer = null
+    let realtimeSession
     const activeSessionTasks = () => taskManager.list({
       ownerId,
       sessionId,
       active: true,
     })
     const schedulePermissionRetry = () => {
-      if (permissionRetryTimer || !outputEnabled || !frontend?.ready) return
+      if (permissionRetryTimer || !outputEnabled || !realtimeSession?.ready) return
       permissionRetryTimer = setTimeout(() => {
         permissionRetryTimer = null
         announcePendingPermissions()
@@ -211,7 +200,7 @@ export function attachRealtimeGateway(server, {
       const permission = task?.authorization
       if (
         !outputEnabled
-        || !frontend?.ready
+        || !realtimeSession?.ready
         || permission?.status !== 'pending'
         || announcedPermissions.has(permission.id)
       ) return
@@ -220,7 +209,7 @@ export function attachRealtimeGateway(server, {
         return
       }
       announcedPermissions.add(permission.id)
-      frontend.injectPermission(permission, {
+      realtimeSession.frontend.injectPermission(permission, {
         turnId: task.turnId,
         taskId: task.id,
         authorizationId: permission.id,
@@ -253,7 +242,7 @@ export function attachRealtimeGateway(server, {
       activeTasks.forEach(announcePermission)
     }
     const announcements = new AnnouncementManager({
-      getFrontend: () => frontend,
+      getFrontend: () => realtimeSession?.frontend,
       isDeliveryBlocked: () => sleeping || waking || !outputEnabled || announcementWindow.isBlocked(),
       announceIntoContext: config.announceIntoContext,
       resultContextMaxChars: config.resultContextMaxChars,
@@ -279,6 +268,67 @@ export function attachRealtimeGateway(server, {
         message: `后台结果暂时无法播报，正在自动重试：${error.message}`,
       }),
     })
+    const reportFrontendError = error => {
+      if (error?.realtimeConnectionReported) return
+      if (error) error.realtimeConnectionReported = true
+      send(ws, { type: GatewayServerEvent.ERROR, message: error?.message || String(error) })
+    }
+    realtimeSession = new RealtimeProviderSession({
+      providerRegistry: realtimeProviderRegistry,
+      defaultProvider: defaultRealtimeProvider,
+      getAgentContext: () => ({
+        client: clientContext,
+        memories: memoryService?.list(ownerId, { limit: 64 }) || [],
+        recentMessages: conversationSync.frontendContext({ ownerId, sessionId }),
+      }),
+      shouldReconnect: () => inputEnabled || outputEnabled,
+      onEvent: event => handleEvent(event),
+      onDiagnostic: diagnostic => {
+        const { event, ...fields } = diagnostic
+        connectionLogger.warn(event, fields)
+      },
+      onConnected: () => announcePendingPermissions(),
+      onReady: createdFrontend => {
+        const resumedFromSleep = waking
+        waking = false
+        if (outputEnabled) claimPendingNotifications()
+        send(ws, {
+          type: GatewayServerEvent.VOICE_READY,
+          inputSampleRate: createdFrontend.provider.inputSampleRate,
+          provider: createdFrontend.provider.key,
+          providerLabel: createdFrontend.provider.label,
+        })
+        prepareSleepMode()
+        sleepController.recordActivity()
+        if (resumedFromSleep) {
+          send(ws, {
+            type: GatewayServerEvent.VOICE_SLEEP,
+            state: 'awake',
+            wakeWord: config.wakeWord,
+          })
+          announcePendingPermissions()
+          claimPendingNotifications()
+          announcements.flush()
+        }
+      },
+      onDisconnected: () => send(ws, {
+        type: GatewayServerEvent.VOICE_STATE,
+        state: 'idle',
+      }),
+      onReconnected: () => announcements.flush(),
+      onConnectionState: event => send(ws, {
+        type: GatewayServerEvent.VOICE_CONNECTION,
+        ...event,
+      }),
+      onError: reportFrontendError,
+      onReconnectError: error => send(ws, {
+        type: GatewayServerEvent.ERROR,
+        message: `实时语音连接恢复失败：${error.message}`,
+      }),
+      logger: connectionLogger,
+      maxPendingAudioChunks: MAX_PENDING_AUDIO_CHUNKS,
+      stableConnectionMs: REALTIME_STABLE_CONNECTION_MS,
+    })
     const voiceClient = {
       ws,
       descriptor,
@@ -291,9 +341,9 @@ export function attachRealtimeGateway(server, {
         inputSuspended = suspend
         if (suspend) {
           // Buffered audio predates the suspension and is no longer wanted.
-          pendingAudio = []
+          realtimeSession.clearPendingAudio()
           sleepController?.disable()
-          frontend?.cancel()
+          realtimeSession.cancelResponse()
           send(ws, { type: GatewayServerEvent.PLAYBACK_CLEAR, reason: 'input_suspended' })
           send(ws, {
             type: GatewayServerEvent.INPUT_SUSPEND,
@@ -306,13 +356,9 @@ export function attachRealtimeGateway(server, {
         send(ws, { type: GatewayServerEvent.INPUT_RESUME })
         prepareSleepMode()
       },
-      realtimeStatus: () => realtimeConnectionStatus({
-        provider: sessionProvider,
-        blockedError: realtimeBlockedError,
+      realtimeStatus: () => realtimeSession.status({
         sleeping,
         waking,
-        ready: frontend?.ready === true,
-        connecting: Boolean(connectPromise),
       }),
       // Lets the arbitration evict this owner once its socket has died without
       // a clean close, so a stale holder never blocks a new voice claim.
@@ -323,11 +369,9 @@ export function attachRealtimeGateway(server, {
         sleepController?.disable()
         inputEnabled = false
         outputEnabled = false
-        pendingAudio = []
         announcementWindow.reset()
         announcements.pause()
-        cancelScheduledRealtimeReconnect()
-        frontend?.close()
+        realtimeSession.close({ notifyDisconnected: true })
         send(ws, { type: 'playback.clear' })
         send(ws, {
           type: 'voice.deactivated',
@@ -365,7 +409,7 @@ export function attachRealtimeGateway(server, {
       ownerId,
       sessionId,
       transcripts,
-      getFrontend: () => frontend,
+      getFrontend: () => realtimeSession.frontend,
       getTurnId: () => turns.committedTurnId,
       getTurnGeneration: () => turns.committedTurnGeneration,
       memoryService,
@@ -375,7 +419,7 @@ export function attachRealtimeGateway(server, {
         ownerId,
         sessionId,
       }),
-      onMemoryChanged: () => frontend?.updateAgentContext({
+      onMemoryChanged: () => realtimeSession.updateAgentContext({
         memories: memoryService?.list(ownerId, { limit: 64 }) || [],
       }),
       coordinator,
@@ -415,52 +459,6 @@ export function attachRealtimeGateway(server, {
       responseTurnCandidate = null
     }
 
-    const cancelScheduledRealtimeReconnect = () => {
-      const scheduled = scheduledRealtimeReconnect
-      if (!scheduled) return
-      scheduledRealtimeReconnect = null
-      clearTimeout(scheduled.timer)
-      scheduled.resolve()
-    }
-
-    const scheduleRealtimeReconnect = () => {
-      if (realtimeBlockedError) return Promise.resolve()
-      if (frontend?.ready) return Promise.resolve()
-      if (scheduledRealtimeReconnect) {
-        return scheduledRealtimeReconnect.promise
-      }
-      let resolveScheduled
-      let rejectScheduled
-      const promise = new Promise((resolve, reject) => {
-        resolveScheduled = resolve
-        rejectScheduled = reject
-      })
-      const scheduled = {
-        promise,
-        resolve: resolveScheduled,
-        reject: rejectScheduled,
-        timer: null,
-      }
-      scheduled.timer = setTimeout(() => {
-        if (scheduledRealtimeReconnect !== scheduled) {
-          scheduled.resolve()
-          return
-        }
-        // Clear the waiting state before connecting. If this attempt closes,
-        // its onClose callback can schedule the next backoff step without
-        // colliding with the promise for the attempt that just started.
-        scheduledRealtimeReconnect = null
-        connectFrontendNow().then(scheduled.resolve, scheduled.reject)
-      }, realtimeReconnectBackoff.next())
-      scheduled.timer.unref?.()
-      scheduledRealtimeReconnect = scheduled
-      return promise
-    }
-    const reportFrontendError = error => {
-      if (error?.realtimeConnectionReported) return
-      if (error) error.realtimeConnectionReported = true
-      send(ws, { type: 'error', message: error?.message || String(error) })
-    }
     const ensurePermissionResponseFor = context => {
       clearTimeout(permissionResponseTimer)
       const hasPendingPermission = () => activeSessionTasks().some(task => (
@@ -469,7 +467,7 @@ export function attachRealtimeGateway(server, {
       if (!hasPendingPermission()) return
       permissionResponseTimer = setTimeout(() => {
         permissionResponseTimer = null
-        frontend?.ensureResponse({
+        realtimeSession.frontend?.ensureResponse({
           turnId: context.turnId,
           turnGeneration: context.turnGeneration,
         }, {
@@ -504,14 +502,12 @@ export function attachRealtimeGateway(server, {
           turnId: context.turnId,
           origin: 'model',
         })
-        const staleFrontend = frontend
-        frontend = null
-        staleFrontend?.close()
-        scheduleRealtimeReconnect().catch(error => send(ws, {
+        realtimeSession.reconnect().catch(error => send(ws, {
           type: 'error',
           message: error.message,
         }))
-      }, frontend?.provider.responseStartTimeoutMs ?? RESPONSE_START_WATCHDOG_MS)
+      }, realtimeSession.frontend?.provider.responseStartTimeoutMs
+        ?? RESPONSE_START_WATCHDOG_MS)
       responseStartWatchdog.unref?.()
     }
 
@@ -525,8 +521,8 @@ export function attachRealtimeGateway(server, {
       announcementWindow,
       announcements,
       send: event => send(ws, event),
-      getFrontend: () => frontend,
-      ensureFrontend: () => ensureFrontend(),
+      getFrontend: () => realtimeSession.frontend,
+      ensureFrontend: () => realtimeSession.ensure(),
       clearResponseCandidate,
       expectResponseFor,
       shouldEnsurePermissionResponse: context => responseTurnCandidate === context,
@@ -543,7 +539,7 @@ export function attachRealtimeGateway(server, {
       announcements,
       toolCalls,
       send: event => send(ws, event),
-      getFrontend: () => frontend,
+      getFrontend: () => realtimeSession.frontend,
       getOutputEnabled: () => outputEnabled,
       getNonVoiceClient: () => nonVoiceClient,
       getResponseTurnCandidate: () => responseTurnCandidate,
@@ -570,7 +566,7 @@ export function attachRealtimeGateway(server, {
       taskIds,
       { includeOtherSessions = !taskIds?.length } = {},
     ) => {
-      if (!outputEnabled || !frontend?.ready) return
+      if (!outputEnabled || !realtimeSession.ready) return
       const claimed = taskManager.claimNotifications({
         ownerId,
         sessionId,
@@ -589,7 +585,7 @@ export function attachRealtimeGateway(server, {
       if (event.ownerId !== ownerId) return
       if (event.type === TaskDomainEvent.PROGRESS_CHECK) {
         if (task.sessionId !== sessionId) return
-        if (!outputEnabled || !frontend?.ready) return
+        if (!outputEnabled || !realtimeSession.ready) return
         const progressContext = {
           taskId: task.id,
           turnId: null,
@@ -604,7 +600,7 @@ export function attachRealtimeGateway(server, {
           event.message,
           '</qwen_audio_agent_progress>',
         ].join('\n')
-        frontend.injectResult(
+        realtimeSession.frontend.injectResult(
           progressText,
           'progress',
           progressContext,
@@ -643,15 +639,15 @@ export function attachRealtimeGateway(server, {
           // 已进入对话的权限询问被其它通道（如 WebUI 按钮）处理后，把结果
           // 静默回注模型上下文：避免模型不知情而重复追问，或把用户随后的
           // 口头确认误报为“请求已失效”。
-          if (announcedPermissions.has(authorizationId) && frontend?.ready) {
-            frontend.appendUserInputContext([{
+          if (announcedPermissions.has(authorizationId) && realtimeSession.ready) {
+            realtimeSession.frontend.appendUserInputContext([{
               type: 'text',
               text: '（系统提示：刚才的后台权限请求已处理完毕，任务继续执行；'
                 + '无需再询问或回应该请求。）',
             }]).catch(() => {})
           }
           announcedPermissions.delete(authorizationId)
-          frontend?.cancelResponses((context, origin) => (
+          realtimeSession.frontend?.cancelResponses((context, origin) => (
             origin === 'permission'
             && context?.authorizationId === authorizationId
           ))
@@ -718,7 +714,7 @@ export function attachRealtimeGateway(server, {
         // frontend transparently; nothing user-facing happened.
         if (event.__voiceRetried) return
         const errorMessage = realtimeEventErrorMessage(event)
-        const providerError = frontend.provider.classifyError(errorMessage)
+        const providerError = realtimeSession.classifyError(errorMessage)
         const recoverableInactivity = providerError === 'inactivity'
         // A local or otherwise capacity-bounded provider can still be draining
         // the previous Session. Its close event drives the shared reconnect
@@ -739,20 +735,15 @@ export function attachRealtimeGateway(server, {
         if (benignCancelRace) return
         if (providerError === 'fatal') {
           connectionLogger.error('realtime.blocked', {
-            provider: sessionProvider,
+            provider: realtimeSession.providerKey,
             classification: providerError,
             errorMessage,
           })
-          realtimeBlockedError = errorMessage
-          pendingAudio = []
-          cancelScheduledRealtimeReconnect()
-          const blockedFrontend = frontend
-          frontend = null
-          blockedFrontend?.close()
+          realtimeSession.block(errorMessage)
           send(ws, {
             type: GatewayServerEvent.VOICE_CONNECTION,
             state: 'unavailable',
-            provider: sessionProvider,
+            provider: realtimeSession.providerKey,
             message: errorMessage,
           })
         }
@@ -767,186 +758,13 @@ export function attachRealtimeGateway(server, {
       }
     }
 
-    const connectFrontendNow = () => {
-      if (frontend?.ready) return Promise.resolve()
-      if (connectPromise) return connectPromise
-      send(ws, {
-        type: GatewayServerEvent.VOICE_CONNECTION,
-        state: 'connecting',
-        provider: sessionProvider,
-      })
-      const connectStartedAt = Date.now()
-      connectionLogger.info('realtime.connecting', {
-        provider: sessionProvider,
-      })
-      let createdFrontend
-      createdFrontend = createRealtimeFrontend({
-        providerName: sessionProvider,
-        providerRegistry: realtimeProviderRegistry,
-        agentContext: {
-          client: clientContext,
-          memories: memoryService?.list(ownerId, { limit: 64 }) || [],
-          recentMessages: conversationSync.frontendContext({ ownerId, sessionId }),
-        },
-        onEvent: handleEvent,
-        onDiagnostic: diagnostic => {
-          const { event, ...fields } = diagnostic
-          connectionLogger.warn(event, fields)
-        },
-        onError: error => {
-          // Closing a frontend while it is still handshaking is expected when
-          // the client enters sleep or reconnects. Its late socket error
-          // belongs to the detached frontend and must not mark the live voice
-          // client unavailable.
-          if (frontend !== createdFrontend) return
-          const classification = createdFrontend.provider.classifyError(error.message)
-          if (classification !== 'inactivity') {
-            connectionLogger.warn('realtime.provider_error', {
-              provider: createdFrontend.provider.key,
-              classification,
-              error,
-            })
-          }
-          if (classification === 'fatal') {
-            realtimeBlockedError = error.message
-            pendingAudio = []
-            error.realtimeConnectionReported = true
-          }
-          // capacity_busy 是瞬时可恢复错误（如 s2s 单 session 槽异步未释放），
-          // 由上层 wakeFromSleep 带退避重试，不向客户端报错以保持唤醒流程静默。
-          if (classification !== 'inactivity' && classification !== 'capacity_busy') {
-            reportFrontendError(error)
-          }
-        },
-        onClose: () => {
-          if (frontend !== createdFrontend) return
-          connectionLogger.warn('realtime.closed', {
-            provider: createdFrontend.provider.key,
-            connectedMs: realtimeConnectedAt
-              ? Date.now() - realtimeConnectedAt
-              : 0,
-            blocked: Boolean(realtimeBlockedError),
-          })
-          send(ws, { type: 'voice.state', state: 'idle' })
-          frontend = null
-          if (!inputEnabled && !outputEnabled) return
-          send(ws, {
-            type: GatewayServerEvent.VOICE_CONNECTION,
-            state: 'unavailable',
-            provider: sessionProvider,
-            ...(realtimeBlockedError ? { message: realtimeBlockedError } : {}),
-          })
-          if (realtimeBlockedError) return
-          if (
-            realtimeConnectedAt
-            && Date.now() - realtimeConnectedAt >= REALTIME_STABLE_CONNECTION_MS
-          ) {
-            realtimeReconnectBackoff.reset()
-          }
-          realtimeConnectedAt = 0
-          scheduleRealtimeReconnect()
-            .then(() => announcements.flush())
-            .catch(error => send(ws, {
-              type: 'error',
-              message: `实时语音连接恢复失败：${error.message}`,
-            }))
-        },
-      })
-      frontend = createdFrontend
-      let createdConnectPromise
-      createdConnectPromise = createdFrontend.connect()
-        .then(() => {
-          if (frontend !== createdFrontend) return
-          realtimeBlockedError = ''
-          realtimeConnectedAt = Date.now()
-          connectionLogger.info('realtime.connected', {
-            provider: createdFrontend.provider.key,
-            durationMs: realtimeConnectedAt - connectStartedAt,
-          })
-          const resumedFromSleep = waking
-          waking = false
-          send(ws, {
-            type: GatewayServerEvent.VOICE_CONNECTION,
-            state: 'connected',
-            provider: createdFrontend.provider.key,
-          })
-          announcePendingPermissions()
-          pendingAudio.forEach(audio => createdFrontend.appendAudio(audio))
-          pendingAudio = []
-          if (outputEnabled) claimPendingNotifications()
-          send(ws, {
-            type: 'voice.ready',
-            inputSampleRate: createdFrontend.provider.inputSampleRate,
-            provider: createdFrontend.provider.key,
-            providerLabel: createdFrontend.provider.label,
-          })
-          prepareSleepMode()
-          sleepController.recordActivity()
-          if (resumedFromSleep) {
-            send(ws, {
-              type: GatewayServerEvent.VOICE_SLEEP,
-              state: 'awake',
-              wakeWord: config.wakeWord,
-            })
-            announcePendingPermissions()
-            claimPendingNotifications()
-            announcements.flush()
-          }
-        })
-        .catch(error => {
-          if (frontend !== createdFrontend) return
-          connectionLogger.error('realtime.connect_failed', {
-            provider: createdFrontend.provider.key,
-            durationMs: Date.now() - connectStartedAt,
-            error,
-          })
-          const classification = createdFrontend.provider.classifyError(error.message)
-          if (classification === 'fatal') {
-            realtimeBlockedError = error.message
-            pendingAudio = []
-          }
-          // capacity_busy 是瞬时可恢复错误（如 s2s 单 session 槽尚未释放），
-          // 由上层带退避重试，不向客户端报 unavailable 以避免唤醒流程闪烁。
-          if (frontend === createdFrontend && classification !== 'capacity_busy') {
-            send(ws, {
-              type: GatewayServerEvent.VOICE_CONNECTION,
-              state: 'unavailable',
-              provider: createdFrontend.provider.key,
-              message: error.message,
-            })
-          }
-          throw error
-        })
-        .finally(() => {
-          if (connectPromise === createdConnectPromise) connectPromise = null
-        })
-      connectPromise = createdConnectPromise
-      return createdConnectPromise
-    }
-
-    const ensureFrontend = () => {
-      if (realtimeBlockedError) {
-        return Promise.reject(new Error(realtimeBlockedError))
-      }
-      if (frontend?.ready) return Promise.resolve()
-      if (connectPromise) return connectPromise
-      if (scheduledRealtimeReconnect) {
-        return scheduledRealtimeReconnect.promise
-      }
-      return connectFrontendNow()
-    }
-
     const enterSleep = () => {
       if (sleeping) return
       sleeping = true
       waking = false
-      pendingAudio = []
       announcementWindow.reset()
       wakeDetector?.reset()
-      cancelScheduledRealtimeReconnect()
-      const staleFrontend = frontend
-      frontend = null
-      staleFrontend?.close()
+      realtimeSession.close()
       if (clientContext.states?.includes('sleeping')) {
         send(ws, {
           type: GatewayServerEvent.CLIENT_STATE,
@@ -956,7 +774,7 @@ export function attachRealtimeGateway(server, {
       send(ws, {
         type: GatewayServerEvent.VOICE_CONNECTION,
         state: 'sleeping',
-        provider: sessionProvider,
+        provider: realtimeSession.providerKey,
       })
       send(ws, {
         type: GatewayServerEvent.VOICE_SLEEP,
@@ -1016,7 +834,7 @@ export function attachRealtimeGateway(server, {
       if (!config.wakeWordEnabled || nonVoiceClient) return false
       explicitSleepRequested = true
       inputEnabled = false
-      pendingAudio = []
+      realtimeSession.clearPendingAudio()
       prepareSleepMode()
       const finish = () => {
         if (!explicitSleepRequested || !wakeDetector) return false
@@ -1032,11 +850,9 @@ export function attachRealtimeGateway(server, {
     const WAKE_CONNECT_RETRY_BACKOFF_MS = 350
 
     const attemptWakeConnect = attempt => {
-      ensureFrontend().catch(error => {
-        const provider =
-          frontend?.provider ?? realtimeProviderRegistry.resolve(sessionProvider)
-        const classification =
-          provider.classifyError?.(error.message) ?? 'other'
+      realtimeSession.ensure().catch(error => {
+        const provider = realtimeSession.provider()
+        const classification = realtimeSession.classifyError(error.message)
         if (
           classification === 'capacity_busy'
           && attempt < WAKE_CONNECT_MAX_ATTEMPTS
@@ -1047,9 +863,7 @@ export function attachRealtimeGateway(server, {
             error: error.message,
           })
           // 先放弃失败的前端，避免其异步 onClose 干扰下一次重试。
-          const failedFrontend = frontend
-          frontend = null
-          failedFrontend?.close()
+          realtimeSession.detach({ clearAudio: false })
           setTimeout(
             () => attemptWakeConnect(attempt + 1),
             WAKE_CONNECT_RETRY_BACKOFF_MS,
@@ -1059,14 +873,11 @@ export function attachRealtimeGateway(server, {
         waking = false
         sleeping = true
         sleepController.holdSleeping()
-        cancelScheduledRealtimeReconnect()
-        const failedFrontend = frontend
-        frontend = null
-        failedFrontend?.close()
+        realtimeSession.close()
         send(ws, {
           type: GatewayServerEvent.VOICE_CONNECTION,
           state: 'sleeping',
-          provider: sessionProvider,
+          provider: realtimeSession.providerKey,
           message: error.message,
         })
       })
@@ -1088,8 +899,7 @@ export function attachRealtimeGateway(server, {
 
     const acceptSleepingAudio = audio => {
       try {
-        const sampleRate = realtimeProviderRegistry.resolve(sessionProvider)
-          .inputSampleRate
+        const sampleRate = realtimeSession.provider().inputSampleRate
         if (wakeDetector?.accept(audio, sampleRate)) wakeFromSleep()
       } catch (error) {
         sleeping = false
@@ -1100,7 +910,7 @@ export function attachRealtimeGateway(server, {
           state: 'disabled',
           message: `唤醒词检测已停止：${error.message}`,
         })
-        ensureFrontend().catch(connectionError => send(ws, {
+        realtimeSession.ensure().catch(connectionError => send(ws, {
           type: 'error',
           message: connectionError.message,
         }))
@@ -1112,10 +922,10 @@ export function attachRealtimeGateway(server, {
       canSleep: () => (
         (inputEnabled || config.wakeWordEnabled)
         && activeVoiceClients.isActive(ownerId, voiceClient)
-        && frontend?.ready
+        && realtimeSession.ready
         && !turns.userSpeaking
         && !announcementWindow.isBlocked()
-        && !connectPromise
+        && !realtimeSession.connecting
         && !waking
       ),
       onSleep: enterSleep,
@@ -1147,7 +957,7 @@ export function attachRealtimeGateway(server, {
         connectionLogger.info('voice_client.configured', {
           clientType: descriptor.type,
           clientLabel: descriptor.label,
-          requestedProvider: event.provider || sessionProvider,
+          requestedProvider: event.provider || realtimeSession.providerKey,
           inputEnabled: event.inputEnabled === true,
           outputEnabled: event.outputEnabled === true,
           textOnly: event.textOnly === true,
@@ -1156,16 +966,9 @@ export function attachRealtimeGateway(server, {
         // The client may pick a realtime front end per session. An unknown
         // name is reported instead of silently falling back, so a typo does
         // not look like a working session on the wrong provider.
-        if (event.provider && event.provider !== sessionProvider) {
+        if (event.provider && event.provider !== realtimeSession.providerKey) {
           try {
-            const requested = realtimeProviderRegistry.resolve(event.provider)
-            sessionProvider = requested.key
-            realtimeBlockedError = ''
-            const staleFrontend = frontend
-            frontend = null
-            cancelScheduledRealtimeReconnect()
-            connectPromise = null
-            staleFrontend?.close()
+            realtimeSession.switchProvider(event.provider)
           } catch (error) {
             send(ws, { type: 'error', message: error.message })
             return
@@ -1217,7 +1020,7 @@ export function attachRealtimeGateway(server, {
             ? 0
             : config.sleepTimeoutMs,
         )
-        frontend?.updateAgentContext({
+        realtimeSession.updateAgentContext({
           client: clientContext,
         })
         if (sleeping) {
@@ -1229,7 +1032,7 @@ export function attachRealtimeGateway(server, {
         if (event.wakeWordOnly === true) {
           requestExplicitSleep()
         } else if (inputEnabled || outputEnabled) {
-          ensureFrontend().catch(reportFrontendError)
+          realtimeSession.ensure().catch(reportFrontendError)
         }
       } else if (event.type === GatewayClientEvent.UNMUTE) {
         explicitSleepRequested = false
@@ -1240,7 +1043,7 @@ export function attachRealtimeGateway(server, {
         } else {
           activateVoiceClient({ takeover: event.takeover === true })
         }
-        ensureFrontend()
+        realtimeSession.ensure()
           .then(() => {
             prepareSleepMode()
             announcePendingPermissions()
@@ -1262,7 +1065,7 @@ export function attachRealtimeGateway(server, {
           prepareSleepMode()
           return
         }
-        ensureFrontend()
+        realtimeSession.ensure()
           .then(() => {
             prepareSleepMode()
             announcePendingPermissions()
@@ -1284,19 +1087,7 @@ export function attachRealtimeGateway(server, {
         ) {
           return
         }
-        if (frontend?.ready) frontend.appendAudio(event.audio)
-        else {
-          pendingAudio.push(event.audio)
-          if (pendingAudio.length > MAX_PENDING_AUDIO_CHUNKS) {
-            pendingAudio.splice(0, pendingAudio.length - MAX_PENDING_AUDIO_CHUNKS)
-          }
-          // CONNECT/onClose owns connection establishment and retries. Audio
-          // arriving during a close/backoff window is buffered, but must never
-          // bypass that window and create a second Realtime connection.
-          if (!connectPromise && !scheduledRealtimeReconnect) {
-            ensureFrontend().catch(reportFrontendError)
-          }
-        }
+        realtimeSession.appendAudio(event.audio)
       } else if (
         event.type === GatewayClientEvent.TEXT_MESSAGE
         || event.type === GatewayClientEvent.INPUT_MESSAGE
@@ -1315,7 +1106,7 @@ export function attachRealtimeGateway(server, {
         turns.advanceBoundary()
         announcementWindow.interrupt()
         announcements.dismissActive()
-        frontend?.cancel()
+        realtimeSession.cancelResponse()
       } else if (event.type === GatewayClientEvent.PLAYBACK_STARTED) {
         const id = String(event.responseId || '')
         if (acceptsPlaybackReceipt({
@@ -1348,13 +1139,11 @@ export function attachRealtimeGateway(server, {
         waking = false
         sleepController?.disable()
         turns.advanceBoundary()
-        pendingAudio = []
         announcementWindow.reset()
-        cancelScheduledRealtimeReconnect()
-        frontend?.close()
+        realtimeSession.close({ notifyDisconnected: true })
       } else if (event.type === GatewayClientEvent.INPUT_MUTE) {
         inputEnabled = false
-        pendingAudio = []
+        realtimeSession.clearPendingAudio()
       } else if (event.type === GatewayClientEvent.SLEEP) {
         requestExplicitSleep()
       } else if (event.type === GatewayClientEvent.WAKE) {
@@ -1388,9 +1177,8 @@ export function attachRealtimeGateway(server, {
       announcements.close()
       clearTimeout(permissionRetryTimer)
       permissionRetryTimer = null
-      cancelScheduledRealtimeReconnect()
       sleepController?.close()
-      frontend?.close()
+      realtimeSession.close()
       // Invisible memory: distil durable personal facts from this session in
       // the background. All gating (debounce, minimum turns, disabled state)
       // lives inside the extractor; it never blocks or breaks the close path,

--- a/server/src/voice/realtime-provider-session.mjs
+++ b/server/src/voice/realtime-provider-session.mjs
@@ -1,0 +1,316 @@
+import { createRealtimeFrontend } from './realtime-provider.mjs'
+import { ReconnectBackoff } from './reconnect-backoff.mjs'
+import { realtimeConnectionStatus } from './realtime-connection-status.mjs'
+
+/**
+ * Owns one provider-facing realtime Session lifecycle.
+ *
+ * The Gateway decides whether the client should be active, sleeping or waking;
+ * this runtime performs provider selection, connection/reconnection, bounded
+ * audio buffering and fatal-error blocking without knowing UI policy.
+ */
+export class RealtimeProviderSession {
+  constructor({
+    providerRegistry,
+    defaultProvider,
+    getAgentContext,
+    shouldReconnect,
+    onEvent,
+    onDiagnostic,
+    onConnected,
+    onReady,
+    onDisconnected,
+    onReconnected,
+    onConnectionState,
+    onError,
+    onReconnectError,
+    logger,
+    maxPendingAudioChunks = 30,
+    stableConnectionMs = 10_000,
+    createFrontend = createRealtimeFrontend,
+    reconnectBackoff = new ReconnectBackoff(),
+  }) {
+    this.providerRegistry = providerRegistry
+    this.providerKey = providerRegistry.resolve(defaultProvider).key
+    this.getAgentContext = getAgentContext
+    this.shouldReconnect = shouldReconnect
+    this.onEvent = onEvent
+    this.onDiagnostic = onDiagnostic
+    this.onConnected = onConnected
+    this.onReady = onReady
+    this.onDisconnected = onDisconnected
+    this.onReconnected = onReconnected
+    this.onConnectionState = onConnectionState
+    this.onError = onError
+    this.onReconnectError = onReconnectError
+    this.logger = logger
+    this.maxPendingAudioChunks = maxPendingAudioChunks
+    this.stableConnectionMs = stableConnectionMs
+    this.createFrontend = createFrontend
+    this.reconnectBackoff = reconnectBackoff
+    this.frontend = null
+    this.connectPromise = null
+    this.pendingAudio = []
+    this.scheduledReconnect = null
+    this.connectedAt = 0
+    this.blockedError = ''
+  }
+
+  get ready() {
+    return this.frontend?.ready === true
+  }
+
+  get connecting() {
+    return Boolean(this.connectPromise)
+  }
+
+  get reconnectScheduled() {
+    return Boolean(this.scheduledReconnect)
+  }
+
+  status({ sleeping = false, waking = false } = {}) {
+    return realtimeConnectionStatus({
+      provider: this.providerKey,
+      blockedError: this.blockedError,
+      sleeping,
+      waking,
+      ready: this.ready,
+      connecting: this.connecting,
+    })
+  }
+
+  provider() {
+    return this.frontend?.provider
+      ?? this.providerRegistry.resolve(this.providerKey)
+  }
+
+  classifyError(message) {
+    return this.provider().classifyError?.(message) ?? 'other'
+  }
+
+  switchProvider(providerName) {
+    const requested = this.providerRegistry.resolve(providerName)
+    if (requested.key === this.providerKey) return false
+    this.providerKey = requested.key
+    this.blockedError = ''
+    this.detach({ clearAudio: false })
+    return true
+  }
+
+  reportError(error) {
+    if (error?.realtimeConnectionReported) return
+    if (error) error.realtimeConnectionReported = true
+    this.onError(error)
+  }
+
+  block(errorMessage) {
+    this.blockedError = String(errorMessage || '')
+    this.clearPendingAudio()
+    this.detach()
+  }
+
+  clearPendingAudio() {
+    this.pendingAudio = []
+  }
+
+  cancelResponse() {
+    this.frontend?.cancel()
+  }
+
+  updateAgentContext(context) {
+    return this.frontend?.updateAgentContext(context)
+  }
+
+  appendAudio(audio) {
+    if (this.ready) {
+      this.frontend.appendAudio(audio)
+      return
+    }
+    this.pendingAudio.push(audio)
+    if (this.pendingAudio.length > this.maxPendingAudioChunks) {
+      this.pendingAudio.splice(
+        0,
+        this.pendingAudio.length - this.maxPendingAudioChunks,
+      )
+    }
+    if (!this.connectPromise && !this.scheduledReconnect) {
+      this.ensure().catch(error => this.reportError(error))
+    }
+  }
+
+  ensure() {
+    if (this.blockedError) return Promise.reject(new Error(this.blockedError))
+    if (this.ready) return Promise.resolve()
+    if (this.connectPromise) return this.connectPromise
+    if (this.scheduledReconnect) return this.scheduledReconnect.promise
+    return this.connectNow()
+  }
+
+  connectNow() {
+    if (this.ready) return Promise.resolve()
+    if (this.connectPromise) return this.connectPromise
+    this.onConnectionState({
+      state: 'connecting',
+      provider: this.providerKey,
+    })
+    const connectStartedAt = Date.now()
+    this.logger.info('realtime.connecting', { provider: this.providerKey })
+    let createdFrontend
+    createdFrontend = this.createFrontend({
+      providerName: this.providerKey,
+      providerRegistry: this.providerRegistry,
+      agentContext: this.getAgentContext(),
+      onEvent: this.onEvent,
+      onDiagnostic: this.onDiagnostic,
+      onError: error => this.#handleProviderError(createdFrontend, error),
+      onClose: () => this.#handleClose(createdFrontend),
+    })
+    this.frontend = createdFrontend
+    let createdConnectPromise
+    createdConnectPromise = createdFrontend.connect()
+      .then(() => {
+        if (this.frontend !== createdFrontend) return
+        this.blockedError = ''
+        this.connectedAt = Date.now()
+        this.logger.info('realtime.connected', {
+          provider: createdFrontend.provider.key,
+          durationMs: this.connectedAt - connectStartedAt,
+        })
+        this.onConnectionState({
+          state: 'connected',
+          provider: createdFrontend.provider.key,
+        })
+        this.onConnected(createdFrontend)
+        this.pendingAudio.forEach(audio => createdFrontend.appendAudio(audio))
+        this.pendingAudio = []
+        this.onReady(createdFrontend)
+      })
+      .catch(error => {
+        if (this.frontend !== createdFrontend) return
+        this.logger.error('realtime.connect_failed', {
+          provider: createdFrontend.provider.key,
+          durationMs: Date.now() - connectStartedAt,
+          error,
+        })
+        const classification = createdFrontend.provider.classifyError(error.message)
+        if (classification === 'fatal') {
+          this.blockedError = error.message
+          this.clearPendingAudio()
+        }
+        if (classification !== 'capacity_busy') {
+          this.onConnectionState({
+            state: 'unavailable',
+            provider: createdFrontend.provider.key,
+            message: error.message,
+          })
+        }
+        throw error
+      })
+      .finally(() => {
+        if (this.connectPromise === createdConnectPromise) {
+          this.connectPromise = null
+        }
+      })
+    this.connectPromise = createdConnectPromise
+    return createdConnectPromise
+  }
+
+  #handleProviderError(createdFrontend, error) {
+    if (this.frontend !== createdFrontend) return
+    const classification = createdFrontend.provider.classifyError(error.message)
+    if (classification !== 'inactivity') {
+      this.logger.warn('realtime.provider_error', {
+        provider: createdFrontend.provider.key,
+        classification,
+        error,
+      })
+    }
+    if (classification === 'fatal') {
+      this.blockedError = error.message
+      this.clearPendingAudio()
+      error.realtimeConnectionReported = true
+    }
+    if (classification !== 'inactivity' && classification !== 'capacity_busy') {
+      this.reportError(error)
+    }
+  }
+
+  #handleClose(createdFrontend) {
+    if (this.frontend !== createdFrontend) return
+    const connectedMs = this.connectedAt ? Date.now() - this.connectedAt : 0
+    this.logger.warn('realtime.closed', {
+      provider: createdFrontend.provider.key,
+      connectedMs,
+      blocked: Boolean(this.blockedError),
+    })
+    this.frontend = null
+    this.onDisconnected()
+    if (!this.shouldReconnect()) return
+    this.onConnectionState({
+      state: 'unavailable',
+      provider: this.providerKey,
+      ...(this.blockedError ? { message: this.blockedError } : {}),
+    })
+    if (this.blockedError) return
+    if (connectedMs >= this.stableConnectionMs) this.reconnectBackoff.reset()
+    this.connectedAt = 0
+    this.scheduleReconnect()
+      .then(() => this.onReconnected())
+      .catch(error => this.onReconnectError(error))
+  }
+
+  scheduleReconnect() {
+    if (this.blockedError || this.ready) return Promise.resolve()
+    if (this.scheduledReconnect) return this.scheduledReconnect.promise
+    let resolveScheduled
+    let rejectScheduled
+    const promise = new Promise((resolve, reject) => {
+      resolveScheduled = resolve
+      rejectScheduled = reject
+    })
+    const scheduled = {
+      promise,
+      resolve: resolveScheduled,
+      reject: rejectScheduled,
+      timer: null,
+    }
+    scheduled.timer = setTimeout(() => {
+      if (this.scheduledReconnect !== scheduled) {
+        scheduled.resolve()
+        return
+      }
+      this.scheduledReconnect = null
+      this.connectNow().then(scheduled.resolve, scheduled.reject)
+    }, this.reconnectBackoff.next())
+    scheduled.timer.unref?.()
+    this.scheduledReconnect = scheduled
+    return promise
+  }
+
+  cancelReconnect() {
+    const scheduled = this.scheduledReconnect
+    if (!scheduled) return
+    this.scheduledReconnect = null
+    clearTimeout(scheduled.timer)
+    scheduled.resolve()
+  }
+
+  detach({ clearAudio = true, notifyDisconnected = false } = {}) {
+    if (clearAudio) this.clearPendingAudio()
+    this.cancelReconnect()
+    const staleFrontend = this.frontend
+    this.frontend = null
+    this.connectPromise = null
+    if (staleFrontend && notifyDisconnected) this.onDisconnected()
+    staleFrontend?.close()
+  }
+
+  reconnect() {
+    this.detach({ clearAudio: false })
+    return this.scheduleReconnect()
+  }
+
+  close(options) {
+    this.detach(options)
+  }
+}

--- a/server/test/realtime-provider-session.test.mjs
+++ b/server/test/realtime-provider-session.test.mjs
@@ -1,0 +1,217 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { RealtimeProviderSession } from '../src/voice/realtime-provider-session.mjs'
+
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return { promise, resolve, reject }
+}
+
+function harness({
+  connectMode = 'manual',
+  shouldReconnect = false,
+  maxPendingAudioChunks = 2,
+} = {}) {
+  const calls = []
+  const frontends = []
+  const profiles = {
+    dashscope: {
+      key: 'dashscope',
+      label: 'DashScope',
+      inputSampleRate: 16000,
+      outputSampleRate: 24000,
+      classifyError: message => String(message).includes('invalid')
+        ? 'fatal'
+        : String(message).includes('busy') ? 'capacity_busy' : 'other',
+    },
+    s2s: {
+      key: 's2s',
+      label: 'Speech-to-Speech',
+      inputSampleRate: 16000,
+      outputSampleRate: 24000,
+      classifyError: () => 'other',
+    },
+  }
+  const providerRegistry = {
+    resolve(name) {
+      const profile = profiles[name]
+      if (!profile) throw new Error(`unknown provider: ${name}`)
+      return profile
+    },
+  }
+  const createFrontend = options => {
+    const connection = deferred()
+    const frontend = {
+      provider: profiles[options.providerName],
+      ready: false,
+      connect: () => {
+        calls.push(['connect', options.providerName])
+        if (connectMode === 'resolve') connection.resolve()
+        if (connectMode === 'reject') connection.reject(new Error('connect failed'))
+        return connection.promise.then(() => {
+          frontend.ready = true
+        })
+      },
+      appendAudio: audio => calls.push(['appendAudio', audio]),
+      cancel: () => calls.push(['cancel']),
+      close: () => calls.push(['close', options.providerName]),
+      updateAgentContext: context => calls.push(['updateAgentContext', context]),
+      triggerError: error => options.onError(error),
+      triggerClose: () => {
+        frontend.ready = false
+        options.onClose()
+      },
+      resolveConnect: connection.resolve,
+      rejectConnect: connection.reject,
+    }
+    frontends.push(frontend)
+    return frontend
+  }
+  const runtime = new RealtimeProviderSession({
+    providerRegistry,
+    defaultProvider: 'dashscope',
+    getAgentContext: () => ({ client: { locale: 'zh-CN' } }),
+    shouldReconnect: () => shouldReconnect,
+    onEvent: event => calls.push(['event', event]),
+    onDiagnostic: value => calls.push(['diagnostic', value]),
+    onConnected: () => calls.push(['onConnected']),
+    onReady: () => calls.push(['onReady']),
+    onDisconnected: () => calls.push(['onDisconnected']),
+    onReconnected: () => calls.push(['onReconnected']),
+    onConnectionState: state => calls.push(['state', state]),
+    onError: error => calls.push(['error', error.message]),
+    onReconnectError: error => calls.push(['reconnectError', error.message]),
+    logger: {
+      info: (...args) => calls.push(['log.info', ...args]),
+      warn: (...args) => calls.push(['log.warn', ...args]),
+      error: (...args) => calls.push(['log.error', ...args]),
+    },
+    maxPendingAudioChunks,
+    stableConnectionMs: 10_000,
+    createFrontend,
+    reconnectBackoff: {
+      next: () => 1,
+      reset: () => calls.push(['backoff.reset']),
+    },
+  })
+  return { runtime, calls, frontends }
+}
+
+test('shares one connection attempt and flushes bounded audio before ready', async () => {
+  const { runtime, calls, frontends } = harness()
+
+  runtime.appendAudio('oldest')
+  runtime.appendAudio('middle')
+  runtime.appendAudio('latest')
+  const shared = runtime.ensure()
+  assert.equal(shared, runtime.connectPromise)
+  assert.equal(frontends.length, 1)
+
+  frontends[0].resolveConnect()
+  await shared
+
+  assert.equal(runtime.ready, true)
+  assert.deepEqual(
+    calls.filter(([name]) => name === 'appendAudio'),
+    [['appendAudio', 'middle'], ['appendAudio', 'latest']],
+  )
+  assert.ok(
+    calls.findIndex(([name]) => name === 'onConnected')
+      < calls.findIndex(([name]) => name === 'appendAudio'),
+  )
+  assert.ok(
+    calls.findIndex(([name]) => name === 'appendAudio')
+      < calls.findIndex(([name]) => name === 'onReady'),
+  )
+})
+
+test('unexpected close reconnects once through the shared backoff', async () => {
+  const { runtime, calls, frontends } = harness({
+    connectMode: 'resolve',
+    shouldReconnect: true,
+  })
+  await runtime.ensure()
+
+  frontends[0].triggerClose()
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  assert.equal(frontends.length, 2)
+  assert.equal(runtime.ready, true)
+  assert.equal(
+    calls.filter(([name]) => name === 'onReconnected').length,
+    1,
+  )
+  assert.equal(
+    calls.some(([, state]) => state?.state === 'unavailable'),
+    true,
+  )
+})
+
+test('fatal errors block later connection attempts and clear buffered audio', async () => {
+  const { runtime, frontends } = harness({ connectMode: 'resolve' })
+  await runtime.ensure()
+  runtime.appendAudio('buffered-directly')
+
+  runtime.block('invalid api key')
+
+  assert.equal(runtime.ready, false)
+  assert.equal(runtime.pendingAudio.length, 0)
+  await assert.rejects(runtime.ensure(), /invalid api key/)
+  assert.deepEqual(runtime.status(), {
+    provider: 'dashscope',
+    state: 'unavailable',
+    error: 'invalid api key',
+  })
+  assert.equal(frontends.length, 1)
+})
+
+test('switching providers detaches the old frontend without losing queued audio', async () => {
+  const { runtime, frontends } = harness()
+  const connecting = runtime.ensure()
+  runtime.pendingAudio.push('queued')
+
+  assert.equal(runtime.switchProvider('s2s'), true)
+  assert.equal(runtime.providerKey, 's2s')
+  assert.deepEqual(runtime.pendingAudio, ['queued'])
+  assert.equal(runtime.ready, false)
+
+  frontends[0].resolveConnect()
+  await connecting
+  const replacement = runtime.ensure()
+  frontends[1].resolveConnect()
+  await replacement
+  assert.equal(frontends[1].provider.key, 's2s')
+})
+
+test('capacity-busy connection failures stay silent and retryable', async () => {
+  const { runtime, calls, frontends } = harness()
+  const connection = runtime.ensure()
+  frontends[0].rejectConnect(new Error('pipeline busy'))
+
+  await assert.rejects(connection, /pipeline busy/)
+
+  assert.equal(runtime.blockedError, '')
+  assert.equal(
+    calls.some(([, state]) => state?.state === 'unavailable'),
+    false,
+  )
+})
+
+test('explicit close can notify disconnection without a duplicate close callback', async () => {
+  const { runtime, calls, frontends } = harness({ connectMode: 'resolve' })
+  await runtime.ensure()
+
+  runtime.close({ notifyDisconnected: true })
+  frontends[0].triggerClose()
+
+  assert.equal(runtime.ready, false)
+  assert.equal(
+    calls.filter(([name]) => name === 'onDisconnected').length,
+    1,
+  )
+})


### PR DESCRIPTION
## Summary
- extract realtime provider selection, connection, reconnection, and bounded audio buffering into `RealtimeProviderSession`
- keep Gateway policy for sleep, ownership, announcements, and UI events while removing provider lifecycle state from the transport handler
- add focused lifecycle tests and mark the Frontend Chatbot Runtime extraction milestone complete

## Validation
- 90 targeted server tests
- `npm run lint`
- `npm run build`
- `git diff --check`

Roadmap: #185