### PR TITLE
fix: smooth realtime startup and task progress

### DIFF
--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { resolve } from 'node:path'
+import { isDeepStrictEqual } from 'node:util'
 import { config } from '../core/config.mjs'
 import { TaskScheduler } from './task-scheduler.mjs'
 import { TaskStore } from './task-store.mjs'
@@ -61,6 +62,7 @@ export class TaskManager {
     pendingNotificationTtlMs = 604_800_000,
     notificationClaimTtlMs = 60_000,
     maxTerminalTasksPerOwner = 100,
+    progressEventIntervalMs = 1_000,
     logger: taskLogger = null,
     sessionJournal = null,
   } = {}) {
@@ -81,6 +83,10 @@ export class TaskManager {
     this.pendingNotificationTtlMs = pendingNotificationTtlMs
     this.notificationClaimTtlMs = notificationClaimTtlMs
     this.maxTerminalTasksPerOwner = maxTerminalTasksPerOwner
+    this.progressEventIntervalMs = Math.max(
+      50,
+      Number(progressEventIntervalMs) || 1_000,
+    )
     this.logger = taskLogger
     this.sessionJournal = sessionJournal
     this.listeners = new Set()
@@ -354,6 +360,27 @@ export class TaskManager {
     if (persist) this.persist()
   }
 
+  markProgressChanged(task, { message = false } = {}) {
+    task.progressChanged = true
+    if (message) task.messageChanged = true
+  }
+
+  flushProgress(task, { heartbeat = false } = {}) {
+    if (!heartbeat && !task.progressChanged) return false
+    const messageChanged = task.messageChanged === true
+    task.progressChanged = false
+    task.messageChanged = false
+    this.emit(
+      messageChanged ? TaskDomainEvent.UPDATED : TaskDomainEvent.PROGRESS,
+      task,
+      {
+        persist: false,
+        ...(messageChanged ? { message: task.message } : {}),
+      },
+    )
+    return true
+  }
+
   create(options = {}) {
     return this.#create({
       ...options,
@@ -531,9 +558,9 @@ export class TaskManager {
     this.emit(TaskDomainEvent.RUNNING, task)
     task.progressTimer = setInterval(() => {
       if (isTaskActive(task.status)) {
-        this.emit(TaskDomainEvent.PROGRESS, task, { persist: false })
+        this.flushProgress(task, { heartbeat: true })
       }
-    }, 1000)
+    }, this.progressEventIntervalMs)
     task.progressTimer.unref?.()
     const onEvent = event => {
       if (
@@ -592,10 +619,7 @@ export class TaskManager {
         const message = String(event.message).trim().slice(0, 4_000)
         if (!message || message === task.message) return
         task.message = message
-        this.emit(TaskDomainEvent.UPDATED, task, {
-          persist: false,
-          message,
-        })
+        this.markProgressChanged(task, { message: true })
         this.persistDeferred()
         return
       }
@@ -603,7 +627,9 @@ export class TaskManager {
         const artifacts = normalizeArtifacts([event.artifact])
         if (!artifacts.length) return
         const artifact = artifacts[0]
-        task.artifacts = mergeArtifacts(task.artifacts, [artifact])
+        const merged = mergeArtifacts(task.artifacts, [artifact])
+        if (isDeepStrictEqual(merged, task.artifacts)) return
+        task.artifacts = merged
         this.emit(TaskDomainEvent.UPDATED, task, { persist: false })
         this.persistDeferred()
         return
@@ -613,10 +639,14 @@ export class TaskManager {
       const index = activity.id
         ? task.activity.findIndex(item => item.id === activity.id)
         : -1
+      if (
+        index === task.activity.length - 1
+        && isDeepStrictEqual(task.activity[index], activity)
+      ) return
       if (index >= 0) task.activity.splice(index, 1)
       task.activity.push(activity)
       task.activity = task.activity.slice(-20)
-      this.emit(TaskDomainEvent.PROGRESS, task, { persist: false })
+      this.markProgressChanged(task)
       this.persistDeferred()
     }
     // Fallback runner for restored scheduled tasks whose runner was lost
@@ -672,6 +702,7 @@ export class TaskManager {
           task.terminalHandled
           || ['cancelling', 'cancelled'].includes(task.status)
         ) return
+        this.flushProgress(task)
         transitionTask(task, TaskStatus.COMPLETED)
         task.result = String(outcome?.content ?? outcome ?? '').trim()
         task.presentation = normalizeTaskPresentation(
@@ -687,6 +718,7 @@ export class TaskManager {
           task.terminalHandled
           || ['cancelling', 'cancelled'].includes(task.status)
         ) return
+        this.flushProgress(task)
         transitionTask(task, TaskStatus.FAILED)
         task.error = error?.message || String(error)
       })

--- a/server/src/voice/realtime-input-runtime.mjs
+++ b/server/src/voice/realtime-input-runtime.mjs
@@ -296,9 +296,19 @@ export class RealtimeInputRuntime {
       turnId: inputTurnId,
     })
     this.ensureFrontend()
-      .then(() => {
-        this.expectResponseFor(inputContext)
-        return this.getFrontend().sendUserInput(parts, inputContext)
+      .then(() => this.getFrontend().sendUserInput(parts, inputContext))
+      .then(outcome => {
+        if (!outcome?.timedOut) return
+        this.turns.failManualInput(inputContext)
+        this.send({
+          type: GatewayServerEvent.VOICE_STATE,
+          state: 'idle',
+          turnId: inputTurnId,
+          origin: 'model',
+        })
+        this.reportFrontendError(new Error(
+          '实时模型没有开始回复，请再试一次。',
+        ))
       })
       .catch(error => {
         this.turns.failManualInput(inputContext)

--- a/server/test/realtime-input-runtime.test.mjs
+++ b/server/test/realtime-input-runtime.test.mjs
@@ -5,7 +5,7 @@ import { RealtimeInputRuntime } from '../src/voice/realtime-input-runtime.mjs'
 import { RealtimeTurnState } from '../src/voice/realtime-turn-state.mjs'
 import { TurnTranscripts } from '../src/voice/tools/turn-transcripts.mjs'
 
-function harness() {
+function harness({ responseOutcome } = {}) {
   const events = []
   const records = []
   const calls = []
@@ -13,6 +13,7 @@ function harness() {
     cancel: () => calls.push(['cancel']),
     sendUserInput: async (parts, context) => {
       calls.push(['sendUserInput', parts, context])
+      return responseOutcome
     },
   }
   const turns = new RealtimeTurnState({
@@ -139,7 +140,7 @@ test('manual text input supersedes speech and reaches the frontend once', async 
   })
   assert.equal(
     calls.some(([name]) => name === 'expectResponseFor'),
-    true,
+    false,
   )
 })
 
@@ -152,4 +153,24 @@ test('invalid manual input fails before changing the current turn', () => {
   assert.equal(events.length, 1)
   assert.equal(events[0].type, 'error')
   assert.match(events[0].message, /不支持的输入片段类型/)
+})
+
+test('reports an explicit text response that never starts without an implicit watchdog', async () => {
+  const { runtime, events, calls } = harness({
+    responseOutcome: { timedOut: true, phase: 'start' },
+  })
+
+  runtime.submit({ text: '你好' })
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(
+    calls.some(([name]) => name === 'expectResponseFor'),
+    false,
+  )
+  assert.match(
+    calls.find(([name]) => name === 'reportFrontendError')?.[1]?.message || '',
+    /没有开始回复/,
+  )
+  assert.equal(events.at(-1).type, 'voice.state')
+  assert.equal(events.at(-1).state, 'idle')
 })

--- a/server/test/task-manager.test.mjs
+++ b/server/test/task-manager.test.mjs
@@ -97,6 +97,45 @@ test('moves updated backend activity to the end so recency stays correct', async
   )
 })
 
+test('coalesces streaming backend activity and messages into bounded progress events', async () => {
+  const manager = new TaskManager({ progressEventIntervalMs: 60_000 })
+  const events = []
+  manager.subscribe(event => events.push(event))
+  const task = manager.create({
+    objective: 'A',
+    ownerId: 'owner',
+    runner: async (_objective, { onEvent }) => {
+      for (let index = 1; index <= 100; index += 1) {
+        onEvent({
+          type: 'backend.activity',
+          activity: {
+            id: 'thinking',
+            kind: 'thinking',
+            status: 'running',
+          },
+        })
+        onEvent({
+          type: 'backend.message',
+          message: `正在处理 ${index}`,
+        })
+      }
+      return { content: 'done' }
+    },
+  })
+
+  await manager.wait(task.id)
+
+  assert.equal(
+    events.filter(event => event.type === 'task.progress').length,
+    0,
+  )
+  assert.equal(
+    events.filter(event => event.type === 'task.updated').length,
+    1,
+  )
+  assert.equal(manager.get(task.id).message, '正在处理 100')
+})
+
 test('persists normalized backend messages and artifacts as Task updates', async () => {
   const manager = new TaskManager()
   const events = []


### PR DESCRIPTION
## Summary

- prevent explicit text turns from arming the automatic voice-turn watchdog and causing false reconnects
- report explicit responses that genuinely fail to start
- deduplicate and coalesce high-frequency ACP activity/message chunks into bounded task progress snapshots
- keep permissions, artifacts, terminal lifecycle events, and one-minute spoken progress semantics unchanged

## Validation

- `npm run lint`
- `npm test`
- focused Realtime, Gateway, TaskManager, Journal recovery, and progress-announcement tests