### PR TITLE
refactor: implement BackendPort in ACP adapter

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -211,7 +211,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 
 - [x] Define and validate BackendPort.
 - [x] Reduce AgentClient to the single-backend runtime.
-- [ ] Implement BackendPort in the ACP adapter.
+- [x] Implement BackendPort in the ACP adapter.
 - [ ] Move coordinator and session tools into the ACP boundary.
 - [ ] Add a reusable backend-adapter conformance suite.
 

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -257,7 +257,7 @@ Presentation 只携带供前台表达的事实材料和投递策略，不携带�
 
 - [x] 定义并校验 BackendPort。
 - [x] 将 AgentClient 收敛为 Single Backend Runtime。
-- [ ] 让 ACP Adapter 实现 BackendPort。
+- [x] 让 ACP Adapter 实现 BackendPort。
 - [ ] 将 Coordinator 和 Session 工具下沉到 ACP Adapter。
 - [ ] 为 Backend Adapter 建立 conformance test suite。
 

--- a/server/src/agent/acp-backend-adapter.mjs
+++ b/server/src/agent/acp-backend-adapter.mjs
@@ -218,6 +218,7 @@ export class AcpBackendAdapter {
     // Track every request that reaches the persistent coordinator Session,
     // whether it stays there or delegates to a project Session.
     this.coordinationRuns = new Map()
+    this.workEventListeners = new Set()
     this.runtimeState = new BackendRuntimeState({
       protocol: this.protocol,
       ownership: this.ownership,
@@ -294,8 +295,29 @@ export class AcpBackendAdapter {
     }
   }
 
-  status() {
+  runtimeStatus() {
     return this.runtimeState.status({ clientReady: this.client.ready })
+  }
+
+  status(workId, { ownerId } = {}) {
+    const id = clean(workId)
+    if (!id) return this.runtimeStatus()
+    const run = this.coordinationRuns.get(id)
+    if (!run || (ownerId !== undefined && run.ownerId !== clean(ownerId))) {
+      return { workId: id, state: 'not_found', activity: [] }
+    }
+    const delegation = run.delegation
+    if (!delegation) {
+      return { workId: id, state: 'working', activity: [] }
+    }
+    const current = this.statusForDelegation({ delegation_id: delegation.id })
+    return {
+      workId: id,
+      state: current.status === 'running' ? 'working' : current.status,
+      activity: current.recent_updates || [],
+      ...(current.result ? { result: current.result } : {}),
+      ...(current.error ? { error: current.error } : {}),
+    }
   }
 
   markRuntimeReady(initialized) {
@@ -306,11 +328,34 @@ export class AcpBackendAdapter {
     this.runtimeState.failed(error)
   }
 
+  async start({ signal } = {}) {
+    // Injected ACP clients used by embedders may already be ready and expose
+    // only Session operations. The adapter itself still satisfies BackendPort.
+    if (typeof this.client.start !== 'function') return this.runtimeStatus()
+    try {
+      await this.waitForBackendReadiness(signal)
+      this.runtimeState.starting()
+      const initialized = await this.client.start()
+      if (this.profile.externalMcp) {
+        assertMcpServerCapabilities({
+          label: this.label,
+          capabilities: initialized?.agentCapabilities,
+          mcpServers: [{ type: 'http' }],
+        })
+      }
+      this.markRuntimeReady(initialized)
+      return this.runtimeStatus()
+    } catch (error) {
+      if (!signal?.aborted) this.markRuntimeFailure(error)
+      throw error
+    }
+  }
+
   async health() {
     if (
       this.runtimeState.shouldBackoff()
     ) {
-      return this.status()
+      return this.runtimeStatus()
     }
     try {
       if (
@@ -320,7 +365,7 @@ export class AcpBackendAdapter {
         && !await this.backendAvailable(this.baseUrl)
       ) {
         this.runtimeState.waiting(this.profile.readinessMessage)
-        return this.status()
+        return this.runtimeStatus()
       }
       this.runtimeState.starting()
       const initialized = await this.client.start()
@@ -332,10 +377,10 @@ export class AcpBackendAdapter {
         })
       }
       this.markRuntimeReady(initialized)
-      return this.status()
+      return this.runtimeStatus()
     } catch (error) {
       this.markRuntimeFailure(error)
-      return this.status()
+      return this.runtimeStatus()
     }
   }
 
@@ -368,6 +413,34 @@ export class AcpBackendAdapter {
 
   serialize(key, operation) {
     return this.sessionExecutor.run(key, operation)
+  }
+
+  publishWorkEvent(event, { workId, ownerId, onEvent } = {}) {
+    try {
+      onEvent?.(event)
+    } catch {
+      // A per-submission observer must not break backend execution.
+    }
+    const published = {
+      ...event,
+      workId: clean(workId) || null,
+      ownerId: clean(ownerId) || null,
+    }
+    for (const listener of this.workEventListeners) {
+      try {
+        listener(published)
+      } catch {
+        // Subscribers are isolated from the adapter and from each other.
+      }
+    }
+  }
+
+  subscribe(listener) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('BackendPort subscriber must be a function')
+    }
+    this.workEventListeners.add(listener)
+    return () => this.workEventListeners.delete(listener)
   }
 
   async ensureCoordinatorSession(ownerId, mcpServers = []) {
@@ -1275,6 +1348,31 @@ export class AcpBackendAdapter {
     }
   }
 
+  async submit(work, { signal, onEvent } = {}) {
+    const workId = clean(work?.id || work?.workId)
+    const ownerId = clean(work?.ownerId)
+    const message = work?.message ?? work?.objective
+    if (!workId || !ownerId || !message) {
+      throw new AgentError('BackendPort submit requires work id, owner and input', {
+        status: 400,
+        protocol: this.protocol,
+      })
+    }
+    const result = await this.runCoordinator(message, {
+      ownerId,
+      coordinationRunId: workId,
+      coordinationRequestId: clean(work?.jobId) || workId,
+      signal,
+      onEvent,
+    })
+    const presentation = coordinatorPresentation(result.content)
+    return {
+      content: presentation?.speech || clean(result.content),
+      artifacts: [],
+      presentation,
+    }
+  }
+
   async runCoordinator(message, {
     ownerId,
     coordinationRunId,
@@ -1282,22 +1380,17 @@ export class AcpBackendAdapter {
     signal,
     onEvent,
   } = {}) {
-    if (typeof this.client.start === 'function') {
-      try {
-        // Health polling and task dispatch share the ACP client's start
-        // promise. The execution path additionally waits for an owned service
-        // endpoint, so the first task after a cold start cannot race its bridge.
-        await this.waitForBackendReadiness(signal)
-        this.runtimeState.starting()
-        this.markRuntimeReady(await this.client.start())
-      } catch (error) {
-        if (signal?.aborted) throw error
-        this.markRuntimeFailure(error)
-        throw error
-      }
-    }
+    // Health polling and task dispatch share the ACP client's start promise.
+    // The execution path additionally waits for an owned service endpoint, so
+    // the first task after a cold start cannot race its bridge.
+    await this.start({ signal })
     const runId = clean(coordinationRunId)
     const key = coordinatorKey(ownerId, this.protocol)
+    const publish = event => this.publishWorkEvent(event, {
+      workId: runId,
+      ownerId,
+      onEvent,
+    })
     try {
       const initial = await this.serialize(
         `coordinator:${key}`,
@@ -1306,12 +1399,12 @@ export class AcpBackendAdapter {
           coordinationRunId,
           coordinationRequestId,
           signal,
-          onEvent,
+          onEvent: publish,
         }),
       )
       if (!initial.run.delegation) return this.resultEnvelope(initial)
       const delegation = initial.run.delegation
-      onEvent?.({
+      publish({
         type: 'backend.delegated',
         delegation: {
           id: delegation.id,
@@ -1322,7 +1415,7 @@ export class AcpBackendAdapter {
         },
       })
       const target = await delegation.promise
-      onEvent?.({
+      publish({
         type: 'backend.delegation.completed',
         delegation: {
           id: target.id,
@@ -1343,7 +1436,7 @@ export class AcpBackendAdapter {
             coordinationRunId,
             coordinationRequestId,
             signal,
-            onEvent,
+            onEvent: publish,
           },
         ),
       )
@@ -1372,13 +1465,18 @@ export class AcpBackendAdapter {
     }
     const ownerId = clean(task.ownerId)
     const coordinationRunId = clean(task.id)
+    const publish = event => this.publishWorkEvent(event, {
+      workId: coordinationRunId,
+      ownerId,
+      onEvent,
+    })
     const key = coordinatorKey(ownerId, this.protocol)
     const session = await this.ensureCoordinatorSession(ownerId)
     const run = {
       ownerId,
       coordinationRunId,
       coordinationRequestId: clean(task.jobId) || coordinationRunId,
-      onEvent,
+      onEvent: publish,
       sessionId: session.sessionId,
       nativeToolCalls: new Map(),
       toolCalls: new Map(),
@@ -1400,7 +1498,7 @@ export class AcpBackendAdapter {
         signal.reason || new Error('用户已取消这项项目任务'),
       )
     }, { once: true })
-    onEvent?.({
+    publish({
       type: 'backend.delegated',
       delegation: {
         id: delegation.id,
@@ -1412,7 +1510,7 @@ export class AcpBackendAdapter {
     })
     try {
       const target = await delegation.promise
-      onEvent?.({
+      publish({
         type: 'backend.delegation.completed',
         delegation: {
           id: target.id,
@@ -1433,7 +1531,7 @@ export class AcpBackendAdapter {
             coordinationRunId,
             coordinationRequestId: clean(task.jobId) || coordinationRunId,
             signal,
-            onEvent,
+            onEvent: publish,
           },
         ),
       )
@@ -1484,6 +1582,27 @@ export class AcpBackendAdapter {
           }
         : {}),
     }
+  }
+
+  async cancel(workId, options = {}) {
+    await this.cancelWork(workId, options)
+    return { workId: clean(workId), state: 'cancelled' }
+  }
+
+  async respondAuthorization(
+    workId,
+    authorizationId,
+    decision,
+    { ownerId } = {},
+  ) {
+    const pending = this.pendingPermissions.get(clean(authorizationId))
+    if (pending && clean(workId) && pending.workId !== clean(workId)) {
+      throw new AgentError('权限请求不属于这项工作', {
+        status: 404,
+        protocol: this.protocol,
+      })
+    }
+    return this.respondPermission(authorizationId, decision, { ownerId })
   }
 
   async queryDelegatedWork(workId, _question, { ownerId } = {}) {
@@ -1561,6 +1680,7 @@ export class AcpBackendAdapter {
       this.client.close(),
     ])
     await this.builtinMcpLifecycle.close()
+    this.workEventListeners.clear()
     this.runtimeState.stopped()
   }
 }

--- a/server/src/agent/acp-backend-factory.mjs
+++ b/server/src/agent/acp-backend-factory.mjs
@@ -1,4 +1,5 @@
 import { config } from '../core/config.mjs'
+import { assertBackendPort } from '../backend/backend-port.mjs'
 import { AcpBackendAdapter } from './acp-backend-adapter.mjs'
 import {
   backendDriver,
@@ -40,7 +41,7 @@ export function createAcpBackendAdapter({
     permissionMode,
     ...options,
   })
-  return new AcpBackendAdapter({
+  const adapter = new AcpBackendAdapter({
     protocol,
     root: config.root,
     ownership,
@@ -54,5 +55,8 @@ export function createAcpBackendAdapter({
     ...(acpClient ? { client: acpClient } : {}),
     ...(acpClientFactory ? { clientFactory: acpClientFactory } : {}),
     ...(sessionToolServer ? { sessionToolServer } : {}),
+  })
+  return assertBackendPort(adapter, {
+    name: `${profile.label || protocol} ACP adapter`,
   })
 }

--- a/server/src/agent/agent-client.mjs
+++ b/server/src/agent/agent-client.mjs
@@ -1,4 +1,5 @@
 import { config } from '../core/config.mjs'
+import { assertBackendPort } from '../backend/backend-port.mjs'
 import { AgentError } from './backend-adapter.mjs'
 import { createAcpBackendAdapter } from './acp-backend-factory.mjs'
 
@@ -6,10 +7,7 @@ export { AgentError }
 
 export class AgentClient {
   constructor({ adapter } = {}) {
-    if (!adapter || typeof adapter !== 'object') {
-      throw new TypeError('AgentClient requires one backend adapter')
-    }
-    this.adapter = adapter
+    this.adapter = assertBackendPort(adapter, { name: 'AgentClient adapter' })
   }
 
   get protocol() {
@@ -32,8 +30,33 @@ export class AgentClient {
     }
   }
 
-  status() {
-    return this.adapter.status()
+  status(workId, options = {}) {
+    return this.adapter.status(workId, options)
+  }
+
+  start(options = {}) {
+    return this.adapter.start(options)
+  }
+
+  submit(work, options = {}) {
+    return this.adapter.submit(work, options)
+  }
+
+  cancel(workId, options = {}) {
+    return this.adapter.cancel(workId, options)
+  }
+
+  respondAuthorization(workId, authorizationId, decision, options = {}) {
+    return this.adapter.respondAuthorization(
+      workId,
+      authorizationId,
+      decision,
+      options,
+    )
+  }
+
+  subscribe(listener) {
+    return this.adapter.subscribe(listener)
   }
 
   runCoordinator(message, options = {}) {
@@ -89,7 +112,7 @@ export class AgentClient {
   }
 
   close() {
-    return this.adapter.close?.() || Promise.resolve()
+    return this.adapter.close()
   }
 }
 

--- a/server/test/acp-backend-port.test.mjs
+++ b/server/test/acp-backend-port.test.mjs
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { AcpBackendAdapter } from '../src/agent/acp-backend-adapter.mjs'
+import { assertBackendPort } from '../src/backend/backend-port.mjs'
+
+function fakeClient({ hold = false } = {}) {
+  const gate = Promise.withResolvers()
+  return {
+    ready: false,
+    gate,
+    async start() {
+      this.ready = true
+      return {
+        agentCapabilities: { sessionCapabilities: { resume: {} } },
+      }
+    },
+    async newSession(options) {
+      return { sessionId: 'coordinator-one', cwd: options.cwd, response: {} }
+    },
+    async resumeSession(sessionId, options) {
+      return { sessionId, cwd: options.cwd, response: {} }
+    },
+    async prompt(_sessionId, _prompt, options = {}) {
+      options.onUpdate?.({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'tool-one',
+        name: 'Read',
+        status: 'in_progress',
+        rawInput: { path: '/project/package.json' },
+      })
+      if (hold) await gate.promise
+      return {
+        content: JSON.stringify({
+          job_id: 'job_1',
+          state: 'completed',
+          mode: 'respond',
+          presentation: { speech: '已经完成。', inline: null },
+        }),
+        response: { stopReason: 'end_turn' },
+      }
+    },
+    async close() {},
+  }
+}
+
+function adapter(options = {}) {
+  return new AcpBackendAdapter({
+    protocol: 'acp',
+    directory: '/project',
+    sessionStatePath: null,
+    builtinMcp: [],
+    profile: {
+      label: 'Test ACP',
+      capabilities: {},
+      acpConnection: { kind: 'process' },
+      externalMcp: false,
+      sessionMcp: false,
+    },
+    ...options,
+  })
+}
+
+test('ACP adapter implements the complete BackendPort surface', () => {
+  const backend = adapter({ client: fakeClient() })
+  assert.equal(assertBackendPort(backend), backend)
+})
+
+test('ACP submit exposes Work values while Session details stay private', async () => {
+  const client = fakeClient({ hold: true })
+  const backend = adapter({ client })
+  const events = []
+  const unsubscribe = backend.subscribe(event => events.push(event))
+
+  const pending = backend.submit({
+    id: 'work-one',
+    jobId: 'job_1',
+    ownerId: 'owner-one',
+    message: '完成请求',
+  })
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.deepEqual(backend.status('work-one', {
+    ownerId: 'owner-one',
+  }), {
+    workId: 'work-one',
+    state: 'working',
+    activity: [],
+  })
+  assert.equal(events[0].type, 'backend.activity')
+  assert.equal(events[0].workId, 'work-one')
+  assert.equal(events[0].ownerId, 'owner-one')
+
+  client.gate.resolve()
+  const outcome = await pending
+  assert.deepEqual(outcome, {
+    content: '已经完成。',
+    artifacts: [],
+    presentation: { speech: '已经完成。', inline: null },
+  })
+  assert.equal('metadata' in outcome, false)
+  assert.equal('sessionId' in outcome, false)
+  assert.equal(backend.status('work-one').state, 'not_found')
+  unsubscribe()
+  await backend.close()
+})
+
+test('ACP authorization decisions remain bound to their Work', async () => {
+  const backend = adapter({ client: fakeClient() })
+  const requested = backend.handlePermission({
+    toolCall: { name: 'write', rawInput: { path: '/project/file' } },
+    options: [
+      { optionId: 'allow', kind: 'allow_once' },
+      { optionId: 'reject', kind: 'reject_once' },
+    ],
+  }, {
+    session: {
+      sessionId: 'coordinator-one',
+      ownerId: 'owner-one',
+      coordinationRunId: 'work-one',
+      permissionScopeId: 'prompt-one',
+    },
+  })
+  const authorizationId = [...backend.pendingPermissions.keys()][0]
+
+  await assert.rejects(
+    backend.respondAuthorization(
+      'work-two',
+      authorizationId,
+      'always',
+      { ownerId: 'owner-one' },
+    ),
+    /不属于这项工作/,
+  )
+  const authorization = await backend.respondAuthorization(
+    'work-one',
+    authorizationId,
+    'always',
+    { ownerId: 'owner-one' },
+  )
+  assert.equal(authorization.workId, 'work-one')
+  assert.equal(authorization.status, 'approved')
+  assert.deepEqual(await requested, {
+    outcome: { outcome: 'selected', optionId: 'allow' },
+  })
+  await backend.close()
+})

--- a/server/test/agent-client-selection.test.mjs
+++ b/server/test/agent-client-selection.test.mjs
@@ -8,7 +8,10 @@ import {
 function fakeAcpClient() {
   return {
     start: async () => ({
-      agentCapabilities: { sessionCapabilities: { resume: {} } },
+      agentCapabilities: {
+        sessionCapabilities: { resume: {} },
+        mcpCapabilities: { http: true },
+      },
     }),
     newSession: async options => ({
       sessionId: 'ses-current',
@@ -163,6 +166,14 @@ test('AgentClient owns exactly one injected backend instance', () => {
     protocol: 'test',
     label: 'Test',
     describe: () => ({ protocol: 'test' }),
+    start: async () => {},
+    health: async () => ({ ok: true }),
+    submit: async () => ({}),
+    status: () => ({ ok: true }),
+    cancel: async () => ({}),
+    respondAuthorization: async () => ({}),
+    subscribe: () => () => {},
+    close: async () => {},
   }
   const client = new AgentClient({ adapter })
   assert.equal(client.adapter, adapter)
@@ -170,6 +181,6 @@ test('AgentClient owns exactly one injected backend instance', () => {
   assert.deepEqual(client.describe(), { protocol: 'test' })
   assert.throws(
     () => new AgentClient(),
-    /requires one backend adapter/,
+    /AgentClient adapter must be an object/,
   )
 })


### PR DESCRIPTION
Roadmap: #185

## Summary
- implement the protocol-neutral BackendPort surface in the ACP adapter
- validate adapters at construction and AgentClient injection boundaries
- expose Work-scoped status, cancellation, authorization, and event subscription without leaking ACP Session details
- mark the ACP BackendPort roadmap item complete

## Verification
- `npm run lint`
- `AGENT_PROTOCOL=none npm test`
- focused BackendPort and ACP adapter tests (76 passed)