### PR TITLE
feat: connect MCP tools to realtime sessions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,6 +226,10 @@ QWEN_AUDIO_WEB_SEARCH_MCP_TOOL=web_search
 ```
 
 Set `QWEN_AUDIO_WEB_SEARCH_PROVIDER=none` to disable frontend web search.
+
+General read-only chatbot tools can be connected through the frontend MCP
+client. Set `QWEN_AUDIO_FRONTEND_MCP_CONFIG` to its versioned JSON file; tools
+must be enabled individually. See [Frontend MCP client](reference/frontend-mcp.md).
 WebUI and terminal clients show the normalized source links below the final
 assistant answer; other clients can consume the same `messages.citations`
 Gateway capability.
@@ -911,6 +915,7 @@ them to the configuration file:
 | `QWEN_AUDIO_WEB_SEARCH_MCP_URL` | Empty; custom Streamable HTTP endpoint used by the `mcp` provider |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOKEN` | `DASHSCOPE_API_KEY` for explicit `bailian`; empty for custom endpoints unless set |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOOL` | `bailian_web_search` for `bailian`; otherwise `web_search` |
+| `QWEN_AUDIO_FRONTEND_MCP_CONFIG` | Empty; absolute path to the versioned frontend MCP JSON file |
 | `QWEN_AUDIO_AGENT_KNOWLEDGE_DIR` | `knowledge` under the shared user data directory |
 | `QWEN_AUDIO_REALTIME_VOICE` | Empty; optional Audio-family override, otherwise runtime uses `longanqian` |
 | `QWEN_OMNI_REALTIME_VOICE` | Empty; optional Omni-family override, otherwise runtime uses `Ethan` |

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -130,6 +130,10 @@ QWEN_AUDIO_WEB_SEARCH_MCP_TOOL=web_search
 ```
 
 设置 `QWEN_AUDIO_WEB_SEARCH_PROVIDER=none` 可以关闭前台联网搜索。
+
+通用的只读 Chatbot 工具可以通过前台 MCP Client 接入。用
+`QWEN_AUDIO_FRONTEND_MCP_CONFIG` 指定带版本的 JSON 文件，并逐个启用工具。
+详见[前台 MCP Client](reference/frontend-mcp.zh.md)。
 WebUI 和终端客户端会在最终回答下方展示规范化的来源链接；其他客户端可通过
 Gateway 的 `messages.citations` 能力位消费同一字段。
 
@@ -747,6 +751,7 @@ Gateway 时，或后续 CLI 运行时使用了冲突的已配置模型时，会�
 | `QWEN_AUDIO_WEB_SEARCH_MCP_URL` | 空；`mcp` Provider 使用的自定义 Streamable HTTP 地址 |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOKEN` | 显式选择 `bailian` 时复用 `DASHSCOPE_API_KEY`；自定义地址默认空 |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOOL` | `bailian` 为 `bailian_web_search`，其他地址为 `web_search` |
+| `QWEN_AUDIO_FRONTEND_MCP_CONFIG` | 空；前台 MCP 版本化 JSON 文件的绝对路径 |
 | `QWEN_AUDIO_AGENT_KNOWLEDGE_DIR` | 共享用户数据目录下的 `knowledge` |
 | `QWEN_AUDIO_REALTIME_VOICE` | 空；Audio 模型族的可选覆盖，未设置时运行时使用 `longanqian` |
 | `QWEN_OMNI_REALTIME_VOICE` | 空；Omni 模型族的可选覆盖，未设置时运行时使用 `Ethan` |

--- a/docs/reference/frontend-mcp.md
+++ b/docs/reference/frontend-mcp.md
@@ -5,9 +5,9 @@ chatbot tools without coupling them to a realtime provider or a backend Agent.
 It is separate from the dedicated Web Search provider: Web Search keeps its
 small built-in fallback, while general MCP servers are configured by the user.
 
-This first foundation release defines configuration, discovery, namespacing,
-health, execution, and result boundaries. Wiring discovered tools into live
-Realtime sessions is tracked as the next Roadmap step.
+The Gateway discovers the explicitly enabled tools at startup, gives them
+stable names, and adds them to each Realtime session through the shared
+frontend tool registry and executor.
 
 ## Configuration
 
@@ -15,7 +15,7 @@ Set `QWEN_AUDIO_FRONTEND_MCP_CONFIG` to a versioned JSON file:
 
 ```env
 QWEN_AUDIO_FRONTEND_MCP_CONFIG=/absolute/path/to/frontend-mcp.json
-DOCUMENT_MCP_TOKEN=replace-me
+DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
 ```
 
 ```json
@@ -25,8 +25,9 @@ DOCUMENT_MCP_TOKEN=replace-me
     "documents": {
       "enabled": true,
       "url": "https://mcp.example.com/mcp",
+      "connectTimeoutMs": 8000,
       "headers": {
-        "authorization": "Bearer ${DOCUMENT_MCP_TOKEN}"
+        "authorization": "${DOCUMENT_MCP_AUTHORIZATION}"
       },
       "tools": {
         "search": {
@@ -50,6 +51,7 @@ Each exposed tool receives a stable model-visible name:
 ## Current policy
 
 - Streamable HTTP is the initial transport.
+- Discovery and connection have a bounded timeout (8 seconds by default).
 - Remote servers require HTTPS. Loopback HTTP is allowed only without headers.
 - Header values may reference one exact environment variable with
   `${VARIABLE}`. A missing variable is a configuration error.

--- a/docs/reference/frontend-mcp.zh.md
+++ b/docs/reference/frontend-mcp.zh.md
@@ -4,8 +4,8 @@
 Realtime Provider，也不绑定后台 Agent。它与专用 Web Search Provider
 相互独立；Web Search 保留一个简单内置兜底，通用 MCP Server 由用户配置。
 
-当前基础版本先定义配置、发现、命名空间、健康状态、执行和结果边界。
-把发现到的工具动态接入 Realtime Session 是 Roadmap 的下一步。
+Gateway 在启动时发现显式启用的工具，为其分配稳定名称，并通过共用的前台工具
+注册表和执行器把它们加入每个 Realtime Session。
 
 ## 配置
 
@@ -13,7 +13,7 @@ Realtime Provider，也不绑定后台 Agent。它与专用 Web Search Provider
 
 ```env
 QWEN_AUDIO_FRONTEND_MCP_CONFIG=/absolute/path/to/frontend-mcp.json
-DOCUMENT_MCP_TOKEN=replace-me
+DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
 ```
 
 ```json
@@ -23,8 +23,9 @@ DOCUMENT_MCP_TOKEN=replace-me
     "documents": {
       "enabled": true,
       "url": "https://mcp.example.com/mcp",
+      "connectTimeoutMs": 8000,
       "headers": {
-        "authorization": "Bearer ${DOCUMENT_MCP_TOKEN}"
+        "authorization": "${DOCUMENT_MCP_AUTHORIZATION}"
       },
       "tools": {
         "search": {
@@ -48,6 +49,7 @@ DOCUMENT_MCP_TOKEN=replace-me
 ## 当前策略
 
 - 首个版本使用 Streamable HTTP Transport。
+- 工具发现和连接有超时边界，默认 8 秒。
 - 远端服务必须使用 HTTPS；回环地址可以使用 HTTP，但不能携带 Header。
 - Header 值可以用 `${VARIABLE}` 精确引用一个环境变量；变量缺失即配置错误。
 - 启用的工具必须明确设置 `readOnly: true`。在通用前台授权链路完成前，

--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -245,7 +245,7 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 - [ ] MCP client with per-tool policy and enablement.
   - [x] Define a provider-neutral source contract, versioned configuration,
     HTTP transport, discovery, and fail-closed read-only policies.
-  - [ ] Wire discovered tools into the dynamic Realtime tool registry and
+  - [x] Wire discovered tools into the dynamic Realtime tool registry and
     executor.
   - [ ] Add generic approval before enabling mutating tools.
 - [ ] OpenAPI tool adapter.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -290,7 +290,7 @@ Presentation 只携带供前台表达的事实材料和投递策略，不携带�
 - [ ] MCP Client 与逐工具授权/启用策略。
   - [x] 定义与供应商无关的 Source Contract、版本化配置、HTTP Transport、
     工具发现和失败关闭的只读策略。
-  - [ ] 把发现到的工具接入动态 Realtime 工具注册表与执行器。
+  - [x] 把发现到的工具接入动态 Realtime 工具注册表与执行器。
   - [ ] 在启用可写工具前增加通用授权链路。
 - [ ] OpenAPI Tool Adapter。
 - [ ] 轻量 Frontend Profile；暂不自创公开 Skill 标准。

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -48,6 +48,11 @@ import { FrontendKnowledgeRuntime } from '../frontend/knowledge/knowledge-runtim
 import {
   LexicalKnowledgeRetrievalProvider,
 } from '../providers/knowledge/lexical-retrieval-provider.mjs'
+import { assertFrontendMcpSource } from '../frontend/mcp/frontend-mcp-source.mjs'
+import { FrontendMcpClient } from '../providers/mcp/frontend-mcp-client.mjs'
+import {
+  loadFrontendMcpConfiguration,
+} from '../providers/mcp/frontend-mcp-config.mjs'
 import {
   projectGatewayTaskEvent,
   projectGatewayTaskSnapshot,
@@ -77,6 +82,7 @@ export function createGatewayApplication({
   knowledgeIndexer = null,
   knowledgeRetrievalProvider = null,
   frontendKnowledge = null,
+  frontendMcp = undefined,
 } = {}) {
 const workBackend = backendRuntime || new BackendWorkRuntime({ backend: agent })
 const inputAssetRegistry = inputAssets || new InputAssetRegistry({
@@ -115,6 +121,16 @@ const retrievalRuntime = frontendRetrieval || new FrontendRetrievalRuntime({
     : webSearchProvider,
   ...(urlFetcher === undefined ? {} : { urlFetcher }),
 })
+const frontendMcpRuntime = frontendMcp === undefined
+  ? new FrontendMcpClient({
+      configuration: loadFrontendMcpConfiguration({
+        filePath: config.frontendMcpConfigPath || '',
+      }),
+    })
+  : frontendMcp
+const frontendToolSources = frontendMcpRuntime
+  ? [assertFrontendMcpSource(frontendMcpRuntime)]
+  : []
 const identityManager = new IdentityManager({
   secret: config.authSecret,
   mode: config.identityMode,
@@ -312,6 +328,12 @@ app.get('/api/health', (req, res) => {
     frontendMemory: frontendMemoryService.health(),
     frontendRetrieval: retrievalRuntime.describe(),
     frontendKnowledge: frontendKnowledgeRuntime.describe(),
+    frontendMcp: frontendMcpRuntime?.health?.() || {
+      ok: true,
+      initialized: true,
+      tools: 0,
+      servers: [],
+    },
     notes: notesStore.health(),
     taskStore: taskStore.health(),
     identityMode: config.identityMode,
@@ -547,6 +569,7 @@ realtimeGateway = attachRealtimeGateway(server, {
   defaultRealtimeProvider: realtimeProvider,
   frontendRetrieval: retrievalRuntime,
   frontendKnowledge: frontendKnowledgeRuntime,
+  frontendToolSources,
 })
 const start = ({ host = config.host, port = config.port } = {}) => {
   if (server.listening) return server
@@ -586,6 +609,7 @@ const close = () => {
     // not survive into the next run.
     inputArbitration.close()
     await realtimeGateway?.close?.()
+    await frontendMcpRuntime?.close?.()
     await knowledgeStoreRuntime.close?.()
     await taskStore?.flush?.()
     if (!server.listening) return
@@ -614,6 +638,7 @@ return {
     frontendMemoryService,
     frontendRetrieval: retrievalRuntime,
     frontendKnowledge: frontendKnowledgeRuntime,
+    frontendMcp: frontendMcpRuntime,
     documentExtractor: documentExtractorRuntime,
     knowledgeStore: knowledgeStoreRuntime,
     knowledgeIndexer: knowledgeIndexerRuntime,

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -226,6 +226,9 @@ export const config = {
   webSearchMcpUrl: webSearch.mcpUrl,
   webSearchMcpToken: webSearch.mcpToken,
   webSearchMcpTool: webSearch.mcpTool,
+  frontendMcpConfigPath: String(
+    process.env.QWEN_AUDIO_FRONTEND_MCP_CONFIG || '',
+  ).trim(),
   allowedOrigins: String(process.env.QWEN_AUDIO_AGENT_ALLOWED_ORIGINS || '')
     .split(',')
     .map(value => value.trim())

--- a/server/src/providers/mcp/frontend-mcp-client.mjs
+++ b/server/src/providers/mcp/frontend-mcp-client.mjs
@@ -173,9 +173,12 @@ export class FrontendMcpClient {
       tools: [],
     }
     this.connections.set(server.key, connection)
+    const discoverySignal = AbortSignal.timeout(server.connectTimeoutMs)
     try {
-      await client.connect(transport)
-      const response = await client.listTools()
+      await client.connect(transport, { signal: discoverySignal })
+      const response = await client.listTools(undefined, {
+        signal: discoverySignal,
+      })
       const remoteTools = Array.isArray(response?.tools) ? response.tools : []
       const discovered = []
       for (const [toolName, policy] of Object.entries(server.tools)) {
@@ -222,7 +225,9 @@ export class FrontendMcpClient {
       for (const name of connection.tools) this.toolsByPublicName.delete(name)
       connection.tools = []
       connection.status = 'error'
-      connection.error = error.message
+      connection.error = discoverySignal.aborted
+        ? `Frontend MCP discovery timed out: ${server.key}`
+        : error.message
       await client.close().catch(() => {})
     }
   }

--- a/server/src/providers/mcp/frontend-mcp-config.mjs
+++ b/server/src/providers/mcp/frontend-mcp-config.mjs
@@ -115,6 +115,12 @@ function normalizedServer(key, value, env) {
   return {
     key,
     enabled: value.enabled === true,
+    connectTimeoutMs: boundedInteger(
+      value.connectTimeoutMs,
+      8_000,
+      100,
+      30_000,
+    ),
     transport: {
       type: 'streamable-http',
       url: normalizedUrl(value.url, {

--- a/server/src/voice/frontend-tools.mjs
+++ b/server/src/voice/frontend-tools.mjs
@@ -373,8 +373,24 @@ export const frontendToolRegistry = new FrontendToolRegistry([
 
 export const TOOLS = frontendToolRegistry.definitions()
 
+function dynamicFrontendTools(agentContext = {}) {
+  const configured = agentContext?.frontend?.tools
+  if (!Array.isArray(configured)) return []
+  const names = new Set(frontendToolRegistry.names())
+  return configured.map(tool => {
+    const name = String(tool?.function?.name || '').trim()
+    if (!name || names.has(name)) {
+      throw new Error(`Invalid or duplicate dynamic frontend tool: ${name || '(unnamed)'}`)
+    }
+    names.add(name)
+    return tool
+  })
+}
+
 export function frontendTools(agentContext = {}) {
   const tools = frontendToolRegistry.definitions(agentContext)
+  const dynamic = dynamicFrontendTools(agentContext)
+  if (dynamic.length) return [...tools, ...dynamic]
   return tools.length === TOOLS.length
     && tools.every((tool, index) => tool === TOOLS[index])
     ? TOOLS

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -105,10 +105,18 @@ export function attachRealtimeGateway(server, {
   defaultRealtimeProvider = config.audioProvider,
   frontendRetrieval = null,
   frontendKnowledge = null,
+  frontendToolSources = [],
 }) {
   const wss = new WebSocketServer({ noServer: true, maxPayload: 20 * 1024 * 1024 })
   const activeVoiceClients = new ActiveVoiceClients()
   const voiceConnections = new Map()
+  const frontendToolSourcesReady = Promise.all(
+    frontendToolSources.map(source => source.initialize()),
+  ).catch(error => {
+    logger.warn('frontend_tools.initialization_failed', {
+      error: error.message,
+    })
+  })
 
   // A suspension is global, not per owner: the host is taking the machine's
   // microphone, so every connected client has to let go of it. The subscription
@@ -191,6 +199,20 @@ export function attachRealtimeGateway(server, {
       ownerId,
       sessionId,
       active: true,
+    })
+    const getAgentContext = () => ({
+      client: clientContext,
+      frontend: {
+        capabilities: [...new Set([
+          ...(frontendRetrieval?.capabilities?.() || []),
+          ...(frontendKnowledge?.capabilities?.() || []),
+        ])],
+        tools: frontendToolSources.flatMap(source => (
+          source.tools().map(tool => tool.definition)
+        )),
+      },
+      memories: memoryService?.list(ownerId, { limit: 64 }) || [],
+      recentMessages: conversationSync.frontendContext({ ownerId, sessionId }),
     })
     const schedulePermissionRetry = () => {
       if (permissionRetryTimer || !outputEnabled || !realtimeSession?.ready) return
@@ -280,17 +302,7 @@ export function attachRealtimeGateway(server, {
     realtimeSession = new RealtimeProviderSession({
       providerRegistry: realtimeProviderRegistry,
       defaultProvider: defaultRealtimeProvider,
-      getAgentContext: () => ({
-        client: clientContext,
-        frontend: {
-          capabilities: [...new Set([
-            ...(frontendRetrieval?.capabilities?.() || []),
-            ...(frontendKnowledge?.capabilities?.() || []),
-          ])],
-        },
-        memories: memoryService?.list(ownerId, { limit: 64 }) || [],
-        recentMessages: conversationSync.frontendContext({ ownerId, sessionId }),
-      }),
+      getAgentContext,
       shouldReconnect: () => inputEnabled || outputEnabled,
       onEvent: event => handleEvent(event),
       onDiagnostic: diagnostic => {
@@ -462,6 +474,7 @@ export function attachRealtimeGateway(server, {
       inputAssets,
       frontendRetrieval,
       frontendKnowledge,
+      frontendToolSources,
       turnCitations,
     })
     const clearResponseCandidate = () => {
@@ -1034,20 +1047,21 @@ export function attachRealtimeGateway(server, {
             ? 0
             : config.sleepTimeoutMs,
         )
-        realtimeSession.updateAgentContext({
-          client: clientContext,
-        })
-        if (sleeping) {
-          sleeping = false
-          waking = true
-          sleepController.wake()
-        }
-        prepareSleepMode()
-        if (event.wakeWordOnly === true) {
-          requestExplicitSleep()
-        } else if (inputEnabled || outputEnabled) {
-          realtimeSession.ensure().catch(reportFrontendError)
-        }
+        frontendToolSourcesReady.then(() => {
+          if (ws.readyState !== WebSocket.OPEN) return
+          realtimeSession.updateAgentContext(getAgentContext())
+          if (sleeping) {
+            sleeping = false
+            waking = true
+            sleepController.wake()
+          }
+          prepareSleepMode()
+          if (event.wakeWordOnly === true) {
+            requestExplicitSleep()
+          } else if (inputEnabled || outputEnabled) {
+            realtimeSession.ensure().catch(reportFrontendError)
+          }
+        }).catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.UNMUTE) {
         explicitSleepRequested = false
         if (nonVoiceClient) {

--- a/server/src/voice/tools/frontend-tool-loop.mjs
+++ b/server/src/voice/tools/frontend-tool-loop.mjs
@@ -87,7 +87,12 @@ export class FrontendToolLoop {
     const now = this.#now()
     let turn = this.#turns.get(key)
     if (!turn) {
-      turn = { startedAt: now, calls: 0, signatures: new Set() }
+      turn = {
+        startedAt: now,
+        calls: 0,
+        callsByTool: new Map(),
+        signatures: new Set(),
+      }
       if (this.#turns.size >= this.#maxTrackedTurns) {
         this.#turns.delete(this.#turns.keys().next().value)
       }
@@ -108,6 +113,16 @@ export class FrontendToolLoop {
         calls: turn.calls,
       }
     }
+    const toolLimit = positiveInteger(tool?.policy?.maxCallsPerTurn, null)
+    const toolCalls = turn.callsByTool.get(name) || 0
+    if (toolLimit !== null && toolCalls >= toolLimit) {
+      return {
+        admitted: false,
+        reason: 'tool_call_limit',
+        calls: turn.calls,
+        toolCalls,
+      }
+    }
 
     const signature = callSignature(name, args)
     if (
@@ -122,6 +137,7 @@ export class FrontendToolLoop {
     }
 
     turn.calls += 1
+    turn.callsByTool.set(name, toolCalls + 1)
     turn.signatures.add(signature)
     return { admitted: true, reason: null, calls: turn.calls }
   }

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -16,6 +16,7 @@ import {
 } from '../frontend-tools.mjs'
 import {
   boundFrontendToolResult,
+  FrontendToolLoop,
 } from './frontend-tool-loop.mjs'
 import { currentTimeSnapshot } from '../../conversation/frontend-agent-context.mjs'
 import { canonicalScope, isMemoryDocument } from '../../core/memory-scopes.mjs'
@@ -116,6 +117,7 @@ export class ToolCallHandler {
     inputAssets = null,
     frontendRetrieval = null,
     frontendKnowledge = null,
+    frontendToolSources = [],
     turnCitations = null,
   }) {
     this.taskManager = taskManager
@@ -140,8 +142,10 @@ export class ToolCallHandler {
     this.inputAssets = inputAssets
     this.frontendRetrieval = frontendRetrieval
     this.frontendKnowledge = frontendKnowledge
+    this.frontendToolSources = frontendToolSources
     this.turnCitations = turnCitations
     this.activeToolEntries = new Map()
+    this.externalToolLoop = new FrontendToolLoop()
     this.toolExecutor = frontendToolRegistry.createExecutor({
       [SPAWN_THINKING_TOOL_NAME]: context => (
         this.executeSpawnThinkingToolCall(context)
@@ -179,6 +183,57 @@ export class ToolCallHandler {
     this.cancelResponseByTurn = new Map()
     this.terminalToolResponses = new Set()
     this.deferredToolResponses = new Map()
+  }
+
+  externalTool(name) {
+    const requested = String(name || '')
+    for (const source of this.frontendToolSources) {
+      const tool = source.tools().find(entry => entry.name === requested)
+      if (tool) return { source, tool }
+    }
+    return null
+  }
+
+  async executeExternalToolCall(external, context) {
+    const { source, tool } = external
+    if (tool.policy?.readOnly !== true) {
+      await this.sendOutput(
+        context.callId,
+        failure('tool_unavailable', '当前前台没有启用这个能力。'),
+        context.turnId,
+      )
+      return { handled: true, executed: false }
+    }
+    const limit = this.externalToolLoop.admit({ ...context, tool })
+    if (!limit.admitted) {
+      await this.sendOutput(
+        context.callId,
+        limit.reason === 'repeated_call'
+          ? {
+              status: 'duplicate',
+              message: '本轮相同操作已经处理，不再重复执行。',
+            }
+          : failure(
+              'tool_loop_limit',
+              '本轮工具调用已达到安全边界，已停止继续执行。',
+              { retryable: true },
+            ),
+        context.turnId,
+      )
+      return { handled: true, executed: false, limit }
+    }
+    let output
+    try {
+      output = await source.execute(tool.name, context.args)
+    } catch {
+      output = failure(
+        'external_tool_unavailable',
+        '外部工具暂时不可用。',
+        { retryable: true },
+      )
+    }
+    await this.sendOutput(context.callId, output, context.turnId)
+    return { handled: true, executed: true, value: output }
   }
 
   markTerminalToolResponse(responseId) {
@@ -863,9 +918,20 @@ export class ToolCallHandler {
       return
     }
 
-    const tool = frontendToolRegistry.get(toolName)
+    const external = this.externalTool(toolName)
+    const tool = frontendToolRegistry.get(toolName) || external?.tool
     if (tool) this.activeToolEntries.set(callId, tool)
     try {
+      if (external) {
+        return await this.executeExternalToolCall(external, {
+          callId,
+          turnId,
+          turnGeneration: generation,
+          args,
+          event,
+          callContext,
+        })
+      }
       const execution = await this.toolExecutor.execute(toolName, {
         callId,
         turnId,

--- a/server/test/frontend-mcp-config.test.mjs
+++ b/server/test/frontend-mcp-config.test.mjs
@@ -44,6 +44,7 @@ test('normalizes explicit server and read-only tool policies', () => {
     servers: [{
       key: 'documents',
       enabled: true,
+      connectTimeoutMs: 8_000,
       transport: {
         type: 'streamable-http',
         url: 'https://mcp.example.test/api',

--- a/server/test/frontend-tool-loop.test.mjs
+++ b/server/test/frontend-tool-loop.test.mjs
@@ -15,6 +15,34 @@ test('admits distinct calls within one bounded turn', () => {
   assert.equal(loop.admit({ turnId: 'turn', tool, args: { value: 3 } }).reason, 'call_limit')
 })
 
+test('applies a per-tool call limit without consuming other tool budgets', () => {
+  const loop = new FrontendToolLoop({ maxCallsPerTurn: 4 })
+  const limited = {
+    name: 'limited',
+    policy: { maxCallsPerTurn: 1 },
+  }
+  const other = {
+    name: 'other',
+    policy: { maxCallsPerTurn: 2 },
+  }
+
+  assert.equal(loop.admit({
+    turnId: 'turn',
+    tool: limited,
+    args: { value: 1 },
+  }).admitted, true)
+  assert.equal(loop.admit({
+    turnId: 'turn',
+    tool: limited,
+    args: { value: 2 },
+  }).reason, 'tool_call_limit')
+  assert.equal(loop.admit({
+    turnId: 'turn',
+    tool: other,
+    args: { value: 1 },
+  }).admitted, true)
+})
+
 test('blocks an exact repeated call before executing it again', () => {
   const loop = new FrontendToolLoop()
 

--- a/server/test/frontend-tool-registry.test.mjs
+++ b/server/test/frontend-tool-registry.test.mjs
@@ -39,6 +39,25 @@ test('registers every default frontend tool once in stable order', () => {
   }
 })
 
+test('appends namespaced dynamic tools without changing the static registry', () => {
+  const dynamic = {
+    type: 'function',
+    function: {
+      name: 'mcp__documents__search',
+      description: 'Search configured documents.',
+      parameters: { type: 'object', properties: {} },
+    },
+  }
+  assert.deepEqual(frontendTools({
+    frontend: { tools: [dynamic] },
+  }), [...TOOLS, dynamic])
+  assert.equal(frontendToolRegistry.has('mcp__documents__search'), false)
+  assert.throws(
+    () => frontendTools({ frontend: { tools: [TOOLS[0]] } }),
+    /duplicate dynamic frontend tool/,
+  )
+})
+
 test('exposes client-state tools only when the client advertises support', () => {
   assert.equal(frontendToolRegistry.isEnabled(ENTER_SLEEP_TOOL_NAME), false)
   assert.equal(

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -52,6 +52,20 @@ test('constructs an injectable Gateway without binding a port on import', async 
   const realtimeProviderRegistry = createRealtimeProviderRegistry({
     providers: [privateProvider],
   })
+  let mcpClosed = false
+  const frontendMcp = {
+    describe: () => ({ key: 'mcp', label: 'Test MCP' }),
+    initialize: async () => [],
+    tools: () => [],
+    execute: async () => ({}),
+    health: () => ({
+      ok: true,
+      initialized: true,
+      tools: 0,
+      servers: [],
+    }),
+    close: async () => { mcpClosed = true },
+  }
   const application = createGatewayApplication({
     config: {
       ...config,
@@ -65,6 +79,7 @@ test('constructs an injectable Gateway without binding a port on import', async 
     inputAssets,
     realtimeProviderRegistry,
     realtimeProvider: privateProvider.key,
+    frontendMcp,
   })
   assert.equal(application.server.listening, false)
   assert.equal(application.services.taskManager != null, true)
@@ -74,6 +89,7 @@ test('constructs an injectable Gateway without binding a port on import', async 
   assert.equal(application.services.knowledgeStore.describe().key, 'local-files')
   assert.equal(application.services.knowledgeIndexer != null, true)
   assert.deepEqual(application.services.frontendKnowledge.capabilities(), ['knowledge'])
+  assert.equal(application.services.frontendMcp, frontendMcp)
 
   application.start()
   if (!application.server.listening) {
@@ -87,6 +103,12 @@ test('constructs an injectable Gateway without binding a port on import', async 
   assert.deepEqual(health.frontendRetrieval.capabilities, ['url-fetch'])
   assert.equal(health.frontendRetrieval.searchProvider, null)
   assert.deepEqual(health.frontendKnowledge.capabilities, ['knowledge'])
+  assert.deepEqual(health.frontendMcp, {
+    ok: true,
+    initialized: true,
+    tools: 0,
+    servers: [],
+  })
   assert.equal(
     health.frontendKnowledge.retrievalProvider.key,
     'local-lexical',
@@ -96,4 +118,5 @@ test('constructs an injectable Gateway without binding a port on import', async 
     false,
   )
   await application.close()
+  assert.equal(mcpClosed, true)
 })

--- a/server/test/realtime-provider.test.mjs
+++ b/server/test/realtime-provider.test.mjs
@@ -653,6 +653,36 @@ test('offers the sleep tool only to a client that advertises the state', () => {
   )
 })
 
+test('projects dynamic frontend tools into each realtime protocol shape', () => {
+  const dynamic = {
+    type: 'function',
+    function: {
+      name: 'mcp__documents__search',
+      description: 'Search configured documents.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+      },
+    },
+  }
+  const agentContext = { frontend: { tools: [dynamic] } }
+  const qwen = REALTIME_PROVIDERS.qwen.buildSession({
+    configured: false,
+    agentContext,
+  })
+  const s2s = REALTIME_PROVIDERS['speech-to-speech'].buildSession({
+    agentContext,
+  })
+
+  assert.deepEqual(qwen.tools.at(-1), dynamic)
+  assert.deepEqual(s2s.tools.at(-1), {
+    type: 'function',
+    name: dynamic.function.name,
+    description: dynamic.function.description,
+    parameters: dynamic.function.parameters,
+  })
+})
+
 test('adds an event id to realtime client events', () => {
   const frontend = createQwenFrontend()
   let sent

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -22,6 +22,7 @@ function harness({
   onAgentActivity,
   frontendRetrieval,
   frontendKnowledge,
+  frontendToolSources,
   getTurnId = () => 'turn-one',
 } = {}) {
   const outputs = []
@@ -60,12 +61,82 @@ function harness({
     inputAssets,
     frontendRetrieval,
     frontendKnowledge,
+    frontendToolSources,
     getConversationContext: () => [
       { role: 'user', content: '之前在改首页' },
     ],
   })
   return { outputs, ensuredResponses, manager, transcripts, handler }
 }
+
+test('executes discovered read-only external tools through the shared boundary', async () => {
+  const calls = []
+  const source = {
+    tools: () => [{
+      name: 'mcp__documents__search',
+      definition: {
+        type: 'function',
+        function: {
+          name: 'mcp__documents__search',
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+      policy: {
+        mode: 'inline',
+        readOnly: true,
+        maxCallsPerTurn: 1,
+        maxResultBytes: 2_048,
+      },
+    }],
+    execute: async (name, args) => {
+      calls.push([name, args])
+      return { status: 'ok', text: 'Found.' }
+    },
+  }
+  const kit = harness({ frontendToolSources: [source] })
+  const invoke = (callId, args) => kit.handler.handle({
+    call_id: callId,
+    name: 'mcp__documents__search',
+    arguments: JSON.stringify(args),
+  }, { turnId: 'turn-one', turnGeneration: 1 })
+
+  await invoke('external-one', { query: 'architecture' })
+  await invoke('external-two', { query: 'different' })
+
+  assert.deepEqual(calls, [[
+    'mcp__documents__search',
+    { query: 'architecture' },
+  ]])
+  assert.equal(kit.outputs[0][1].text, 'Found.')
+  assert.equal(kit.outputs[1][1].error_code, 'tool_loop_limit')
+})
+
+test('never executes a dynamic external tool without a read-only policy', async () => {
+  let executed = false
+  const source = {
+    tools: () => [{
+      name: 'mcp__documents__write',
+      definition: {
+        type: 'function',
+        function: {
+          name: 'mcp__documents__write',
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+      policy: { mode: 'inline', readOnly: false },
+    }],
+    execute: async () => { executed = true },
+  }
+  const kit = harness({ frontendToolSources: [source] })
+  await kit.handler.handle({
+    call_id: 'external-write',
+    name: 'mcp__documents__write',
+    arguments: '{}',
+  }, { turnId: 'turn-one', turnGeneration: 1 })
+
+  assert.equal(executed, false)
+  assert.equal(kit.outputs[0][1].error_code, 'tool_unavailable')
+})
 
 function taskForJob(manager, jobId) {
   return manager.getByJobId(jobId, { ownerId: 'owner' })


### PR DESCRIPTION
Roadmap: #185

## Summary
- initialize configured frontend MCP sources before opening each Realtime session and project namespaced tools into both supported protocol shapes
- execute discovered tools through the shared turn loop with global and per-tool call limits, duplicate suppression, read-only enforcement, timeouts, and bounded results
- expose MCP health, document the runtime configuration, and keep Web Search unchanged

## Validation
- `AGENT_PROTOCOL=none npm run release:check`
- focused coverage for discovery, dynamic session projection, execution, limits, health, and lifecycle