### PR TITLE
test: add backend adapter conformance suite

### DIFF
--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -213,7 +213,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 - [x] Reduce AgentClient to the single-backend runtime.
 - [x] Implement BackendPort in the ACP adapter.
 - [x] Move coordinator and session tools into the ACP boundary.
-- [ ] Add a reusable backend-adapter conformance suite.
+- [x] Add a reusable backend-adapter conformance suite.
 
 ### R5 — Complete the frontend
 

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -259,7 +259,7 @@ Presentation 只携带供前台表达的事实材料和投递策略，不携带�
 - [x] 将 AgentClient 收敛为 Single Backend Runtime。
 - [x] 让 ACP Adapter 实现 BackendPort。
 - [x] 将 Coordinator 和 Session 工具下沉到 ACP Adapter。
-- [ ] 为 Backend Adapter 建立 conformance test suite。
+- [x] 为 Backend Adapter 建立 conformance test suite。
 
 完成条件：新增非 ACP Adapter 不修改 Frontend、Work 或客户端代码。
 

--- a/server/src/agent/acp-backend-adapter.mjs
+++ b/server/src/agent/acp-backend-adapter.mjs
@@ -225,6 +225,7 @@ export class AcpBackendAdapter {
     // Track every request that reaches the persistent coordinator Session,
     // whether it stays there or delegates to a project Session.
     this.coordinationRuns = new Map()
+    this.workControllers = new Map()
     this.workEventListeners = new Set()
     this.runtimeState = new BackendRuntimeState({
       protocol: this.protocol,
@@ -1366,47 +1367,64 @@ export class AcpBackendAdapter {
         protocol: this.protocol,
       })
     }
-    const prompt = buildAcpCoordinatorPrompt({
-      ...work,
-      objective,
-      workId,
-      jobId,
-      includeStableInstructions: !this.coordinatorUsesMcpInstructions(),
-    })
-    const run = message => this.runCoordinator(message, {
-      ownerId,
-      coordinationRunId: workId,
-      coordinationRequestId: jobId,
-      signal,
-      onEvent,
-    })
-    let result = await run(promptWithInputParts(prompt, work?.inputParts))
-    if (!clean(result?.content)) {
-      throw new AgentError('Coordinator backend returned an empty response', {
-        status: 502,
+    if (this.workControllers.has(workId)) {
+      throw new AgentError('BackendPort Work is already active', {
+        status: 409,
         protocol: this.protocol,
       })
     }
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const state = acpCoordinatorResponseState(result.content)
-      if (!state || state === 'completed') break
-      result = await run(acpCoordinatorRetryPrompt(jobId, state))
-    }
-    const finalState = acpCoordinatorResponseState(result.content)
-    if (finalState && finalState !== 'completed') {
-      throw new AgentError(
-        `Coordinator did not return a final result (state=${finalState})`,
-        { status: 502, protocol: this.protocol },
-      )
-    }
-    const presentation = parseAcpCoordinatorDecision(
-      result.content,
-      jobId,
-    ).presentation
-    return {
-      content: presentation.speech,
-      artifacts: [],
-      presentation,
+    const controller = new AbortController()
+    const workSignal = signal
+      ? AbortSignal.any([signal, controller.signal])
+      : controller.signal
+    this.workControllers.set(workId, controller)
+    try {
+      const prompt = buildAcpCoordinatorPrompt({
+        ...work,
+        objective,
+        workId,
+        jobId,
+        includeStableInstructions: !this.coordinatorUsesMcpInstructions(),
+      })
+      const run = message => this.runCoordinator(message, {
+        ownerId,
+        coordinationRunId: workId,
+        coordinationRequestId: jobId,
+        signal: workSignal,
+        onEvent,
+      })
+      let result = await run(promptWithInputParts(prompt, work?.inputParts))
+      if (!clean(result?.content)) {
+        throw new AgentError('Coordinator backend returned an empty response', {
+          status: 502,
+          protocol: this.protocol,
+        })
+      }
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const state = acpCoordinatorResponseState(result.content)
+        if (!state || state === 'completed') break
+        result = await run(acpCoordinatorRetryPrompt(jobId, state))
+      }
+      const finalState = acpCoordinatorResponseState(result.content)
+      if (finalState && finalState !== 'completed') {
+        throw new AgentError(
+          `Coordinator did not return a final result (state=${finalState})`,
+          { status: 502, protocol: this.protocol },
+        )
+      }
+      const presentation = parseAcpCoordinatorDecision(
+        result.content,
+        jobId,
+      ).presentation
+      return {
+        content: presentation.speech,
+        artifacts: [],
+        presentation,
+      }
+    } finally {
+      if (this.workControllers.get(workId) === controller) {
+        this.workControllers.delete(workId)
+      }
     }
   }
 
@@ -1622,8 +1640,17 @@ export class AcpBackendAdapter {
   }
 
   async cancel(workId, options = {}) {
-    await this.cancelWork(workId, options)
-    return { workId: clean(workId), state: 'cancelled' }
+    const id = clean(workId)
+    const controller = this.workControllers.get(id)
+    if (!controller && !this.coordinationRuns.has(id)) {
+      return { workId: id, state: 'not_found' }
+    }
+    await this.cancelWork(id, options)
+    controller?.abort(new AgentError('用户已取消这项工作', {
+      status: 499,
+      protocol: this.protocol,
+    }))
+    return { workId: id, state: 'cancelled' }
   }
 
   async respondAuthorization(
@@ -1698,6 +1725,13 @@ export class AcpBackendAdapter {
   }
 
   async close() {
+    for (const controller of this.workControllers.values()) {
+      controller.abort(new AgentError('后台 Agent 已关闭', {
+        status: 503,
+        protocol: this.protocol,
+      }))
+    }
+    this.workControllers.clear()
     for (const run of this.coordinationRuns.values()) {
       run.delegation?.controller.abort(
         new Error(`${this.label} backend is shutting down`),

--- a/server/test/backend-adapter-conformance.test.mjs
+++ b/server/test/backend-adapter-conformance.test.mjs
@@ -1,0 +1,96 @@
+import test from 'node:test'
+import { AcpBackendAdapter } from '../src/agent/acp-backend-adapter.mjs'
+import {
+  verifyBackendAdapterConformance,
+} from './support/backend-adapter-conformance.mjs'
+
+function work(index) {
+  return {
+    id: `work-${index}`,
+    jobId: `job_${index}`,
+    ownerId: 'owner-one',
+    originalRequest: `完成请求 ${index}`,
+    objective: `完成请求 ${index}`,
+  }
+}
+
+function fakeClient({ hold }) {
+  const started = Promise.withResolvers()
+  return {
+    ready: false,
+    started: started.promise,
+    async start() {
+      this.ready = true
+      return {
+        agentCapabilities: { sessionCapabilities: { resume: {} } },
+      }
+    },
+    async newSession(options) {
+      return { sessionId: 'coordinator-one', cwd: options.cwd, response: {} }
+    },
+    async resumeSession(sessionId, options) {
+      return { sessionId, cwd: options.cwd, response: {} }
+    },
+    async prompt(_sessionId, _prompt, options = {}) {
+      options.onUpdate?.({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'tool-one',
+        name: 'Read',
+        status: 'in_progress',
+        rawInput: { path: '/project/package.json' },
+      })
+      started.resolve()
+      if (hold) {
+        await new Promise((resolve, reject) => {
+          if (options.signal?.aborted) {
+            reject(options.signal.reason)
+            return
+          }
+          options.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal.reason),
+            { once: true },
+          )
+        })
+      }
+      return {
+        content: JSON.stringify({
+          job_id: 'job',
+          state: 'completed',
+          mode: 'respond',
+          presentation: { speech: '已经完成。', inline: null },
+        }),
+        response: { stopReason: 'end_turn' },
+      }
+    },
+    async close() {},
+  }
+}
+
+function createFixture({ hold }) {
+  const client = fakeClient({ hold })
+  return {
+    name: 'ACP',
+    backend: new AcpBackendAdapter({
+      protocol: 'acp',
+      directory: '/project',
+      sessionStatePath: null,
+      builtinMcp: [],
+      client,
+      profile: {
+        label: 'Test ACP',
+        capabilities: {},
+        acpConnection: { kind: 'process' },
+        externalMcp: false,
+        sessionMcp: false,
+      },
+    }),
+    work: work(1),
+    nextWork: work(2),
+    started: client.started,
+  }
+}
+
+test('ACP adapter passes the reusable BackendPort conformance suite', async () => {
+  await verifyBackendAdapterConformance({ createFixture })
+})

--- a/server/test/support/backend-adapter-conformance.mjs
+++ b/server/test/support/backend-adapter-conformance.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import { assertBackendPort } from '../../src/backend/backend-port.mjs'
+
+async function usingFixture(createFixture, options, operation) {
+  const fixture = await createFixture(options)
+  const backend = assertBackendPort(fixture.backend, {
+    name: `${fixture.name || 'Backend'} conformance adapter`,
+  })
+  try {
+    return await operation({ ...fixture, backend })
+  } finally {
+    await backend.close()
+  }
+}
+
+function assertOutcome(outcome) {
+  assert.equal(typeof outcome?.content, 'string')
+  assert.ok(Array.isArray(outcome?.artifacts))
+  assert.ok(
+    outcome?.presentation == null
+      || typeof outcome.presentation === 'object',
+  )
+  for (const privateField of [
+    'metadata',
+    'raw',
+    'protocol',
+    'sessionId',
+    'delegationId',
+  ]) {
+    assert.equal(privateField in outcome, false)
+  }
+}
+
+/**
+ * Verify the observable contract every backend adapter must implement.
+ *
+ * createFixture({ hold }) returns:
+ *   backend: a fresh BackendPort
+ *   work: a valid Work value
+ *   started: optional Promise resolved once held work reaches execution
+ */
+export async function verifyBackendAdapterConformance({ createFixture }) {
+  await usingFixture(createFixture, { hold: false }, async ({ backend }) => {
+    const description = backend.describe()
+    assert.ok(description && typeof description === 'object')
+    assert.ok(
+      description.capabilities == null
+        || typeof description.capabilities === 'object',
+    )
+    const first = await backend.start()
+    const second = await backend.start()
+    assert.equal(first?.ok, true)
+    assert.equal(second?.ok, true)
+    assert.equal((await backend.health())?.ok, true)
+    assert.equal(backend.status('missing-work')?.state, 'not_found')
+    await assert.rejects(backend.submit({}), /requires work id, owner and input/i)
+    await backend.close()
+  })
+
+  await usingFixture(
+    createFixture,
+    { hold: false },
+    async ({ backend, work, nextWork }) => {
+      const events = []
+      const unsubscribe = backend.subscribe(event => events.push(event))
+      const unsubscribeThrowing = backend.subscribe(() => {
+        throw new Error('observer failure')
+      })
+      const outcome = await backend.submit(work)
+      assertOutcome(outcome)
+      assert.ok(events.length > 0)
+      assert.ok(events.every(event => event.workId === work.id))
+      assert.ok(events.every(event => event.ownerId === work.ownerId))
+      assert.equal(backend.status(work.id).state, 'not_found')
+
+      unsubscribe()
+      unsubscribeThrowing()
+      const eventCount = events.length
+      assertOutcome(await backend.submit(nextWork))
+      assert.equal(events.length, eventCount)
+    },
+  )
+
+  await usingFixture(
+    createFixture,
+    { hold: true },
+    async ({ backend, work, started }) => {
+      const pending = backend.submit(work)
+      await started
+      assert.equal(backend.status(work.id, {
+        ownerId: work.ownerId,
+      }).state, 'working')
+      assert.equal(backend.status(work.id, {
+        ownerId: 'another-owner',
+      }).state, 'not_found')
+      await assert.rejects(backend.submit(work), /already active/)
+      await assert.rejects(backend.cancel(work.id, {
+        ownerId: 'another-owner',
+      }))
+      assert.deepEqual(await backend.cancel(work.id, {
+        ownerId: work.ownerId,
+      }), {
+        workId: work.id,
+        state: 'cancelled',
+      })
+      await assert.rejects(pending)
+      assert.equal((await backend.cancel(work.id, {
+        ownerId: work.ownerId,
+      })).state, 'not_found')
+    },
+  )
+}


### PR DESCRIPTION
Roadmap: #185

## Summary
- add a reusable BackendPort adapter conformance suite
- verify lifecycle, Work validation, result privacy, event isolation, owner isolation, duplicate submission, cancellation, and close semantics
- make ACP cancellation adapter-owned instead of relying on a later TaskManager abort
- mark Backend Runtime R4 complete

## Verification
- `AGENT_PROTOCOL=none npm run release:check`
- focused ACP and conformance tests (55 passed)