### PR TITLE
refactor: define backend port contract

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -115,6 +115,11 @@ with A2A Task semantics: `submitted`, `working`, `auth_required`, `completed`,
 Backends implement `describe`, `start`, `health`, `submit`, `status`, `cancel`,
 `respondAuthorization`, `subscribe`, and `close`. ACP sessions, coordinator
 prompts, coordinator MCP, and native delegation stay inside the ACP adapter.
+Every adapter implements the complete method surface and is checked at the
+composition boundary. Optional capabilities are declared by `describe()` and
+rejected explicitly, never inferred from a missing function. `submit`,
+`status`, `cancel`, and `respondAuthorization` operate on Gateway Work IDs;
+backend-private session and task identifiers never cross the port.
 
 ### Artifact and Presentation
 
@@ -201,7 +206,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 
 ### R4 — Backend Runtime
 
-- [ ] Define and validate BackendPort.
+- [x] Define and validate BackendPort.
 - [ ] Reduce AgentClient to the single-backend runtime.
 - [ ] Implement BackendPort in the ACP adapter.
 - [ ] Move coordinator and session tools into the ACP boundary.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -152,6 +152,9 @@ submitted → working → completed
 ```
 
 ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter 内部。
+每个 Adapter 必须实现完整方法面，并在组合边界接受校验。可选能力由 `describe()` 声明，
+不支持时必须明确拒绝，不能依赖“缺少某个函数”来推断。`submit`、`status`、`cancel` 与
+`respondAuthorization` 只操作 Gateway Work ID，后台私有 Session 与任务 ID 不越过端口。
 
 ### 4.5 Artifact 与 Presentation
 
@@ -250,7 +253,7 @@ Presentation 只携带供前台表达的事实材料和投递策略，不携带�
 
 ### R4：Backend Runtime
 
-- [ ] 定义并校验 BackendPort。
+- [x] 定义并校验 BackendPort。
 - [ ] 将 AgentClient 收敛为 Single Backend Runtime。
 - [ ] 让 ACP Adapter 实现 BackendPort。
 - [ ] 将 Coordinator 和 Session 工具下沉到 ACP Adapter。

--- a/server/src/backend/backend-port.mjs
+++ b/server/src/backend/backend-port.mjs
@@ -1,0 +1,56 @@
+/**
+ * Protocol-neutral boundary between the Gateway and one configured backend.
+ *
+ * Every adapter exposes the complete method surface. Optional behavior is
+ * advertised by describe() and rejected explicitly by the adapter; callers
+ * never infer support from a missing method.
+ *
+ * Method contract:
+ *   describe() -> stable identity and capabilities
+ *   start(context?) -> idempotently make the backend ready
+ *   health() -> current backend availability
+ *   submit(work, context?) -> run one Work and return its final outcome
+ *   status(workId, context?) -> current adapter-owned Work status
+ *   cancel(workId, context?) -> cancel one adapter-owned Work
+ *   respondAuthorization(workId, authorizationId, decision, context?)
+ *   subscribe(listener) -> unsubscribe function for backend Work events
+ *   close() -> idempotently release adapter-owned resources
+ */
+export const BACKEND_PORT_METHODS = Object.freeze([
+  'describe',
+  'start',
+  'health',
+  'submit',
+  'status',
+  'cancel',
+  'respondAuthorization',
+  'subscribe',
+  'close',
+])
+
+export class BackendPortContractError extends TypeError {
+  constructor(message, { missing = [] } = {}) {
+    super(message)
+    this.name = 'BackendPortContractError'
+    this.code = 'INVALID_BACKEND_PORT'
+    this.missing = [...missing]
+  }
+}
+
+export function assertBackendPort(value, { name = 'BackendPort' } = {}) {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+    throw new BackendPortContractError(`${name} must be an object`, {
+      missing: BACKEND_PORT_METHODS,
+    })
+  }
+  const missing = BACKEND_PORT_METHODS.filter(
+    method => typeof value[method] !== 'function',
+  )
+  if (missing.length) {
+    throw new BackendPortContractError(
+      `${name} is missing required methods: ${missing.join(', ')}`,
+      { missing },
+    )
+  }
+  return value
+}

--- a/server/test/backend-port.test.mjs
+++ b/server/test/backend-port.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  assertBackendPort,
+  BACKEND_PORT_METHODS,
+  BackendPortContractError,
+} from '../src/backend/backend-port.mjs'
+
+function completePort() {
+  return Object.fromEntries(BACKEND_PORT_METHODS.map(method => [
+    method,
+    () => {},
+  ]))
+}
+
+test('defines the complete protocol-neutral backend boundary', () => {
+  assert.deepEqual(BACKEND_PORT_METHODS, [
+    'describe',
+    'start',
+    'health',
+    'submit',
+    'status',
+    'cancel',
+    'respondAuthorization',
+    'subscribe',
+    'close',
+  ])
+  assert.equal(Object.isFrozen(BACKEND_PORT_METHODS), true)
+  const port = completePort()
+  assert.equal(assertBackendPort(port), port)
+})
+
+test('rejects missing methods as one actionable contract error', () => {
+  const port = completePort()
+  delete port.submit
+  delete port.respondAuthorization
+
+  assert.throws(
+    () => assertBackendPort(port, { name: 'Test adapter' }),
+    error => {
+      assert.equal(error instanceof BackendPortContractError, true)
+      assert.equal(error.code, 'INVALID_BACKEND_PORT')
+      assert.deepEqual(error.missing, ['submit', 'respondAuthorization'])
+      assert.match(error.message, /Test adapter/)
+      return true
+    },
+  )
+})
+
+test('does not accept non-callable method placeholders', () => {
+  const port = completePort()
+  port.subscribe = true
+  assert.throws(
+    () => assertBackendPort(port),
+    error => error.missing.length === 1 && error.missing[0] === 'subscribe',
+  )
+})

--- a/server/test/dependency-boundaries.test.mjs
+++ b/server/test/dependency-boundaries.test.mjs
@@ -11,6 +11,7 @@ const allowedDependencies = {
   app: new Set([
     'agent',
     'app',
+    'backend',
     'conversation',
     'core',
     'task',
@@ -19,7 +20,8 @@ const allowedDependencies = {
   ]),
   process: new Set(['process', 'shared']),
   core: new Set(['core', 'shared']),
-  agent: new Set(['agent', 'core', 'shared']),
+  agent: new Set(['agent', 'backend', 'core', 'shared']),
+  backend: new Set(['backend', 'core', 'shared']),
   conversation: new Set(['conversation', 'core', 'shared']),
   task: new Set(['agent', 'core', 'task']),
   transport: new Set(['shared', 'task', 'transport']),


### PR DESCRIPTION
Roadmap: #185

## Summary
- define the protocol-neutral nine-method BackendPort contract
- validate complete adapter implementations with actionable contract errors
- enforce the new backend layer in dependency-boundary tests
- document method responsibilities and private-identifier boundaries in English and Chinese

## Verification
- `AGENT_PROTOCOL=none npm test`
- `npm run lint`
- `git diff --check`