### PR TITLE
fix: recover stalled voice result delivery

### DIFF
--- a/server/src/voice/announcement/announcement-manager.mjs
+++ b/server/src/voice/announcement/announcement-manager.mjs
@@ -271,7 +271,14 @@ export class AnnouncementManager {
   }
 
   async deliver() {
-    if (this.closed || this.delivering || this.isDeliveryBlocked()) return
+    if (this.closed || this.delivering) return
+    if (this.isDeliveryBlocked()) {
+      // Playback completion normally flushes the queue again. Keep a delayed
+      // self-wakeup as well: a throttled renderer or a lost playback receipt
+      // must not leave a completed task parked in "replying" forever.
+      this.scheduleDelivery(this.retryBaseMs)
+      return
+    }
     const frontend = this.getFrontend()
     if (!frontend?.ready) {
       if (!this.activeBatch) this.activeBatch = this.createBatch()

--- a/server/test/announcement-manager.test.mjs
+++ b/server/test/announcement-manager.test.mjs
@@ -78,6 +78,31 @@ test('waits while duplex speech blocks delivery', async () => {
   manager.close()
 })
 
+test('rechecks blocked delivery without requiring a playback edge', async () => {
+  let blocked = true
+  let spoken = 0
+  const manager = new AnnouncementManager({
+    getFrontend: () => ({
+      ready: true,
+      injectResult: async () => {
+        spoken += 1
+        return { completed: true, contextInjected: true }
+      },
+    }),
+    isDeliveryBlocked: () => blocked,
+    batchWindowMs: 0,
+    retryBaseMs: 2,
+  })
+
+  manager.completed({ id: 'task_1', objective: '处理', result: '完成' })
+  await new Promise(resolve => setTimeout(resolve, 5))
+  assert.equal(spoken, 0)
+
+  blocked = false
+  await waitFor(() => spoken === 1)
+  manager.close()
+})
+
 test('batches nearby completed work into one realtime response', async () => {
   const inputs = []
   const manager = new AnnouncementManager({

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -252,6 +252,8 @@ export default function useRealtimeVoice({
     cursor: 0,
     sources: [],
     startTimers: new Map(),
+    endTimers: new Map(),
+    responseEnds: new Map(),
     startedResponses: new Set(),
     sourceCounts: new Map(),
     doneResponses: new Set(),
@@ -328,10 +330,14 @@ export default function useRealtimeVoice({
     const playback = playbackRef.current
     const activeResponseIds = new Set([
       ...playback.startTimers.keys(),
+      ...playback.endTimers.keys(),
       ...playback.startedResponses,
       ...playback.sourceCounts.keys(),
     ])
     for (const timer of playback.startTimers.values()) {
+      clearTimeout(timer)
+    }
+    for (const timer of playback.endTimers.values()) {
       clearTimeout(timer)
     }
     for (const responseId of activeResponseIds) {
@@ -348,6 +354,8 @@ export default function useRealtimeVoice({
       cursor: 0,
       sources: [],
       startTimers: new Map(),
+      endTimers: new Map(),
+      responseEnds: new Map(),
       startedResponses: new Set(),
       sourceCounts: new Map(),
       doneResponses: new Set(),
@@ -364,6 +372,10 @@ export default function useRealtimeVoice({
       || (playback.sourceCounts.get(responseId) || 0) > 0
     ) return
     sendPlaybackEvent(GatewayClientEvent.PLAYBACK_ENDED, responseId)
+    const endTimer = playback.endTimers.get(responseId)
+    if (endTimer !== undefined) clearTimeout(endTimer)
+    playback.endTimers.delete(responseId)
+    playback.responseEnds.delete(responseId)
     playback.startedResponses.delete(responseId)
     playback.sourceCounts.delete(responseId)
     playback.doneResponses.delete(responseId)
@@ -375,6 +387,39 @@ export default function useRealtimeVoice({
     if (playback.failedResponses.delete(responseId)) return
     playback.doneResponses.add(responseId)
     finishPlaybackIfReady(responseId)
+    const responseEnd = playback.responseEnds.get(responseId)
+    if (
+      !playback.doneResponses.has(responseId)
+      || playback.endTimers.has(responseId)
+      || !Number.isFinite(responseEnd)
+    ) return
+    const checkTimelineFinished = () => {
+      const current = playbackRef.current
+      if (!current.endTimers.has(responseId)) return
+      const context = audioRef.current
+      const responseEnd = current.responseEnds.get(responseId)
+      if (
+        !context
+        || !Number.isFinite(responseEnd)
+        || context.state !== 'running'
+        || context.currentTime + 0.01 < responseEnd
+      ) {
+        const timer = setTimeout(checkTimelineFinished, 50)
+        current.endTimers.set(responseId, timer)
+        return
+      }
+      // AudioContext time has crossed the last scheduled sample. Treat that
+      // as a reliable fallback when Electron misses AudioBufferSource.onended.
+      current.sourceCounts.set(responseId, 0)
+      finishPlaybackIfReady(responseId)
+    }
+    const delay = Math.max(
+      0,
+      ((responseEnd || audioRef.current?.currentTime || 0)
+        - (audioRef.current?.currentTime || 0)) * 1000,
+    ) + 50
+    const timer = setTimeout(checkTimelineFinished, delay)
+    playback.endTimers.set(responseId, timer)
   }, [finishPlaybackIfReady])
 
   const failPlayback = useCallback((responseId, reason) => {
@@ -383,7 +428,11 @@ export default function useRealtimeVoice({
       playback.failedResponses.add(responseId)
       const timer = playback.startTimers.get(responseId)
       if (timer !== undefined) clearTimeout(timer)
+      const endTimer = playback.endTimers.get(responseId)
+      if (endTimer !== undefined) clearTimeout(endTimer)
       playback.startTimers.delete(responseId)
+      playback.endTimers.delete(responseId)
+      playback.responseEnds.delete(responseId)
       playback.startedResponses.delete(responseId)
       playback.sourceCounts.delete(responseId)
       playback.doneResponses.delete(responseId)
@@ -436,6 +485,10 @@ export default function useRealtimeVoice({
         playback.sourceCounts.set(
           responseId,
           (playback.sourceCounts.get(responseId) || 0) + 1,
+        )
+        playback.responseEnds.set(
+          responseId,
+          Math.max(playback.responseEnds.get(responseId) || 0, playback.cursor),
         )
       }
     } catch (reason) {


### PR DESCRIPTION
## Summary
- retry completed-task announcements when playback temporarily blocks delivery
- add an AudioContext timeline fallback when Electron misses an `onended` callback
- cover blocked announcement recovery with a regression test

## Validation
- `node --test server/test/announcement-manager.test.mjs web/test/playback-lifecycle.test.mjs`
- `npm test --workspace web`
- `npm run build --workspace web`

The full local suite is currently affected only by unrelated, uncommitted Session Journal files in the working tree; PR CI runs from this clean commit.