### PR TITLE
feat: add optional A2A backend adapter

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,6 +15,7 @@ qwen-audio-agent 使用并分发若干开源组件。项目自身使用 Apache L
 | react-markdown | MIT | https://github.com/remarkjs/react-markdown |
 | remark-gfm | MIT | https://github.com/remarkjs/remark-gfm |
 | electron-builder | MIT | https://github.com/electron-userland/electron-builder |
+| Agent2Agent Protocol JavaScript SDK | Apache-2.0 | https://github.com/a2aproject/a2a-js |
 | Agent Client Protocol TypeScript SDK | Apache-2.0 | https://github.com/agentclientprotocol/typescript-sdk |
 | Codex ACP adapter | Apache-2.0 | https://github.com/agentclientprotocol/codex-acp |
 | Claude Code ACP adapter | Apache-2.0 | https://github.com/zed-industries/claude-code-acp |

--- a/docs/reference/a2a-backend-adapter.md
+++ b/docs/reference/a2a-backend-adapter.md
@@ -1,0 +1,96 @@
+# A2A Backend Adapter
+
+The optional A2A Backend Adapter connects one remote A2A agent to the existing
+`BackendPort`. It uses the official A2A JavaScript SDK for Agent Card discovery,
+protocol negotiation, messages, Tasks, cancellation, and Artifact decoding.
+A2A objects remain private to the adapter; the Gateway, Work runtime, frontend,
+and clients continue to use their protocol-neutral contracts.
+
+This is a programmatic extension for custom Gateway launchers. It does not add
+an `AGENT_PROTOCOL` value or a Desktop setting.
+
+## Connect an agent
+
+```js
+import { createGatewayApplication } from 'qwen-audio-agent/gateway-application'
+import { createBackendAgentHost } from 'qwen-audio-agent/backend-adapter-sdk'
+import {
+  createA2ABackendAdapter,
+} from 'qwen-audio-agent/a2a-backend-adapter'
+
+const backend = createA2ABackendAdapter({
+  agentCardUrl: 'https://agent.example/.well-known/agent-card.json',
+  token: process.env.MY_A2A_TOKEN,
+})
+const agent = createBackendAgentHost(backend)
+const application = createGatewayApplication({ agent })
+
+process.once('SIGTERM', () => application.close())
+```
+
+`agentCardUrl` is the complete public Agent Card URL. It must use HTTP or HTTPS
+and cannot contain credentials. Use `token` for Bearer authentication, or
+`headers` for another scheme:
+
+```js
+const backend = createA2ABackendAdapter({
+  agentCardUrl: process.env.MY_A2A_AGENT_CARD_URL,
+  headers: async () => ({
+    Authorization: `Bearer ${await refreshAccessToken()}`,
+    'X-Tenant': 'tenant-one',
+  }),
+})
+```
+
+Configured headers are applied to both discovery and task requests but are
+never returned by `describe()`. An in-memory standard `agentCard` can replace
+URL discovery. JSON-RPC and HTTP+JSON/REST are supported; the first compatible
+interface declared by the Agent Card is selected. A2A 0.3 compatibility is
+enabled by default through the official SDK and can be disabled with
+`legacyCompat: false`.
+
+## Work projection
+
+- The Work objective becomes the user Message text.
+- Input attachments become standard A2A raw or URL Parts with MIME types.
+- The adapter requests non-blocking execution, then polls `GetTask` so Gateway
+  status and cancellation remain responsive without requiring streaming.
+- A2A status updates become `backend.activity` events.
+- Final A2A Artifacts become standard Gateway Artifacts; the final agent status
+  Message supplies natural speech material.
+- `CancelTask` is used when the remote task ID is known. Local cancellation
+  still terminates a request that has not received a Task ID yet.
+
+Gateway Work IDs never become remote task identities. The mapping exists only
+while a submission is active and remote IDs do not cross `BackendPort`.
+
+## State mapping
+
+| A2A Task state | Backend state |
+| --- | --- |
+| `SUBMITTED` | `submitted` |
+| `WORKING` / `UNSPECIFIED` | `working` |
+| `COMPLETED` | completed outcome |
+| `FAILED` / `REJECTED` | failed outcome |
+| `CANCELED` | cancelled outcome |
+| `INPUT_REQUIRED` / `AUTH_REQUIRED` | explicit unsupported-interaction error |
+
+A2A does not assign universal semantics to an authorization decision after
+`AUTH_REQUIRED`; agents define that through their own flow or an extension.
+The adapter therefore does not guess credentials or approval behavior. A
+future authorization extension can be implemented inside this adapter without
+changing Work or frontend contracts.
+
+## Options
+
+- `agentCardUrl` or `agentCard`: exactly one discovery source is required;
+- `token`, `headers`, `fetchImpl`: authentication and transport hooks;
+- `acceptedOutputModes`: requested result MIME types;
+- `pollIntervalMs`: task polling interval, default 1 second;
+- `timeoutMs`: per-Work timeout, default 5 minutes;
+- `legacyCompat`: official A2A 0.3 compatibility, default enabled;
+- `clientFactory`: test or advanced transport injection.
+
+Run the public Backend Adapter conformance suite for any derived adapter. The
+built-in A2A adapter itself is covered by conformance tests plus an A2A 1.0
+HTTP+JSON discovery and task round trip.

--- a/docs/reference/a2a-backend-adapter.zh.md
+++ b/docs/reference/a2a-backend-adapter.zh.md
@@ -1,0 +1,88 @@
+# A2A Backend Adapter
+
+可选 A2A Backend Adapter 用于把一个远程 A2A Agent 接到现有 `BackendPort`。它使用
+官方 A2A JavaScript SDK 完成 Agent Card 发现、协议协商、消息提交、Task 查询与取消、
+Artifact 解码。A2A 对象只存在于 Adapter 内部；Gateway、Work Runtime、语音前台和
+客户端仍使用协议无关的现有契约。
+
+这是供自定义 Gateway 启动器使用的编程扩展，不新增 `AGENT_PROTOCOL` 值，也不在桌面
+设置中增加选项。
+
+## 连接 Agent
+
+```js
+import { createGatewayApplication } from 'qwen-audio-agent/gateway-application'
+import { createBackendAgentHost } from 'qwen-audio-agent/backend-adapter-sdk'
+import {
+  createA2ABackendAdapter,
+} from 'qwen-audio-agent/a2a-backend-adapter'
+
+const backend = createA2ABackendAdapter({
+  agentCardUrl: 'https://agent.example/.well-known/agent-card.json',
+  token: process.env.MY_A2A_TOKEN,
+})
+const agent = createBackendAgentHost(backend)
+const application = createGatewayApplication({ agent })
+
+process.once('SIGTERM', () => application.close())
+```
+
+`agentCardUrl` 是完整的公开 Agent Card URL，只允许 HTTP/HTTPS，且不能在 URL 中携带
+用户名或密码。Bearer 认证使用 `token`；其他认证方式使用 `headers`：
+
+```js
+const backend = createA2ABackendAdapter({
+  agentCardUrl: process.env.MY_A2A_AGENT_CARD_URL,
+  headers: async () => ({
+    Authorization: `Bearer ${await refreshAccessToken()}`,
+    'X-Tenant': 'tenant-one',
+  }),
+})
+```
+
+配置的 Header 同时用于 Agent Card 发现和 Task 请求，不会由 `describe()` 返回。也可以
+直接传入标准 `agentCard` 对象。Adapter 支持 JSON-RPC 与 HTTP+JSON/REST，并按 Agent
+Card 的声明顺序选择首个兼容接口。官方 SDK 的 A2A 0.3 兼容默认开启，可通过
+`legacyCompat: false` 关闭。
+
+## Work 投射
+
+- Work objective 成为用户 Message 文本；
+- 输入附件变成带 MIME 类型的标准 A2A raw 或 URL Part；
+- Adapter 请求非阻塞执行，再轮询 `GetTask`，无需依赖 Streaming 也能保持 Gateway 状态
+  和取消响应；
+- A2A 状态更新投射为 `backend.activity`；
+- 最终 A2A Artifact 投射为标准 Gateway Artifact，最终 Agent 状态 Message 提供自然播报
+  材料；
+- 获得远程 Task ID 后使用 `CancelTask`；尚未获得 ID 时仍可中止本地请求。
+
+Gateway Work ID 不会成为远程 Task 身份。二者映射只在当前提交执行期间存在，远程 ID
+不会越过 `BackendPort`。
+
+## 状态映射
+
+| A2A Task 状态 | Backend 状态 |
+| --- | --- |
+| `SUBMITTED` | `submitted` |
+| `WORKING` / `UNSPECIFIED` | `working` |
+| `COMPLETED` | 完成结果 |
+| `FAILED` / `REJECTED` | 失败结果 |
+| `CANCELED` | 取消结果 |
+| `INPUT_REQUIRED` / `AUTH_REQUIRED` | 明确返回暂不支持交互的错误 |
+
+A2A 不为 `AUTH_REQUIRED` 后的授权决定规定统一语义，具体流程由 Agent 或协议扩展定义。
+因此当前 Adapter 不猜测凭据或审批行为。以后可以在 Adapter 内实现具体授权扩展，无需
+修改 Work 或前台契约。
+
+## 配置项
+
+- `agentCardUrl` 或 `agentCard`：必须提供一种发现来源；
+- `token`、`headers`、`fetchImpl`：认证与传输扩展；
+- `acceptedOutputModes`：期望接收的结果 MIME 类型；
+- `pollIntervalMs`：Task 轮询间隔，默认 1 秒；
+- `timeoutMs`：单个 Work 超时，默认 5 分钟；
+- `legacyCompat`：官方 A2A 0.3 兼容，默认开启；
+- `clientFactory`：测试或高级传输注入。
+
+派生 Adapter 仍应运行公共 Backend Adapter conformance suite。内置 A2A Adapter 已覆盖
+完整 conformance 测试，以及 A2A 1.0 HTTP+JSON 的 Agent Card 发现和任务回环测试。

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cli"
       ],
       "dependencies": {
+        "@a2a-js/sdk": "1.0.1",
         "@agentclientprotocol/sdk": "1.3.0",
         "@modelcontextprotocol/sdk": "1.30.0",
         "@qwen-code/open-computer-use": "^0.2.3",
@@ -58,6 +59,35 @@
       },
       "devDependencies": {
         "electron": "^43.2.0"
+      }
+    },
+    "node_modules/@a2a-js/sdk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^6.2.3",
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -8567,6 +8597,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "./gateway-client-state": "./shared/gateway-client-state.mjs",
     "./gateway-application": "./server/src/app/gateway-application.mjs",
     "./backend-adapter-sdk": "./server/src/backend/backend-adapter-sdk.mjs",
+    "./a2a-backend-adapter": "./server/src/backend/a2a-backend-adapter.mjs",
     "./realtime-provider": "./server/src/voice/realtime-provider-extension.mjs",
     "./settings": "./desktop/src/settings-store.mjs",
     "./skin-store": "./desktop/src/skin-store.mjs",
@@ -104,6 +105,8 @@
     "docs/reference/frontend-profile.zh.md",
     "docs/reference/backend-adapter-sdk.md",
     "docs/reference/backend-adapter-sdk.zh.md",
+    "docs/reference/a2a-backend-adapter.md",
+    "docs/reference/a2a-backend-adapter.zh.md",
     "docs/voice-frontends/speech-to-speech.md",
     "docs/voice-frontends/speech-to-speech.zh.md",
     "docs/voice-frontends/custom-provider.md",
@@ -191,6 +194,7 @@
     "release:check": "./scripts/release-check"
   },
   "dependencies": {
+    "@a2a-js/sdk": "1.0.1",
     "@agentclientprotocol/sdk": "1.3.0",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@qwen-code/open-computer-use": "^0.2.3",

--- a/server/src/backend/a2a-backend-adapter.mjs
+++ b/server/src/backend/a2a-backend-adapter.mjs
@@ -1,0 +1,801 @@
+import { randomUUID } from 'node:crypto'
+import {
+  Role,
+  TaskState,
+} from '@a2a-js/sdk'
+import {
+  ClientFactory,
+  DefaultAgentCardResolver,
+  JsonRpcTransportFactory,
+  RestTransportFactory,
+} from '@a2a-js/sdk/client'
+import { parseDataUrl } from '../../../shared/input-parts.mjs'
+import { defineBackendAdapter } from './backend-adapter-sdk.mjs'
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000
+const DEFAULT_TIMEOUT_MS = 300_000
+const MAX_TEXT_CHARS = 1_000_000
+const MAX_ARTIFACTS = 32
+const MAX_ARTIFACT_PARTS = 64
+const DEFAULT_OUTPUT_MODES = Object.freeze([
+  'text/plain',
+  'text/markdown',
+  'application/json',
+  'image/png',
+  'image/jpeg',
+])
+
+const TERMINAL_STATES = new Set([
+  TaskState.TASK_STATE_COMPLETED,
+  TaskState.TASK_STATE_FAILED,
+  TaskState.TASK_STATE_CANCELED,
+  TaskState.TASK_STATE_REJECTED,
+])
+
+const INTERRUPTED_STATES = new Set([
+  TaskState.TASK_STATE_INPUT_REQUIRED,
+  TaskState.TASK_STATE_AUTH_REQUIRED,
+])
+
+function clean(value) {
+  return String(value || '').trim()
+}
+
+function bounded(value, max = 4_000) {
+  return clean(value).slice(0, max)
+}
+
+function positiveNumber(value, fallback, minimum) {
+  const number = Number(value)
+  return Number.isFinite(number) && number >= minimum ? number : fallback
+}
+
+function cancellationError(workId, cause) {
+  const error = new A2ABackendError(`Work ${workId} was cancelled`, {
+    code: 'WORK_CANCELLED',
+    cause,
+  })
+  return error
+}
+
+function asErrorMessage(error) {
+  return bounded(error?.message || error, 1_000) || 'Unknown A2A error'
+}
+
+function safeUrl(value, label) {
+  const input = clean(value)
+  if (!input) return ''
+  let url
+  try {
+    url = new URL(input)
+  } catch {
+    throw new TypeError(`${label} must be an absolute URL`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new TypeError(`${label} must use HTTP or HTTPS`)
+  }
+  if (url.username || url.password) {
+    throw new TypeError(`${label} must not contain credentials`)
+  }
+  return url.toString()
+}
+
+function requestHeaders(input, init) {
+  const result = new Headers(
+    typeof Request !== 'undefined' && input instanceof Request
+      ? input.headers
+      : undefined,
+  )
+  new Headers(init?.headers).forEach((value, key) => result.set(key, value))
+  return result
+}
+
+function authenticatedFetch({ fetchImpl, headers, token, timeoutMs }) {
+  const base = fetchImpl || globalThis.fetch
+  if (typeof base !== 'function') {
+    throw new TypeError('A2A adapter requires a Fetch API implementation')
+  }
+  return async (input, init = {}) => {
+    const configured = typeof headers === 'function'
+      ? await headers()
+      : headers
+    const merged = requestHeaders(input, init)
+    if (clean(token) && !merged.has('authorization')) {
+      merged.set('authorization', `Bearer ${clean(token)}`)
+    }
+    new Headers(configured).forEach((value, key) => merged.set(key, value))
+    const timeout = AbortSignal.timeout(timeoutMs)
+    const signal = init.signal
+      ? AbortSignal.any([init.signal, timeout])
+      : timeout
+    return base(input, { ...init, headers: merged, signal })
+  }
+}
+
+async function createOfficialClient({
+  agentCard,
+  agentCardUrl,
+  fetchImpl,
+  legacyCompat,
+  acceptedOutputModes,
+}) {
+  const compatibility = legacyCompat ? { enabled: true } : undefined
+  const transports = [
+    new JsonRpcTransportFactory({
+      fetchImpl,
+      ...(compatibility ? { legacyCompat: compatibility } : {}),
+    }),
+    new RestTransportFactory({
+      fetchImpl,
+      ...(compatibility ? { legacyCompat: compatibility } : {}),
+    }),
+  ]
+  const resolver = new DefaultAgentCardResolver({
+    fetchImpl,
+    ...(compatibility ? { legacyCompat: compatibility } : {}),
+  })
+  const factory = new ClientFactory({
+    transports,
+    clientConfig: {
+      polling: true,
+      acceptedOutputModes,
+    },
+    cardResolver: resolver,
+  })
+  const resolvedCard = agentCard || await resolver.resolve(agentCardUrl, '')
+  const client = await factory.createFromAgentCard(resolvedCard)
+  return {
+    client,
+    agentCard: resolvedCard,
+  }
+}
+
+function textContent(part) {
+  if (part?.content?.$case === 'text') {
+    return bounded(part.content.value, MAX_TEXT_CHARS)
+  }
+  return bounded(part?.text, MAX_TEXT_CHARS)
+}
+
+function partContent(part) {
+  const mediaType = clean(part?.mediaType || part?.mimeType)
+  const filename = clean(part?.filename)
+  const common = {
+    ...(mediaType ? { mediaType } : {}),
+    ...(filename ? { filename } : {}),
+  }
+  if (part?.content?.$case === 'text' || part?.text !== undefined) {
+    const text = textContent(part)
+    return text ? { text, ...common } : null
+  }
+  if (part?.content?.$case === 'raw' || part?.raw !== undefined) {
+    const value = part?.content?.$case === 'raw'
+      ? part.content.value
+      : part.raw
+    const raw = Buffer.isBuffer(value)
+      ? value.toString('base64')
+      : value instanceof Uint8Array
+        ? Buffer.from(value).toString('base64')
+        : clean(value)
+    return raw ? { raw, ...common } : null
+  }
+  if (part?.content?.$case === 'url' || part?.url !== undefined) {
+    const url = clean(
+      part?.content?.$case === 'url' ? part.content.value : part.url,
+    )
+    return url ? { url, ...common } : null
+  }
+  if (part?.content?.$case === 'data' || part?.data !== undefined) {
+    return {
+      data: part?.content?.$case === 'data'
+        ? part.content.value
+        : part.data,
+      ...common,
+    }
+  }
+  return null
+}
+
+function messageText(message) {
+  return (Array.isArray(message?.parts) ? message.parts : [])
+    .map(textContent)
+    .filter(Boolean)
+    .join('\n')
+}
+
+function artifactParts(artifact) {
+  return (Array.isArray(artifact?.parts) ? artifact.parts : [])
+    .slice(0, MAX_ARTIFACT_PARTS)
+    .map(partContent)
+    .filter(Boolean)
+}
+
+function projectArtifact(artifact, index) {
+  const parts = artifactParts(artifact)
+  if (!parts.length) return null
+  return {
+    artifactId: bounded(artifact?.artifactId, 160) || `a2a_artifact_${index + 1}`,
+    ...(bounded(artifact?.name, 240) ? { name: bounded(artifact.name, 240) } : {}),
+    ...(bounded(artifact?.description, 1_000)
+      ? { description: bounded(artifact.description, 1_000) }
+      : {}),
+    parts,
+  }
+}
+
+function messageArtifact(message) {
+  const parts = (Array.isArray(message?.parts) ? message.parts : [])
+    .map(partContent)
+    .filter(part => part && part.text === undefined)
+  if (!parts.length) return []
+  return [{
+    artifactId: 'a2a_message',
+    name: 'A2A response',
+    parts,
+  }]
+}
+
+function taskArtifacts(task) {
+  return (Array.isArray(task?.artifacts) ? task.artifacts : [])
+    .slice(0, MAX_ARTIFACTS)
+    .map(projectArtifact)
+    .filter(Boolean)
+}
+
+function agentHistoryText(task) {
+  return (Array.isArray(task?.history) ? task.history : [])
+    .filter(message => (
+      message?.role === Role.ROLE_AGENT
+      || String(message?.role).toUpperCase() === 'ROLE_AGENT'
+    ))
+    .map(messageText)
+    .filter(Boolean)
+}
+
+function uniqueLines(values) {
+  const used = new Set()
+  return values.filter(value => {
+    const text = clean(value)
+    if (!text || used.has(text)) return false
+    used.add(text)
+    return true
+  })
+}
+
+function taskSummary(task) {
+  const status = messageText(task?.status?.message)
+  const history = agentHistoryText(task)
+  const artifactText = taskArtifacts(task)
+    .flatMap(artifact => artifact.parts)
+    .map(part => clean(part.text))
+    .filter(Boolean)
+  const lines = uniqueLines([status, ...history, ...artifactText])
+  return {
+    content: bounded(lines.join('\n\n'), MAX_TEXT_CHARS),
+    speech: status || history.at(-1) || '',
+  }
+}
+
+function taskState(task) {
+  return task?.status?.state ?? TaskState.TASK_STATE_UNSPECIFIED
+}
+
+function publicState(state) {
+  switch (state) {
+    case TaskState.TASK_STATE_SUBMITTED:
+      return 'submitted'
+    case TaskState.TASK_STATE_WORKING:
+    case TaskState.TASK_STATE_UNSPECIFIED:
+      return 'working'
+    case TaskState.TASK_STATE_COMPLETED:
+      return 'completed'
+    case TaskState.TASK_STATE_FAILED:
+    case TaskState.TASK_STATE_REJECTED:
+      return 'failed'
+    case TaskState.TASK_STATE_CANCELED:
+      return 'cancelled'
+    case TaskState.TASK_STATE_INPUT_REQUIRED:
+      return 'input_required'
+    case TaskState.TASK_STATE_AUTH_REQUIRED:
+      return 'auth_required'
+    default:
+      return 'working'
+  }
+}
+
+function taskLike(value) {
+  return Boolean(value && typeof value === 'object' && value.status && clean(value.id))
+}
+
+function messageLike(value) {
+  return Boolean(value && typeof value === 'object' && Array.isArray(value.parts))
+}
+
+function outgoingText(work) {
+  const objective = clean(work?.objective || work?.originalRequest || work?.message)
+  const original = clean(work?.originalRequest)
+  const supplied = (Array.isArray(work?.inputParts) ? work.inputParts : [])
+    .filter(part => part?.type === 'text')
+    .map(part => clean(part.text))
+    .filter(text => text && text !== objective && text !== original)
+  return uniqueLines([objective, ...supplied]).join('\n\n')
+}
+
+function outgoingPart(part) {
+  if (part?.type !== 'file') return null
+  const mediaType = clean(part.mime || part.mimeType) || 'application/octet-stream'
+  const filename = clean(part.filename)
+  const parsed = parseDataUrl(part.url)
+  if (parsed) {
+    return {
+      content: { $case: 'raw', value: Buffer.from(parsed.data, 'base64') },
+      metadata: undefined,
+      filename,
+      mediaType,
+    }
+  }
+  const url = clean(part.url)
+  if (!url) return null
+  return {
+    content: { $case: 'url', value: url },
+    metadata: undefined,
+    filename,
+    mediaType,
+  }
+}
+
+function outgoingMessage(work) {
+  const text = outgoingText(work)
+  const parts = [{
+    content: { $case: 'text', value: text },
+    metadata: undefined,
+    filename: '',
+    mediaType: 'text/plain',
+  }]
+  parts.push(
+    ...(Array.isArray(work?.inputParts) ? work.inputParts : [])
+      .map(outgoingPart)
+      .filter(Boolean),
+  )
+  return {
+    messageId: randomUUID(),
+    contextId: '',
+    taskId: '',
+    role: Role.ROLE_USER,
+    parts,
+    metadata: {
+      'qwen.audio/workId': clean(work.id),
+      'qwen.audio/jobId': clean(work.jobId),
+    },
+    extensions: [],
+    referenceTaskIds: [],
+  }
+}
+
+function wait(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason)
+      return
+    }
+    const done = () => {
+      signal?.removeEventListener('abort', abort)
+      resolve()
+    }
+    const timer = setTimeout(done, ms)
+    const abort = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', abort)
+      reject(signal.reason)
+    }
+    signal?.addEventListener('abort', abort, { once: true })
+  })
+}
+
+export class A2ABackendError extends Error {
+  constructor(message, { code = 'A2A_BACKEND_ERROR', cause } = {}) {
+    super(message, { cause })
+    this.name = 'A2ABackendError'
+    this.code = code
+  }
+}
+
+/**
+ * Optional A2A client adapter for one remote Backend Action Agent.
+ *
+ * A2A discovery, transport selection, Tasks, Messages and Artifacts stay in
+ * this adapter. The Gateway observes only the protocol-neutral BackendPort.
+ */
+export class A2ABackendAdapter {
+  constructor({
+    agentCard,
+    agentCardUrl = '',
+    headers = {},
+    token = '',
+    fetchImpl,
+    clientFactory = createOfficialClient,
+    acceptedOutputModes = DEFAULT_OUTPUT_MODES,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    legacyCompat = true,
+    label = 'A2A Agent',
+  } = {}) {
+    if (!agentCard && !clean(agentCardUrl)) {
+      throw new TypeError('A2A adapter requires agentCard or agentCardUrl')
+    }
+    this.configuredCard = agentCard || null
+    this.agentCardUrl = safeUrl(agentCardUrl, 'agentCardUrl')
+    this.clientFactory = clientFactory
+    this.acceptedOutputModes = [...acceptedOutputModes]
+    this.pollIntervalMs = positiveNumber(
+      pollIntervalMs,
+      DEFAULT_POLL_INTERVAL_MS,
+      10,
+    )
+    this.timeoutMs = positiveNumber(timeoutMs, DEFAULT_TIMEOUT_MS, 100)
+    this.fetchImpl = authenticatedFetch({
+      fetchImpl,
+      headers,
+      token,
+      timeoutMs: Math.min(this.timeoutMs, 30_000),
+    })
+    this.legacyCompat = legacyCompat !== false
+    this.label = clean(agentCard?.name || label) || 'A2A Agent'
+    this.client = null
+    this.agentCard = null
+    this.startPromise = null
+    this.ready = false
+    this.closed = false
+    this.failure = null
+    this.active = new Map()
+    this.listeners = new Set()
+  }
+
+  describe() {
+    const card = this.agentCard || this.configuredCard
+    const selected = this.client?.transport
+    return {
+      configured: true,
+      enabled: true,
+      protocol: 'a2a',
+      label: clean(card?.name || this.label) || 'A2A Agent',
+      transport: clean(selected?.protocolName) || 'a2a',
+      protocolVersion: clean(this.client?.protocolVersion) || null,
+      agentVersion: clean(card?.version) || null,
+      capabilities: {
+        cancel: true,
+        authorization: false,
+        discovery: true,
+        streaming: card?.capabilities?.streaming === true,
+        inputModes: Array.isArray(card?.defaultInputModes)
+          ? [...card.defaultInputModes]
+          : [],
+        outputModes: Array.isArray(card?.defaultOutputModes)
+          ? [...card.defaultOutputModes]
+          : [],
+      },
+    }
+  }
+
+  async start() {
+    if (this.closed) throw new A2ABackendError('A2A adapter is closed')
+    if (this.ready) return this.health()
+    if (this.startPromise) return this.startPromise
+    this.startPromise = (async () => {
+      try {
+        const connected = await this.clientFactory({
+          agentCard: this.configuredCard,
+          agentCardUrl: this.agentCardUrl,
+          fetchImpl: this.fetchImpl,
+          legacyCompat: this.legacyCompat,
+          acceptedOutputModes: this.acceptedOutputModes,
+        })
+        this.client = connected?.client || connected
+        if (!this.client || typeof this.client.sendMessage !== 'function') {
+          throw new TypeError('A2A client factory returned an invalid client')
+        }
+        this.agentCard = connected?.agentCard || this.configuredCard || null
+        this.ready = true
+        this.failure = null
+        return {
+          ok: true,
+          status: 'ready',
+          ...this.describe(),
+        }
+      } catch (error) {
+        this.ready = false
+        this.failure = error
+        throw error
+      } finally {
+        this.startPromise = null
+      }
+    })()
+    return this.startPromise
+  }
+
+  async health() {
+    if (!this.ready && !this.closed) {
+      try {
+        await this.start()
+      } catch (error) {
+        return {
+          ok: false,
+          status: 'failed',
+          code: clean(error?.code) || 'A2A_CONNECTION_FAILED',
+          error: asErrorMessage(error),
+          protocol: 'a2a',
+        }
+      }
+    }
+    return {
+      ok: this.ready && !this.closed,
+      status: this.ready && !this.closed ? 'ready' : 'stopped',
+      protocol: 'a2a',
+      ...(this.failure ? { error: asErrorMessage(this.failure) } : {}),
+    }
+  }
+
+  publish(event, record) {
+    try {
+      record?.onEvent?.(event)
+    } catch {
+      // Per-submission observers cannot interrupt backend execution.
+    }
+    const published = {
+      ...event,
+      workId: record?.workId || null,
+      ownerId: record?.ownerId || null,
+    }
+    for (const listener of this.listeners) {
+      try {
+        listener(published)
+      } catch {
+        // Subscribers are isolated from the adapter and from each other.
+      }
+    }
+  }
+
+  update(record, task) {
+    record.task = task
+    record.taskId = clean(task?.id) || record.taskId
+    const state = publicState(taskState(task))
+    const message = bounded(messageText(task?.status?.message), 1_000)
+    const digest = `${state}\u0000${message}`
+    if (digest === record.lastDigest) return
+    record.lastDigest = digest
+    record.activity = [{
+      id: 'a2a-status',
+      kind: 'status',
+      status: state,
+      message: message || `A2A task is ${state}`,
+    }]
+    this.publish({
+      type: 'backend.activity',
+      activity: record.activity[0],
+    }, record)
+  }
+
+  outcomeFromMessage(message) {
+    const content = messageText(message)
+    const speech = bounded(content) || '后台工作已经完成。'
+    return {
+      content: content || speech,
+      artifacts: messageArtifact(message),
+      presentation: { speech, inline: null },
+    }
+  }
+
+  outcomeFromTask(task) {
+    const summary = taskSummary(task)
+    const speech = bounded(summary.speech) || '后台工作已经完成。'
+    return {
+      content: summary.content || speech,
+      artifacts: taskArtifacts(task),
+      presentation: { speech, inline: null },
+    }
+  }
+
+  taskError(task) {
+    const state = taskState(task)
+    const detail = bounded(messageText(task?.status?.message), 1_000)
+    if (state === TaskState.TASK_STATE_CANCELED) {
+      return cancellationError(clean(task?.id), detail)
+    }
+    if (INTERRUPTED_STATES.has(state)) {
+      return new A2ABackendError(
+        detail || `A2A task requires unsupported interaction (${publicState(state)})`,
+        { code: 'A2A_INTERACTION_REQUIRED' },
+      )
+    }
+    return new A2ABackendError(
+      detail || `A2A task ended with state ${publicState(state)}`,
+      { code: state === TaskState.TASK_STATE_REJECTED ? 'A2A_TASK_REJECTED' : 'A2A_TASK_FAILED' },
+    )
+  }
+
+  async bestEffortCancel(record) {
+    if (!record?.taskId || !record.client?.cancelTask) return
+    try {
+      await record.client.cancelTask({ id: record.taskId }, {
+        signal: AbortSignal.timeout(Math.min(this.timeoutMs, 10_000)),
+      })
+    } catch {
+      // The primary operation error is more useful than cleanup failure.
+    }
+  }
+
+  async awaitTask(record, initial, signal) {
+    let task = initial
+    this.update(record, task)
+    while (!TERMINAL_STATES.has(taskState(task))) {
+      if (INTERRUPTED_STATES.has(taskState(task))) {
+        await this.bestEffortCancel(record)
+        throw this.taskError(task)
+      }
+      await wait(this.pollIntervalMs, signal)
+      task = await record.client.getTask({
+        id: record.taskId,
+        historyLength: 20,
+      }, { signal })
+      this.update(record, task)
+    }
+    if (taskState(task) !== TaskState.TASK_STATE_COMPLETED) {
+      throw this.taskError(task)
+    }
+    return this.outcomeFromTask(task)
+  }
+
+  async submit(work, { signal, onEvent } = {}) {
+    const workId = clean(work?.id || work?.workId)
+    const ownerId = clean(work?.ownerId)
+    const input = outgoingText(work)
+    if (!workId || !ownerId || !input) {
+      throw new A2ABackendError(
+        'Backend submit requires work id, owner and input',
+        { code: 'INVALID_WORK' },
+      )
+    }
+    if (this.active.has(workId)) {
+      throw new A2ABackendError(`Work ${workId} is already active`, {
+        code: 'WORK_ALREADY_ACTIVE',
+      })
+    }
+    await this.start()
+    const controller = new AbortController()
+    const timeout = AbortSignal.timeout(this.timeoutMs)
+    const workSignal = signal
+      ? AbortSignal.any([signal, controller.signal, timeout])
+      : AbortSignal.any([controller.signal, timeout])
+    const record = {
+      workId,
+      ownerId,
+      client: this.client,
+      controller,
+      onEvent,
+      taskId: '',
+      task: null,
+      activity: [],
+      lastDigest: '',
+    }
+    this.active.set(workId, record)
+    try {
+      const result = await record.client.sendMessage({
+        message: outgoingMessage(work),
+        configuration: {
+          acceptedOutputModes: this.acceptedOutputModes,
+          historyLength: 20,
+          returnImmediately: true,
+        },
+        metadata: {
+          'qwen.audio/workId': workId,
+          'qwen.audio/jobId': clean(work?.jobId),
+        },
+      }, { signal: workSignal })
+      if (taskLike(result)) {
+        record.taskId = clean(result.id)
+        return await this.awaitTask(record, result, workSignal)
+      }
+      if (messageLike(result)) return this.outcomeFromMessage(result)
+      throw new A2ABackendError('A2A agent returned an invalid response', {
+        code: 'A2A_INVALID_RESPONSE',
+      })
+    } catch (error) {
+      if (controller.signal.aborted || signal?.aborted) {
+        throw cancellationError(workId, error)
+      }
+      if (timeout.aborted) {
+        await this.bestEffortCancel(record)
+        throw new A2ABackendError(`A2A task timed out after ${this.timeoutMs} ms`, {
+          code: 'A2A_TIMEOUT',
+          cause: error,
+        })
+      }
+      throw error
+    } finally {
+      if (this.active.get(workId) === record) this.active.delete(workId)
+    }
+  }
+
+  status(workId, { ownerId } = {}) {
+    const id = clean(workId)
+    if (!id) {
+      return {
+        ok: this.ready && !this.closed,
+        status: this.ready && !this.closed ? 'ready' : 'stopped',
+        protocol: 'a2a',
+      }
+    }
+    const record = this.active.get(id)
+    if (!record || (ownerId && clean(ownerId) !== record.ownerId)) {
+      return { workId: id, state: 'not_found', activity: [] }
+    }
+    return {
+      workId: id,
+      state: record.task ? publicState(taskState(record.task)) : 'working',
+      activity: [...record.activity],
+    }
+  }
+
+  async cancel(workId, { ownerId } = {}) {
+    const id = clean(workId)
+    const record = this.active.get(id)
+    if (!record) return { workId: id, state: 'not_found' }
+    if (ownerId && clean(ownerId) !== record.ownerId) {
+      throw new A2ABackendError('Cannot cancel work owned by another user', {
+        code: 'WORK_NOT_FOUND',
+      })
+    }
+    let state = 'cancelled'
+    if (record.taskId) {
+      const task = await record.client.cancelTask({ id: record.taskId }, {
+        signal: AbortSignal.timeout(Math.min(this.timeoutMs, 10_000)),
+      })
+      if (taskLike(task)) {
+        this.update(record, task)
+        state = publicState(taskState(task))
+      }
+    }
+    if (state === 'cancelled') {
+      record.controller.abort(cancellationError(id))
+    }
+    return { workId: id, state }
+  }
+
+  async respondAuthorization() {
+    throw new A2ABackendError(
+      'A2A adapter does not define an authorization decision extension',
+      { code: 'A2A_AUTHORIZATION_UNSUPPORTED' },
+    )
+  }
+
+  subscribe(listener) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('Backend event listener must be a function')
+    }
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  async close() {
+    if (this.closed) return
+    this.closed = true
+    const active = [...this.active.values()]
+    await Promise.allSettled(active.map(record => this.bestEffortCancel(record)))
+    for (const record of active) {
+      record.controller.abort(cancellationError(record.workId))
+    }
+    this.active.clear()
+    this.listeners.clear()
+    this.ready = false
+    this.client = null
+  }
+}
+
+export function createA2ABackendAdapter(options) {
+  return defineBackendAdapter(new A2ABackendAdapter(options), {
+    name: 'A2A backend adapter',
+  })
+}
+
+export const A2A_BACKEND_ADAPTER_VERSION = '1.0.0'
+export { Role as A2ARole, TaskState as A2ATaskState }

--- a/server/test/a2a-backend-adapter.test.mjs
+++ b/server/test/a2a-backend-adapter.test.mjs
@@ -1,0 +1,364 @@
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import test from 'node:test'
+import {
+  A2ABackendAdapter,
+  A2ARole,
+  A2ATaskState,
+  createA2ABackendAdapter,
+} from '../src/backend/a2a-backend-adapter.mjs'
+import {
+  verifyBackendAdapterConformance,
+} from '../src/backend/backend-adapter-conformance.mjs'
+
+function textPart(text, mediaType = 'text/plain') {
+  return {
+    content: { $case: 'text', value: text },
+    metadata: undefined,
+    filename: '',
+    mediaType,
+  }
+}
+
+function message(text, options = {}) {
+  return {
+    messageId: options.messageId || 'message-one',
+    contextId: options.contextId || 'context-one',
+    taskId: options.taskId || '',
+    role: options.role ?? A2ARole.ROLE_AGENT,
+    parts: options.parts || [textPart(text)],
+    metadata: undefined,
+    extensions: [],
+    referenceTaskIds: [],
+  }
+}
+
+function task(state, options = {}) {
+  return {
+    id: options.id || 'a2a-task-one',
+    contextId: options.contextId || 'context-one',
+    status: {
+      state,
+      message: options.statusText
+        ? message(options.statusText, { taskId: options.id || 'a2a-task-one' })
+        : undefined,
+      timestamp: new Date().toISOString(),
+    },
+    artifacts: options.artifacts || [],
+    history: options.history || [],
+    metadata: undefined,
+  }
+}
+
+function work(index = 1) {
+  return {
+    id: `work-${index}`,
+    jobId: `job_${index}`,
+    ownerId: 'owner-one',
+    originalRequest: `完成请求 ${index}`,
+    objective: `完成请求 ${index}`,
+  }
+}
+
+function fakeClient({ hold = false, result = null } = {}) {
+  const started = Promise.withResolvers()
+  const cancelled = new Set()
+  const sent = []
+  return {
+    protocolVersion: '1.0',
+    transport: { protocolName: 'HTTP+JSON' },
+    started: started.promise,
+    sent,
+    async sendMessage(request) {
+      sent.push(request)
+      started.resolve()
+      if (result) return result
+      return task(A2ATaskState.TASK_STATE_WORKING)
+    },
+    async getTask({ id }, { signal } = {}) {
+      if (hold && !cancelled.has(id)) {
+        await new Promise((resolve, reject) => {
+          if (signal?.aborted) return reject(signal.reason)
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          })
+        })
+      }
+      if (cancelled.has(id)) {
+        return task(A2ATaskState.TASK_STATE_CANCELED, { id })
+      }
+      return task(A2ATaskState.TASK_STATE_COMPLETED, {
+        id,
+        statusText: '已经完成。',
+      })
+    },
+    async cancelTask({ id }) {
+      cancelled.add(id)
+      return task(A2ATaskState.TASK_STATE_CANCELED, { id })
+    },
+  }
+}
+
+function fixture({ hold }) {
+  const client = fakeClient({ hold })
+  return {
+    name: 'A2A',
+    backend: createA2ABackendAdapter({
+      agentCard: {
+        name: 'Fixture Agent',
+        version: '1.0.0',
+        defaultInputModes: ['text/plain'],
+        defaultOutputModes: ['text/plain'],
+        capabilities: { streaming: false },
+      },
+      pollIntervalMs: 10,
+      clientFactory: async () => ({
+        client,
+        agentCard: {
+          name: 'Fixture Agent',
+          version: '1.0.0',
+          defaultInputModes: ['text/plain'],
+          defaultOutputModes: ['text/plain'],
+          capabilities: { streaming: false },
+        },
+      }),
+    }),
+    work: work(1),
+    nextWork: work(2),
+    started: client.started,
+  }
+}
+
+test('A2A adapter passes the reusable BackendPort conformance suite', async () => {
+  await verifyBackendAdapterConformance({ createFixture: fixture })
+})
+
+test('discovers identity without exposing credentials', async () => {
+  let configured
+  let requestHeaders
+  const client = fakeClient({
+    result: message('直接回复。'),
+  })
+  const backend = new A2ABackendAdapter({
+    agentCardUrl: 'https://agent.example/.well-known/agent-card.json',
+    token: 'secret-token',
+    headers: { 'X-Tenant': 'tenant-one' },
+    fetchImpl: async (_input, init) => {
+      requestHeaders = new Headers(init?.headers)
+      return new Response('{}', { status: 200 })
+    },
+    clientFactory: async options => {
+      configured = options
+      return {
+        client,
+        agentCard: {
+          name: 'Remote Agent',
+          version: '2.0.0',
+          capabilities: { streaming: true },
+          defaultInputModes: ['text/plain', 'image/png'],
+          defaultOutputModes: ['text/plain'],
+        },
+      }
+    },
+  })
+
+  await backend.start()
+  const description = backend.describe()
+  assert.equal(description.label, 'Remote Agent')
+  assert.equal(description.transport, 'HTTP+JSON')
+  assert.equal(description.protocolVersion, '1.0')
+  assert.equal(description.capabilities.streaming, true)
+  assert.equal(JSON.stringify(description).includes('secret-token'), false)
+
+  await configured.fetchImpl('https://agent.example/rpc', {
+    headers: { Accept: 'application/json' },
+  })
+  assert.equal(requestHeaders.get('authorization'), 'Bearer secret-token')
+  assert.equal(requestHeaders.get('x-tenant'), 'tenant-one')
+  assert.equal(requestHeaders.get('accept'), 'application/json')
+  await backend.close()
+})
+
+test('projects A2A messages and task artifacts into public outcomes', async () => {
+  const completed = task(A2ATaskState.TASK_STATE_COMPLETED, {
+    statusText: '报告已经完成。',
+    history: [message('分析过程。')],
+    artifacts: [{
+      artifactId: 'report',
+      name: '报告',
+      description: '最终报告',
+      parts: [
+        textPart('# 结果', 'text/markdown'),
+        {
+          content: { $case: 'url', value: 'https://example.com/report.pdf' },
+          metadata: undefined,
+          filename: 'report.pdf',
+          mediaType: 'application/pdf',
+        },
+      ],
+    }],
+  })
+  const client = fakeClient({ result: completed })
+  const backend = new A2ABackendAdapter({
+    agentCard: { name: 'Artifact Agent' },
+    clientFactory: async () => ({ client }),
+  })
+
+  const outcome = await backend.submit(work())
+  assert.equal(outcome.presentation.speech, '报告已经完成。')
+  assert.match(outcome.content, /分析过程/)
+  assert.match(outcome.content, /# 结果/)
+  assert.deepEqual(outcome.artifacts, [{
+    artifactId: 'report',
+    name: '报告',
+    description: '最终报告',
+    parts: [
+      { text: '# 结果', mediaType: 'text/markdown' },
+      {
+        url: 'https://example.com/report.pdf',
+        mediaType: 'application/pdf',
+        filename: 'report.pdf',
+      },
+    ],
+  }])
+  await backend.close()
+})
+
+test('sends objective and attachments as standard A2A message parts', async () => {
+  const client = fakeClient({ result: message('收到。') })
+  const backend = new A2ABackendAdapter({
+    agentCard: { name: 'Multimodal Agent' },
+    clientFactory: async () => ({ client }),
+  })
+  await backend.submit({
+    ...work(),
+    inputParts: [{
+      type: 'file',
+      mime: 'image/png',
+      filename: 'reference.png',
+      url: 'data:image/png;base64,aGVsbG8=',
+    }, {
+      type: 'file',
+      mime: 'text/plain',
+      filename: 'guide.txt',
+      url: 'https://example.com/guide.txt',
+    }],
+  })
+
+  const request = client.sent[0]
+  assert.equal(request.configuration.returnImmediately, true)
+  assert.equal(request.message.role, A2ARole.ROLE_USER)
+  assert.equal(request.message.parts[0].content.value, '完成请求 1')
+  assert.equal(request.message.parts[1].content.$case, 'raw')
+  assert.equal(
+    request.message.parts[1].content.value.toString(),
+    'hello',
+  )
+  assert.equal(request.message.parts[2].content.$case, 'url')
+  assert.equal(request.metadata['qwen.audio/jobId'], 'job_1')
+  await backend.close()
+})
+
+test('fails explicitly when an A2A task requires an unsupported interaction', async () => {
+  const client = fakeClient({
+    result: task(A2ATaskState.TASK_STATE_AUTH_REQUIRED, {
+      statusText: '请完成登录。',
+    }),
+  })
+  const backend = new A2ABackendAdapter({
+    agentCard: { name: 'Auth Agent' },
+    clientFactory: async () => ({ client }),
+  })
+
+  await assert.rejects(
+    backend.submit(work()),
+    error => error.code === 'A2A_INTERACTION_REQUIRED'
+      && /请完成登录/.test(error.message),
+  )
+  await backend.close()
+})
+
+test('rejects credential-bearing and non-HTTP Agent Card URLs', () => {
+  assert.throws(
+    () => new A2ABackendAdapter({
+      agentCardUrl: 'https://user:password@agent.example/card.json',
+    }),
+    /must not contain credentials/,
+  )
+  assert.throws(
+    () => new A2ABackendAdapter({ agentCardUrl: 'file:///tmp/card.json' }),
+    /must use HTTP or HTTPS/,
+  )
+})
+
+test('interoperates with an A2A 1.0 HTTP+JSON agent through official discovery', async () => {
+  let received
+  const server = http.createServer(async (request, response) => {
+    if (request.url === '/.well-known/agent-card.json') {
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({
+        name: 'Loopback Agent',
+        description: 'A2A integration fixture',
+        version: '1.0.0',
+        supportedInterfaces: [{
+          url: `http://127.0.0.1:${server.address().port}`,
+          protocolBinding: 'HTTP+JSON',
+          protocolVersion: '1.0',
+          tenant: '',
+        }],
+        capabilities: { streaming: false, extensions: [] },
+        securitySchemes: {},
+        securityRequirements: [],
+        defaultInputModes: ['text/plain'],
+        defaultOutputModes: ['text/plain'],
+        skills: [],
+        signatures: [],
+      }))
+      return
+    }
+    if (request.url === '/message:send' && request.method === 'POST') {
+      let body = ''
+      for await (const chunk of request) body += chunk
+      received = JSON.parse(body)
+      response.setHeader('content-type', 'application/a2a+json')
+      response.end(JSON.stringify({
+        task: {
+          id: 'remote-task',
+          contextId: 'remote-context',
+          status: {
+            state: 'TASK_STATE_COMPLETED',
+            message: {
+              messageId: 'remote-message',
+              contextId: 'remote-context',
+              taskId: 'remote-task',
+              role: 'ROLE_AGENT',
+              parts: [{ text: '回环任务已经完成。', mediaType: 'text/plain' }],
+              extensions: [],
+              referenceTaskIds: [],
+            },
+            timestamp: new Date().toISOString(),
+          },
+          artifacts: [],
+          history: [],
+        },
+      }))
+      return
+    }
+    response.statusCode = 404
+    response.end()
+  })
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const backend = new A2ABackendAdapter({
+    agentCardUrl: `http://127.0.0.1:${server.address().port}/.well-known/agent-card.json`,
+  })
+  try {
+    const outcome = await backend.submit({ ...work(), objective: '回环测试' })
+    assert.equal(backend.describe().transport, 'HTTP+JSON')
+    assert.equal(received.message.parts[0].text, '回环测试')
+    assert.equal(received.configuration.returnImmediately, true)
+    assert.equal(outcome.presentation.speech, '回环任务已经完成。')
+  } finally {
+    await backend.close()
+    await new Promise(resolve => server.close(resolve))
+  }
+})

--- a/test/a2a-package-export.test.mjs
+++ b/test/a2a-package-export.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  A2A_BACKEND_ADAPTER_VERSION,
+  createA2ABackendAdapter,
+} from 'qwen-audio-agent/a2a-backend-adapter'
+
+test('exports one stable optional A2A Backend Adapter entry point', () => {
+  assert.equal(A2A_BACKEND_ADAPTER_VERSION, '1.0.0')
+  assert.equal(typeof createA2ABackendAdapter, 'function')
+})


### PR DESCRIPTION
Roadmap: #185

## Summary
- add an optional A2A 1.0 BackendPort adapter using the official JavaScript SDK
- discover Agent Cards and negotiate JSON-RPC or HTTP+JSON while keeping A2A objects inside the adapter
- map messages, task state, cancellation, progress, multimodal parts, and artifacts to existing Work contracts
- publish a stable npm subpath with bilingual integration documentation

## Verification
- `AGENT_PROTOCOL=none npm run release:check`
- Backend Adapter conformance suite
- A2A 1.0 HTTP+JSON Agent Card and task round trip