### PR TITLE
feat: add 360 Web Search fallback

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,10 +202,10 @@ DASHSCOPE_API_KEY=your-key
 
 The frontend `web_search` tool returns verifiable source links, does not create
 backend Agent work, and does not invoke another text model. Without explicit
-configuration it uses a small, key-free Bing adapter that parses one public
-search results page and is reachable in mainland China. This basic fallback is
-experimental: it may be blocked, return weak results, or break with upstream
-changes. Configure your own provider for reliable search.
+configuration it uses a small, key-free 360 search adapter that parses one
+public search results page and is reachable in mainland China. This basic
+fallback is experimental: it may be blocked, return weak results, or break
+with upstream changes. Configure your own provider for reliable search.
 
 After enabling Model Studio's Web Search MCP service, select its built-in preset
 explicitly; it then reuses `DASHSCOPE_API_KEY`:
@@ -923,7 +923,7 @@ them to the configuration file:
 | `QWEN_AUDIO_AGENT_ACP_FORWARD_ENV` | Empty; comma-separated opt-in environment names for generic ACP only |
 | `QWEN_AUDIO_REALTIME_MODEL` | `qwen-audio-3.0-realtime-plus` |
 | `QWEN_AUDIO_REALTIME_PROVIDER` | `dashscope` |
-| `QWEN_AUDIO_WEB_SEARCH_PROVIDER` | `bing`; optional `bailian`, `mcp`, or `none` |
+| `QWEN_AUDIO_WEB_SEARCH_PROVIDER` | `so360`; optional `bailian`, `bing`, `mcp`, or `none` |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_URL` | Empty; custom Streamable HTTP endpoint used by the `mcp` provider |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOKEN` | `DASHSCOPE_API_KEY` for explicit `bailian`; empty for custom endpoints unless set |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOOL` | `bailian_web_search` for `bailian`; otherwise `web_search` |

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -107,9 +107,9 @@ DASHSCOPE_API_KEY=your-key
 ```
 
 语音前台的 `web_search` 工具返回可核验的来源链接，不会创建后台 Agent 工作，也不会
-额外调用文本大模型。用户未配置时，默认使用无需 Key、国内可访问的简易 Bing Adapter，
-只解析一次公开搜索结果页。该基础兜底属于实验性实现，可能被拦截、结果质量不稳定或受上游
-变化影响；稳定使用时应配置自己的 Provider。
+额外调用文本大模型。用户未配置时，默认使用无需 Key、国内可访问的简易 360 搜索
+Adapter，只解析一次公开搜索结果页。该基础兜底属于实验性实现，可能被拦截、结果质量
+不稳定或受上游变化影响；稳定使用时应配置自己的 Provider。
 
 在百炼开通联网搜索 MCP 后，需要显式选择内置预设；此时会复用
 `DASHSCOPE_API_KEY`：
@@ -756,7 +756,7 @@ Gateway 时，或后续 CLI 运行时使用了冲突的已配置模型时，会�
 | `QWEN_AUDIO_AGENT_ACP_FORWARD_ENV` | 空；仅供通用 ACP 显式传递的环境变量名，逗号分隔 |
 | `QWEN_AUDIO_REALTIME_MODEL` | `qwen-audio-3.0-realtime-plus` |
 | `QWEN_AUDIO_REALTIME_PROVIDER` | `dashscope` |
-| `QWEN_AUDIO_WEB_SEARCH_PROVIDER` | `bing`；可选 `bailian`、`mcp` 或 `none` |
+| `QWEN_AUDIO_WEB_SEARCH_PROVIDER` | `so360`；可选 `bailian`、`bing`、`mcp` 或 `none` |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_URL` | 空；`mcp` Provider 使用的自定义 Streamable HTTP 地址 |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOKEN` | 显式选择 `bailian` 时复用 `DASHSCOPE_API_KEY`；自定义地址默认空 |
 | `QWEN_AUDIO_WEB_SEARCH_MCP_TOOL` | `bailian` 为 `bailian_web_search`，其他地址为 `web_search` |

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -108,11 +108,11 @@ export function resolveWebSearchConfiguration(env = process.env) {
   const requestedProvider = String(
     env.QWEN_AUDIO_WEB_SEARCH_PROVIDER || '',
   ).trim().toLowerCase()
-  const provider = requestedProvider || (explicitMcpUrl ? 'mcp' : 'bing')
-  if (!['bailian', 'bing', 'mcp', 'none'].includes(provider)) {
+  const provider = requestedProvider || (explicitMcpUrl ? 'mcp' : 'so360')
+  if (!['bailian', 'bing', 'mcp', 'none', 'so360'].includes(provider)) {
     throw new Error(
       '不支持的 Web Search Provider：'
-      + `${provider}（可选 bailian、bing、mcp、none）`,
+      + `${provider}（可选 bailian、bing、mcp、none、so360）`,
     )
   }
   const mcpUrl = provider === 'bailian' ? bailianMcpUrl : explicitMcpUrl

--- a/server/src/providers/search/factory.mjs
+++ b/server/src/providers/search/factory.mjs
@@ -1,11 +1,15 @@
 import { McpWebSearchProvider } from './mcp.mjs'
 import { BingWebSearchProvider } from './bing.mjs'
+import { So360WebSearchProvider } from './so360.mjs'
 
 export function createWebSearchProvider(config, options = {}) {
   const provider = String(config?.webSearchProvider || 'none').toLowerCase()
   if (provider === 'none') return null
   if (provider === 'bing') {
     return new BingWebSearchProvider(options)
+  }
+  if (provider === 'so360') {
+    return new So360WebSearchProvider(options)
   }
   if (provider === 'mcp' || provider === 'bailian') {
     return new McpWebSearchProvider({

--- a/server/src/providers/search/so360.mjs
+++ b/server/src/providers/search/so360.mjs
@@ -1,0 +1,191 @@
+const SEARCH_ENDPOINT = 'https://www.so.com/s'
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+
+export class So360WebSearchError extends Error {
+  constructor(code, message) {
+    super(message)
+    this.name = 'So360WebSearchError'
+    this.code = code
+  }
+}
+
+function clean(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim()
+}
+
+function decodedCodePoint(value, radix) {
+  const codePoint = Number.parseInt(value, radix)
+  if (
+    !Number.isInteger(codePoint)
+    || codePoint < 0
+    || codePoint > 0x10ffff
+    || (codePoint >= 0xd800 && codePoint <= 0xdfff)
+  ) return '\ufffd'
+  return String.fromCodePoint(codePoint)
+}
+
+function decodeEntities(value) {
+  return String(value || '')
+    .replace(/&amp;/giu, '&')
+    .replace(/&lt;/giu, '<')
+    .replace(/&gt;/giu, '>')
+    .replace(/&quot;/giu, '"')
+    .replace(/&(?:apos|#(?:39|x27));/giu, "'")
+    .replace(/&nbsp;/giu, ' ')
+    .replace(/&ensp;/giu, ' ')
+    .replace(/&emsp;/giu, ' ')
+    .replace(/&middot;/giu, '·')
+    .replace(/&#(\d+);/gu, (_, code) => decodedCodePoint(code, 10))
+    .replace(/&#x([0-9a-f]+);/giu, (_, code) => decodedCodePoint(code, 16))
+}
+
+function plainText(value) {
+  return clean(decodeEntities(
+    String(value || '')
+      .replace(/^<!\[CDATA\[|\]\]>$/gu, '')
+      // 360 wraps query terms in <em> inside words; drop them without
+      // spacing so highlighted words stay intact.
+      .replace(/<\/?em\b[^>]*>/giu, '')
+      .replace(/<[^>]+>/gu, ' '),
+  ))
+}
+
+function publicUrl(value) {
+  try {
+    const url = new URL(decodeEntities(value))
+    if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) {
+      return ''
+    }
+    return url.toString()
+  } catch {
+    return ''
+  }
+}
+
+function attributeValue(tag, name) {
+  const match = new RegExp(`\\b${name}=(?:"([^"]*)"|'([^']*)')`, 'iu').exec(tag)
+  return match ? (match[1] ?? match[2]) : ''
+}
+
+export function parseSo360Results(html) {
+  const results = []
+  const seen = new Set()
+  for (const match of String(html || '').matchAll(/<li\b[^>]*\bres-list\b[\s\S]*?<\/li>/giu)) {
+    const block = match[0]
+    const titleMatch = /<h3\b[^>]*\bres-title\b[\s\S]*?<a\b[^>]*>([\s\S]*?)<\/a>/iu.exec(block)
+    if (!titleMatch) continue
+    const anchorTag = /<a\b[^>]*>/iu.exec(titleMatch[0])?.[0] || ''
+    const title = plainText(titleMatch[1])
+    // data-mdurl carries the real destination; href is an so.com redirect.
+    const url = publicUrl(
+      attributeValue(anchorTag, 'data-mdurl') || attributeValue(anchorTag, 'href'),
+    )
+    if (!title || !url || seen.has(url)) continue
+    seen.add(url)
+    const descMatch = /<p\b[^>]*\bres-desc\b[^>]*>([\s\S]*?)<\/p>/iu.exec(block)
+    const snippet = descMatch ? plainText(descMatch[1]) : ''
+    results.push({
+      title,
+      url,
+      ...(snippet ? { snippet } : {}),
+      source: new URL(url).hostname,
+    })
+  }
+  return results
+}
+
+function isChallenge(html) {
+  return !/\bres-title\b/iu.test(html)
+    && /captcha|antispider|人机验证/iu.test(html)
+}
+
+async function boundedText(response) {
+  const declaredLength = Number(response.headers?.get?.('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
+    throw new So360WebSearchError(
+      'search_response_too_large',
+      '简易搜索返回内容过大。',
+    )
+  }
+  const text = await response.text()
+  if (Buffer.byteLength(text, 'utf8') > MAX_RESPONSE_BYTES) {
+    throw new So360WebSearchError(
+      'search_response_too_large',
+      '简易搜索返回内容过大。',
+    )
+  }
+  return text
+}
+
+export class So360WebSearchProvider {
+  constructor({ fetchImpl = fetch } = {}) {
+    this.fetchImpl = fetchImpl
+  }
+
+  describe() {
+    return {
+      key: 'so360',
+      label: '360 Web Search (fallback)',
+    }
+  }
+
+  isConfigured() {
+    return true
+  }
+
+  async #fetchPage(url, signal) {
+    try {
+      const response = await this.fetchImpl(url, {
+        method: 'GET',
+        headers: {
+          accept: 'text/html',
+          'user-agent': 'qwen-audio-agent web-search',
+        },
+        redirect: 'error',
+        signal,
+      })
+      const html = await boundedText(response)
+      if (!response.ok) {
+        throw new So360WebSearchError(
+          'search_request_failed',
+          `简易搜索服务返回 HTTP ${response.status}。`,
+        )
+      }
+      return html
+    } catch (error) {
+      if (error instanceof So360WebSearchError) throw error
+      throw new So360WebSearchError(
+        signal?.aborted ? 'search_aborted' : 'search_request_failed',
+        signal?.aborted ? '搜索已中止。' : '简易搜索服务暂时不可用。',
+      )
+    }
+  }
+
+  async search(query, { limit = 5, signal } = {}) {
+    const normalizedQuery = clean(query).slice(0, 400)
+    if (!normalizedQuery) {
+      throw new So360WebSearchError(
+        'missing_search_query',
+        '搜索内容不能为空。',
+      )
+    }
+    const boundedLimit = Math.max(1, Math.min(8, Math.trunc(Number(limit) || 5)))
+    const url = new URL(SEARCH_ENDPOINT)
+    url.searchParams.set('q', normalizedQuery)
+    const html = await this.#fetchPage(url, signal)
+    if (isChallenge(html)) {
+      throw new So360WebSearchError(
+        'search_challenge',
+        '简易搜索服务要求进行人机验证。',
+      )
+    }
+    const results = parseSo360Results(html).slice(0, boundedLimit)
+    if (!results.length) {
+      throw new So360WebSearchError(
+        'search_results_missing',
+        '简易搜索没有返回结果。',
+      )
+    }
+    return { results }
+  }
+}

--- a/server/test/config.test.mjs
+++ b/server/test/config.test.mjs
@@ -28,7 +28,7 @@ test('preserves explicit zero numeric settings', () => {
 
 test('uses a key-free fallback until the user configures a search provider', () => {
   assert.deepEqual(resolveWebSearchConfiguration({}), {
-    provider: 'bing',
+    provider: 'so360',
     mcpUrl: '',
     mcpToken: '',
     mcpTool: 'web_search',
@@ -54,7 +54,7 @@ test('uses a key-free fallback until the user configures a search provider', () 
   })
   assert.equal(resolveWebSearchConfiguration({
     DASHSCOPE_API_KEY: 'dashscope-key',
-  }).provider, 'bing')
+  }).provider, 'so360')
   assert.equal(resolveWebSearchConfiguration({
     DASHSCOPE_API_KEY: 'dashscope-key',
     QWEN_AUDIO_WEB_SEARCH_MCP_URL: 'https://search.example/mcp',

--- a/server/test/mcp-web-search-provider.test.mjs
+++ b/server/test/mcp-web-search-provider.test.mjs
@@ -176,6 +176,9 @@ test('factory selects only configured built-in search adapters', () => {
   assert.equal(createWebSearchProvider({
     webSearchProvider: 'bing',
   }).describe().key, 'bing')
+  assert.equal(createWebSearchProvider({
+    webSearchProvider: 'so360',
+  }).describe().key, 'so360')
   const provider = createWebSearchProvider({
     webSearchProvider: 'mcp',
     webSearchMcpUrl: 'https://search.example/mcp',

--- a/server/test/so360-web-search-provider.test.mjs
+++ b/server/test/so360-web-search-provider.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  So360WebSearchProvider,
+  parseSo360Results,
+} from '../src/providers/search/so360.mjs'
+
+const SEARCH_HTML = `<html><ol id="main">
+<li class="res-list"><h3 class="res-title " >
+<a  href="https://www.so.com/link?m=abc" data-mdurl="http://www.sina.cn/news/detail/1.html"  rel="noopener" target="_blank"><em>王力宏</em>摔倒受伤|<em>王力宏</em>_新浪<em>新闻</em></a></h3>
+<p class="res-desc"><span class="gray g-c-gray">2026年7月4日&nbsp;-&nbsp;</span><em>王力宏</em>在演唱会中摔倒导致脸和耳朵出血,粉丝批评团队疏忽</p>
+<p class="g-linkinfo"><cite><a href="https://www.so.com/link?m=xyz">www.sina.cn</a></cite></p></li>
+<li class="res-list"><h3 class="res-title">
+<a href="https://example.org/plain" >Second result</a></h3>
+<p class="res-desc">Another source.</p></li>
+<li class="res-ad"><h3 class="res-title"><a href="https://ad.example/">ad</a></h3></li>
+</ol></html>`
+
+test('parses 360 result blocks and prefers data-mdurl over the redirect href', async () => {
+  const requests = []
+  const provider = new So360WebSearchProvider({
+    fetchImpl: async (url, options) => {
+      requests.push({ url, options })
+      return new Response(SEARCH_HTML, {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      })
+    },
+  })
+
+  const result = await provider.search('王力宏最近的新闻', { limit: 5 })
+
+  assert.equal(requests.length, 1)
+  assert.equal(requests[0].url.origin, 'https://www.so.com')
+  assert.equal(requests[0].url.pathname, '/s')
+  assert.equal(requests[0].url.searchParams.get('q'), '王力宏最近的新闻')
+  assert.equal(requests[0].options.redirect, 'error')
+  assert.deepEqual(result, {
+    results: [{
+      title: '王力宏摔倒受伤|王力宏_新浪新闻',
+      url: 'http://www.sina.cn/news/detail/1.html',
+      snippet: '2026年7月4日 - 王力宏在演唱会中摔倒导致脸和耳朵出血,粉丝批评团队疏忽',
+      source: 'www.sina.cn',
+    }, {
+      title: 'Second result',
+      url: 'https://example.org/plain',
+      snippet: 'Another source.',
+      source: 'example.org',
+    }],
+  })
+})
+
+test('rejects anti-spider challenge pages and empty result pages', async () => {
+  const challenge = new So360WebSearchProvider({
+    fetchImpl: async () => new Response(
+      '<html><div id="antispider">请完成人机验证</div></html>',
+    ),
+  })
+  await assert.rejects(
+    challenge.search('facts'),
+    error => error.code === 'search_challenge',
+  )
+
+  const empty = new So360WebSearchProvider({
+    fetchImpl: async () => new Response('<html><div>没有相关结果</div></html>'),
+  })
+  await assert.rejects(
+    empty.search('facts'),
+    error => error.code === 'search_results_missing',
+  )
+})
+
+test('propagates an aborted request', async () => {
+  const controller = new AbortController()
+  controller.abort()
+  const provider = new So360WebSearchProvider({
+    fetchImpl: async () => { throw new Error('aborted') },
+  })
+  await assert.rejects(
+    provider.search('facts', { signal: controller.signal }),
+    error => error.code === 'search_aborted',
+  )
+})
+
+test('normalizes response body failures', async () => {
+  const provider = new So360WebSearchProvider({
+    fetchImpl: async () => ({
+      ok: true,
+      headers: new Headers(),
+      text: async () => { throw new Error('broken response body') },
+    }),
+  })
+  await assert.rejects(
+    provider.search('facts'),
+    error => error.code === 'search_request_failed',
+  )
+})
+
+test('drops credential-bearing URLs and tolerates invalid numeric entities', () => {
+  const withCredentials = SEARCH_HTML.replace(
+    'http://www.sina.cn/news/detail/1.html',
+    'https://user:secret@example.com/first',
+  )
+  assert.equal(parseSo360Results(withCredentials).length, 1)
+
+  const withBadEntity = SEARCH_HTML.replace(
+    '摔倒受伤',
+    '摔倒 &#9999999999;受伤',
+  )
+  assert.ok(parseSo360Results(withBadEntity)[0].title.includes('\ufffd'))
+})


### PR DESCRIPTION
Roadmap: #185

## Summary
- add a key-free 360 Search HTML adapter
- use 360 Search as the default unconfigured fallback while retaining Bing as an explicit option
- normalize provider failures and document the new provider in English and Chinese

## Validation
- npm run lint
- npm test
- live search against www.so.com