### PR TITLE
refactor: separate user work from system jobs

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -181,11 +181,12 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 
 ### R3 — Work Runtime
 
-- [ ] Extract state machine, scheduler, repository, and notification concerns.
+- [x] Extract state machine, scheduler, repository, and notification concerns.
   - [x] Centralize task phases, legal transitions, and public snapshots.
+  - [x] Keep concurrency and lane limits in the dedicated scheduler.
   - [x] Extract notification claim, lease, release, and delivery state.
   - [x] Extract durable Work records and short job-id allocation.
-- [ ] Separate user work from system jobs.
+- [x] Separate user work from system jobs.
 - [ ] Add artifact and authorization models.
 - [ ] Preserve restart, cancellation, and exactly-once delivery semantics.
 

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -231,11 +231,12 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 
 ### R3：Work Runtime
 
-- [ ] 从 TaskManager 提取 State Machine、Scheduler、Repository 和 Notification。
+- [x] 从 TaskManager 提取 State Machine、Scheduler、Repository 和 Notification。
   - [x] 集中管理任务阶段、合法状态迁移与公开快照。
+  - [x] 由独立 Scheduler 管理并发与 Lane 限制。
   - [x] 提取通知领取、租约、释放与送达状态。
   - [x] 提取持久化 Work 记录与短 Job ID 分配。
-- [ ] 区分 User Work 与 System Job。
+- [x] 区分 User Work 与 System Job。
 - [ ] 建立 Artifact 与统一 Authorization 模型。
 - [ ] 保持重启、取消和恰好一次结果投递语义。
 

--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -9,8 +9,11 @@ import {
   isTaskActive,
   isTaskCancellable,
   isTaskTerminal,
+  isUserWork,
+  normalizeTaskScope,
   persistedTask,
   publicTask,
+  TaskScope,
   TaskStatus,
   transitionTask,
 } from './task-state.mjs'
@@ -38,6 +41,7 @@ export class TaskManager {
     store = null,
     maxConcurrent = 4,
     maxConcurrentPerOwner = 2,
+    systemMaxConcurrent = 2,
     terminalTtlMs = 86_400_000,
     pendingNotificationTtlMs = 604_800_000,
     notificationClaimTtlMs = 60_000,
@@ -53,6 +57,10 @@ export class TaskManager {
     this.scheduler = new TaskScheduler({
       maxConcurrent,
       maxConcurrentPerOwner,
+    })
+    this.systemScheduler = new TaskScheduler({
+      maxConcurrent: systemMaxConcurrent,
+      maxConcurrentPerOwner: systemMaxConcurrent,
     })
     this.terminalTtlMs = terminalTtlMs
     this.pendingNotificationTtlMs = pendingNotificationTtlMs
@@ -94,10 +102,23 @@ export class TaskManager {
     this.scheduledTaskRunner = runner
   }
 
+  schedulerFor(task) {
+    return isUserWork(task) ? this.scheduler : this.systemScheduler
+  }
+
+  releaseScheduler(task) {
+    if (!task.schedulerHeld) return
+    this.schedulerFor(task).release(task)
+    task.schedulerHeld = false
+  }
+
   restore() {
     const savedTasks = this.repository.load()
     for (const saved of savedTasks) {
-      saved.jobId = String(saved.jobId || this.allocateJobId())
+      saved.scope = normalizeTaskScope(saved.scope)
+      saved.jobId = isUserWork(saved)
+        ? String(saved.jobId || this.allocateJobId())
+        : null
       // Scheduled tasks survive restarts intact. ReminderScheduler.start()
       // handles overdue vs future dispatch. Reminders that had already fired
       // (queued/running) when the Gateway stopped are also restored as
@@ -133,10 +154,19 @@ export class TaskManager {
       }
       const wasActive = isTaskActive(saved.status)
       const canRecoverDelegation = (
-        ['delegated', 'finalizing'].includes(saved.status)
+        isUserWork(saved)
+        && ['delegated', 'finalizing'].includes(saved.status)
         && saved.delegation?.id
         && saved.delegation?.sessionId
       )
+      const recoveredNotificationStatus = !isUserWork(saved)
+        ? 'none'
+        : (wasActive && !canRecoverDelegation)
+          || saved.notificationStatus === 'delivering'
+          ? 'pending'
+          : canRecoverDelegation
+            ? 'none'
+            : saved.notificationStatus || 'none'
       const task = {
         ...saved,
         status: canRecoverDelegation
@@ -155,12 +185,7 @@ export class TaskManager {
         authorization: wasActive || isTaskTerminal(saved.status)
           ? null
           : saved.authorization || null,
-        notificationStatus: (
-          (wasActive && !canRecoverDelegation)
-          || saved.notificationStatus === 'delivering'
-        )
-          ? 'pending'
-          : canRecoverDelegation ? 'none' : saved.notificationStatus || 'none',
+        notificationStatus: recoveredNotificationStatus,
         notificationClaimantId: null,
         notificationClaimedAt: null,
         resolve: null,
@@ -197,11 +222,13 @@ export class TaskManager {
         transitionTask(task, TaskStatus.FAILED)
         task.error = 'qwen-audio-agent 重启时这项项目任务失去连接，请重新提交。'
         task.completedAt = Date.now()
-        task.notificationStatus = 'pending'
+        task.notificationStatus = isUserWork(task) ? 'pending' : 'none'
         task.promise = Promise.resolve(publicTask(task))
         task.resolve = null
         this.emit(TaskDomainEvent.FAILED, task)
-        this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
+        if (isUserWork(task)) {
+          this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
+        }
         continue
       }
       task.runner = (_objective, context) => runner(snapshot, context)
@@ -224,9 +251,10 @@ export class TaskManager {
     return this.repository.allocateJobId()
   }
 
-  subscribe(listener) {
-    this.listeners.add(listener)
-    return () => this.listeners.delete(listener)
+  subscribe(listener, { scope = TaskScope.USER } = {}) {
+    const subscription = { listener, scope }
+    this.listeners.add(subscription)
+    return () => this.listeners.delete(subscription)
   }
 
   emit(type, task, { persist = true, ...details } = {}) {
@@ -258,9 +286,13 @@ export class TaskManager {
       elapsedMs: task.elapsedMs,
       hasError: Boolean(task.error),
     })
-    for (const listener of this.listeners) {
+    for (const subscription of this.listeners) {
+      if (
+        subscription.scope !== 'all'
+        && normalizeTaskScope(task.scope) !== subscription.scope
+      ) continue
       try {
-        listener(event)
+        subscription.listener(event)
       } catch {
         // One observer must not break the work queue.
       }
@@ -268,7 +300,25 @@ export class TaskManager {
     if (persist) this.persist()
   }
 
-  create({
+  create(options = {}) {
+    return this.#create({
+      ...options,
+      scope: TaskScope.USER,
+      kind: options.kind || 'work',
+    })
+  }
+
+  createSystemJob(options = {}) {
+    return this.#create({
+      ...options,
+      scope: TaskScope.SYSTEM,
+      kind: options.kind || 'system_job',
+      ownerId: options.ownerId || 'system',
+      sessionId: options.sessionId || 'system',
+    })
+  }
+
+  #create({
     objective,
     ownerId,
     sessionId,
@@ -276,26 +326,32 @@ export class TaskManager {
     submissionKey,
     laneKey,
     laneLimit = 1,
-    kind = 'work',
+    kind,
+    scope,
     parentWorkId = null,
     priority = 0,
     runner,
     canceler,
   }) {
+    const normalizedScope = normalizeTaskScope(scope)
     const normalizedOwnerId = String(ownerId || '')
     const normalizedSubmissionKey = String(submissionKey || '').trim()
     if (normalizedSubmissionKey) {
       const existing = [...this.tasks.values()].find(item => (
         item.ownerId === normalizedOwnerId
+        && normalizeTaskScope(item.scope) === normalizedScope
         && item.submissionKey === normalizedSubmissionKey
       ))
       if (existing) return { ...publicTask(existing), reused: true }
     }
     const task = {
       id: `work_${randomUUID()}`,
-      jobId: this.allocateJobId(),
+      jobId: normalizedScope === TaskScope.USER
+        ? this.allocateJobId()
+        : null,
       status: 'queued',
-      kind: String(kind || 'work'),
+      scope: normalizedScope,
+      kind: String(kind),
       parentWorkId: parentWorkId ? String(parentWorkId) : null,
       priority: Number.isFinite(Number(priority)) ? Number(priority) : 0,
       objective: String(objective || '').trim(),
@@ -325,7 +381,7 @@ export class TaskManager {
       terminalHandled: false,
       abortController: null,
       schedulerHeld: false,
-      progressCheckMs: String(kind || 'work') === 'work'
+      progressCheckMs: normalizedScope === TaskScope.USER && kind === 'work'
         ? this.progressCheckMs
         : null,
     }
@@ -353,6 +409,7 @@ export class TaskManager {
       id: `work_${randomUUID()}`,
       jobId: this.allocateJobId(),
       status: 'scheduled',
+      scope: TaskScope.USER,
       kind,
       objective: String(objective || '').trim(),
       ownerId: String(ownerId || ''),
@@ -408,7 +465,7 @@ export class TaskManager {
         || left.createdAt - right.createdAt
       ))
     for (const task of queued) {
-      if (!this.scheduler.canStart(task)) continue
+      if (!this.schedulerFor(task).canStart(task)) continue
       this.start(task)
     }
   }
@@ -417,7 +474,7 @@ export class TaskManager {
     transitionTask(task, TaskStatus.RUNNING)
     task.startedAt = Date.now()
     task.abortController = new AbortController()
-    this.scheduler.acquire(task)
+    this.schedulerFor(task).acquire(task)
     task.schedulerHeld = true
     this.emit(TaskDomainEvent.RUNNING, task)
     task.progressTimer = setInterval(() => {
@@ -445,10 +502,7 @@ export class TaskManager {
       if (event?.type === 'backend.delegated' && event.delegation) {
         transitionTask(task, TaskStatus.DELEGATED)
         task.delegation = { ...event.delegation }
-        if (task.schedulerHeld) {
-          this.scheduler.release(task)
-          task.schedulerHeld = false
-        }
+        this.releaseScheduler(task)
         this.emit(TaskDomainEvent.DELEGATED, task)
         this.drain()
         return
@@ -503,10 +557,7 @@ export class TaskManager {
           task.progressTimer = null
           clearInterval(task.progressCheckTimer)
           task.progressCheckTimer = null
-          if (task.schedulerHeld) {
-            this.scheduler.release(task)
-            task.schedulerHeld = false
-          }
+          this.releaseScheduler(task)
           this.emit(TaskDomainEvent.FAILED, task)
           this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
           this.persistDeferred()
@@ -592,10 +643,7 @@ export class TaskManager {
         task.authorization = null
         if (task.status === 'cancelling') return
         if (task.status === 'cancelled') {
-          if (task.schedulerHeld) {
-            this.scheduler.release(task)
-            task.schedulerHeld = false
-          }
+          this.releaseScheduler(task)
           this.drain()
           return
         }
@@ -603,29 +651,29 @@ export class TaskManager {
         task.elapsedMs = task.startedAt
           ? task.completedAt - task.startedAt
           : 0
-        task.notificationStatus = 'pending'
+        task.notificationStatus = isUserWork(task) ? 'pending' : 'none'
         task.terminalHandled = true
-        if (task.schedulerHeld) {
-          this.scheduler.release(task)
-          task.schedulerHeld = false
-        }
+        this.releaseScheduler(task)
         this.emit(
           task.status === 'completed'
             ? TaskDomainEvent.COMPLETED
             : TaskDomainEvent.FAILED,
           task,
         )
-        this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
+        if (isUserWork(task)) {
+          this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
+        }
         task.resolve?.(publicTask(task))
         this.prune()
         this.drain()
       })
   }
 
-  async cancel(id, { ownerId } = {}) {
+  async cancel(id, { ownerId, scope = TaskScope.USER } = {}) {
     const task = this.tasks.get(String(id))
     if (
       !task
+      || normalizeTaskScope(task.scope) !== scope
       || (ownerId !== undefined && task.ownerId !== String(ownerId))
       || (!isTaskCancellable(task.status) && task.status !== 'cancelling')
     ) {
@@ -673,14 +721,13 @@ export class TaskManager {
         task.elapsedMs = task.startedAt
           ? task.completedAt - task.startedAt
           : 0
-        task.notificationStatus = 'pending'
+        task.notificationStatus = isUserWork(task) ? 'pending' : 'none'
         task.terminalHandled = true
-        if (task.schedulerHeld) {
-          this.scheduler.release(task)
-          task.schedulerHeld = false
-        }
+        this.releaseScheduler(task)
         this.emit(TaskDomainEvent.FAILED, task)
-        this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
+        if (isUserWork(task)) {
+          this.emit(TaskDomainEvent.NOTIFICATION_PENDING, task)
+        }
         task.resolve?.(publicTask(task))
         this.prune()
         this.drain()
@@ -704,10 +751,7 @@ export class TaskManager {
     if (task.timeoutTimer) { clearTimeout(task.timeoutTimer); task.timeoutTimer = null }
     if (task.progressCheckTimer) { clearInterval(task.progressCheckTimer); task.progressCheckTimer = null }
     task.abortController = null
-    if (task.schedulerHeld) {
-      this.scheduler.release(task)
-      task.schedulerHeld = false
-    }
+    this.releaseScheduler(task)
     this.emit(TaskDomainEvent.CANCELLED, task)
     task.resolve?.(publicTask(task))
     this.prune()
@@ -715,9 +759,13 @@ export class TaskManager {
     return publicTask(task)
   }
 
-  get(id, { ownerId } = {}) {
+  get(id, { ownerId, scope = TaskScope.USER } = {}) {
     const task = this.tasks.get(String(id))
-    if (!task || (ownerId !== undefined && task.ownerId !== String(ownerId))) {
+    if (
+      !task
+      || normalizeTaskScope(task.scope) !== scope
+      || (ownerId !== undefined && task.ownerId !== String(ownerId))
+    ) {
       return null
     }
     return publicTask(task)
@@ -728,6 +776,7 @@ export class TaskManager {
     const task = [...this.tasks.values()]
       .filter(item => (
         item.jobId === normalized
+        && isUserWork(item)
         && (ownerId === undefined || item.ownerId === String(ownerId))
       ))
       .sort((left, right) => right.createdAt - left.createdAt)[0]
@@ -738,11 +787,13 @@ export class TaskManager {
     ownerId,
     sessionId,
     active = false,
+    scope = TaskScope.USER,
   } = {}) {
     this.prune()
     return [...this.tasks.values()]
       .filter(task => (
-        (ownerId === undefined || task.ownerId === String(ownerId))
+        (scope === 'all' || normalizeTaskScope(task.scope) === scope)
+        && (ownerId === undefined || task.ownerId === String(ownerId))
         && (sessionId === undefined || task.sessionId === String(sessionId))
         && (!active || isTaskActive(task.status))
       ))

--- a/server/src/task/task-state.mjs
+++ b/server/src/task/task-state.mjs
@@ -10,6 +10,11 @@ export const TaskStatus = Object.freeze({
   CANCELLED: 'cancelled',
 })
 
+export const TaskScope = Object.freeze({
+  USER: 'user',
+  SYSTEM: 'system',
+})
+
 const ACTIVE = new Set([
   TaskStatus.QUEUED,
   TaskStatus.RUNNING,
@@ -77,6 +82,14 @@ export function isTaskTerminal(status) {
   return TERMINAL.has(status)
 }
 
+export function normalizeTaskScope(scope) {
+  return scope === TaskScope.SYSTEM ? TaskScope.SYSTEM : TaskScope.USER
+}
+
+export function isUserWork(task) {
+  return normalizeTaskScope(task?.scope) === TaskScope.USER
+}
+
 export function transitionTask(task, nextStatus) {
   const currentStatus = task?.status
   if (!KNOWN.has(currentStatus) || !KNOWN.has(nextStatus)) {
@@ -119,6 +132,7 @@ export function publicTask(task, { now = Date.now() } = {}) {
     jobId: task.jobId,
     workState: isTaskActive(task.status) ? 'active' : task.status,
     status: task.status,
+    scope: normalizeTaskScope(task.scope),
     kind: task.kind || 'work',
     parentWorkId: task.parentWorkId || null,
     objective: task.objective,

--- a/server/src/transport/gateway-task-event-projector.mjs
+++ b/server/src/transport/gateway-task-event-projector.mjs
@@ -3,6 +3,7 @@ import {
 } from '../../../shared/protocol/gateway-events.mjs'
 import { GatewayTaskEvent } from '../../../shared/realtime-events.mjs'
 import { TaskDomainEvent } from '../task/task-events.mjs'
+import { TaskScope } from '../task/task-state.mjs'
 
 const PUBLIC_EVENT_TYPE = new Map([
   [TaskDomainEvent.ACCEPTED, GatewayTaskEvent.ACCEPTED],
@@ -54,6 +55,7 @@ export function projectGatewayTaskEvent(event) {
   if (!event || typeof event !== 'object') return null
   const type = PUBLIC_EVENT_TYPE.get(event.type)
   if (!type || !event.task || typeof event.task !== 'object') return null
+  if (event.task.scope === TaskScope.SYSTEM) return null
   return GatewayTaskEventMessageSchema.parse({
     type,
     task: event.task,
@@ -63,6 +65,7 @@ export function projectGatewayTaskEvent(event) {
 
 export function projectGatewayTaskSnapshot(task) {
   if (!task || typeof task !== 'object') return null
+  if (task.scope === TaskScope.SYSTEM) return null
   return GatewayTaskEventMessageSchema.parse({
     type: GatewayTaskEvent.SNAPSHOT,
     task,

--- a/server/test/gateway-task-event-projector.test.mjs
+++ b/server/test/gateway-task-event-projector.test.mjs
@@ -71,3 +71,12 @@ test('does not expose malformed or unrelated internal events', () => {
   assert.equal(projectGatewayTaskEvent({ type: 'backend.activity' }), null)
   assert.equal(projectGatewayTaskSnapshot(null), null)
 })
+
+test('never projects system jobs into the public task protocol', () => {
+  const system = task({ scope: 'system', jobId: null, kind: 'system_job' })
+  assert.equal(projectGatewayTaskEvent({
+    type: TaskDomainEvent.RUNNING,
+    task: system,
+  }), null)
+  assert.equal(projectGatewayTaskSnapshot(system), null)
+})

--- a/server/test/task-manager-system-jobs.test.mjs
+++ b/server/test/task-manager-system-jobs.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TaskManager } from '../src/task/task-manager.mjs'
+import { TaskScope } from '../src/task/task-state.mjs'
+
+test('keeps system jobs out of user work queries, events, ids, and notifications', async () => {
+  const manager = new TaskManager()
+  const userEvents = []
+  const systemEvents = []
+  manager.subscribe(event => userEvents.push(event))
+  manager.subscribe(event => systemEvents.push(event), {
+    scope: TaskScope.SYSTEM,
+  })
+
+  const job = manager.createSystemJob({
+    objective: '索引知识文档',
+    runner: async () => ({ content: '索引完成' }),
+  })
+  const completed = await manager.wait(job.id)
+
+  assert.equal(job.scope, TaskScope.SYSTEM)
+  assert.equal(job.jobId, null)
+  assert.equal(completed.notificationStatus, 'none')
+  assert.equal(manager.get(job.id), null)
+  assert.equal(manager.get(job.id, { scope: TaskScope.SYSTEM }).status, 'completed')
+  assert.deepEqual(manager.list(), [])
+  assert.equal(manager.list({ scope: TaskScope.SYSTEM }).length, 1)
+  assert.equal(userEvents.length, 0)
+  assert.equal(systemEvents.some(event => event.type === 'task.completed'), true)
+  assert.equal(
+    systemEvents.some(event => event.type === 'task.notification.pending'),
+    false,
+  )
+})
+
+test('runs system jobs in a pool independent from blocked user work', async () => {
+  const manager = new TaskManager({
+    maxConcurrent: 1,
+    maxConcurrentPerOwner: 1,
+    systemMaxConcurrent: 1,
+  })
+  let releaseUser
+  let secondUserStarted = false
+  let systemStarted = false
+  const firstUser = manager.create({
+    objective: '长期用户任务',
+    ownerId: 'owner',
+    runner: async () => new Promise(resolve => { releaseUser = resolve }),
+  })
+  const secondUser = manager.create({
+    objective: '排队用户任务',
+    ownerId: 'owner',
+    runner: async () => {
+      secondUserStarted = true
+      return { content: '完成' }
+    },
+  })
+  const system = manager.createSystemJob({
+    objective: '刷新索引',
+    runner: async () => {
+      systemStarted = true
+      return { content: '完成' }
+    },
+  })
+
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(systemStarted, true)
+  assert.equal(secondUserStarted, false)
+
+  releaseUser({ content: '完成' })
+  await Promise.all([
+    manager.wait(firstUser.id),
+    manager.wait(secondUser.id),
+    manager.wait(system.id),
+  ])
+  assert.equal(secondUserStarted, true)
+})
+
+test('persists system scope without consuming user-facing job ids', async () => {
+  let saved = []
+  const store = {
+    nextJobNumber: 1,
+    load: () => structuredClone(saved),
+    save(tasks, state) {
+      saved = structuredClone(tasks)
+      this.nextJobNumber = state.nextJobNumber
+    },
+  }
+  const first = new TaskManager({ store })
+  const system = first.createSystemJob({
+    objective: '重建索引',
+    runner: async () => ({ content: '完成' }),
+  })
+  await first.wait(system.id)
+  const user = first.create({
+    objective: '用户工作',
+    ownerId: 'owner',
+    runner: async () => ({ content: '完成' }),
+  })
+  await first.wait(user.id)
+
+  assert.equal(user.jobId, 'job_1')
+
+  const restored = new TaskManager({ store })
+  assert.equal(restored.list().length, 1)
+  assert.equal(restored.list({ scope: TaskScope.SYSTEM }).length, 1)
+  assert.equal(
+    restored.list({ scope: TaskScope.SYSTEM })[0].jobId,
+    null,
+  )
+})

--- a/server/test/task-state.test.mjs
+++ b/server/test/task-state.test.mjs
@@ -5,6 +5,7 @@ import {
   isTaskCancellable,
   isTaskTerminal,
   publicTask,
+  TaskScope,
   TaskStatus,
   transitionTask,
 } from '../src/task/task-state.mjs'
@@ -16,6 +17,20 @@ test('centralizes active, cancellable, and terminal task phases', () => {
   assert.equal(isTaskCancellable(TaskStatus.CANCELLING), false)
   assert.equal(isTaskTerminal(TaskStatus.COMPLETED), true)
   assert.equal(isTaskTerminal(TaskStatus.RUNNING), false)
+})
+
+test('defaults old records to user work and preserves explicit system jobs', () => {
+  assert.equal(publicTask({
+    id: 'old-work',
+    status: TaskStatus.QUEUED,
+    activity: [],
+  }).scope, TaskScope.USER)
+  assert.equal(publicTask({
+    id: 'system-job',
+    scope: TaskScope.SYSTEM,
+    status: TaskStatus.QUEUED,
+    activity: [],
+  }).scope, TaskScope.SYSTEM)
 })
 
 test('accepts valid transitions and rejects backwards or terminal transitions', () => {


### PR DESCRIPTION
Roadmap: #185

## Summary
- distinguish user-visible work from internal system jobs in the Work Runtime
- run system jobs in an independent scheduler pool and persist their scope
- keep system jobs out of user job IDs, frontend task events, queries, and notifications
- update the bilingual roadmap and add focused lifecycle tests

## Verification
- 126 related server tests passed
- `npm run lint`
- `git diff --check`