### PR TITLE
feat: add lightweight frontend profiles

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,6 +235,9 @@ enabled individually and writable operations require confirmation. See
 REST services with an OpenAPI 3.x document use the same tool and approval
 boundary through `QWEN_AUDIO_FRONTEND_OPENAPI_CONFIG`. See
 [Frontend OpenAPI tool adapter](reference/frontend-openapi.md).
+To keep the assistant persona, MCP configuration, and OpenAPI configuration as
+one local frontend bundle, set only `QWEN_AUDIO_FRONTEND_PROFILE`. See
+[Lightweight Frontend Profiles](reference/frontend-profile.md).
 WebUI and terminal clients show the normalized source links below the final
 assistant answer; other clients can consume the same `messages.citations`
 Gateway capability.
@@ -920,6 +923,7 @@ them to the configuration file:
 | `QWEN_AUDIO_WEB_SEARCH_MCP_URL` | Empty; custom Streamable HTTP endpoint used by the `mcp` provider |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOKEN` | `DASHSCOPE_API_KEY` for explicit `bailian`; empty for custom endpoints unless set |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOOL` | `bailian_web_search` for `bailian`; otherwise `web_search` |
+| `QWEN_AUDIO_FRONTEND_PROFILE` | Empty; path to a lightweight Frontend Profile JSON file |
 | `QWEN_AUDIO_FRONTEND_MCP_CONFIG` | Empty; absolute path to the versioned frontend MCP JSON file |
 | `QWEN_AUDIO_FRONTEND_OPENAPI_CONFIG` | Empty; absolute path to the versioned frontend OpenAPI JSON config file |
 | `QWEN_AUDIO_AGENT_KNOWLEDGE_DIR` | `knowledge` under the shared user data directory |

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -138,6 +138,8 @@ QWEN_AUDIO_WEB_SEARCH_MCP_TOOL=web_search
 具有 OpenAPI 3.x 文档的 REST 服务，通过
 `QWEN_AUDIO_FRONTEND_OPENAPI_CONFIG` 复用同一套工具和授权边界。详见
 [前台 OpenAPI Tool Adapter](reference/frontend-openapi.zh.md)。
+需要把助手画像、MCP 和 OpenAPI 工具配置作为一套本地前台组合时，可以只设置
+`QWEN_AUDIO_FRONTEND_PROFILE`。详见[轻量 Frontend Profile](reference/frontend-profile.zh.md)。
 WebUI 和终端客户端会在最终回答下方展示规范化的来源链接；其他客户端可通过
 Gateway 的 `messages.citations` 能力位消费同一字段。
 
@@ -755,6 +757,7 @@ Gateway 时，或后续 CLI 运行时使用了冲突的已配置模型时，会�
 | `QWEN_AUDIO_WEB_SEARCH_MCP_URL` | 空；`mcp` Provider 使用的自定义 Streamable HTTP 地址 |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOKEN` | 显式选择 `bailian` 时复用 `DASHSCOPE_API_KEY`；自定义地址默认空 |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOOL` | `bailian` 为 `bailian_web_search`，其他地址为 `web_search` |
+| `QWEN_AUDIO_FRONTEND_PROFILE` | 空；轻量 Frontend Profile JSON 文件路径 |
 | `QWEN_AUDIO_FRONTEND_MCP_CONFIG` | 空；前台 MCP 版本化 JSON 文件的绝对路径 |
 | `QWEN_AUDIO_FRONTEND_OPENAPI_CONFIG` | 空；前台 OpenAPI 版本化 JSON 配置文件的绝对路径 |
 | `QWEN_AUDIO_AGENT_KNOWLEDGE_DIR` | 共享用户数据目录下的 `knowledge` |

--- a/docs/reference/frontend-profile.md
+++ b/docs/reference/frontend-profile.md
@@ -1,0 +1,71 @@
+# Lightweight Frontend Profiles
+
+A Frontend Profile is a local, versioned composition manifest that selects a
+frontend assistant persona and external tool configurations through one entry
+point. It can keep or share a frontend setup as a directory without introducing
+a new skill or plugin protocol.
+
+## Configuration
+
+Create a directory:
+
+```text
+research-profile/
+├── frontend-profile.json
+├── ASSISTANT.md
+└── tools/
+    ├── mcp.json
+    └── openapi.json
+```
+
+`frontend-profile.json`:
+
+```json
+{
+  "version": 1,
+  "name": "research",
+  "description": "A voice frontend for research and source review",
+  "assistant": "./ASSISTANT.md",
+  "toolSources": {
+    "mcp": "./tools/mcp.json",
+    "openapi": "./tools/openapi.json"
+  }
+}
+```
+
+Enable it:
+
+```dotenv
+QWEN_AUDIO_FRONTEND_PROFILE=/absolute/path/to/research-profile/frontend-profile.json
+```
+
+`assistant`, `toolSources.mcp`, and `toolSources.openapi` are optional, but at
+least one must be present. References must be relative paths to existing files
+inside the profile directory. MCP and OpenAPI files retain their own versioned
+formats and authorization policies; the profile does not duplicate those
+protocols.
+
+## Precedence
+
+Existing focused settings have higher priority and can temporarily override a
+profile:
+
+1. `QWEN_AUDIO_AGENT_ASSISTANT_PROFILE_PATH`, `QWEN_AUDIO_FRONTEND_MCP_CONFIG`,
+   and `QWEN_AUDIO_FRONTEND_OPENAPI_CONFIG`;
+2. references in the Frontend Profile;
+3. qwen-audio-agent defaults.
+
+`frontendProfile` in `/api/health` reports only enablement, name, and
+description. It never exposes local paths.
+
+## Boundaries
+
+A Frontend Profile cannot change the core prompt and does not contain user
+memory, a Realtime Provider, a backend Agent, secrets, scripts, or executable
+code. Secrets remain environment references in MCP/OpenAPI configurations.
+Unknown fields, paths outside the profile directory, and missing files fail
+explicitly during Gateway startup.
+
+Web Search keeps its independent Provider configuration. Without user
+configuration, only the simple built-in search fallback is used; profiles do
+not add a search-engine fallback chain.

--- a/docs/reference/frontend-profile.zh.md
+++ b/docs/reference/frontend-profile.zh.md
@@ -1,0 +1,62 @@
+# 轻量 Frontend Profile
+
+Frontend Profile 是一个本地、版本化的组合清单，用一个入口选择前台助手画像和外部工具
+配置。它适合把一套前台体验作为目录保存或分享，但不会引入新的 Skill 或插件协议。
+
+## 配置
+
+创建一个目录：
+
+```text
+research-profile/
+├── frontend-profile.json
+├── ASSISTANT.md
+└── tools/
+    ├── mcp.json
+    └── openapi.json
+```
+
+`frontend-profile.json`：
+
+```json
+{
+  "version": 1,
+  "name": "research",
+  "description": "面向检索与资料整理的语音前台",
+  "assistant": "./ASSISTANT.md",
+  "toolSources": {
+    "mcp": "./tools/mcp.json",
+    "openapi": "./tools/openapi.json"
+  }
+}
+```
+
+启用：
+
+```dotenv
+QWEN_AUDIO_FRONTEND_PROFILE=/absolute/path/to/research-profile/frontend-profile.json
+```
+
+`assistant`、`toolSources.mcp` 和 `toolSources.openapi` 都是可选项，但至少配置一项。
+引用必须是 Profile 目录内已有文件的相对路径。MCP 与 OpenAPI 文件继续使用各自的
+版本化格式和授权策略；Profile 不复制它们的协议。
+
+## 优先级
+
+原有单项设置拥有更高优先级，便于临时覆盖：
+
+1. `QWEN_AUDIO_AGENT_ASSISTANT_PROFILE_PATH`、`QWEN_AUDIO_FRONTEND_MCP_CONFIG`、
+   `QWEN_AUDIO_FRONTEND_OPENAPI_CONFIG`；
+2. Frontend Profile 中的引用；
+3. qwen-audio-agent 默认配置。
+
+`/api/health` 的 `frontendProfile` 只报告是否启用、名称和描述，不暴露本地路径。
+
+## 边界
+
+Frontend Profile 不能修改核心 Prompt，也不包含用户记忆、Realtime Provider、后台
+Agent、密钥、脚本或可执行代码。密钥仍通过环境变量传入 MCP/OpenAPI 配置。未知字段、
+越出目录的路径和缺失文件会在 Gateway 启动时明确失败。
+
+Web Search 继续使用独立的 Provider 配置；未配置时只有内置的简易搜索兜底。Profile
+不会增加搜索引擎回退链。

--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -249,7 +249,11 @@ delegation strategy, and backend MCP/skills/models remain backend-private.
     executor.
   - [x] Add generic approval before enabling mutating tools.
 - [x] OpenAPI tool adapter.
-- [ ] Lightweight frontend profiles; do not invent a public skill standard.
+- [x] Lightweight frontend profiles; do not invent a public skill standard.
+  - [x] Compose assistant persona, MCP, and OpenAPI configuration references
+    through one versioned local manifest.
+  - [x] Keep secrets, user memory, Realtime Providers, and backend Agents
+    outside the profile boundary.
 - [ ] Backend adapter SDK and examples.
 - [ ] Optional A2A backend adapter.
 

--- a/docs/roadmap/frontend-chatbot-runtime.zh.md
+++ b/docs/roadmap/frontend-chatbot-runtime.zh.md
@@ -293,7 +293,9 @@ Presentation 只携带供前台表达的事实材料和投递策略，不携带�
   - [x] 把发现到的工具接入动态 Realtime 工具注册表与执行器。
   - [x] 在启用可写工具前增加通用授权链路。
 - [x] OpenAPI Tool Adapter。
-- [ ] 轻量 Frontend Profile；暂不自创公开 Skill 标准。
+- [x] 轻量 Frontend Profile；暂不自创公开 Skill 标准。
+  - [x] 用版本化本地清单组合助手画像、MCP 与 OpenAPI 配置引用。
+  - [x] 保持密钥、用户记忆、Realtime Provider 和后台 Agent 在 Profile 边界之外。
 - [ ] Backend Adapter SDK 与示例。
 - [ ] 可选 A2A Backend Adapter。
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "docs/reference/frontend-mcp.zh.md",
     "docs/reference/frontend-openapi.md",
     "docs/reference/frontend-openapi.zh.md",
+    "docs/reference/frontend-profile.md",
+    "docs/reference/frontend-profile.zh.md",
     "docs/voice-frontends/speech-to-speech.md",
     "docs/voice-frontends/speech-to-speech.zh.md",
     "docs/voice-frontends/custom-provider.md",

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -341,6 +341,11 @@ app.get('/api/health', (req, res) => {
     announcementBatchMs: config.announcementBatchMs,
     announcementQuietMs: config.announcementQuietMs,
     frontendMemory: frontendMemoryService.health(),
+    frontendProfile: config.frontendProfile || {
+      configured: false,
+      name: 'default',
+      description: '',
+    },
     frontendRetrieval: retrievalRuntime.describe(),
     frontendKnowledge: frontendKnowledgeRuntime.describe(),
     frontendMcp: frontendMcpRuntime?.health?.() || {

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -14,6 +14,10 @@ import {
 import {
   resolveRealtimeFrontendConfiguration,
 } from '../../../shared/realtime-provider-catalog.mjs'
+import {
+  loadFrontendProfile,
+  resolveFrontendProfileConfiguration,
+} from './frontend-profile.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const sourceRoot = resolve(here, '../../..')
@@ -193,6 +197,15 @@ export function resolveOpenCodeCoordinatorAgent(env = process.env) {
 
 const realtimeFrontend = resolveRealtimeFrontendConfiguration(process.env)
 const webSearch = resolveWebSearchConfiguration(process.env)
+const loadedFrontendProfile = loadFrontendProfile({
+  filePath: process.env.QWEN_AUDIO_FRONTEND_PROFILE,
+})
+const frontendProfileConfiguration = resolveFrontendProfileConfiguration({
+  profile: loadedFrontendProfile,
+  env: process.env,
+  defaultAssistantProfilePath: runtimeEnvironment.assistantProfilePath,
+  baseDirectory: root,
+})
 
 export const config = {
   root,
@@ -226,12 +239,9 @@ export const config = {
   webSearchMcpUrl: webSearch.mcpUrl,
   webSearchMcpToken: webSearch.mcpToken,
   webSearchMcpTool: webSearch.mcpTool,
-  frontendMcpConfigPath: String(
-    process.env.QWEN_AUDIO_FRONTEND_MCP_CONFIG || '',
-  ).trim(),
-  frontendOpenApiConfigPath: String(
-    process.env.QWEN_AUDIO_FRONTEND_OPENAPI_CONFIG || '',
-  ).trim(),
+  frontendProfile: frontendProfileConfiguration.frontendProfile,
+  frontendMcpConfigPath: frontendProfileConfiguration.frontendMcpConfigPath,
+  frontendOpenApiConfigPath: frontendProfileConfiguration.frontendOpenApiConfigPath,
   allowedOrigins: String(process.env.QWEN_AUDIO_AGENT_ALLOWED_ORIGINS || '')
     .split(',')
     .map(value => value.trim())
@@ -406,9 +416,7 @@ export const config = {
   frontendPromptDir: process.env.QWEN_AUDIO_AGENT_FRONTEND_PROMPT_DIR
     ? resolve(root, process.env.QWEN_AUDIO_AGENT_FRONTEND_PROMPT_DIR)
     : resolve(root, 'config/frontend-agent'),
-  assistantProfilePath: process.env.QWEN_AUDIO_AGENT_ASSISTANT_PROFILE_PATH
-    ? resolve(root, process.env.QWEN_AUDIO_AGENT_ASSISTANT_PROFILE_PATH)
-    : runtimeEnvironment.assistantProfilePath,
+  assistantProfilePath: frontendProfileConfiguration.assistantProfilePath,
   frontendMemoryPath: process.env.QWEN_AUDIO_AGENT_MEMORY_PATH
     ? resolve(root, process.env.QWEN_AUDIO_AGENT_MEMORY_PATH)
     : process.env.QWEN_AUDIO_AGENT_FRONTEND_MEMORY_PATH

--- a/server/src/core/frontend-profile.mjs
+++ b/server/src/core/frontend-profile.mjs
@@ -1,0 +1,183 @@
+import { readFileSync, realpathSync, statSync } from 'node:fs'
+import { dirname, isAbsolute, relative, resolve } from 'node:path'
+
+const PROFILE_KEYS = new Set([
+  '$schema',
+  'version',
+  'name',
+  'description',
+  'assistant',
+  'toolSources',
+])
+const TOOL_SOURCE_KEYS = new Set(['mcp', 'openapi'])
+
+function clean(value, maxChars = 1_000) {
+  return [...String(value || '').replace(/\s+/gu, ' ').trim()]
+    .slice(0, maxChars)
+    .join('')
+}
+
+function assertObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`)
+  }
+}
+
+function assertKnownKeys(value, allowed, label) {
+  const unknown = Object.keys(value).filter(key => !allowed.has(key))
+  if (unknown.length) {
+    throw new Error(`${label} contains unsupported fields: ${unknown.join(', ')}.`)
+  }
+}
+
+function optionalText(value, { field, maxChars }) {
+  if (value === undefined) return ''
+  if (typeof value !== 'string') {
+    throw new Error(`Frontend Profile ${field} must be a string.`)
+  }
+  return clean(value, maxChars)
+}
+
+function bundlePath(value, { baseDirectory, field }) {
+  const source = optionalText(value, { field, maxChars: 2_048 })
+  if (!source) return ''
+  if (isAbsolute(source) || /^(?:[a-z][a-z0-9+.-]*:|[\\/]{2})/iu.test(source)) {
+    throw new Error(`Frontend Profile ${field} must be a relative local path.`)
+  }
+  const path = resolve(baseDirectory, source)
+  const relativePath = relative(baseDirectory, path)
+  if (
+    !relativePath
+    || relativePath === '..'
+    || relativePath.startsWith('../')
+    || relativePath.startsWith('..\\')
+    || isAbsolute(relativePath)
+  ) {
+    throw new Error(`Frontend Profile ${field} must stay inside its profile directory.`)
+  }
+  let stats
+  try {
+    stats = statSync(path)
+  } catch (error) {
+    throw new Error(`Frontend Profile ${field} is unavailable: ${error.message}`)
+  }
+  if (!stats.isFile()) {
+    throw new Error(`Frontend Profile ${field} must reference a file.`)
+  }
+  const realBase = realpathSync(baseDirectory)
+  const realPath = realpathSync(path)
+  const realRelativePath = relative(realBase, realPath)
+  if (
+    realRelativePath === '..'
+    || realRelativePath.startsWith('../')
+    || realRelativePath.startsWith('..\\')
+    || isAbsolute(realRelativePath)
+  ) {
+    throw new Error(`Frontend Profile ${field} must stay inside its profile directory.`)
+  }
+  return path
+}
+
+export function emptyFrontendProfile() {
+  return {
+    version: 1,
+    configured: false,
+    name: 'default',
+    description: '',
+    assistantProfilePath: '',
+    frontendMcpConfigPath: '',
+    frontendOpenApiConfigPath: '',
+  }
+}
+
+export function normalizeFrontendProfile(value, {
+  baseDirectory = process.cwd(),
+} = {}) {
+  assertObject(value, 'Frontend Profile')
+  assertKnownKeys(value, PROFILE_KEYS, 'Frontend Profile')
+  if (value.$schema !== undefined && typeof value.$schema !== 'string') {
+    throw new Error('Frontend Profile $schema must be a string.')
+  }
+  if (value.version !== 1) {
+    throw new Error('Frontend Profile version must be 1.')
+  }
+  const name = optionalText(value.name, { field: 'name', maxChars: 80 })
+  if (!name) throw new Error('Frontend Profile requires a name.')
+  const toolSources = value.toolSources === undefined ? {} : value.toolSources
+  assertObject(toolSources, 'Frontend Profile toolSources')
+  assertKnownKeys(toolSources, TOOL_SOURCE_KEYS, 'Frontend Profile toolSources')
+  const profile = {
+    version: 1,
+    configured: true,
+    name,
+    description: optionalText(value.description, {
+      field: 'description',
+      maxChars: 280,
+    }),
+    assistantProfilePath: bundlePath(value.assistant, {
+      baseDirectory,
+      field: 'assistant',
+    }),
+    frontendMcpConfigPath: bundlePath(toolSources.mcp, {
+      baseDirectory,
+      field: 'toolSources.mcp',
+    }),
+    frontendOpenApiConfigPath: bundlePath(toolSources.openapi, {
+      baseDirectory,
+      field: 'toolSources.openapi',
+    }),
+  }
+  if (![
+    profile.assistantProfilePath,
+    profile.frontendMcpConfigPath,
+    profile.frontendOpenApiConfigPath,
+  ].some(Boolean)) {
+    throw new Error('Frontend Profile must reference an assistant or tool source.')
+  }
+  return profile
+}
+
+export function loadFrontendProfile({
+  filePath = process.env.QWEN_AUDIO_FRONTEND_PROFILE,
+} = {}) {
+  const configuredPath = clean(filePath, 2_048)
+  if (!configuredPath) return emptyFrontendProfile()
+  const path = resolve(configuredPath)
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'))
+  } catch (error) {
+    const failure = new Error(`Unable to read Frontend Profile: ${error.message}`)
+    failure.cause = error
+    throw failure
+  }
+  return normalizeFrontendProfile(parsed, { baseDirectory: dirname(path) })
+}
+
+export function resolveFrontendProfileConfiguration({
+  profile = emptyFrontendProfile(),
+  env = process.env,
+  defaultAssistantProfilePath = '',
+  baseDirectory = process.cwd(),
+} = {}) {
+  const explicit = name => clean(env[name], 2_048)
+  const explicitAssistant = explicit('QWEN_AUDIO_AGENT_ASSISTANT_PROFILE_PATH')
+  return {
+    frontendProfile: {
+      configured: profile.configured === true,
+      name: clean(profile.name, 80) || 'default',
+      description: clean(profile.description, 280),
+    },
+    assistantProfilePath: (explicitAssistant
+      ? resolve(baseDirectory, explicitAssistant)
+      : '')
+      || profile.assistantProfilePath
+      || defaultAssistantProfilePath,
+    frontendMcpConfigPath: explicit('QWEN_AUDIO_FRONTEND_MCP_CONFIG')
+      || profile.frontendMcpConfigPath
+      || '',
+    frontendOpenApiConfigPath: explicit('QWEN_AUDIO_FRONTEND_OPENAPI_CONFIG')
+      || profile.frontendOpenApiConfigPath
+      || '',
+  }
+}

--- a/server/test/frontend-profile.test.mjs
+++ b/server/test/frontend-profile.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import {
+  emptyFrontendProfile,
+  loadFrontendProfile,
+  normalizeFrontendProfile,
+  resolveFrontendProfileConfiguration,
+} from '../src/core/frontend-profile.mjs'
+
+function fixture() {
+  const directory = mkdtempSync(join(tmpdir(), 'qwen-audio-profile-'))
+  mkdirSync(join(directory, 'tools'))
+  writeFileSync(join(directory, 'ASSISTANT.md'), '# Assistant\n', 'utf8')
+  writeFileSync(join(directory, 'tools', 'mcp.json'), '{}\n', 'utf8')
+  writeFileSync(join(directory, 'tools', 'openapi.json'), '{}\n', 'utf8')
+  return directory
+}
+
+test('uses one inert default when no Frontend Profile is configured', () => {
+  assert.deepEqual(loadFrontendProfile({ filePath: '' }), emptyFrontendProfile())
+})
+
+test('loads a portable profile and resolves only local bundle references', () => {
+  const directory = fixture()
+  const filePath = join(directory, 'frontend-profile.json')
+  try {
+    writeFileSync(filePath, JSON.stringify({
+      version: 1,
+      name: '  Research   Voice  ',
+      description: ' Search and reference tools. ',
+      assistant: './ASSISTANT.md',
+      toolSources: {
+        mcp: './tools/mcp.json',
+        openapi: './tools/openapi.json',
+      },
+    }), 'utf8')
+    assert.deepEqual(loadFrontendProfile({ filePath }), {
+      version: 1,
+      configured: true,
+      name: 'Research Voice',
+      description: 'Search and reference tools.',
+      assistantProfilePath: join(directory, 'ASSISTANT.md'),
+      frontendMcpConfigPath: join(directory, 'tools', 'mcp.json'),
+      frontendOpenApiConfigPath: join(directory, 'tools', 'openapi.json'),
+    })
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('keeps explicit environment paths above profile defaults', () => {
+  const profile = {
+    ...emptyFrontendProfile(),
+    configured: true,
+    name: 'work',
+    description: 'Work profile',
+    assistantProfilePath: '/profile/ASSISTANT.md',
+    frontendMcpConfigPath: '/profile/mcp.json',
+    frontendOpenApiConfigPath: '/profile/openapi.json',
+  }
+  assert.deepEqual(resolveFrontendProfileConfiguration({
+    profile,
+    env: {
+      QWEN_AUDIO_AGENT_ASSISTANT_PROFILE_PATH: '/explicit/ASSISTANT.md',
+      QWEN_AUDIO_FRONTEND_MCP_CONFIG: '/explicit/mcp.json',
+    },
+    defaultAssistantProfilePath: '/default/ASSISTANT.md',
+  }), {
+    frontendProfile: {
+      configured: true,
+      name: 'work',
+      description: 'Work profile',
+    },
+    assistantProfilePath: '/explicit/ASSISTANT.md',
+    frontendMcpConfigPath: '/explicit/mcp.json',
+    frontendOpenApiConfigPath: '/profile/openapi.json',
+  })
+})
+
+test('fails closed for unsupported fields, escapes, and empty manifests', () => {
+  const directory = fixture()
+  try {
+    assert.throws(() => normalizeFrontendProfile({
+      version: 1,
+      name: 'bad',
+      backend: 'qwen',
+      assistant: './ASSISTANT.md',
+    }, { baseDirectory: directory }), /unsupported fields: backend/)
+    assert.throws(() => normalizeFrontendProfile({
+      version: 1,
+      name: 'escape',
+      assistant: '../ASSISTANT.md',
+    }, { baseDirectory: directory }), /must stay inside/)
+    assert.throws(() => normalizeFrontendProfile({
+      version: 1,
+      name: 'empty',
+    }, { baseDirectory: directory }), /must reference an assistant or tool source/)
+    assert.throws(() => normalizeFrontendProfile({
+      version: 1,
+      name: ['not', 'text'],
+      assistant: './ASSISTANT.md',
+    }, { baseDirectory: directory }), /name must be a string/)
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})

--- a/server/test/frontend-profile.test.mjs
+++ b/server/test/frontend-profile.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import test from 'node:test'
 import {
   emptyFrontendProfile,
@@ -74,7 +74,7 @@ test('keeps explicit environment paths above profile defaults', () => {
       name: 'work',
       description: 'Work profile',
     },
-    assistantProfilePath: '/explicit/ASSISTANT.md',
+    assistantProfilePath: resolve('/explicit/ASSISTANT.md'),
     frontendMcpConfigPath: '/explicit/mcp.json',
     frontendOpenApiConfigPath: '/profile/openapi.json',
   })

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -52,6 +52,11 @@ test('constructs an injectable Gateway without binding a port on import', async 
   const realtimeProviderRegistry = createRealtimeProviderRegistry({
     providers: [privateProvider],
   })
+  const frontendProfile = {
+    configured: true,
+    name: 'test-profile',
+    description: 'Test frontend composition',
+  }
   let mcpClosed = false
   let openApiClosed = false
   const frontendMcp = {
@@ -86,6 +91,7 @@ test('constructs an injectable Gateway without binding a port on import', async 
       port: 0,
       webSearchProvider: 'none',
       webSearchMcpUrl: '',
+      frontendProfile,
     },
     parentPort: null,
     autoStart: false,
@@ -119,6 +125,7 @@ test('constructs an injectable Gateway without binding a port on import', async 
   assert.deepEqual(health.frontendRetrieval.capabilities, ['url-fetch'])
   assert.equal(health.frontendRetrieval.searchProvider, null)
   assert.deepEqual(health.frontendKnowledge.capabilities, ['knowledge'])
+  assert.deepEqual(health.frontendProfile, frontendProfile)
   assert.deepEqual(health.frontendMcp, {
     ok: true,
     initialized: true,


### PR DESCRIPTION
Roadmap: #185

## Summary
- add a versioned local Frontend Profile manifest for assistant, MCP, and OpenAPI configuration references
- preserve focused environment overrides and expose only safe profile metadata in Gateway health
- document the portable bundle boundary in English and Chinese without defining a new Skill protocol

## Validation
- `AGENT_PROTOCOL=none npm run release:check`
- `node --test server/test/frontend-profile.test.mjs server/test/gateway-application.test.mjs`