### PR TITLE
refactor: centralize work state transitions

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -182,6 +182,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 ### R3 — Work Runtime
 
 - [ ] Extract state machine, scheduler, repository, and notification concerns.
+  - [x] Centralize task phases, legal transitions, and public snapshots.
   - [x] Extract notification claim, lease, release, and delivery state.
 - [ ] Separate user work from system jobs.
 - [ ] Add artifact and authorization models.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -232,6 +232,7 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 ### R3：Work Runtime
 
 - [ ] 从 TaskManager 提取 State Machine、Scheduler、Repository 和 Notification。
+  - [x] 集中管理任务阶段、合法状态迁移与公开快照。
   - [x] 提取通知领取、租约、释放与送达状态。
 - [ ] 区分 User Work 与 System Job。
 - [ ] 建立 Artifact 与统一 Authorization 模型。

--- a/server/src/task/reminder-scheduler.mjs
+++ b/server/src/task/reminder-scheduler.mjs
@@ -1,4 +1,5 @@
 import { TaskDomainEvent } from './task-events.mjs'
+import { TaskStatus, transitionTask } from './task-state.mjs'
 
 /**
  * ReminderScheduler — setTimeout-driven scheduler for scheduled tasks.
@@ -68,7 +69,7 @@ export class ReminderScheduler {
       const delay = index * this.staggerMs
       const timer = setTimeout(() => {
         if (task.status !== 'scheduled') return
-        task.status = 'queued'
+        transitionTask(task, TaskStatus.QUEUED)
         this.taskManager.emit(TaskDomainEvent.SCHEDULED_FIRED, task)
         this.taskManager.persistDeferred()
         this.taskManager.drain()
@@ -105,7 +106,7 @@ export class ReminderScheduler {
     let fired = 0
     for (const task of this.taskManager.tasks.values()) {
       if (task.status === 'scheduled' && task.schedule?.at <= now) {
-        task.status = 'queued'
+        transitionTask(task, TaskStatus.QUEUED)
         // Phase 3: recurrence handling (create next cycle's new scheduled task)
         fired += 1
       }

--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -4,17 +4,16 @@ import { TaskScheduler } from './task-scheduler.mjs'
 import { TaskStore } from './task-store.mjs'
 import { TaskDomainEvent } from './task-events.mjs'
 import { TaskNotificationQueue } from './task-notification-queue.mjs'
+import {
+  isTaskActive,
+  isTaskCancellable,
+  isTaskTerminal,
+  publicTask,
+  TaskStatus,
+  transitionTask,
+} from './task-state.mjs'
 import { logger } from '../core/logger.mjs'
 
-const ACTIVE = new Set([
-  'queued',
-  'running',
-  'delegated',
-  'finalizing',
-  'cancelling',
-])
-const CANCELLABLE = new Set(['scheduled', 'queued', 'running', 'delegated', 'finalizing'])
-const TERMINAL = new Set(['completed', 'failed', 'cancelled'])
 const REPLAYABLE_REMINDER = new Set(['queued', 'running'])
 const MAX_JOB_NUMBER = 99_999
 
@@ -37,77 +36,6 @@ export function taskExecutionContext(task, { onEvent, signal }) {
     onEvent,
     signal,
   })
-}
-
-function publicResultMetadata(metadata) {
-  if (!metadata || typeof metadata !== 'object') return null
-  const source = metadata.presentation || metadata.decision?.presentation
-  if (!source || typeof source !== 'object') return null
-  const inline = source.inline && typeof source.inline === 'object'
-    && typeof source.inline.content === 'string'
-    && source.inline.content.trim()
-    ? {
-        title: typeof source.inline.title === 'string'
-          ? source.inline.title.slice(0, 120)
-          : '',
-        format: ['markdown', 'code', 'link'].includes(source.inline.format)
-          ? source.inline.format
-          : 'markdown',
-        content: source.inline.content,
-      }
-    : null
-  const speech = typeof source.speech === 'string' ? source.speech : ''
-  if (!speech && !inline) return null
-  return { presentation: { speech, inline } }
-}
-
-function publicTask(task) {
-  const now = Date.now()
-  return {
-    id: task.id,
-    workId: task.id,
-    jobId: task.jobId,
-    workState: ACTIVE.has(task.status) ? 'active' : task.status,
-    status: task.status,
-    kind: task.kind || 'work',
-    parentWorkId: task.parentWorkId || null,
-    objective: task.objective,
-    ownerId: task.ownerId,
-    sessionId: task.sessionId,
-    turnId: task.turnId,
-    createdAt: task.createdAt,
-    startedAt: task.startedAt,
-    completedAt: task.completedAt,
-    elapsedMs: task.startedAt && ACTIVE.has(task.status)
-      ? now - task.startedAt
-      : task.elapsedMs,
-    result: task.result,
-    error: task.error,
-    resultMetadata: publicResultMetadata(task.resultMetadata),
-    activity: [...(task.activity || [])],
-    delegation: task.delegation
-      ? {
-          status: task.delegation.status || 'running',
-          title: String(task.delegation.title || '').slice(0, 160),
-          presentation: task.delegation.presentation
-            ? {
-                speech: String(
-                  task.delegation.presentation.speech || '',
-                ).slice(0, 1200),
-                inline: task.delegation.presentation.inline || null,
-              }
-            : null,
-        }
-      : null,
-    authorization: task.authorization
-      ? { ...task.authorization }
-      : null,
-    notificationStatus: task.notificationStatus,
-    notificationDeliveredAt: task.notificationDeliveredAt,
-    schedule: task.schedule || null,
-    timeoutMs: task.timeoutMs || null,
-    progressCheckMs: task.progressCheckMs || null,
-  }
 }
 
 export class TaskManager {
@@ -201,7 +129,7 @@ export class TaskManager {
         this.tasks.set(task.id, task)
         continue
       }
-      const wasActive = ACTIVE.has(saved.status)
+      const wasActive = isTaskActive(saved.status)
       const canRecoverDelegation = (
         ['delegated', 'finalizing'].includes(saved.status)
         && saved.delegation?.id
@@ -222,7 +150,7 @@ export class TaskManager {
         delegation: canRecoverDelegation || !wasActive
           ? saved.delegation || null
           : null,
-        authorization: wasActive || TERMINAL.has(saved.status)
+        authorization: wasActive || isTaskTerminal(saved.status)
           ? null
           : saved.authorization || null,
         notificationStatus: (
@@ -280,7 +208,7 @@ export class TaskManager {
         delegation: task.delegation ? { ...task.delegation } : null,
       }
       if (!canRecover?.(snapshot)) {
-        task.status = 'failed'
+        transitionTask(task, TaskStatus.FAILED)
         task.error = 'qwen-audio-agent 重启时这项项目任务失去连接，请重新提交。'
         task.completedAt = Date.now()
         task.notificationStatus = 'pending'
@@ -508,14 +436,14 @@ export class TaskManager {
   }
 
   start(task) {
-    task.status = 'running'
+    transitionTask(task, TaskStatus.RUNNING)
     task.startedAt = Date.now()
     task.abortController = new AbortController()
     this.scheduler.acquire(task)
     task.schedulerHeld = true
     this.emit(TaskDomainEvent.RUNNING, task)
     task.progressTimer = setInterval(() => {
-      if (ACTIVE.has(task.status)) {
+      if (isTaskActive(task.status)) {
         this.emit(TaskDomainEvent.PROGRESS, task, { persist: false })
       }
     }, 1000)
@@ -537,7 +465,7 @@ export class TaskManager {
       }
       if (['cancelling', 'cancelled'].includes(task.status)) return
       if (event?.type === 'backend.delegated' && event.delegation) {
-        task.status = 'delegated'
+        transitionTask(task, TaskStatus.DELEGATED)
         task.delegation = { ...event.delegation }
         if (task.schedulerHeld) {
           this.scheduler.release(task)
@@ -551,7 +479,7 @@ export class TaskManager {
         event?.type === 'backend.delegation.completed'
         && event.delegation
       ) {
-        task.status = 'finalizing'
+        transitionTask(task, TaskStatus.FINALIZING)
         task.delegation = { ...event.delegation, status: 'completed' }
         this.emit(TaskDomainEvent.FINALIZING, task)
         return
@@ -580,14 +508,14 @@ export class TaskManager {
     // cleanup window before force-failing.
     if (task.kind === 'scheduled_task' && task.timeoutMs) {
       task.timeoutTimer = setTimeout(() => {
-        if (!ACTIVE.has(task.status)) return
+        if (!isTaskActive(task.status)) return
         task.abortController?.abort(
           new Error('定时任务执行超时，正在终止'),
         )
         const cleanup = setTimeout(() => {
-          if (!ACTIVE.has(task.status)) return
+          if (!isTaskActive(task.status)) return
           task.terminalHandled = true
-          task.status = 'failed'
+          transitionTask(task, TaskStatus.FAILED)
           task.error = `定时任务执行超时（${Math.round(task.timeoutMs / 60000)} 分钟）`
           task.completedAt = Date.now()
           task.elapsedMs = task.startedAt
@@ -614,7 +542,7 @@ export class TaskManager {
     // work stays quiet until it completes, fails, or needs permission.
     if (task.kind === 'work' && task.progressCheckMs) {
       task.progressCheckTimer = setInterval(() => {
-        if (!ACTIVE.has(task.status)) {
+        if (!isTaskActive(task.status)) {
           clearInterval(task.progressCheckTimer)
           task.progressCheckTimer = null
           return
@@ -664,7 +592,7 @@ export class TaskManager {
           task.terminalHandled
           || ['cancelling', 'cancelled'].includes(task.status)
         ) return
-        task.status = 'completed'
+        transitionTask(task, TaskStatus.COMPLETED)
         task.result = String(outcome?.content ?? outcome ?? '').trim()
         task.resultMetadata = outcome?.metadata || null
       })
@@ -673,7 +601,7 @@ export class TaskManager {
           task.terminalHandled
           || ['cancelling', 'cancelled'].includes(task.status)
         ) return
-        task.status = 'failed'
+        transitionTask(task, TaskStatus.FAILED)
         task.error = error?.message || String(error)
       })
       .finally(() => {
@@ -721,7 +649,7 @@ export class TaskManager {
     if (
       !task
       || (ownerId !== undefined && task.ownerId !== String(ownerId))
-      || (!CANCELLABLE.has(task.status) && task.status !== 'cancelling')
+      || (!isTaskCancellable(task.status) && task.status !== 'cancelling')
     ) {
       return null
     }
@@ -730,7 +658,7 @@ export class TaskManager {
     if (previousStatus === 'queued' || previousStatus === 'scheduled') {
       return this.finishCancellation(task)
     }
-    task.status = 'cancelling'
+    transitionTask(task, TaskStatus.CANCELLING)
     task.authorization = null
     this.emit(TaskDomainEvent.CANCELLING, task)
     task.cancelPromise = Promise.resolve()
@@ -761,7 +689,7 @@ export class TaskManager {
         if (task.progressCheckTimer) { clearInterval(task.progressCheckTimer); task.progressCheckTimer = null }
         task.abortController = null
         task.authorization = null
-        task.status = 'failed'
+        transitionTask(task, TaskStatus.FAILED)
         task.error = `取消失败：${error?.message || String(error)}`
         task.completedAt = Date.now()
         task.elapsedMs = task.startedAt
@@ -784,7 +712,7 @@ export class TaskManager {
   }
 
   finishCancellation(task) {
-    task.status = 'cancelled'
+    transitionTask(task, TaskStatus.CANCELLED)
     task.authorization = null
     task.completedAt = Date.now()
     task.elapsedMs = task.startedAt
@@ -838,7 +766,7 @@ export class TaskManager {
       .filter(task => (
         (ownerId === undefined || task.ownerId === String(ownerId))
         && (sessionId === undefined || task.sessionId === String(sessionId))
-        && (!active || ACTIVE.has(task.status))
+        && (!active || isTaskActive(task.status))
       ))
       .sort((left, right) => right.createdAt - left.createdAt)
       .map(publicTask)
@@ -886,7 +814,7 @@ export class TaskManager {
     let changed = this.reclaimExpiredNotificationClaims(now, { persist: false }) > 0
     const terminalByOwner = new Map()
     for (const task of this.tasks.values()) {
-      if (!TERMINAL.has(task.status)) continue
+      if (!isTaskTerminal(task.status)) continue
       const age = now - (task.completedAt || task.createdAt)
       const awaitingDelivery = ['pending', 'delivering'].includes(
         task.notificationStatus,

--- a/server/src/task/task-state.mjs
+++ b/server/src/task/task-state.mjs
@@ -1,0 +1,161 @@
+export const TaskStatus = Object.freeze({
+  SCHEDULED: 'scheduled',
+  QUEUED: 'queued',
+  RUNNING: 'running',
+  DELEGATED: 'delegated',
+  FINALIZING: 'finalizing',
+  CANCELLING: 'cancelling',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  CANCELLED: 'cancelled',
+})
+
+const ACTIVE = new Set([
+  TaskStatus.QUEUED,
+  TaskStatus.RUNNING,
+  TaskStatus.DELEGATED,
+  TaskStatus.FINALIZING,
+  TaskStatus.CANCELLING,
+])
+const CANCELLABLE = new Set([
+  TaskStatus.SCHEDULED,
+  TaskStatus.QUEUED,
+  TaskStatus.RUNNING,
+  TaskStatus.DELEGATED,
+  TaskStatus.FINALIZING,
+])
+const TERMINAL = new Set([
+  TaskStatus.COMPLETED,
+  TaskStatus.FAILED,
+  TaskStatus.CANCELLED,
+])
+const KNOWN = new Set(Object.values(TaskStatus))
+const TRANSITIONS = new Map([
+  [TaskStatus.SCHEDULED, new Set([
+    TaskStatus.QUEUED,
+    TaskStatus.FAILED,
+    TaskStatus.CANCELLED,
+  ])],
+  [TaskStatus.QUEUED, new Set([
+    TaskStatus.RUNNING,
+    TaskStatus.FAILED,
+    TaskStatus.CANCELLED,
+  ])],
+  [TaskStatus.RUNNING, new Set([
+    TaskStatus.DELEGATED,
+    TaskStatus.FINALIZING,
+    TaskStatus.CANCELLING,
+    TaskStatus.COMPLETED,
+    TaskStatus.FAILED,
+  ])],
+  [TaskStatus.DELEGATED, new Set([
+    TaskStatus.FINALIZING,
+    TaskStatus.CANCELLING,
+    TaskStatus.COMPLETED,
+    TaskStatus.FAILED,
+  ])],
+  [TaskStatus.FINALIZING, new Set([
+    TaskStatus.CANCELLING,
+    TaskStatus.COMPLETED,
+    TaskStatus.FAILED,
+  ])],
+  [TaskStatus.CANCELLING, new Set([
+    TaskStatus.CANCELLED,
+    TaskStatus.FAILED,
+  ])],
+])
+
+export function isTaskActive(status) {
+  return ACTIVE.has(status)
+}
+
+export function isTaskCancellable(status) {
+  return CANCELLABLE.has(status)
+}
+
+export function isTaskTerminal(status) {
+  return TERMINAL.has(status)
+}
+
+export function transitionTask(task, nextStatus) {
+  const currentStatus = task?.status
+  if (!KNOWN.has(currentStatus) || !KNOWN.has(nextStatus)) {
+    throw new Error(`Unknown task transition: ${currentStatus} -> ${nextStatus}`)
+  }
+  if (currentStatus === nextStatus) return task
+  if (!TRANSITIONS.get(currentStatus)?.has(nextStatus)) {
+    throw new Error(`Invalid task transition: ${currentStatus} -> ${nextStatus}`)
+  }
+  task.status = nextStatus
+  return task
+}
+
+function publicResultMetadata(metadata) {
+  if (!metadata || typeof metadata !== 'object') return null
+  const source = metadata.presentation || metadata.decision?.presentation
+  if (!source || typeof source !== 'object') return null
+  const inline = source.inline && typeof source.inline === 'object'
+    && typeof source.inline.content === 'string'
+    && source.inline.content.trim()
+    ? {
+        title: typeof source.inline.title === 'string'
+          ? source.inline.title.slice(0, 120)
+          : '',
+        format: ['markdown', 'code', 'link'].includes(source.inline.format)
+          ? source.inline.format
+          : 'markdown',
+        content: source.inline.content,
+      }
+    : null
+  const speech = typeof source.speech === 'string' ? source.speech : ''
+  if (!speech && !inline) return null
+  return { presentation: { speech, inline } }
+}
+
+export function publicTask(task, { now = Date.now() } = {}) {
+  return {
+    id: task.id,
+    workId: task.id,
+    jobId: task.jobId,
+    workState: isTaskActive(task.status) ? 'active' : task.status,
+    status: task.status,
+    kind: task.kind || 'work',
+    parentWorkId: task.parentWorkId || null,
+    objective: task.objective,
+    ownerId: task.ownerId,
+    sessionId: task.sessionId,
+    turnId: task.turnId,
+    createdAt: task.createdAt,
+    startedAt: task.startedAt,
+    completedAt: task.completedAt,
+    elapsedMs: task.startedAt && isTaskActive(task.status)
+      ? now - task.startedAt
+      : task.elapsedMs,
+    result: task.result,
+    error: task.error,
+    resultMetadata: publicResultMetadata(task.resultMetadata),
+    activity: [...(task.activity || [])],
+    delegation: task.delegation
+      ? {
+          status: task.delegation.status || 'running',
+          title: String(task.delegation.title || '').slice(0, 160),
+          presentation: task.delegation.presentation
+            ? {
+                speech: String(
+                  task.delegation.presentation.speech || '',
+                ).slice(0, 1200),
+                inline: task.delegation.presentation.inline || null,
+              }
+            : null,
+        }
+      : null,
+    authorization: task.authorization
+      ? { ...task.authorization }
+      : null,
+    notificationStatus: task.notificationStatus,
+    notificationDeliveredAt: task.notificationDeliveredAt,
+    schedule: task.schedule || null,
+    timeoutMs: task.timeoutMs || null,
+    progressCheckMs: task.progressCheckMs || null,
+  }
+}

--- a/server/test/task-state.test.mjs
+++ b/server/test/task-state.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  isTaskActive,
+  isTaskCancellable,
+  isTaskTerminal,
+  publicTask,
+  TaskStatus,
+  transitionTask,
+} from '../src/task/task-state.mjs'
+
+test('centralizes active, cancellable, and terminal task phases', () => {
+  assert.equal(isTaskActive(TaskStatus.QUEUED), true)
+  assert.equal(isTaskActive(TaskStatus.CANCELLING), true)
+  assert.equal(isTaskCancellable(TaskStatus.SCHEDULED), true)
+  assert.equal(isTaskCancellable(TaskStatus.CANCELLING), false)
+  assert.equal(isTaskTerminal(TaskStatus.COMPLETED), true)
+  assert.equal(isTaskTerminal(TaskStatus.RUNNING), false)
+})
+
+test('accepts valid transitions and rejects backwards or terminal transitions', () => {
+  const work = { status: TaskStatus.QUEUED }
+  transitionTask(work, TaskStatus.RUNNING)
+  transitionTask(work, TaskStatus.DELEGATED)
+  transitionTask(work, TaskStatus.FINALIZING)
+  transitionTask(work, TaskStatus.COMPLETED)
+
+  assert.equal(work.status, TaskStatus.COMPLETED)
+  assert.throws(
+    () => transitionTask(work, TaskStatus.RUNNING),
+    /Invalid task transition/,
+  )
+  assert.throws(
+    () => transitionTask({ status: 'unknown' }, TaskStatus.RUNNING),
+    /Unknown task transition/,
+  )
+})
+
+test('projects an active task without leaking private result metadata', () => {
+  const projected = publicTask({
+    id: 'work-one',
+    jobId: 'job_1',
+    status: TaskStatus.RUNNING,
+    objective: '生成报告',
+    ownerId: 'owner',
+    sessionId: 'voice',
+    createdAt: 10,
+    startedAt: 40,
+    elapsedMs: 0,
+    activity: [],
+    resultMetadata: {
+      presentation: {
+        speech: '报告已完成。',
+        inline: { title: '报告', format: 'markdown', content: '# 完成' },
+      },
+      backendRef: { sessionId: 'private-session' },
+    },
+    notificationStatus: 'none',
+  }, { now: 100 })
+
+  assert.equal(projected.workState, 'active')
+  assert.equal(projected.elapsedMs, 60)
+  assert.deepEqual(projected.resultMetadata, {
+    presentation: {
+      speech: '报告已完成。',
+      inline: { title: '报告', format: 'markdown', content: '# 完成' },
+    },
+  })
+  assert.equal('backendRef' in projected.resultMetadata, false)
+})


### PR DESCRIPTION
## Summary
- centralize task phase vocabulary, active/cancellable/terminal predicates, and legal transitions
- extract the public Work snapshot projector from `TaskManager`
- route scheduled-task firing and runtime lifecycle changes through the shared transition function

## Validation
- 55 focused Work state, manager, scheduler, persistence, notification, and delivery tests
- `npm run lint`
- `git diff --check`

Roadmap: #185