### PR TITLE
refactor: add work artifact and authorization models

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -18,9 +18,12 @@ a feature then degrades instead of failing.
 Versioning follows SemVer: the minor rises for an additive capability, the
 major for a breaking change to any endpoint or event named below.
 
-The current version is `2.1.0`. The `2.1` line adds the optional AG-UI Task
-event projection; it succeeds the `2.0` contract without changing its default
-event stream. The `2.x` line succeeds the `1.x` line of the
+The current version is `3.0.0`. The `3.0` line gives native Task events
+A2A-aligned `submitted`, `working`, and `auth_required` states together with
+typed artifact, presentation, and authorization values. It replaces the `2.x`
+`active` state and opaque result metadata, so event consumers must check the
+capability table below. The `2.1` line added the optional AG-UI Task event
+projection without changing its default event stream. The `2.x` line succeeds the `1.x` line of the
 `feat/embedded-gateway-host-contract` fork (which ended at `1.7.0`): the major
 bump records that capabilities that line advertised — such as
 `gateway.embedded-lifecycle` and `desktop.settings-window` — are not part of
@@ -41,6 +44,7 @@ below instead of assuming the old list.
 | `input.suspend-ttl` | A suspension expires on its own when the holder never resumes | `server/test/input-arbitration.test.mjs` |
 | `input.suspend-ack` | Clients confirm a suspension with `input.suspend.ack` (status display only — never wait for it) | `server/test/input-suspend-protocol.test.mjs` |
 | `tasks.ag-ui-event-stream` | `GET /api/tasks/:id/events?format=ag-ui` projects the existing Task stream into AG-UI `ACTIVITY_SNAPSHOT` events; omitting `format` preserves the native stream | `server/test/agui-event-projector.test.mjs` |
+| `tasks.work-artifacts-authorization` | Native Task events use A2A-aligned work states and expose typed `artifacts`, `presentation`, and `authorization` values | `test/gateway-event-schema.test.mjs`, `server/test/task-state.test.mjs` |
 | `desktop.orb-shell` | The orb form's main-process contract ships: `bindOrbShell` answers the channels the shipped preload sends | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` owns the orb window recipe; its `destroy()` is the host's synchronous teardown path (renderer exit is what releases the microphone) | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` covers the default anchor, display clamping and drop persistence | `desktop/test/orb-placement.test.mjs` |

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -14,8 +14,11 @@
 版本号遵循 SemVer：新增能力升 minor；下文点名的任一端点或事件发生破坏性
 变更升 major。
 
-当前版本为 `2.1.0`。`2.1` 新增可选的 AG-UI Task 事件投射，默认事件流保持
-`2.0` 契约不变。`2.x` 接替 `feat/embedded-gateway-host-contract` 分支的 `1.x`
+当前版本为 `3.0.0`。`3.0` 为原生 Task 事件提供与 A2A 对齐的 `submitted`、
+`working`、`auth_required` 状态，以及类型明确的产物、呈现与授权对象。它替换了
+`2.x` 的 `active` 状态与不透明结果元数据，因此事件消费者必须检查下方能力位。
+`2.1` 新增了可选的 AG-UI Task 事件投射，且未改变默认事件流。`2.x` 接替
+`feat/embedded-gateway-host-contract` 分支的 `1.x`
 版本线（止于 `1.7.0`）：升 major 记录的事实是——那条线宣告过的部分能力位
 （如 `gateway.embedded-lifecycle`、`desktop.settings-window`）不在本契约中。
 从该分支迁移的宿主应重新核对下方能力位表，而不是假设旧清单仍然成立。
@@ -34,6 +37,7 @@
 | `input.suspend-ttl` | 持有者不主动释放时抢占自行过期 | `server/test/input-arbitration.test.mjs` |
 | `input.suspend-ack` | 客户端以 `input.suspend.ack` 确认抢占生效（仅用于状态展示——不要等待它） | `server/test/input-suspend-protocol.test.mjs` |
 | `tasks.ag-ui-event-stream` | `GET /api/tasks/:id/events?format=ag-ui` 将现有 Task 事件流投射为 AG-UI `ACTIVITY_SNAPSHOT`；不传 `format` 时仍为原生事件流 | `server/test/agui-event-projector.test.mjs` |
+| `tasks.work-artifacts-authorization` | 原生 Task 事件使用与 A2A 对齐的工作状态，并暴露类型明确的 `artifacts`、`presentation` 与 `authorization` 对象 | `test/gateway-event-schema.test.mjs`、`server/test/task-state.test.mjs` |
 | `desktop.orb-shell` | 悬浮球形态的主进程契约随包发布：`bindOrbShell` 应答随包 preload 发出的全部通道 | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` 持有悬浮球窗口配方；其 `destroy()` 是宿主的同步销毁路径（渲染进程退出才能确定性释放麦克风） | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` 覆盖默认锚点、显示器夹取与拖放持久化 | `desktop/test/orb-placement.test.mjs` |

--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -118,9 +118,12 @@ prompts, coordinator MCP, and native delegation stay inside the ACP adapter.
 
 ### Artifact and Presentation
 
-Artifacts consist of MIME-typed parts. Presentation contains factual material
-and delivery policy for the frontend, not a script that must be spoken
-verbatim.
+Artifacts use the A2A-aligned `artifactId`, `name`, `description`, and Parts
+shape. Each Part contains exactly one of text, URL, base64 raw content, or
+structured data plus its MIME type. Authorization is a bounded Work request
+with identity, state, summary, category, and timestamps; it carries a decision
+request, never credentials. Presentation contains factual material and delivery
+policy for the frontend, not a script that must be spoken verbatim.
 
 ## 5. Standards strategy
 
@@ -187,7 +190,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
   - [x] Extract notification claim, lease, release, and delivery state.
   - [x] Extract durable Work records and short job-id allocation.
 - [x] Separate user work from system jobs.
-- [ ] Add artifact and authorization models.
+- [x] Add artifact and authorization models.
 - [ ] Preserve restart, cancellation, and exactly-once delivery semantics.
 
 ### R4 — Backend Runtime

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -155,8 +155,10 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 
 ### 4.5 Artifact 与 Presentation
 
-后台输出统一为包含 MIME 类型的 Artifact Parts。Presentation 只携带供前台表达的
-事实材料和投递策略，不携带必须逐字播报的脚本。
+Artifact 采用与 A2A 对齐的 `artifactId`、名称、描述和 Parts 结构。每个 Part 只包含
+text、URL、base64 原始内容或结构化数据中的一种，并声明 MIME 类型。Authorization
+是有界的 Work 决策请求，包含身份、状态、摘要、类别和时间戳，只转交决策，不承载凭据。
+Presentation 只携带供前台表达的事实材料和投递策略，不携带必须逐字播报的脚本。
 
 ## 5. 标准协议策略
 
@@ -237,7 +239,7 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
   - [x] 提取通知领取、租约、释放与送达状态。
   - [x] 提取持久化 Work 记录与短 Job ID 分配。
 - [x] 区分 User Work 与 System Job。
-- [ ] 建立 Artifact 与统一 Authorization 模型。
+- [x] 建立 Artifact 与统一 Authorization 模型。
 - [ ] 保持重启、取消和恰好一次结果投递语义。
 
 完成条件：Work Runtime 不包含任何 ACP 或后台产品名称。

--- a/server/src/agent/permission-broker.mjs
+++ b/server/src/agent/permission-broker.mjs
@@ -1,6 +1,11 @@
 import { randomUUID } from 'node:crypto'
 import { AgentError } from './backend-adapter.mjs'
 import { ACP_SESSION_TOOL_NAMES } from './acp-session-tools.mjs'
+import {
+  AuthorizationStatus,
+  normalizeAuthorization,
+  resolveAuthorization,
+} from '../core/work-authorization.mjs'
 
 function clean(value) {
   return String(value || '').trim()
@@ -50,10 +55,10 @@ export class PermissionBroker {
     }
     const id = `auth_${randomUUID().replaceAll('-', '')}`
     const pending = deferred()
-    const permission = {
+    const permission = normalizeAuthorization({
       id,
       workId: session?.coordinationRunId || null,
-      status: 'pending',
+      status: AuthorizationStatus.PENDING,
       category: bounded(name, 80) || 'unknown',
       summary: [
         bounded(name, 80),
@@ -63,9 +68,9 @@ export class PermissionBroker {
           || params?.toolCall?.rawInput?.path
           || '',
         ),
-      ].filter(Boolean).join('：'),
+      ].filter(Boolean).join('：') || '后台操作',
       patterns: [],
-    }
+    })
     const record = {
       ...permission,
       ownerId: clean(session?.ownerId),
@@ -84,15 +89,13 @@ export class PermissionBroker {
   cancel(record) {
     if (!record || !this.pending.delete(record.id)) return false
     record.pending.resolve({ outcome: { outcome: 'cancelled' } })
+    const permission = resolveAuthorization(
+      record,
+      AuthorizationStatus.CANCELLED,
+    )
     record.onEvent?.({
       type: 'backend.permission.resolved',
-      permission: {
-        id: record.id,
-        workId: record.workId,
-        status: 'cancelled',
-        category: record.category,
-        summary: record.summary,
-      },
+      permission,
     })
     return true
   }
@@ -118,13 +121,10 @@ export class PermissionBroker {
     record.pending.resolve(option
       ? { outcome: { outcome: 'selected', optionId: option.optionId } }
       : { outcome: { outcome: 'cancelled' } })
-    const permission = {
-      id: record.id,
-      workId: record.workId,
-      status: approved ? 'approved' : 'denied',
-      category: record.category,
-      summary: record.summary,
-    }
+    const permission = resolveAuthorization(
+      record,
+      approved ? AuthorizationStatus.APPROVED : AuthorizationStatus.DENIED,
+    )
     record.onEvent?.({ type: 'backend.permission.resolved', permission })
     this.resolved.set(permission.id, { ownerId: record.ownerId, permission })
     while (this.resolved.size > this.resolvedLimit) {

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -332,13 +332,13 @@ app.get('/api/timeline', (req, res) => {
     ownerId: req.identity.ownerId,
     sessionId: req.query.sessionId,
   })
-    .filter(task => task.resultMetadata?.presentation?.inline?.content)
+    .filter(task => task.presentation?.inline?.content)
     .map(task => ({
       id: `inline_${task.id}`,
       taskId: task.id,
       turnId: task.turnId || null,
       createdAt: task.completedAt || task.createdAt,
-      ...task.resultMetadata.presentation.inline,
+      ...task.presentation.inline,
     }))
     .sort((left, right) => left.createdAt - right.createdAt)
   res.json({ items })

--- a/server/src/app/offline-notifications.mjs
+++ b/server/src/app/offline-notifications.mjs
@@ -1,4 +1,5 @@
 import { TaskDomainEvent } from '../task/task-events.mjs'
+import { isTaskActive } from '../task/task-state.mjs'
 
 export function installOfflineNotifications({
   taskManager,
@@ -17,7 +18,7 @@ export function installOfflineNotifications({
       })
       if (!current) return
       if (event.type === TaskDomainEvent.PROGRESS_CHECK) {
-        if (current.workState !== 'active') return
+        if (!isTaskActive(current.status)) return
         parentPort?.postMessage({
           type: 'qwen-audio-agent:offline-notification',
           task: {

--- a/server/src/core/gateway-protocol.mjs
+++ b/server/src/core/gateway-protocol.mjs
@@ -10,6 +10,10 @@
 // Every capability listed here is locked by a test (see docs/contract.md);
 // anything not listed is internal and may change in any release.
 //
+// 3.0.0 gives public Tasks A2A-aligned work states and first-class artifact,
+// presentation and authorization values. This replaces the 2.x `active`
+// state and opaque result metadata, so event consumers must branch on the
+// capability below before reading the new fields.
 // 2.1.0 adds an opt-in AG-UI projection while preserving the native stream.
 // 2.0.0 succeeds the 1.x line of the feat/embedded-gateway-host-contract
 // fork (last 1.7.0). The major bump is semantic, not cosmetic: capabilities
@@ -17,7 +21,7 @@
 // desktop.settings-window, …) are not part of this contract, and a removed
 // capability is a breaking change. Hosts migrating from the fork must branch
 // on the capability list below, never on the version number.
-export const GATEWAY_PROTOCOL_VERSION = '2.1.0'
+export const GATEWAY_PROTOCOL_VERSION = '3.0.0'
 
 export const GATEWAY_CAPABILITIES = Object.freeze([
   // The Gateway statically hosts web/dist at its own origin, so a client may
@@ -60,6 +64,9 @@ export const GATEWAY_CAPABILITIES = Object.freeze([
   // stream into AG-UI ACTIVITY_SNAPSHOT events. The default stream is
   // unchanged.
   'tasks.ag-ui-event-stream',
+  // Native Task events expose A2A-aligned submitted/working/auth_required
+  // states plus typed artifact, presentation and authorization values.
+  'tasks.work-artifacts-authorization',
   // The orb shell contract ships: qwen-audio-agent/orb/preload plus
   // orb/main's bindOrbShell, so a host may run the floating orb form.
   'desktop.orb-shell',

--- a/server/src/core/work-authorization.mjs
+++ b/server/src/core/work-authorization.mjs
@@ -1,0 +1,68 @@
+export const AuthorizationStatus = Object.freeze({
+  PENDING: 'pending',
+  APPROVED: 'approved',
+  DENIED: 'denied',
+  CANCELLED: 'cancelled',
+})
+
+const KNOWN_STATUSES = new Set(Object.values(AuthorizationStatus))
+
+function clean(value, max = 300) {
+  return String(value || '').replaceAll('\u0000', '').replace(/\s+/g, ' ')
+    .trim().slice(0, max)
+}
+
+export function normalizeAuthorization(value, {
+  workId = '',
+  defaultStatus = AuthorizationStatus.PENDING,
+  now = Date.now(),
+} = {}) {
+  if (!value || typeof value !== 'object') return null
+  const id = clean(value.id, 160)
+  const summary = clean(value.summary, 600)
+  if (!id || !summary) return null
+  const status = KNOWN_STATUSES.has(value.status)
+    ? value.status
+    : defaultStatus
+  const createdAt = Number(value.createdAt) || now
+  const resolvedAt = status === AuthorizationStatus.PENDING
+    ? null
+    : Number(value.resolvedAt) || now
+  return {
+    id,
+    workId: clean(workId || value.workId, 160) || null,
+    status,
+    category: clean(value.category, 80) || 'unknown',
+    summary,
+    patterns: (Array.isArray(value.patterns) ? value.patterns : [])
+      .map(pattern => clean(pattern, 300))
+      .filter(Boolean)
+      .slice(0, 32),
+    createdAt,
+    resolvedAt,
+  }
+}
+
+export function resolveAuthorization(value, status, {
+  workId = '',
+  now = Date.now(),
+} = {}) {
+  if (!KNOWN_STATUSES.has(status) || status === AuthorizationStatus.PENDING) {
+    return null
+  }
+  const authorization = normalizeAuthorization(value, { workId, now })
+  if (!authorization) return null
+  return {
+    ...authorization,
+    status,
+    resolvedAt: now,
+  }
+}
+
+export function publicAuthorization(value, { workId = '' } = {}) {
+  const authorization = normalizeAuthorization(value, {
+    workId,
+    now: Number(value?.createdAt) || Date.now(),
+  })
+  return authorization ? { ...authorization } : null
+}

--- a/server/src/task/task-artifact.mjs
+++ b/server/src/task/task-artifact.mjs
@@ -1,0 +1,161 @@
+const MAX_ARTIFACTS = 32
+const MAX_PARTS = 64
+const MAX_TEXT_CHARS = 1_000_000
+const MAX_RAW_CHARS = 16_000_000
+const MAX_DATA_CHARS = 1_000_000
+const MAX_TOTAL_PART_CHARS = 16_000_000
+const PUBLIC_URL_PROTOCOLS = new Set(['data:', 'http:', 'https:'])
+
+function clean(value, max) {
+  return String(value || '').replaceAll('\u0000', '').trim().slice(0, max)
+}
+
+function own(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key)
+}
+
+function mediaType(value, fallback) {
+  const normalized = clean(value, 160).toLowerCase()
+  return /^[a-z\d!#$&^_.+-]+\/[a-z\d!#$&^_.+-]+$/.test(normalized)
+    ? normalized
+    : fallback
+}
+
+function jsonValue(value) {
+  try {
+    const serialized = JSON.stringify(value)
+    if (serialized === undefined || serialized.length > MAX_DATA_CHARS) return null
+    return JSON.parse(serialized)
+  } catch {
+    return null
+  }
+}
+
+function normalizePart(part) {
+  if (!part || typeof part !== 'object') return null
+  const filename = clean(part.filename, 240)
+  if (own(part, 'text')) {
+    const text = clean(part.text, MAX_TEXT_CHARS)
+    if (!text) return null
+    return {
+      text,
+      mediaType: mediaType(part.mediaType || part.mimeType, 'text/plain'),
+      ...(filename ? { filename } : {}),
+    }
+  }
+  if (own(part, 'raw')) {
+    const raw = clean(part.raw, MAX_RAW_CHARS).replace(/\s/g, '')
+    if (!raw || !/^[a-z\d+/]*={0,2}$/i.test(raw)) return null
+    return {
+      raw,
+      mediaType: mediaType(
+        part.mediaType || part.mimeType,
+        'application/octet-stream',
+      ),
+      ...(filename ? { filename } : {}),
+    }
+  }
+  if (own(part, 'url')) {
+    const url = clean(part.url, 20_000)
+    if (!url) return null
+    try {
+      if (!PUBLIC_URL_PROTOCOLS.has(new URL(url).protocol)) return null
+    } catch {
+      return null
+    }
+    return {
+      url,
+      mediaType: mediaType(
+        part.mediaType || part.mimeType,
+        'application/octet-stream',
+      ),
+      ...(filename ? { filename } : {}),
+    }
+  }
+  if (own(part, 'data')) {
+    const data = jsonValue(part.data)
+    if (data === null && part.data !== null) return null
+    return {
+      data,
+      mediaType: mediaType(part.mediaType || part.mimeType, 'application/json'),
+      ...(filename ? { filename } : {}),
+    }
+  }
+  return null
+}
+
+function normalizeArtifact(artifact, index) {
+  if (!artifact || typeof artifact !== 'object') return null
+  const parts = (Array.isArray(artifact.parts) ? artifact.parts : [])
+    .slice(0, MAX_PARTS)
+    .map(normalizePart)
+    .filter(Boolean)
+  if (!parts.length) return null
+  const artifactId = clean(artifact.artifactId || artifact.id, 160)
+    || `artifact_${index + 1}`
+  const name = clean(artifact.name, 240)
+  const description = clean(artifact.description, 1000)
+  return {
+    artifactId,
+    ...(name ? { name } : {}),
+    ...(description ? { description } : {}),
+    parts,
+  }
+}
+
+function partSize(part) {
+  if (part.text !== undefined) return part.text.length
+  if (part.raw !== undefined) return part.raw.length
+  if (part.url !== undefined) return part.url.length
+  try {
+    return JSON.stringify(part.data).length
+  } catch {
+    return MAX_TOTAL_PART_CHARS + 1
+  }
+}
+
+export function normalizeArtifacts(artifacts) {
+  const normalized = (Array.isArray(artifacts) ? artifacts : [])
+    .slice(0, MAX_ARTIFACTS)
+    .map(normalizeArtifact)
+    .filter(Boolean)
+  const used = new Set()
+  let remaining = MAX_TOTAL_PART_CHARS
+  return normalized.flatMap(artifact => {
+    if (used.has(artifact.artifactId)) return []
+    used.add(artifact.artifactId)
+    const parts = artifact.parts.filter(part => {
+      const size = partSize(part)
+      if (size > remaining) return false
+      remaining -= size
+      return true
+    })
+    return parts.length ? [{ ...artifact, parts }] : []
+  })
+}
+
+export function artifactFromInlinePresentation(presentation) {
+  const inline = presentation?.inline
+  const content = clean(inline?.content, MAX_TEXT_CHARS)
+  if (!content) return null
+  const format = ['markdown', 'code', 'link'].includes(inline.format)
+    ? inline.format
+    : 'markdown'
+  return {
+    artifactId: 'artifact_inline',
+    ...(clean(inline.title, 240) ? { name: clean(inline.title, 240) } : {}),
+    parts: [{
+      text: content,
+      mediaType: format === 'link' ? 'text/uri-list' : 'text/markdown',
+    }],
+  }
+}
+
+export function artifactsFromOutcome(outcome, presentation = null) {
+  const supplied = normalizeArtifacts(
+    outcome?.artifacts || outcome?.metadata?.artifacts,
+  )
+  if (supplied.length) return supplied
+  const inline = artifactFromInlinePresentation(presentation)
+  return inline ? [inline] : []
+}

--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -6,11 +6,20 @@ import { TaskDomainEvent } from './task-events.mjs'
 import { TaskNotificationQueue } from './task-notification-queue.mjs'
 import { TaskRepository } from './task-repository.mjs'
 import {
+  artifactsFromOutcome,
+  normalizeArtifacts,
+} from './task-artifact.mjs'
+import {
+  normalizeAuthorization,
+  resolveAuthorization,
+} from '../core/work-authorization.mjs'
+import {
   isTaskActive,
   isTaskCancellable,
   isTaskTerminal,
   isUserWork,
   normalizeTaskScope,
+  normalizeTaskPresentation,
   persistedTask,
   publicTask,
   TaskScope,
@@ -119,6 +128,13 @@ export class TaskManager {
       saved.jobId = isUserWork(saved)
         ? String(saved.jobId || this.allocateJobId())
         : null
+      saved.presentation = normalizeTaskPresentation(
+        saved.presentation || saved.resultMetadata || null,
+      )
+      saved.artifacts = normalizeArtifacts(saved.artifacts)
+      saved.authorization = normalizeAuthorization(saved.authorization, {
+        workId: saved.id,
+      })
       // Scheduled tasks survive restarts intact. ReminderScheduler.start()
       // handles overdue vs future dispatch. Reminders that had already fired
       // (queued/running) when the Gateway stopped are also restored as
@@ -184,7 +200,7 @@ export class TaskManager {
           : null,
         authorization: wasActive || isTaskTerminal(saved.status)
           ? null
-          : saved.authorization || null,
+          : saved.authorization,
         notificationStatus: recoveredNotificationStatus,
         notificationClaimantId: null,
         notificationClaimedAt: null,
@@ -367,7 +383,8 @@ export class TaskManager {
       elapsedMs: 0,
       result: null,
       error: null,
-      resultMetadata: null,
+      artifacts: [],
+      presentation: null,
       activity: [],
       delegation: null,
       cancellation: null,
@@ -428,7 +445,8 @@ export class TaskManager {
       elapsedMs: 0,
       result: null,
       error: null,
-      resultMetadata: null,
+      artifacts: [],
+      presentation: null,
       activity: [],
       delegation: null,
       cancellation: null,
@@ -485,16 +503,30 @@ export class TaskManager {
     task.progressTimer.unref?.()
     const onEvent = event => {
       if (event?.type === 'backend.permission.requested' && event.permission) {
-        task.authorization = { ...event.permission }
-        this.emit(TaskDomainEvent.PERMISSION_REQUESTED, task)
+        const authorization = normalizeAuthorization(event.permission, {
+          workId: task.id,
+        })
+        if (!authorization) return
+        task.authorization = authorization
+        this.emit(TaskDomainEvent.PERMISSION_REQUESTED, task, {
+          permission: authorization,
+        })
         return
       }
       if (event?.type === 'backend.permission.resolved' && event.permission) {
-        if (task.authorization?.id === event.permission.id) {
+        const permission = resolveAuthorization(
+          task.authorization?.id === event.permission.id
+            ? task.authorization
+            : event.permission,
+          event.permission.status,
+          { workId: task.id },
+        )
+        if (!permission) return
+        if (task.authorization?.id === permission.id) {
           task.authorization = null
         }
         this.emit(TaskDomainEvent.PERMISSION_RESOLVED, task, {
-          permission: { ...event.permission },
+          permission,
         })
         return
       }
@@ -623,7 +655,10 @@ export class TaskManager {
         ) return
         transitionTask(task, TaskStatus.COMPLETED)
         task.result = String(outcome?.content ?? outcome ?? '').trim()
-        task.resultMetadata = outcome?.metadata || null
+        task.presentation = normalizeTaskPresentation(
+          outcome?.presentation || outcome?.metadata || null,
+        )
+        task.artifacts = artifactsFromOutcome(outcome, task.presentation)
       })
       .catch(error => {
         if (

--- a/server/src/task/task-state.mjs
+++ b/server/src/task/task-state.mjs
@@ -1,3 +1,9 @@
+import {
+  artifactFromInlinePresentation,
+  normalizeArtifacts,
+} from './task-artifact.mjs'
+import { publicAuthorization } from '../core/work-authorization.mjs'
+
 export const TaskStatus = Object.freeze({
   SCHEDULED: 'scheduled',
   QUEUED: 'queued',
@@ -90,6 +96,15 @@ export function isUserWork(task) {
   return normalizeTaskScope(task?.scope) === TaskScope.USER
 }
 
+export function publicWorkState(task) {
+  if (task?.authorization?.status === 'pending') return 'auth_required'
+  if ([TaskStatus.SCHEDULED, TaskStatus.QUEUED].includes(task?.status)) {
+    return 'submitted'
+  }
+  if (isTaskActive(task?.status)) return 'working'
+  return isTaskTerminal(task?.status) ? task.status : 'submitted'
+}
+
 export function transitionTask(task, nextStatus) {
   const currentStatus = task?.status
   if (!KNOWN.has(currentStatus) || !KNOWN.has(nextStatus)) {
@@ -103,9 +118,9 @@ export function transitionTask(task, nextStatus) {
   return task
 }
 
-function publicResultMetadata(metadata) {
-  if (!metadata || typeof metadata !== 'object') return null
-  const source = metadata.presentation || metadata.decision?.presentation
+export function normalizeTaskPresentation(value) {
+  if (!value || typeof value !== 'object') return null
+  const source = value.presentation || value.decision?.presentation || value
   if (!source || typeof source !== 'object') return null
   const inline = source.inline && typeof source.inline === 'object'
     && typeof source.inline.content === 'string'
@@ -122,15 +137,29 @@ function publicResultMetadata(metadata) {
     : null
   const speech = typeof source.speech === 'string' ? source.speech : ''
   if (!speech && !inline) return null
-  return { presentation: { speech, inline } }
+  return { speech, inline }
+}
+
+function taskPresentation(task) {
+  return normalizeTaskPresentation(
+    task.presentation || task.resultMetadata || null,
+  )
+}
+
+function taskArtifacts(task, presentation) {
+  const normalized = normalizeArtifacts(task.artifacts)
+  if (normalized.length) return normalized
+  const legacy = artifactFromInlinePresentation(presentation)
+  return legacy ? [legacy] : []
 }
 
 export function publicTask(task, { now = Date.now() } = {}) {
+  const presentation = taskPresentation(task)
   return {
     id: task.id,
     workId: task.id,
     jobId: task.jobId,
-    workState: isTaskActive(task.status) ? 'active' : task.status,
+    workState: publicWorkState(task),
     status: task.status,
     scope: normalizeTaskScope(task.scope),
     kind: task.kind || 'work',
@@ -147,7 +176,8 @@ export function publicTask(task, { now = Date.now() } = {}) {
       : task.elapsedMs,
     result: task.result,
     error: task.error,
-    resultMetadata: publicResultMetadata(task.resultMetadata),
+    artifacts: taskArtifacts(task, presentation),
+    presentation,
     activity: [...(task.activity || [])],
     delegation: task.delegation
       ? {
@@ -163,9 +193,7 @@ export function publicTask(task, { now = Date.now() } = {}) {
             : null,
         }
       : null,
-    authorization: task.authorization
-      ? { ...task.authorization }
-      : null,
+    authorization: publicAuthorization(task.authorization, { workId: task.id }),
     notificationStatus: task.notificationStatus,
     notificationDeliveredAt: task.notificationDeliveredAt,
     schedule: task.schedule || null,

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -673,7 +673,7 @@ export function attachRealtimeGateway(server, {
         TaskDomainEvent.FAILED,
       ].includes(event.type)) {
         recordResult(task)
-        const inline = task.resultMetadata?.presentation?.inline
+        const inline = task.presentation?.inline
         if (inline?.content) {
           send(ws, {
             type: 'timeline.inline',

--- a/server/test/agui-event-projector.test.mjs
+++ b/server/test/agui-event-projector.test.mjs
@@ -16,7 +16,7 @@ function task(overrides = {}) {
     id: 'work_1',
     workId: 'work_1',
     jobId: 'job_1',
-    workState: 'active',
+    workState: 'working',
     status: 'running',
     kind: 'work',
     objective: 'inspect the system',
@@ -25,6 +25,19 @@ function task(overrides = {}) {
     result: null,
     error: null,
     ...overrides,
+  }
+}
+
+function authorization() {
+  return {
+    id: 'permission_1',
+    workId: 'work_1',
+    status: 'pending',
+    category: 'shell',
+    summary: 'run command',
+    patterns: [],
+    createdAt: 1,
+    resolvedAt: null,
   }
 }
 
@@ -69,15 +82,12 @@ test('preserves public details without exposing undeclared fields', () => {
   const projected = projectGatewayTaskEventToAgui({
     type: GatewayTaskEvent.PERMISSION_REQUESTED,
     task: task({ internalSchedulerLane: 'coordinator:owner' }),
-    permission: { id: 'permission_1', summary: 'run command' },
+    permission: authorization(),
     message: 'permission needed',
     privateReason: 'adapter-only',
   })
 
-  assert.deepEqual(projected.content.permission, {
-    id: 'permission_1',
-    summary: 'run command',
-  })
+  assert.deepEqual(projected.content.permission, authorization())
   assert.equal(projected.content.message, 'permission needed')
   assert.equal('internalSchedulerLane' in projected.content.task, false)
   assert.equal('privateReason' in projected.content, false)

--- a/server/test/gateway-task-event-projector.test.mjs
+++ b/server/test/gateway-task-event-projector.test.mjs
@@ -12,7 +12,7 @@ function task(overrides = {}) {
     id: 'work_1',
     workId: 'work_1',
     jobId: 'job_1',
-    workState: 'active',
+    workState: 'working',
     status: 'running',
     kind: 'work',
     objective: 'inspect the system',
@@ -21,6 +21,19 @@ function task(overrides = {}) {
     result: null,
     error: null,
     ...overrides,
+  }
+}
+
+function authorization() {
+  return {
+    id: 'permission_1',
+    workId: 'work_1',
+    status: 'pending',
+    category: 'shell',
+    summary: 'run command',
+    patterns: [],
+    createdAt: 1,
+    resolvedAt: null,
   }
 }
 
@@ -41,15 +54,12 @@ test('keeps public details and strips undeclared Task fields', () => {
   const projected = projectGatewayTaskEvent({
     type: TaskDomainEvent.PERMISSION_REQUESTED,
     task: task({ internalSchedulerLane: 'coordinator:owner' }),
-    permission: { id: 'permission_1', summary: 'run command' },
+    permission: authorization(),
     message: 'public progress',
     privateReason: 'adapter-only',
   })
 
-  assert.deepEqual(projected.permission, {
-    id: 'permission_1',
-    summary: 'run command',
-  })
+  assert.deepEqual(projected.permission, authorization())
   assert.equal(projected.message, 'public progress')
   assert.equal('internalSchedulerLane' in projected.task, false)
   assert.equal('privateReason' in projected, false)

--- a/server/test/offline-notifications.test.mjs
+++ b/server/test/offline-notifications.test.mjs
@@ -38,7 +38,7 @@ test('drops delayed progress after the task has completed', () => {
     id: 'work-1',
     ownerId: 'owner',
     objective: 'build',
-    workState: 'active',
+    workState: 'working',
     status: 'running',
   }
   const testHarness = harness(task)
@@ -63,7 +63,7 @@ test('delivers delayed progress only while the task remains active', () => {
     id: 'work-1',
     ownerId: 'owner',
     objective: 'build',
-    workState: 'active',
+    workState: 'working',
     status: 'running',
   }
   const testHarness = harness(task)

--- a/server/test/result-delivery.test.mjs
+++ b/server/test/result-delivery.test.mjs
@@ -119,7 +119,7 @@ function createDeliveryHarness() {
 
     if (['task.completed', 'task.failed'].includes(event.type)) {
       recordResult(task)
-      const inline = task.resultMetadata?.presentation?.inline
+      const inline = task.presentation?.inline
       if (inline?.content) {
         send(ws, {
           type: 'timeline.inline',
@@ -388,7 +388,7 @@ test('multiple programming tasks: each gets one inline and one injectResult', as
 test('failed task: no inline shown, error delivered via injectResult once', async () => {
   const h = createDeliveryHarness()
 
-  // Runner throws — TaskManager sets task.error, resultMetadata stays null,
+  // Runner throws — TaskManager sets task.error, presentation stays null,
   // so no inline content is available for timeline.inline.
   const { id: taskId } = h.taskManager.create({
     objective: '编写一个快速排序',
@@ -400,7 +400,7 @@ test('failed task: no inline shown, error delivered via injectResult once', asyn
   await h.taskManager.wait(taskId)
   await flush()
 
-  // Failed tasks have no resultMetadata → no timeline.inline
+  // Failed tasks have no presentation → no timeline.inline
   const inlineMsg = h.wsMessages.find(m => m.type === 'timeline.inline')
   assert.equal(inlineMsg, undefined, 'no timeline.inline for failed task')
 

--- a/server/test/task-artifact.test.mjs
+++ b/server/test/task-artifact.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  artifactFromInlinePresentation,
+  artifactsFromOutcome,
+  normalizeArtifacts,
+} from '../src/task/task-artifact.mjs'
+
+test('normalizes A2A-aligned MIME-typed artifact parts', () => {
+  assert.deepEqual(normalizeArtifacts([{
+    id: 'report',
+    name: '系统报告',
+    description: '检查结果',
+    parts: [
+      { text: '# 完成', mimeType: 'Text/Markdown' },
+      { data: { memoryGb: 24 } },
+      {
+        url: 'https://example.com/report.pdf',
+        mediaType: 'application/pdf',
+        filename: 'report.pdf',
+      },
+    ],
+  }]), [{
+    artifactId: 'report',
+    name: '系统报告',
+    description: '检查结果',
+    parts: [
+      { text: '# 完成', mediaType: 'text/markdown' },
+      { data: { memoryGb: 24 }, mediaType: 'application/json' },
+      {
+        url: 'https://example.com/report.pdf',
+        mediaType: 'application/pdf',
+        filename: 'report.pdf',
+      },
+    ],
+  }])
+})
+
+test('drops duplicate artifacts and unsafe or malformed parts', () => {
+  assert.deepEqual(normalizeArtifacts([
+    {
+      artifactId: 'one',
+      parts: [
+        { url: 'javascript:alert(1)', mediaType: 'text/html' },
+        { raw: 'not base64!', mediaType: 'image/png' },
+        { text: 'safe' },
+      ],
+    },
+    { artifactId: 'one', parts: [{ text: 'duplicate' }] },
+    { artifactId: 'empty', parts: [] },
+  ]), [{
+    artifactId: 'one',
+    parts: [{ text: 'safe', mediaType: 'text/plain' }],
+  }])
+})
+
+test('adapts the legacy inline presentation into one stable artifact', () => {
+  const presentation = {
+    speech: '报告已完成。',
+    inline: { title: '报告', format: 'code', content: 'const done = true' },
+  }
+  const artifact = artifactFromInlinePresentation(presentation)
+  assert.deepEqual(artifactsFromOutcome({ metadata: {} }, presentation), [
+    artifact,
+  ])
+  assert.deepEqual(artifact, {
+    artifactId: 'artifact_inline',
+    name: '报告',
+    parts: [{ text: 'const done = true', mediaType: 'text/markdown' }],
+  })
+})
+
+test('prefers backend artifacts over the inline compatibility projection', () => {
+  const artifacts = artifactsFromOutcome({
+    artifacts: [{
+      artifactId: 'image',
+      parts: [{
+        url: 'https://example.com/cat.png',
+        mediaType: 'image/png',
+      }],
+    }],
+  }, {
+    inline: { title: 'ignored', format: 'markdown', content: 'ignored' },
+  })
+  assert.equal(artifacts.length, 1)
+  assert.equal(artifacts[0].artifactId, 'image')
+})

--- a/server/test/task-authorization.test.mjs
+++ b/server/test/task-authorization.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  AuthorizationStatus,
+  normalizeAuthorization,
+  publicAuthorization,
+  resolveAuthorization,
+} from '../src/core/work-authorization.mjs'
+
+test('normalizes one bounded pending authorization request', () => {
+  const authorization = normalizeAuthorization({
+    id: 'auth_1',
+    category: 'shell',
+    summary: '  执行   npm test  ',
+    patterns: ['npm test', '', 'npm test -- server'],
+  }, { workId: 'work_1', now: 10 })
+  assert.deepEqual(authorization, {
+    id: 'auth_1',
+    workId: 'work_1',
+    status: AuthorizationStatus.PENDING,
+    category: 'shell',
+    summary: '执行 npm test',
+    patterns: ['npm test', 'npm test -- server'],
+    createdAt: 10,
+    resolvedAt: null,
+  })
+})
+
+test('resolves authorization without mutating the pending request', () => {
+  const pending = normalizeAuthorization({
+    id: 'auth_1',
+    summary: '写入文件',
+  }, { workId: 'work_1', now: 10 })
+  const resolved = resolveAuthorization(
+    pending,
+    AuthorizationStatus.APPROVED,
+    { now: 20 },
+  )
+  assert.equal(pending.status, AuthorizationStatus.PENDING)
+  assert.equal(resolved.status, AuthorizationStatus.APPROVED)
+  assert.equal(resolved.createdAt, 10)
+  assert.equal(resolved.resolvedAt, 20)
+  assert.deepEqual(publicAuthorization(resolved), resolved)
+})
+
+test('rejects malformed requests and invalid resolution states', () => {
+  assert.equal(normalizeAuthorization({ id: 'auth_1' }), null)
+  assert.equal(normalizeAuthorization({ summary: '执行命令' }), null)
+  assert.equal(resolveAuthorization({
+    id: 'auth_1',
+    summary: '执行命令',
+  }, AuthorizationStatus.PENDING), null)
+})

--- a/server/test/task-manager.test.mjs
+++ b/server/test/task-manager.test.mjs
@@ -94,7 +94,11 @@ test('publishes a bounded pending permission on the active work', async () => {
     },
   })
   await new Promise(resolve => setImmediate(resolve))
-  assert.equal(manager.get(task.id).authorization.id, 'auth_one')
+  const pending = manager.get(task.id)
+  assert.equal(pending.authorization.id, 'auth_one')
+  assert.equal(pending.authorization.workId, task.id)
+  assert.equal(pending.workState, 'auth_required')
+  assert.equal(Number.isFinite(pending.authorization.createdAt), true)
   assert.equal(
     events.some(event => event.type === 'task.permission.requested'),
     true,
@@ -168,7 +172,7 @@ test('keeps delegated work active while releasing its coordinator lane', async (
 
   const delegated = manager.get(task.id)
   assert.equal(delegated.status, 'delegated')
-  assert.equal(delegated.workState, 'active')
+  assert.equal(delegated.workState, 'working')
   assert.equal(delegated.delegation.status, 'running')
   assert.equal(delegated.delegation.title, '已有项目')
   assert.equal(
@@ -419,7 +423,7 @@ test('listing tasks does not rewrite unchanged persistent state', async () => {
   assert.equal(saves, before)
 })
 
-test('publishes only presentation metadata from a completed result', async () => {
+test('publishes presentation and standard artifacts from a completed result', async () => {
   const events = []
   const manager = new TaskManager()
   manager.subscribe(event => events.push(event))
@@ -451,20 +455,23 @@ test('publishes only presentation metadata from a completed result', async () =>
   })
 
   const completed = await manager.wait(task.id)
-  assert.deepEqual(completed.resultMetadata, {
-    presentation: {
-      speech: '报告已经生成。',
-      inline: {
-        title: '报告',
-        format: 'markdown',
-        content: '# 完成',
-      },
+  assert.deepEqual(completed.presentation, {
+    speech: '报告已经生成。',
+    inline: {
+      title: '报告',
+      format: 'markdown',
+      content: '# 完成',
     },
   })
+  assert.deepEqual(completed.artifacts, [{
+    artifactId: 'artifact_inline',
+    name: '报告',
+    parts: [{ text: '# 完成', mediaType: 'text/markdown' }],
+  }])
   assert.deepEqual(
     events.find(event => event.type === 'task.completed')
-      ?.task.resultMetadata,
-    completed.resultMetadata,
+      ?.task.artifacts,
+    completed.artifacts,
   )
 })
 
@@ -501,16 +508,16 @@ test('projects legacy decision presentation when restoring a task', () => {
   })
 
   const restored = manager.get('legacy-work')
-  assert.deepEqual(restored.resultMetadata, {
-    presentation: {
-      speech: '旧任务已经完成。',
-      inline: {
-        title: '旧结果',
-        format: 'code',
-        content: 'const done = true',
-      },
+  assert.deepEqual(restored.presentation, {
+    speech: '旧任务已经完成。',
+    inline: {
+      title: '旧结果',
+      format: 'code',
+      content: 'const done = true',
     },
   })
   manager.persist()
-  assert.deepEqual(saved[0].resultMetadata, restored.resultMetadata)
+  assert.deepEqual(saved[0].presentation, restored.presentation)
+  assert.deepEqual(saved[0].artifacts, restored.artifacts)
+  assert.equal('resultMetadata' in saved[0], false)
 })

--- a/server/test/task-state.test.mjs
+++ b/server/test/task-state.test.mjs
@@ -51,7 +51,7 @@ test('accepts valid transitions and rejects backwards or terminal transitions', 
   )
 })
 
-test('projects an active task without leaking private result metadata', () => {
+test('projects an active task into presentation and standard artifacts', () => {
   const projected = publicTask({
     id: 'work-one',
     jobId: 'job_1',
@@ -73,13 +73,35 @@ test('projects an active task without leaking private result metadata', () => {
     notificationStatus: 'none',
   }, { now: 100 })
 
-  assert.equal(projected.workState, 'active')
+  assert.equal(projected.workState, 'working')
   assert.equal(projected.elapsedMs, 60)
-  assert.deepEqual(projected.resultMetadata, {
-    presentation: {
-      speech: '报告已完成。',
-      inline: { title: '报告', format: 'markdown', content: '# 完成' },
+  assert.deepEqual(projected.presentation, {
+    speech: '报告已完成。',
+    inline: { title: '报告', format: 'markdown', content: '# 完成' },
+  })
+  assert.deepEqual(projected.artifacts, [{
+    artifactId: 'artifact_inline',
+    name: '报告',
+    parts: [{ text: '# 完成', mediaType: 'text/markdown' }],
+  }])
+  assert.equal('resultMetadata' in projected, false)
+})
+
+test('projects pending authorization as the public auth_required state', () => {
+  const projected = publicTask({
+    id: 'work-auth',
+    jobId: 'job_2',
+    status: TaskStatus.RUNNING,
+    objective: '执行命令',
+    createdAt: 1,
+    activity: [],
+    authorization: {
+      id: 'auth_1',
+      status: 'pending',
+      summary: '执行 npm test',
+      createdAt: 2,
     },
   })
-  assert.equal('backendRef' in projected.resultMetadata, false)
+  assert.equal(projected.workState, 'auth_required')
+  assert.equal(projected.authorization.workId, 'work-auth')
 })

--- a/shared/protocol/gateway-events.mjs
+++ b/shared/protocol/gateway-events.mjs
@@ -15,11 +15,68 @@ export const GatewayEventEnvelopeSchema = z.object({
   type: z.string().min(1),
 }).passthrough()
 
+export const GatewayArtifactPartSchema = z.union([
+  z.object({
+    text: z.string(),
+    mediaType: z.string().min(1),
+    filename: z.string().optional(),
+  }),
+  z.object({
+    raw: z.string().min(1),
+    mediaType: z.string().min(1),
+    filename: z.string().optional(),
+  }),
+  z.object({
+    url: z.string().min(1),
+    mediaType: z.string().min(1),
+    filename: z.string().optional(),
+  }),
+  z.object({
+    data: z.unknown(),
+    mediaType: z.string().min(1),
+    filename: z.string().optional(),
+  }),
+])
+
+export const GatewayArtifactSchema = z.object({
+  artifactId: z.string().min(1),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  parts: z.array(GatewayArtifactPartSchema).min(1),
+})
+
+export const GatewayPresentationSchema = z.object({
+  speech: z.string(),
+  inline: z.object({
+    title: z.string(),
+    format: z.enum(['markdown', 'code', 'link']),
+    content: z.string(),
+  }).nullable(),
+})
+
+export const GatewayAuthorizationSchema = z.object({
+  id: z.string().min(1),
+  workId: z.string().nullable(),
+  status: z.enum(['pending', 'approved', 'denied', 'cancelled']),
+  category: z.string().min(1),
+  summary: z.string().min(1),
+  patterns: z.array(z.string()),
+  createdAt: z.number(),
+  resolvedAt: z.number().nullable(),
+})
+
 export const GatewayTaskSchema = z.object({
   id: z.string().min(1),
   workId: z.string().min(1),
   jobId: z.string().min(1),
-  workState: z.string().min(1),
+  workState: z.enum([
+    'submitted',
+    'working',
+    'auth_required',
+    'completed',
+    'failed',
+    'cancelled',
+  ]),
   status: z.string().min(1),
   kind: z.string().min(1),
   parentWorkId: z.string().nullable().optional(),
@@ -33,10 +90,11 @@ export const GatewayTaskSchema = z.object({
   elapsedMs: z.number(),
   result: z.string().nullable().optional(),
   error: z.string().nullable().optional(),
-  resultMetadata: z.unknown().optional(),
+  artifacts: z.array(GatewayArtifactSchema).optional(),
+  presentation: GatewayPresentationSchema.nullable().optional(),
   activity: z.array(z.unknown()).optional(),
   delegation: z.unknown().optional(),
-  authorization: z.unknown().optional(),
+  authorization: GatewayAuthorizationSchema.nullable().optional(),
   notificationStatus: z.string().optional(),
   notificationDeliveredAt: z.number().nullable().optional(),
   schedule: z.unknown().optional(),
@@ -63,7 +121,7 @@ export const GatewayVoiceMessageSchema = GatewayEventEnvelopeSchema.extend({
 export const GatewayTaskEventMessageSchema = GatewayEventEnvelopeSchema.extend({
   type: GatewayTaskEventTypeSchema,
   task: GatewayTaskSchema,
-  permission: z.record(z.string(), z.unknown()).optional(),
+  permission: GatewayAuthorizationSchema.optional(),
   message: z.string().optional(),
 })
 

--- a/test/gateway-event-schema.test.mjs
+++ b/test/gateway-event-schema.test.mjs
@@ -16,7 +16,7 @@ function task(overrides = {}) {
     id: 'work_1',
     workId: 'work_1',
     jobId: 'job_1',
-    workState: 'active',
+    workState: 'working',
     status: 'running',
     kind: 'work',
     objective: 'test work',

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -30,6 +30,7 @@ import {
   removeTaskInPhase,
   taskDeliverySettled,
   taskDetail,
+  taskIsActive,
   taskLabel,
   taskView,
 } from './task-view.js'
@@ -521,7 +522,7 @@ export default function App() {
             })
             serverTasks
               .filter(task => (
-                task.workState === 'active'
+                taskIsActive(task)
                 && !known.has(task.id)
               ))
               .reverse()

--- a/web/src/task-view.js
+++ b/web/src/task-view.js
@@ -12,8 +12,15 @@ export function phaseForTask(task) {
   if (task.status === 'delegated') return 'delegated'
   if (task.status === 'finalizing') return 'finalizing'
   if (task.status === 'cancelling') return 'cancelling'
-  if (task.workState === 'active') return 'running'
+  if (['working', 'auth_required', 'active'].includes(task.workState)) {
+    return 'running'
+  }
   return 'running'
+}
+
+export function taskIsActive(task) {
+  return ['submitted', 'working', 'auth_required', 'active']
+    .includes(task?.workState)
 }
 
 export function removeDeliveredTask(tasks, taskId) {

--- a/web/test/task-view.test.mjs
+++ b/web/test/task-view.test.mjs
@@ -10,6 +10,7 @@ import {
   removeTaskInPhase,
   taskDeliverySettled,
   taskDetail,
+  taskIsActive,
   taskLabel,
   taskView,
 } from '../src/task-view.js'
@@ -17,11 +18,11 @@ import {
 test('presents every active coordinator request as one frontend processing phase', () => {
   assert.equal(phaseForTask({
     status: 'queued',
-    workState: 'active',
+    workState: 'submitted',
   }), 'queued')
   assert.equal(phaseForTask({
     status: 'running',
-    workState: 'active',
+    workState: 'working',
   }), 'running')
   assert.equal(taskLabel({ phase: 'queued' }), '排队中')
   assert.equal(taskLabel({ phase: 'running' }), '进行中')
@@ -30,15 +31,15 @@ test('presents every active coordinator request as one frontend processing phase
   assert.equal(taskLabel({ phase: 'cancelling' }), '正在取消')
   assert.equal(phaseForTask({
     status: 'finalizing',
-    workState: 'active',
+    workState: 'working',
   }), 'finalizing')
   assert.equal(phaseForTask({
     status: 'cancelling',
-    workState: 'active',
+    workState: 'working',
   }), 'cancelling')
   assert.equal(phaseForTask({
     status: 'delegated',
-    workState: 'active',
+    workState: 'working',
   }), 'delegated')
   assert.equal(taskDetail({
     phase: 'delegated',
@@ -58,6 +59,10 @@ test('presents every active coordinator request as one frontend processing phase
   }), 'cancelled')
   assert.equal(taskLabel({ phase: 'cancelled' }), '已取消')
   assert.equal(taskDetail({ phase: 'cancelled' }), '这项工作已停止')
+  assert.equal(taskIsActive({ workState: 'submitted' }), true)
+  assert.equal(taskIsActive({ workState: 'working' }), true)
+  assert.equal(taskIsActive({ workState: 'auth_required' }), true)
+  assert.equal(taskIsActive({ workState: 'completed' }), false)
 })
 
 test('separates backend completion from realtime result delivery', () => {


### PR DESCRIPTION
Roadmap: #185

## Summary
- add A2A-aligned MIME-typed Work artifacts and a protocol-neutral authorization value model
- expose typed artifact, presentation, authorization, and work-state fields across native Gateway Task events
- migrate persisted legacy presentation metadata while preserving restart and delivery behavior
- bump the Gateway contract to 3.0.0 and document the new capability in English and Chinese

## Verification
- `AGENT_PROTOCOL=none npm test`
- `npm run lint`
- `git diff --check`