### PR TITLE
refactor: extract work repository

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -184,6 +184,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 - [ ] Extract state machine, scheduler, repository, and notification concerns.
   - [x] Centralize task phases, legal transitions, and public snapshots.
   - [x] Extract notification claim, lease, release, and delivery state.
+  - [x] Extract durable Work records and short job-id allocation.
 - [ ] Separate user work from system jobs.
 - [ ] Add artifact and authorization models.
 - [ ] Preserve restart, cancellation, and exactly-once delivery semantics.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -234,6 +234,7 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 - [ ] 从 TaskManager 提取 State Machine、Scheduler、Repository 和 Notification。
   - [x] 集中管理任务阶段、合法状态迁移与公开快照。
   - [x] 提取通知领取、租约、释放与送达状态。
+  - [x] 提取持久化 Work 记录与短 Job ID 分配。
 - [ ] 区分 User Work 与 System Job。
 - [ ] 建立 Artifact 与统一 Authorization 模型。
 - [ ] 保持重启、取消和恰好一次结果投递语义。

--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -4,10 +4,12 @@ import { TaskScheduler } from './task-scheduler.mjs'
 import { TaskStore } from './task-store.mjs'
 import { TaskDomainEvent } from './task-events.mjs'
 import { TaskNotificationQueue } from './task-notification-queue.mjs'
+import { TaskRepository } from './task-repository.mjs'
 import {
   isTaskActive,
   isTaskCancellable,
   isTaskTerminal,
+  persistedTask,
   publicTask,
   TaskStatus,
   transitionTask,
@@ -15,14 +17,6 @@ import {
 import { logger } from '../core/logger.mjs'
 
 const REPLAYABLE_REMINDER = new Set(['queued', 'running'])
-const MAX_JOB_NUMBER = 99_999
-
-function normalizedJobNumber(value) {
-  const number = Number(value)
-  return Number.isInteger(number) && number >= 1 && number <= MAX_JOB_NUMBER
-    ? number
-    : 1
-}
 
 export function taskExecutionContext(task, { onEvent, signal }) {
   return Object.freeze({
@@ -52,7 +46,10 @@ export class TaskManager {
     logger: taskLogger = null,
   } = {}) {
     this.runner = runner
-    this.store = store
+    this.repository = new TaskRepository({ store, serialize: persistedTask })
+    // Compatibility view for ReminderScheduler and existing integrations.
+    // New persistence behavior belongs to repository, not this Map-like view.
+    this.tasks = this.repository
     this.scheduler = new TaskScheduler({
       maxConcurrent,
       maxConcurrentPerOwner,
@@ -63,7 +60,6 @@ export class TaskManager {
     this.maxTerminalTasksPerOwner = maxTerminalTasksPerOwner
     this.progressCheckMs = Math.max(0, Number(progressCheckMs) || 0)
     this.logger = taskLogger
-    this.tasks = new Map()
     this.listeners = new Set()
     this.notifications = new TaskNotificationQueue({
       tasks: this.tasks,
@@ -78,8 +74,15 @@ export class TaskManager {
     })
     this.recoveryCandidates = []
     this.scheduledTaskRunner = null
-    this.nextJobNumber = 1
     this.restore()
+  }
+
+  get nextJobNumber() {
+    return this.repository.nextJobNumber
+  }
+
+  set nextJobNumber(value) {
+    this.repository.nextJobNumber = value
   }
 
   configureRetention(options = {}) {
@@ -92,8 +95,7 @@ export class TaskManager {
   }
 
   restore() {
-    const savedTasks = this.store?.load() || []
-    this.nextJobNumber = normalizedJobNumber(this.store?.nextJobNumber)
+    const savedTasks = this.repository.load()
     for (const saved of savedTasks) {
       saved.jobId = String(saved.jobId || this.allocateJobId())
       // Scheduled tasks survive restarts intact. ReminderScheduler.start()
@@ -180,22 +182,6 @@ export class TaskManager {
     this.prune()
   }
 
-  persistedTask(task) {
-    const saved = publicTask(task)
-    delete saved.workId
-    delete saved.workState
-    saved.submissionKey = task.submissionKey || null
-    saved.delegation = task.delegation
-      ? {
-          ...task.delegation,
-          presentation: task.delegation.presentation
-            ? { ...task.delegation.presentation }
-            : null,
-        }
-      : null
-    return saved
-  }
-
   recoverDelegated({
     canRecover,
     runner,
@@ -227,23 +213,15 @@ export class TaskManager {
   }
 
   persist() {
-    this.store?.save(
-      [...this.tasks.values()].map(task => this.persistedTask(task)),
-      { nextJobNumber: this.nextJobNumber },
-    )
+    this.repository.save()
   }
 
   persistDeferred() {
-    const tasks = [...this.tasks.values()].map(task => this.persistedTask(task))
-    const state = { nextJobNumber: this.nextJobNumber }
-    if (this.store?.saveDeferred) this.store.saveDeferred(tasks, state)
-    else this.store?.save(tasks, state)
+    this.repository.saveDeferred()
   }
 
   allocateJobId() {
-    const current = this.nextJobNumber
-    this.nextJobNumber = current >= MAX_JOB_NUMBER ? 1 : current + 1
-    return `job_${current}`
+    return this.repository.allocateJobId()
   }
 
   subscribe(listener) {

--- a/server/src/task/task-repository.mjs
+++ b/server/src/task/task-repository.mjs
@@ -1,0 +1,70 @@
+const MAX_JOB_NUMBER = 99_999
+
+function normalizedJobNumber(value) {
+  const number = Number(value)
+  return Number.isInteger(number) && number >= 1 && number <= MAX_JOB_NUMBER
+    ? number
+    : 1
+}
+
+/**
+ * Durable repository for internal Work records.
+ *
+ * Recovery policy remains in TaskManager; this boundary owns the record
+ * collection, its persisted projection, atomic/deferred writes, and the
+ * durable short job-id cursor.
+ */
+export class TaskRepository {
+  constructor({ store = null, serialize = task => task } = {}) {
+    this.store = store
+    this.serialize = serialize
+    this.records = new Map()
+    this.nextJobNumber = 1
+  }
+
+  load() {
+    const saved = this.store?.load() || []
+    this.nextJobNumber = normalizedJobNumber(this.store?.nextJobNumber)
+    return saved
+  }
+
+  get(id) {
+    return this.records.get(String(id))
+  }
+
+  set(id, task) {
+    this.records.set(String(id), task)
+    return this
+  }
+
+  delete(id) {
+    return this.records.delete(String(id))
+  }
+
+  values() {
+    return this.records.values()
+  }
+
+  allocateJobId() {
+    const current = normalizedJobNumber(this.nextJobNumber)
+    this.nextJobNumber = current >= MAX_JOB_NUMBER ? 1 : current + 1
+    return `job_${current}`
+  }
+
+  save() {
+    this.store?.save(this.#serializedRecords(), {
+      nextJobNumber: this.nextJobNumber,
+    })
+  }
+
+  saveDeferred() {
+    const tasks = this.#serializedRecords()
+    const state = { nextJobNumber: this.nextJobNumber }
+    if (this.store?.saveDeferred) this.store.saveDeferred(tasks, state)
+    else this.store?.save(tasks, state)
+  }
+
+  #serializedRecords() {
+    return [...this.records.values()].map(this.serialize)
+  }
+}

--- a/server/src/task/task-state.mjs
+++ b/server/src/task/task-state.mjs
@@ -159,3 +159,19 @@ export function publicTask(task, { now = Date.now() } = {}) {
     progressCheckMs: task.progressCheckMs || null,
   }
 }
+
+export function persistedTask(task) {
+  const saved = publicTask(task)
+  delete saved.workId
+  delete saved.workState
+  saved.submissionKey = task.submissionKey || null
+  saved.delegation = task.delegation
+    ? {
+        ...task.delegation,
+        presentation: task.delegation.presentation
+          ? { ...task.delegation.presentation }
+          : null,
+      }
+    : null
+  return saved
+}

--- a/server/test/task-repository.test.mjs
+++ b/server/test/task-repository.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TaskRepository } from '../src/task/task-repository.mjs'
+
+test('owns persisted records and the durable short job-id cursor', () => {
+  const saves = []
+  const store = {
+    nextJobNumber: 7,
+    load: () => [{ id: 'restored' }],
+    save: (tasks, state) => saves.push({ tasks, state }),
+  }
+  const repository = new TaskRepository({
+    store,
+    serialize: task => ({ id: task.id, status: task.status }),
+  })
+
+  assert.deepEqual(repository.load(), [{ id: 'restored' }])
+  assert.equal(repository.allocateJobId(), 'job_7')
+  repository.set('work-one', { id: 'work-one', status: 'running', secret: true })
+  repository.save()
+
+  assert.deepEqual(saves, [{
+    tasks: [{ id: 'work-one', status: 'running' }],
+    state: { nextJobNumber: 8 },
+  }])
+})
+
+test('cycles job ids and falls back to synchronous persistence', () => {
+  let saved
+  const repository = new TaskRepository({
+    store: {
+      save: (tasks, state) => { saved = { tasks, state } },
+    },
+  })
+  repository.nextJobNumber = 99_999
+  repository.set('work-one', { id: 'work-one' })
+
+  assert.equal(repository.allocateJobId(), 'job_99999')
+  assert.equal(repository.allocateJobId(), 'job_1')
+  repository.saveDeferred()
+
+  assert.deepEqual(saved.state, { nextJobNumber: 2 })
+  assert.deepEqual(saved.tasks, [{ id: 'work-one' }])
+})
+
+test('uses deferred persistence when the store supports it', () => {
+  let deferred
+  const repository = new TaskRepository({
+    store: {
+      saveDeferred: (tasks, state) => { deferred = { tasks, state } },
+    },
+  })
+  repository.set('work-one', { id: 'work-one' })
+
+  repository.saveDeferred()
+
+  assert.deepEqual(deferred, {
+    tasks: [{ id: 'work-one' }],
+    state: { nextJobNumber: 1 },
+  })
+})


### PR DESCRIPTION
## Summary
- extract durable Work record collection, serialization, and persistence from `TaskManager`
- move short model-facing job-id allocation and restart cursor into the repository
- retain the existing `tasks` and `nextJobNumber` compatibility views while callers migrate incrementally

## Validation
- 109 Work, scheduler, persistence, delivery, and tool tests
- `npm run lint`
- `git diff --check`

Roadmap: #185