### PR TITLE
refactor: isolate single backend runtime

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -120,6 +120,9 @@ composition boundary. Optional capabilities are declared by `describe()` and
 rejected explicitly, never inferred from a missing function. `submit`,
 `status`, `cancel`, and `respondAuthorization` operate on Gateway Work IDs;
 backend-private session and task identifiers never cross the port.
+AgentClient owns exactly one injected backend instance. Driver selection,
+profile construction, and protocol-specific dependencies belong to the adapter
+factory rather than the runtime facade.
 
 ### Artifact and Presentation
 
@@ -207,7 +210,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 ### R4 — Backend Runtime
 
 - [x] Define and validate BackendPort.
-- [ ] Reduce AgentClient to the single-backend runtime.
+- [x] Reduce AgentClient to the single-backend runtime.
 - [ ] Implement BackendPort in the ACP adapter.
 - [ ] Move coordinator and session tools into the ACP boundary.
 - [ ] Add a reusable backend-adapter conformance suite.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -155,6 +155,8 @@ ACP Session、协调 Prompt、协调 MCP 和原生委托全部属于 ACP Adapter
 每个 Adapter 必须实现完整方法面，并在组合边界接受校验。可选能力由 `describe()` 声明，
 不支持时必须明确拒绝，不能依赖“缺少某个函数”来推断。`submit`、`status`、`cancel` 与
 `respondAuthorization` 只操作 Gateway Work ID，后台私有 Session 与任务 ID 不越过端口。
+AgentClient 只持有一个注入的后台实例。驱动选择、Profile 构造和协议专属依赖属于
+Adapter Factory，不再由运行时门面承担。
 
 ### 4.5 Artifact 与 Presentation
 
@@ -254,7 +256,7 @@ Presentation 只携带供前台表达的事实材料和投递策略，不携带�
 ### R4：Backend Runtime
 
 - [x] 定义并校验 BackendPort。
-- [ ] 将 AgentClient 收敛为 Single Backend Runtime。
+- [x] 将 AgentClient 收敛为 Single Backend Runtime。
 - [ ] 让 ACP Adapter 实现 BackendPort。
 - [ ] 将 Coordinator 和 Session 工具下沉到 ACP Adapter。
 - [ ] 为 Backend Adapter 建立 conformance test suite。

--- a/server/src/agent/acp-backend-factory.mjs
+++ b/server/src/agent/acp-backend-factory.mjs
@@ -1,0 +1,58 @@
+import { config } from '../core/config.mjs'
+import { AcpBackendAdapter } from './acp-backend-adapter.mjs'
+import {
+  backendDriver,
+  createBackendProfile,
+} from './backends/registry.mjs'
+
+/**
+ * ACP composition belongs to the ACP boundary, not AgentClient. This factory
+ * selects one configured driver and returns one concrete adapter instance.
+ */
+export function createAcpBackendAdapter({
+  protocol = config.agentProtocol,
+  ownership = config.backendOwnership,
+  permissionMode = config.backendPermissionMode,
+  model,
+  coordinatorAgent,
+  timeoutMs = config.agentTimeoutMs,
+  backends = {},
+  sessionStatePath = config.backendSessionStatePath,
+  acpClient,
+  acpClientFactory,
+  sessionToolServer,
+} = {}) {
+  const driver = backendDriver(protocol)
+  const backend = {
+    ...(config.backends?.[driver.id] || {}),
+    ...(backends?.[driver.id] || {}),
+  }
+  const options = {
+    baseUrl: '',
+    ...backend,
+    model: model ?? backend.model,
+    coordinatorAgent: coordinatorAgent ?? backend.coordinatorAgent,
+  }
+  const profile = createBackendProfile(protocol, {
+    protocol,
+    root: config.root,
+    ownership,
+    permissionMode,
+    ...options,
+  })
+  return new AcpBackendAdapter({
+    protocol,
+    root: config.root,
+    ownership,
+    permissionMode,
+    timeoutMs,
+    ...options,
+    profile,
+    nativeDelegationAdapter:
+      driver.createNativeDelegationAdapter?.(options) || null,
+    sessionStatePath,
+    ...(acpClient ? { client: acpClient } : {}),
+    ...(acpClientFactory ? { clientFactory: acpClientFactory } : {}),
+    ...(sessionToolServer ? { sessionToolServer } : {}),
+  })
+}

--- a/server/src/agent/agent-client.mjs
+++ b/server/src/agent/agent-client.mjs
@@ -1,63 +1,15 @@
 import { config } from '../core/config.mjs'
 import { AgentError } from './backend-adapter.mjs'
-import { AcpBackendAdapter } from './acp-backend-adapter.mjs'
-import {
-  backendDriver,
-  createBackendProfile,
-} from './backends/registry.mjs'
+import { createAcpBackendAdapter } from './acp-backend-factory.mjs'
 
 export { AgentError }
 
 export class AgentClient {
-  constructor({
-    protocol = config.agentProtocol,
-    ownership = config.backendOwnership,
-    permissionMode = config.backendPermissionMode,
-    model,
-    coordinatorAgent,
-    timeoutMs = config.agentTimeoutMs,
-    backends = {},
-    sessionStatePath = config.backendSessionStatePath,
-    acpClient,
-    acpClientFactory,
-    sessionToolServer,
-  } = {}) {
-    const driver = backendDriver(protocol)
-    // The selected backend's option namespace (config defaults merged with
-    // per-construction overrides) plus the two cross-cutting overrides. New
-    // backends only need a config.backends entry; nothing to thread here.
-    const backend = {
-      ...(config.backends?.[driver.id] || {}),
-      ...(backends?.[driver.id] || {}),
+  constructor({ adapter } = {}) {
+    if (!adapter || typeof adapter !== 'object') {
+      throw new TypeError('AgentClient requires one backend adapter')
     }
-    const options = {
-      baseUrl: '',
-      ...backend,
-      model: model ?? backend.model,
-      coordinatorAgent: coordinatorAgent ?? backend.coordinatorAgent,
-    }
-    const profile = createBackendProfile(protocol, {
-      protocol,
-      root: config.root,
-      ownership,
-      permissionMode,
-      ...options,
-    })
-    this.adapter = new AcpBackendAdapter({
-      protocol,
-      root: config.root,
-      ownership,
-      permissionMode,
-      timeoutMs,
-      ...options,
-      profile,
-      nativeDelegationAdapter:
-        driver.createNativeDelegationAdapter?.(options) || null,
-      sessionStatePath,
-      ...(acpClient ? { client: acpClient } : {}),
-      ...(acpClientFactory ? { clientFactory: acpClientFactory } : {}),
-      ...(sessionToolServer ? { sessionToolServer } : {}),
-    })
+    this.adapter = adapter
   }
 
   get protocol() {
@@ -141,6 +93,12 @@ export class AgentClient {
   }
 }
 
+export function createAgentClient(options = {}) {
+  return new AgentClient({
+    adapter: createAcpBackendAdapter(options),
+  })
+}
+
 let sharedAgent = null
 
 function requireAgent() {
@@ -150,7 +108,7 @@ function requireAgent() {
         protocol: '',
       })
     }
-    sharedAgent = new AgentClient()
+    sharedAgent = createAgentClient()
   }
   return sharedAgent
 }

--- a/server/test/agent-client-selection.test.mjs
+++ b/server/test/agent-client-selection.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { AgentClient } from '../src/agent/agent-client.mjs'
+import {
+  AgentClient,
+  createAgentClient,
+} from '../src/agent/agent-client.mjs'
 
 function fakeAcpClient() {
   return {
@@ -41,7 +44,7 @@ function fakeToolServer() {
 }
 
 test('selects one shared ACP adapter for OpenCode', () => {
-  const client = new AgentClient({
+  const client = createAgentClient({
     protocol: 'opencode',
     backends: {
       opencode: {
@@ -61,7 +64,7 @@ test('selects one shared ACP adapter for OpenCode', () => {
 })
 
 test('opens the active OpenCode ACP coordinator Session directly', async () => {
-  const client = new AgentClient({
+  const client = createAgentClient({
     protocol: 'opencode',
     model: '',
     backends: {
@@ -97,7 +100,7 @@ for (const protocol of [
   'acp',
 ]) {
   test(`selects ${protocol} through the same ACP adapter`, () => {
-    const client = new AgentClient({
+    const client = createAgentClient({
       protocol,
       backends: {
         openclaw: {
@@ -131,7 +134,7 @@ for (const protocol of [
 }
 
 test('does not leak opencode coordinatorAgent to drivers without a coordinatorAgent', () => {
-  const client = new AgentClient({
+  const client = createAgentClient({
     protocol: 'qoder',
     backends: {
       opencode: { coordinatorAgent: 'opencode-coordinator' },
@@ -145,7 +148,7 @@ test('does not leak opencode coordinatorAgent to drivers without a coordinatorAg
 })
 
 test('handles null backends option gracefully', () => {
-  const client = new AgentClient({
+  const client = createAgentClient({
     protocol: 'opencode',
     backends: null,
     sessionStatePath: null,
@@ -153,4 +156,20 @@ test('handles null backends option gracefully', () => {
     sessionToolServer: fakeToolServer(),
   })
   assert.equal(client.protocol, 'opencode')
+})
+
+test('AgentClient owns exactly one injected backend instance', () => {
+  const adapter = {
+    protocol: 'test',
+    label: 'Test',
+    describe: () => ({ protocol: 'test' }),
+  }
+  const client = new AgentClient({ adapter })
+  assert.equal(client.adapter, adapter)
+  assert.equal(client.protocol, 'test')
+  assert.deepEqual(client.describe(), { protocol: 'test' })
+  assert.throws(
+    () => new AgentClient(),
+    /requires one backend adapter/,
+  )
 })


### PR DESCRIPTION
Roadmap: #185

## Summary
- reduce AgentClient to a facade over exactly one injected backend instance
- move ACP driver selection, profile construction, and adapter dependencies into an ACP factory
- preserve all named backend selection and coordinator behavior
- document the single-backend runtime boundary in English and Chinese

## Verification
- `AGENT_PROTOCOL=none npm test`
- `npm run lint`
- `git diff --check`