### PR TITLE
refactor: extract work notification queue

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -182,6 +182,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 ### R3 — Work Runtime
 
 - [ ] Extract state machine, scheduler, repository, and notification concerns.
+  - [x] Extract notification claim, lease, release, and delivery state.
 - [ ] Separate user work from system jobs.
 - [ ] Add artifact and authorization models.
 - [ ] Preserve restart, cancellation, and exactly-once delivery semantics.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -232,6 +232,7 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 ### R3：Work Runtime
 
 - [ ] 从 TaskManager 提取 State Machine、Scheduler、Repository 和 Notification。
+  - [x] 提取通知领取、租约、释放与送达状态。
 - [ ] 区分 User Work 与 System Job。
 - [ ] 建立 Artifact 与统一 Authorization 模型。
 - [ ] 保持重启、取消和恰好一次结果投递语义。

--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -3,6 +3,7 @@ import { config } from '../core/config.mjs'
 import { TaskScheduler } from './task-scheduler.mjs'
 import { TaskStore } from './task-store.mjs'
 import { TaskDomainEvent } from './task-events.mjs'
+import { TaskNotificationQueue } from './task-notification-queue.mjs'
 import { logger } from '../core/logger.mjs'
 
 const ACTIVE = new Set([
@@ -136,6 +137,17 @@ export class TaskManager {
     this.logger = taskLogger
     this.tasks = new Map()
     this.listeners = new Set()
+    this.notifications = new TaskNotificationQueue({
+      tasks: this.tasks,
+      snapshot: publicTask,
+      claimTtlMs: () => this.notificationClaimTtlMs,
+      onChanged: () => this.persist(),
+      onDelivered: task => this.emit(
+        TaskDomainEvent.NOTIFICATION_DELIVERED,
+        task,
+        { persist: false },
+      ),
+    })
     this.recoveryCandidates = []
     this.scheduledTaskRunner = null
     this.nextJobNumber = 1
@@ -844,109 +856,29 @@ export class TaskManager {
     claimantId,
     taskIds,
   }) {
-    this.reclaimExpiredNotificationClaims()
-    const requested = taskIds?.length ? new Set(taskIds.map(String)) : null
-    const claimed = []
-    for (const task of this.tasks.values()) {
-      if (
-        task.ownerId !== String(ownerId)
-        || task.notificationStatus !== 'pending'
-        || (
-          sessionId !== undefined
-          && !includeOtherSessions
-          && task.sessionId !== String(sessionId)
-        )
-        || (requested && !requested.has(task.id))
-      ) continue
-      task.notificationStatus = 'delivering'
-      task.notificationClaimantId = claimantId
-      task.notificationClaimedAt = Date.now()
-      claimed.push(publicTask(task))
-    }
-    if (claimed.length) this.persist()
-    return claimed.sort((a, b) => a.createdAt - b.createdAt)
+    return this.notifications.claim({
+      ownerId,
+      sessionId,
+      includeOtherSessions,
+      claimantId,
+      taskIds,
+    })
   }
 
   markNotificationsDelivered(taskIds, { claimantId } = {}) {
-    let delivered = 0
-    for (const id of taskIds || []) {
-      const task = this.tasks.get(String(id))
-      if (
-        !task
-        || task.notificationStatus !== 'delivering'
-        || (
-          claimantId !== undefined
-          && task.notificationClaimantId !== claimantId
-        )
-      ) continue
-      task.notificationStatus = 'delivered'
-      task.notificationClaimantId = null
-      task.notificationClaimedAt = null
-      task.notificationDeliveredAt = Date.now()
-      delivered += 1
-      this.emit(TaskDomainEvent.NOTIFICATION_DELIVERED, task, {
-        persist: false,
-      })
-    }
-    if (delivered) this.persist()
-    return delivered
+    return this.notifications.markDelivered(taskIds, { claimantId })
   }
 
   renewNotificationClaims(taskIds, { claimantId } = {}) {
-    let renewed = 0
-    const now = Date.now()
-    for (const id of taskIds || []) {
-      const task = this.tasks.get(String(id))
-      if (
-        !task
-        || task.notificationStatus !== 'delivering'
-        || (
-          claimantId !== undefined
-          && task.notificationClaimantId !== claimantId
-        )
-      ) continue
-      task.notificationClaimedAt = now
-      renewed += 1
-    }
-    return renewed
+    return this.notifications.renew(taskIds, { claimantId })
   }
 
   releaseNotificationClaims(taskIds, { claimantId } = {}) {
-    let released = 0
-    for (const id of taskIds || []) {
-      const task = this.tasks.get(String(id))
-      if (
-        !task
-        || task.notificationStatus !== 'delivering'
-        || (
-          claimantId !== undefined
-          && task.notificationClaimantId !== claimantId
-        )
-      ) continue
-      task.notificationStatus = 'pending'
-      task.notificationClaimantId = null
-      task.notificationClaimedAt = null
-      released += 1
-    }
-    if (released) this.persist()
-    return released
+    return this.notifications.release(taskIds, { claimantId })
   }
 
   reclaimExpiredNotificationClaims(now = Date.now(), { persist = true } = {}) {
-    let reclaimed = 0
-    for (const task of this.tasks.values()) {
-      if (
-        task.notificationStatus !== 'delivering'
-        || !task.notificationClaimedAt
-        || now - task.notificationClaimedAt < this.notificationClaimTtlMs
-      ) continue
-      task.notificationStatus = 'pending'
-      task.notificationClaimantId = null
-      task.notificationClaimedAt = null
-      reclaimed += 1
-    }
-    if (reclaimed && persist) this.persist()
-    return reclaimed
+    return this.notifications.reclaimExpired(now, { persist })
   }
 
   prune() {

--- a/server/src/task/task-notification-queue.mjs
+++ b/server/src/task/task-notification-queue.mjs
@@ -1,0 +1,127 @@
+/**
+ * Owns the delivery lease for completed Work notifications.
+ *
+ * Task execution and transport delivery stay outside this class. It only
+ * mutates notification fields on the shared Work records and reports durable
+ * changes to its owner.
+ */
+export class TaskNotificationQueue {
+  constructor({
+    tasks,
+    snapshot,
+    claimTtlMs,
+    onChanged = () => {},
+    onDelivered = () => {},
+    now = () => Date.now(),
+  }) {
+    this.tasks = tasks
+    this.snapshot = snapshot
+    this.claimTtlMs = claimTtlMs
+    this.onChanged = onChanged
+    this.onDelivered = onDelivered
+    this.now = now
+  }
+
+  claim({
+    ownerId,
+    sessionId,
+    includeOtherSessions = false,
+    claimantId,
+    taskIds,
+  }) {
+    this.reclaimExpired()
+    const requested = taskIds?.length ? new Set(taskIds.map(String)) : null
+    const claimed = []
+    for (const task of this.tasks.values()) {
+      if (
+        task.ownerId !== String(ownerId)
+        || task.notificationStatus !== 'pending'
+        || (
+          sessionId !== undefined
+          && !includeOtherSessions
+          && task.sessionId !== String(sessionId)
+        )
+        || (requested && !requested.has(task.id))
+      ) continue
+      task.notificationStatus = 'delivering'
+      task.notificationClaimantId = claimantId
+      task.notificationClaimedAt = this.now()
+      claimed.push(this.snapshot(task))
+    }
+    if (claimed.length) this.onChanged()
+    return claimed.sort((left, right) => left.createdAt - right.createdAt)
+  }
+
+  markDelivered(taskIds, { claimantId } = {}) {
+    let delivered = 0
+    for (const id of taskIds || []) {
+      const task = this.#ownedClaim(id, claimantId)
+      if (!task) continue
+      task.notificationStatus = 'delivered'
+      task.notificationClaimantId = null
+      task.notificationClaimedAt = null
+      task.notificationDeliveredAt = this.now()
+      delivered += 1
+      this.onDelivered(task)
+    }
+    if (delivered) this.onChanged()
+    return delivered
+  }
+
+  renew(taskIds, { claimantId } = {}) {
+    let renewed = 0
+    const claimedAt = this.now()
+    for (const id of taskIds || []) {
+      const task = this.#ownedClaim(id, claimantId)
+      if (!task) continue
+      task.notificationClaimedAt = claimedAt
+      renewed += 1
+    }
+    return renewed
+  }
+
+  release(taskIds, { claimantId } = {}) {
+    let released = 0
+    for (const id of taskIds || []) {
+      const task = this.#ownedClaim(id, claimantId)
+      if (!task) continue
+      task.notificationStatus = 'pending'
+      task.notificationClaimantId = null
+      task.notificationClaimedAt = null
+      released += 1
+    }
+    if (released) this.onChanged()
+    return released
+  }
+
+  reclaimExpired(now = this.now(), { persist = true } = {}) {
+    let reclaimed = 0
+    const claimTtlMs = Number(this.claimTtlMs())
+    for (const task of this.tasks.values()) {
+      if (
+        task.notificationStatus !== 'delivering'
+        || !task.notificationClaimedAt
+        || now - task.notificationClaimedAt < claimTtlMs
+      ) continue
+      task.notificationStatus = 'pending'
+      task.notificationClaimantId = null
+      task.notificationClaimedAt = null
+      reclaimed += 1
+    }
+    if (reclaimed && persist) this.onChanged()
+    return reclaimed
+  }
+
+  #ownedClaim(id, claimantId) {
+    const task = this.tasks.get(String(id))
+    if (
+      !task
+      || task.notificationStatus !== 'delivering'
+      || (
+        claimantId !== undefined
+        && task.notificationClaimantId !== claimantId
+      )
+    ) return null
+    return task
+  }
+}

--- a/server/test/task-notification-queue.test.mjs
+++ b/server/test/task-notification-queue.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TaskNotificationQueue } from '../src/task/task-notification-queue.mjs'
+
+function task({
+  id,
+  ownerId = 'owner',
+  sessionId = 'voice',
+  createdAt = 1,
+  notificationStatus = 'pending',
+  notificationClaimantId = null,
+  notificationClaimedAt = null,
+} = {}) {
+  return {
+    id,
+    ownerId,
+    sessionId,
+    createdAt,
+    notificationStatus,
+    notificationClaimantId,
+    notificationClaimedAt,
+  }
+}
+
+function harness(records, { now = 100, claimTtlMs = 50 } = {}) {
+  const tasks = new Map(records.map(item => [item.id, item]))
+  const changes = []
+  const delivered = []
+  const queue = new TaskNotificationQueue({
+    tasks,
+    snapshot: item => ({ ...item }),
+    claimTtlMs: () => claimTtlMs,
+    onChanged: () => changes.push('changed'),
+    onDelivered: item => delivered.push(item.id),
+    now: () => now,
+  })
+  return { queue, tasks, changes, delivered }
+}
+
+test('claims only matching pending notifications in creation order', () => {
+  const { queue, tasks, changes } = harness([
+    task({ id: 'later', createdAt: 2 }),
+    task({ id: 'earlier', createdAt: 1 }),
+    task({ id: 'other-session', sessionId: 'other' }),
+    task({ id: 'other-owner', ownerId: 'other' }),
+  ])
+
+  const claimed = queue.claim({
+    ownerId: 'owner',
+    sessionId: 'voice',
+    claimantId: 'desktop',
+  })
+
+  assert.deepEqual(claimed.map(item => item.id), ['earlier', 'later'])
+  assert.equal(tasks.get('earlier').notificationStatus, 'delivering')
+  assert.equal(tasks.get('other-session').notificationStatus, 'pending')
+  assert.equal(changes.length, 1)
+})
+
+test('renews, releases, and completes only the matching delivery lease', () => {
+  const { queue, tasks, changes, delivered } = harness([
+    task({
+      id: 'work-one',
+      notificationStatus: 'delivering',
+      notificationClaimantId: 'desktop',
+      notificationClaimedAt: 10,
+    }),
+  ], { now: 100 })
+
+  assert.equal(queue.renew(['work-one'], { claimantId: 'other' }), 0)
+  assert.equal(queue.renew(['work-one'], { claimantId: 'desktop' }), 1)
+  assert.equal(tasks.get('work-one').notificationClaimedAt, 100)
+  assert.equal(queue.release(['work-one'], { claimantId: 'desktop' }), 1)
+  assert.equal(tasks.get('work-one').notificationStatus, 'pending')
+
+  queue.claim({ ownerId: 'owner', claimantId: 'desktop' })
+  assert.equal(queue.markDelivered(['work-one'], { claimantId: 'desktop' }), 1)
+  assert.equal(tasks.get('work-one').notificationStatus, 'delivered')
+  assert.equal(tasks.get('work-one').notificationDeliveredAt, 100)
+  assert.deepEqual(delivered, ['work-one'])
+  assert.equal(changes.length, 3)
+})
+
+test('reclaims an expired lease but preserves a live lease', () => {
+  const { queue, tasks, changes } = harness([
+    task({
+      id: 'expired',
+      notificationStatus: 'delivering',
+      notificationClaimantId: 'stale',
+      notificationClaimedAt: 10,
+    }),
+    task({
+      id: 'live',
+      notificationStatus: 'delivering',
+      notificationClaimantId: 'active',
+      notificationClaimedAt: 80,
+    }),
+  ], { now: 100, claimTtlMs: 50 })
+
+  assert.equal(queue.reclaimExpired(), 1)
+  assert.equal(tasks.get('expired').notificationStatus, 'pending')
+  assert.equal(tasks.get('live').notificationStatus, 'delivering')
+  assert.equal(changes.length, 1)
+})


### PR DESCRIPTION
## Summary
- extract notification claim, lease renewal, release, expiry recovery, and delivered transitions from `TaskManager`
- preserve the existing TaskManager API, persistence callbacks, and delivery events
- add focused lease tests and record the first R3 Work Runtime extraction

## Validation
- 121 Work, notification, scheduling, delivery, and tool tests
- `npm run lint`
- `git diff --check`

Roadmap: #185