### PR TITLE
feat: add frontend tool approval

### DIFF
--- a/docs/reference/frontend-mcp.md
+++ b/docs/reference/frontend-mcp.md
@@ -37,6 +37,12 @@ DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
           "maxResultBytes": 32768,
           "maxCallsPerTurn": 2,
           "description": "Search the user's configured document source."
+        },
+        "create_issue": {
+          "enabled": true,
+          "readOnly": false,
+          "approval": "required",
+          "description": "Create an issue in the configured tracker."
         }
       }
     }
@@ -55,8 +61,12 @@ Each exposed tool receives a stable model-visible name:
 - Remote servers require HTTPS. Loopback HTTP is allowed only without headers.
 - Header values may reference one exact environment variable with
   `${VARIABLE}`. A missing variable is a configuration error.
-- Every enabled tool must explicitly set `readOnly: true`. Mutating tools stay
-  unavailable until the generic frontend approval path is implemented.
+- Every enabled tool must explicitly declare `readOnly`. A writable tool must
+  also set `approval: "required"`; otherwise it is rejected at startup.
+- Writable operations execute only after a natural-language user confirmation.
+  Each confirmation covers one pending operation exactly once. Rejection,
+  replay, and a reconnect before confirmation all fail closed; there is no
+  session-wide automatic approval.
 - Schemas, descriptions, calls, time, and results are bounded. MCP results are
   treated as untrusted data and cannot override system or user instructions.
 - If an enabled tool is absent or invalid during discovery, that server fails

--- a/docs/reference/frontend-mcp.zh.md
+++ b/docs/reference/frontend-mcp.zh.md
@@ -35,6 +35,12 @@ DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
           "maxResultBytes": 32768,
           "maxCallsPerTurn": 2,
           "description": "检索用户配置的文档来源。"
+        },
+        "create_issue": {
+          "enabled": true,
+          "readOnly": false,
+          "approval": "required",
+          "description": "在用户配置的项目系统中创建 Issue。"
         }
       }
     }
@@ -52,8 +58,10 @@ DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
 - 工具发现和连接有超时边界，默认 8 秒。
 - 远端服务必须使用 HTTPS；回环地址可以使用 HTTP，但不能携带 Header。
 - Header 值可以用 `${VARIABLE}` 精确引用一个环境变量；变量缺失即配置错误。
-- 启用的工具必须明确设置 `readOnly: true`。在通用前台授权链路完成前，
-  可写工具不会开放。
+- 启用的工具必须明确声明 `readOnly`。可写工具还必须设置
+  `approval: "required"`，否则 Gateway 会在启动时拒绝该配置。
+- 可写操作只有在用户自然语言确认后才会执行。每次确认只覆盖一个等待中的操作，
+  且只能执行一次；拒绝、重复确认或确认前重连都会失败关闭，不提供会话级自动授权。
 - Schema、描述、调用次数、执行时间和结果大小都有边界；MCP 结果按不可信数据
   处理，不能覆盖系统指令或用户要求。
 - 发现阶段若缺少已启用工具或工具定义无效，该 Server 失败关闭，不暴露半套工具。

--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -242,12 +242,12 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
 
 ### R6 — Open the ecosystem
 
-- [ ] MCP client with per-tool policy and enablement.
+- [x] MCP client with per-tool policy and enablement.
   - [x] Define a provider-neutral source contract, versioned configuration,
     HTTP transport, discovery, and fail-closed read-only policies.
   - [x] Wire discovered tools into the dynamic Realtime tool registry and
     executor.
-  - [ ] Add generic approval before enabling mutating tools.
+  - [x] Add generic approval before enabling mutating tools.
 - [ ] OpenAPI tool adapter.
 - [ ] Lightweight frontend profiles; do not invent a public skill standard.
 - [ ] Backend adapter SDK and examples.

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -287,11 +287,11 @@ Presentation 只携带供前台表达的事实材料和投递策略，不携带�
 
 ### R6：开放生态
 
-- [ ] MCP Client 与逐工具授权/启用策略。
+- [x] MCP Client 与逐工具授权/启用策略。
   - [x] 定义与供应商无关的 Source Contract、版本化配置、HTTP Transport、
     工具发现和失败关闭的只读策略。
   - [x] 把发现到的工具接入动态 Realtime 工具注册表与执行器。
-  - [ ] 在启用可写工具前增加通用授权链路。
+  - [x] 在启用可写工具前增加通用授权链路。
 - [ ] OpenAPI Tool Adapter。
 - [ ] 轻量 Frontend Profile；暂不自创公开 Skill 标准。
 - [ ] Backend Adapter SDK 与示例。

--- a/server/src/frontend/tools/frontend-tool-source.mjs
+++ b/server/src/frontend/tools/frontend-tool-source.mjs
@@ -1,0 +1,35 @@
+export const FRONTEND_TOOL_APPROVAL_CAPABILITY = 'external-tool-approval'
+
+export function frontendSourceTools(sources = []) {
+  const catalog = []
+  const names = new Set()
+  for (const source of sources) {
+    for (const tool of source.tools()) {
+      const name = String(tool?.name || '').trim()
+      if (!name || names.has(name)) {
+        throw new Error(`Invalid or duplicate frontend source tool: ${name || '(unnamed)'}`)
+      }
+      names.add(name)
+      catalog.push({ source, tool })
+    }
+  }
+  return catalog
+}
+
+export function frontendSourceToolDefinitions(sources = []) {
+  return frontendSourceTools(sources).map(({ tool }) => tool.definition)
+}
+
+export function frontendSourceToolCapabilities(sources = []) {
+  return frontendSourceTools(sources).some(({ tool }) => (
+    tool.policy?.readOnly === false
+    && tool.policy?.approval === 'required'
+  )) ? [FRONTEND_TOOL_APPROVAL_CAPABILITY] : []
+}
+
+export function findFrontendSourceTool(sources, name) {
+  const requested = String(name || '')
+  return frontendSourceTools(sources).find(({ tool }) => (
+    tool.name === requested
+  )) || null
+}

--- a/server/src/providers/mcp/frontend-mcp-client.mjs
+++ b/server/src/providers/mcp/frontend-mcp-client.mjs
@@ -210,7 +210,8 @@ export class FrontendMcpClient {
           },
           policy: {
             mode: 'inline',
-            readOnly: true,
+            readOnly: policy.readOnly,
+            approval: policy.approval,
             timeoutMs: policy.timeoutMs,
             maxResultBytes: policy.maxResultBytes,
             maxCallsPerTurn: policy.maxCallsPerTurn,

--- a/server/src/providers/mcp/frontend-mcp-config.mjs
+++ b/server/src/providers/mcp/frontend-mcp-config.mjs
@@ -76,14 +76,22 @@ function normalizedPolicy(value = {}) {
   }
   const enabled = value.enabled === true
   const readOnly = value.readOnly === true
-  if (enabled && !readOnly) {
+  const approval = clean(value.approval, 40).toLowerCase() || 'none'
+  if (enabled && typeof value.readOnly !== 'boolean') {
     throw new Error(
-      'Frontend MCP tools must be explicitly enabled and readOnly in this release.',
+      'Enabled Frontend MCP tools must explicitly declare readOnly.',
     )
+  }
+  if (enabled && !readOnly && approval !== 'required') {
+    throw new Error('Writable Frontend MCP tools require approval=required.')
+  }
+  if (readOnly && approval !== 'none') {
+    throw new Error('Read-only Frontend MCP tools cannot require approval.')
   }
   return {
     enabled,
     readOnly,
+    approval,
     timeoutMs: boundedInteger(value.timeoutMs, 8_000, 100, 30_000),
     maxResultBytes: boundedInteger(
       value.maxResultBytes,

--- a/server/src/voice/frontend-tools.mjs
+++ b/server/src/voice/frontend-tools.mjs
@@ -11,6 +11,9 @@ import {
 import {
   FRONTEND_KNOWLEDGE_CAPABILITY,
 } from '../frontend/knowledge/knowledge-runtime.mjs'
+import {
+  FRONTEND_TOOL_APPROVAL_CAPABILITY,
+} from '../frontend/tools/frontend-tool-source.mjs'
 
 export const SPAWN_THINKING_TOOL_NAME = 'spawn_thinking'
 export const SCHEDULE_REMINDER_TOOL_NAME = 'schedule_reminder'
@@ -20,6 +23,7 @@ export const GET_CURRENT_TIME_TOOL_NAME = 'get_current_time'
 export const MEMORY_TOOL_NAME = 'memory'
 export const NOTES_TOOL_NAME = 'notes'
 export const RESPOND_AGENT_PERMISSION_TOOL_NAME = 'respond_agent_permission'
+export const RESPOND_FRONTEND_TOOL_PERMISSION_NAME = 'respond_frontend_tool_permission'
 export const ENTER_SLEEP_TOOL_NAME = 'enter_sleep'
 export const WEB_SEARCH_TOOL_NAME = 'web_search'
 export const FETCH_URL_TOOL_NAME = 'fetch_url'
@@ -283,6 +287,30 @@ const respondAgentPermissionTool = {
   },
 }
 
+const respondFrontendToolPermission = {
+  type: 'function',
+  function: {
+    name: RESPOND_FRONTEND_TOOL_PERMISSION_NAME,
+    description: '回复当前正在等待用户决定的前台外部工具执行请求。结合刚提出的具体操作和用户本轮自然表达判断允许或拒绝；不要依赖固定关键词，也不要代替用户作决定。每次允许只执行当前这一项操作，不会自动允许后续请求。',
+    parameters: {
+      type: 'object',
+      properties: {
+        authorization_id: {
+          type: 'string',
+          description: '待确认请求的 authorization_id，必须来自当前对话中的前台外部工具确认请求，不得猜造。',
+        },
+        decision: {
+          type: 'string',
+          enum: ['allow', 'reject'],
+          description: 'allow 表示只允许当前操作执行一次；reject 表示拒绝当前操作。',
+        },
+      },
+      required: ['authorization_id', 'decision'],
+      additionalProperties: false,
+    },
+  },
+}
+
 const enterSleepTool = {
   type: 'function',
   function: {
@@ -349,6 +377,13 @@ export const frontendToolRegistry = new FrontendToolRegistry([
     },
   },
   { definition: respondAgentPermissionTool, policy: { mode: 'control' } },
+  {
+    definition: respondFrontendToolPermission,
+    policy: {
+      mode: 'control',
+      requiredCapabilities: [FRONTEND_TOOL_APPROVAL_CAPABILITY],
+    },
+  },
   {
     definition: webSearchTool,
     policy: {

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -42,6 +42,10 @@ import {
   isResponseActivityEvent,
   realtimeResponseId,
 } from './response-lifecycle.mjs'
+import {
+  frontendSourceToolCapabilities,
+  frontendSourceToolDefinitions,
+} from '../frontend/tools/frontend-tool-source.mjs'
 
 const MAX_PENDING_AUDIO_CHUNKS = 30
 const RESPONSE_START_WATCHDOG_MS = 12000
@@ -206,10 +210,9 @@ export function attachRealtimeGateway(server, {
         capabilities: [...new Set([
           ...(frontendRetrieval?.capabilities?.() || []),
           ...(frontendKnowledge?.capabilities?.() || []),
+          ...frontendSourceToolCapabilities(frontendToolSources),
         ])],
-        tools: frontendToolSources.flatMap(source => (
-          source.tools().map(tool => tool.definition)
-        )),
+        tools: frontendSourceToolDefinitions(frontendToolSources),
       },
       memories: memoryService?.list(ownerId, { limit: 64 }) || [],
       recentMessages: conversationSync.frontendContext({ ownerId, sessionId }),

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import {
   CANCEL_AGENT_TASK_TOOL_NAME,
   SCHEDULE_REMINDER_TOOL_NAME,
@@ -9,11 +9,16 @@ import {
   NOTES_TOOL_NAME,
   MEMORY_TOOL_NAME,
   RESPOND_AGENT_PERMISSION_TOOL_NAME,
+  RESPOND_FRONTEND_TOOL_PERMISSION_NAME,
   WEB_SEARCH_TOOL_NAME,
   FETCH_URL_TOOL_NAME,
   KNOWLEDGE_TOOL_NAME,
   frontendToolRegistry,
 } from '../frontend-tools.mjs'
+import {
+  findFrontendSourceTool,
+  frontendSourceToolCapabilities,
+} from '../../frontend/tools/frontend-tool-source.mjs'
 import {
   boundFrontendToolResult,
   FrontendToolLoop,
@@ -31,6 +36,7 @@ const CANCEL_RECEIPT_INSTRUCTIONS = [
 ].join(' ')
 
 const STATUS_RESULT_MESSAGE = '请根据这次查询结果自然回答用户；不要再次调用状态工具，不要展示 job_id。'
+const MAX_PENDING_EXTERNAL_AUTHORIZATIONS = 8
 
 function objectiveFingerprint(objective) {
   return createHash('sha256')
@@ -169,6 +175,9 @@ export class ToolCallHandler {
       [RESPOND_AGENT_PERMISSION_TOOL_NAME]: ({ callId, turnId, args }) => (
         this.respondAgentPermission(callId, turnId, args)
       ),
+      [RESPOND_FRONTEND_TOOL_PERMISSION_NAME]: ({ callId, turnId, args }) => (
+        this.respondFrontendToolPermission(callId, turnId, args)
+      ),
       [ENTER_SLEEP_TOOL_NAME]: ({ callId, turnId }) => (
         this.enterSleep(callId, turnId)
       ),
@@ -183,20 +192,88 @@ export class ToolCallHandler {
     this.cancelResponseByTurn = new Map()
     this.terminalToolResponses = new Set()
     this.deferredToolResponses = new Map()
+    this.pendingExternalAuthorizations = new Map()
   }
 
   externalTool(name) {
-    const requested = String(name || '')
-    for (const source of this.frontendToolSources) {
-      const tool = source.tools().find(entry => entry.name === requested)
-      if (tool) return { source, tool }
+    return findFrontendSourceTool(this.frontendToolSources, name)
+  }
+
+  async executeExternalSource(external, args) {
+    const { source, tool } = external
+    let output
+    try {
+      output = await source.execute(tool.name, args)
+    } catch {
+      output = failure(
+        'external_tool_unavailable',
+        '外部工具暂时不可用。',
+        { retryable: true },
+      )
     }
-    return null
+    const bounded = boundFrontendToolResult(
+      output,
+      tool.policy?.maxResultBytes,
+    )
+    return bounded.accepted
+      ? bounded.value
+      : failure(
+          'tool_result_too_large',
+          '工具结果过大，无法在当前语音轮次中安全返回。',
+          { retryable: true },
+        )
+  }
+
+  async requestExternalToolApproval(external, context) {
+    if (
+      this.pendingExternalAuthorizations.size
+      >= MAX_PENDING_EXTERNAL_AUTHORIZATIONS
+    ) {
+      await this.sendOutput(
+        context.callId,
+        failure(
+          'external_authorization_limit',
+          '当前等待确认的外部操作过多，请先处理已有请求。',
+          { retryable: true },
+        ),
+        context.turnId,
+      )
+      return { handled: true, executed: false }
+    }
+    const authorizationId = `frontend_auth_${randomUUID()}`
+    const description = String(
+      external.tool.definition?.function?.description || external.tool.name,
+    ).replace(/\s+/gu, ' ').trim().slice(0, 400)
+    this.pendingExternalAuthorizations.set(authorizationId, {
+      ...external,
+      args: context.args,
+      operation: description,
+    })
+    await this.sendOutput(context.callId, {
+      status: 'confirmation_required',
+      authorization_id: authorizationId,
+      operation: description,
+      message: '此操作会修改外部系统，必须先获得用户明确同意。',
+    }, context.turnId, null, {
+      response: {
+        instructions: [
+          '这是前台外部工具执行前的确认请求。',
+          '自然、简短地说明 operation 并询问用户是否允许，不要声称已经执行。',
+          '用户回答后按语义调用 respond_frontend_tool_permission；不要要求固定口令，也不要朗读 authorization_id。',
+        ].join(' '),
+      },
+    })
+    return { handled: true, executed: false, authorizationId }
   }
 
   async executeExternalToolCall(external, context) {
-    const { source, tool } = external
-    if (tool.policy?.readOnly !== true) {
+    const { tool } = external
+    const directlyExecutable = tool.policy?.readOnly === true
+    const requiresApproval = (
+      tool.policy?.readOnly === false
+      && tool.policy?.approval === 'required'
+    )
+    if (!directlyExecutable && !requiresApproval) {
       await this.sendOutput(
         context.callId,
         failure('tool_unavailable', '当前前台没有启用这个能力。'),
@@ -222,18 +299,43 @@ export class ToolCallHandler {
       )
       return { handled: true, executed: false, limit }
     }
-    let output
-    try {
-      output = await source.execute(tool.name, context.args)
-    } catch {
-      output = failure(
-        'external_tool_unavailable',
-        '外部工具暂时不可用。',
-        { retryable: true },
-      )
+    if (requiresApproval) {
+      return this.requestExternalToolApproval(external, context)
     }
+    const output = await this.executeExternalSource(external, context.args)
     await this.sendOutput(context.callId, output, context.turnId)
     return { handled: true, executed: true, value: output }
+  }
+
+  async respondFrontendToolPermission(callId, turnId, args = {}) {
+    const authorizationId = String(args.authorization_id || '').trim()
+    const decision = String(args.decision || '').trim()
+    const pending = this.pendingExternalAuthorizations.get(authorizationId)
+    if (!pending || !['allow', 'reject'].includes(decision)) {
+      await this.sendOutput(
+        callId,
+        failure(
+          'external_authorization_not_pending',
+          '没有找到仍在等待决定的外部工具请求。',
+        ),
+        turnId,
+      )
+      return
+    }
+    this.pendingExternalAuthorizations.delete(authorizationId)
+    if (decision === 'reject') {
+      await this.sendOutput(callId, {
+        status: 'rejected',
+        message: '用户拒绝了这次外部工具操作。',
+      }, turnId, null, {
+        response: {
+          instructions: '自然、简短地确认本次操作未执行，不要调用工具。',
+        },
+      })
+      return
+    }
+    const output = await this.executeExternalSource(pending, pending.args)
+    await this.sendOutput(callId, output, turnId)
   }
 
   markTerminalToolResponse(responseId) {
@@ -943,6 +1045,7 @@ export class ToolCallHandler {
           capabilities: [...new Set([
             ...(this.frontendRetrieval?.capabilities?.() || []),
             ...(this.frontendKnowledge?.capabilities?.() || []),
+            ...frontendSourceToolCapabilities(this.frontendToolSources),
           ])],
         },
       })

--- a/server/test/frontend-mcp-client.test.mjs
+++ b/server/test/frontend-mcp-client.test.mjs
@@ -107,6 +107,7 @@ test('discovers only explicitly enabled tools under stable namespaced names', as
   assert.deepEqual(tools[0].policy, {
     mode: 'inline',
     readOnly: true,
+    approval: 'none',
     timeoutMs: 8_000,
     maxResultBytes: 32 * 1024,
     maxCallsPerTurn: 1,
@@ -124,6 +125,33 @@ test('discovers only explicitly enabled tools under stable namespaced names', as
   })
   await client.close()
   assert.equal(mocks.clients[0].closed, true)
+})
+
+test('discovers explicitly approved writable tools without executing them', async () => {
+  const mocks = harness({
+    remoteTools: [{
+      name: 'create_issue',
+      description: 'Create an issue.',
+      inputSchema: { type: 'object', properties: {} },
+    }],
+  })
+  const client = new FrontendMcpClient({
+    configuration: configuration({
+      create_issue: {
+        enabled: true,
+        readOnly: false,
+        approval: 'required',
+      },
+    }),
+    clientFactory: mocks.clientFactory,
+    transportFactory: mocks.transportFactory,
+  })
+
+  const [tool] = await client.initialize()
+  assert.equal(tool.name, 'mcp__documents__create_issue')
+  assert.equal(tool.policy.readOnly, false)
+  assert.equal(tool.policy.approval, 'required')
+  assert.equal(mocks.calls.length, 0)
 })
 
 test('executes a discovered tool and labels bounded results as untrusted', async () => {

--- a/server/test/frontend-mcp-config.test.mjs
+++ b/server/test/frontend-mcp-config.test.mjs
@@ -35,7 +35,7 @@ test('loads no frontend MCP servers when no config path is set', () => {
   })
 })
 
-test('normalizes explicit server and read-only tool policies', () => {
+test('normalizes explicit server and tool policies', () => {
   const normalized = normalizeFrontendMcpConfiguration(configuration(), {
     env: { MCP_TOKEN: 'secret-token' },
   })
@@ -54,6 +54,7 @@ test('normalizes explicit server and read-only tool policies', () => {
         search: {
           enabled: true,
           readOnly: true,
+          approval: 'none',
           timeoutMs: 8_000,
           maxResultBytes: 32 * 1024,
           maxCallsPerTurn: 2,
@@ -78,7 +79,7 @@ test('loads and validates a versioned frontend MCP JSON file', () => {
   }
 })
 
-test('fails closed for unsafe endpoints, missing secrets, and mutating tools', () => {
+test('fails closed for unsafe endpoints, missing secrets, and unapproved mutations', () => {
   assert.throws(
     () => normalizeFrontendMcpConfiguration(configuration(), { env: {} }),
     /environment variable is missing: MCP_TOKEN/,
@@ -120,7 +121,63 @@ test('fails closed for unsafe endpoints, missing secrets, and mutating tools', (
         },
       },
     })),
-    /explicitly enabled and readOnly/,
+    /require approval=required/,
+  )
+})
+
+test('allows explicitly approved writable tools and rejects ambiguous policies', () => {
+  const normalized = normalizeFrontendMcpConfiguration(configuration({
+    servers: {
+      actions: {
+        enabled: true,
+        url: 'https://mcp.example.test/api',
+        tools: {
+          create_issue: {
+            enabled: true,
+            readOnly: false,
+            approval: 'required',
+          },
+        },
+      },
+    },
+  }))
+  assert.deepEqual(normalized.servers[0].tools.create_issue, {
+    enabled: true,
+    readOnly: false,
+    approval: 'required',
+    timeoutMs: 8_000,
+    maxResultBytes: 32 * 1024,
+    maxCallsPerTurn: 2,
+  })
+  assert.throws(
+    () => normalizeFrontendMcpConfiguration(configuration({
+      servers: {
+        ambiguous: {
+          enabled: true,
+          url: 'https://mcp.example.test/api',
+          tools: { action: { enabled: true } },
+        },
+      },
+    })),
+    /explicitly declare readOnly/,
+  )
+  assert.throws(
+    () => normalizeFrontendMcpConfiguration(configuration({
+      servers: {
+        read_only: {
+          enabled: true,
+          url: 'https://mcp.example.test/api',
+          tools: {
+            search: {
+              enabled: true,
+              readOnly: true,
+              approval: 'required',
+            },
+          },
+        },
+      },
+    })),
+    /cannot require approval/,
   )
 })
 

--- a/server/test/frontend-tool-registry.test.mjs
+++ b/server/test/frontend-tool-registry.test.mjs
@@ -4,6 +4,7 @@ import {
   ENTER_SLEEP_TOOL_NAME,
   FETCH_URL_TOOL_NAME,
   KNOWLEDGE_TOOL_NAME,
+  RESPOND_FRONTEND_TOOL_PERMISSION_NAME,
   WEB_SEARCH_TOOL_NAME,
   frontendToolRegistry,
   frontendTools,
@@ -99,6 +100,19 @@ test('exposes retrieval tools only when the frontend advertises each capability'
   )
 })
 
+test('exposes external-tool approval only when a source requires it', () => {
+  assert.equal(
+    frontendToolRegistry.isEnabled(RESPOND_FRONTEND_TOOL_PERMISSION_NAME),
+    false,
+  )
+  assert.deepEqual(
+    names(frontendTools({
+      frontend: { capabilities: ['external-tool-approval'] },
+    })),
+    [...DEFAULT_TOOL_NAMES, RESPOND_FRONTEND_TOOL_PERMISSION_NAME],
+  )
+})
+
 test('exposes the knowledge tool only with the frontend knowledge capability', () => {
   assert.equal(frontendToolRegistry.isEnabled(KNOWLEDGE_TOOL_NAME), false)
   assert.deepEqual(
@@ -150,6 +164,7 @@ test('declares one background tool and classifies every other tool', () => {
     notes: 'inline',
     knowledge: 'inline',
     respond_agent_permission: 'control',
+    respond_frontend_tool_permission: 'control',
     web_search: 'inline',
     fetch_url: 'inline',
     enter_sleep: 'control',

--- a/server/test/frontend-tool-source.test.mjs
+++ b/server/test/frontend-tool-source.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  findFrontendSourceTool,
+  frontendSourceToolCapabilities,
+  frontendSourceToolDefinitions,
+  frontendSourceTools,
+} from '../src/frontend/tools/frontend-tool-source.mjs'
+
+function source(name, policy) {
+  const tool = {
+    name,
+    definition: {
+      type: 'function',
+      function: { name, parameters: { type: 'object' } },
+    },
+    policy,
+  }
+  return { tools: () => [tool], tool }
+}
+
+test('projects source tools, definitions, and approval capability', () => {
+  const read = source('mcp__docs__search', {
+    readOnly: true,
+    approval: 'none',
+  })
+  const write = source('mcp__docs__create', {
+    readOnly: false,
+    approval: 'required',
+  })
+  const sources = [read, write]
+
+  assert.deepEqual(
+    frontendSourceTools(sources).map(entry => entry.tool.name),
+    ['mcp__docs__search', 'mcp__docs__create'],
+  )
+  assert.deepEqual(
+    frontendSourceToolDefinitions(sources),
+    [read.tool.definition, write.tool.definition],
+  )
+  assert.deepEqual(frontendSourceToolCapabilities(sources), [
+    'external-tool-approval',
+  ])
+  assert.equal(findFrontendSourceTool(sources, write.tool.name)?.tool, write.tool)
+})
+
+test('omits approval capability for read-only sources and rejects duplicates', () => {
+  const first = source('mcp__docs__search', {
+    readOnly: true,
+    approval: 'none',
+  })
+  const duplicate = source('mcp__docs__search', {
+    readOnly: false,
+    approval: 'required',
+  })
+
+  assert.deepEqual(frontendSourceToolCapabilities([first]), [])
+  assert.throws(
+    () => frontendSourceTools([first, duplicate]),
+    /duplicate frontend source tool/,
+  )
+})

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -84,6 +84,7 @@ test('executes discovered read-only external tools through the shared boundary',
       policy: {
         mode: 'inline',
         readOnly: true,
+        approval: 'none',
         maxCallsPerTurn: 1,
         maxResultBytes: 2_048,
       },
@@ -109,6 +110,126 @@ test('executes discovered read-only external tools through the shared boundary',
   ]])
   assert.equal(kit.outputs[0][1].text, 'Found.')
   assert.equal(kit.outputs[1][1].error_code, 'tool_loop_limit')
+})
+
+test('executes an approved writable external tool exactly once', async () => {
+  const calls = []
+  let currentTurn = 'turn-one'
+  const source = {
+    tools: () => [{
+      name: 'mcp__issues__create',
+      definition: {
+        type: 'function',
+        function: {
+          name: 'mcp__issues__create',
+          description: 'Create an issue in the configured tracker.',
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+      policy: {
+        mode: 'inline',
+        readOnly: false,
+        approval: 'required',
+        maxCallsPerTurn: 1,
+        maxResultBytes: 2_048,
+      },
+    }],
+    execute: async (name, args) => {
+      calls.push([name, args])
+      return { status: 'ok', issue: 42 }
+    },
+  }
+  const kit = harness({
+    frontendToolSources: [source],
+    getTurnId: () => currentTurn,
+  })
+
+  await kit.handler.handle({
+    call_id: 'external-write',
+    name: 'mcp__issues__create',
+    arguments: JSON.stringify({ title: 'Fix it' }),
+  }, { turnId: 'turn-one', turnGeneration: 1 })
+
+  const authorizationId = kit.outputs[0][1].authorization_id
+  assert.equal(kit.outputs[0][1].status, 'confirmation_required')
+  assert.match(authorizationId, /^frontend_auth_/u)
+  assert.equal(calls.length, 0)
+
+  currentTurn = 'turn-two'
+  await kit.handler.handle({
+    call_id: 'allow-write',
+    name: 'respond_frontend_tool_permission',
+    arguments: JSON.stringify({
+      authorization_id: authorizationId,
+      decision: 'allow',
+    }),
+  }, { turnId: 'turn-two', turnGeneration: 1 })
+  assert.deepEqual(calls, [[
+    'mcp__issues__create',
+    { title: 'Fix it' },
+  ]])
+  assert.equal(kit.outputs[1][1].issue, 42)
+
+  currentTurn = 'turn-three'
+  await kit.handler.handle({
+    call_id: 'replay-write',
+    name: 'respond_frontend_tool_permission',
+    arguments: JSON.stringify({
+      authorization_id: authorizationId,
+      decision: 'allow',
+    }),
+  }, { turnId: 'turn-three', turnGeneration: 1 })
+  assert.equal(calls.length, 1)
+  assert.equal(kit.outputs[2][1].error_code, 'external_authorization_not_pending')
+})
+
+test('rejects a writable external tool without executing it', async () => {
+  let executed = false
+  let currentTurn = 'turn-one'
+  const source = {
+    tools: () => [{
+      name: 'mcp__issues__delete',
+      definition: {
+        type: 'function',
+        function: {
+          name: 'mcp__issues__delete',
+          description: 'Delete an issue.',
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+      policy: {
+        mode: 'inline',
+        readOnly: false,
+        approval: 'required',
+        maxCallsPerTurn: 1,
+        maxResultBytes: 2_048,
+      },
+    }],
+    execute: async () => { executed = true },
+  }
+  const kit = harness({
+    frontendToolSources: [source],
+    getTurnId: () => currentTurn,
+  })
+
+  await kit.handler.handle({
+    call_id: 'external-delete',
+    name: 'mcp__issues__delete',
+    arguments: JSON.stringify({ id: 42 }),
+  }, { turnId: 'turn-one', turnGeneration: 1 })
+  const authorizationId = kit.outputs[0][1].authorization_id
+  currentTurn = 'turn-two'
+  await kit.handler.handle({
+    call_id: 'reject-delete',
+    name: 'respond_frontend_tool_permission',
+    arguments: JSON.stringify({
+      authorization_id: authorizationId,
+      decision: 'reject',
+    }),
+  }, { turnId: 'turn-two', turnGeneration: 1 })
+
+  assert.equal(executed, false)
+  assert.equal(kit.outputs[1][1].status, 'rejected')
 })
 
 test('never executes a dynamic external tool without a read-only policy', async () => {


### PR DESCRIPTION
Roadmap: #185

## Summary
- allow explicitly configured writable frontend MCP tools only with per-operation approval
- add a protocol-neutral external tool authorization boundary reusable by future adapters
- fail closed on rejection, replay, reconnect, ambiguous policy, and oversized results
- complete the MCP client item in the bilingual frontend runtime roadmap

## Verification
- `AGENT_PROTOCOL=none npm run release:check`
- 141 focused MCP, registry, provider, and tool-handler tests