### PR TITLE
refactor: make frontend memory provider pluggable

### DIFF
--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -97,6 +97,47 @@ several durable changes; the Gateway still produces only one follow-up response.
 starts from the latest document, and an exact replacement fails safely when its source fragment
 is missing or ambiguous.
 
+## Replacing the Memory Provider
+
+The built-in `USER.md` and `MEMORY.md` files are the default implementation, not a fixed Gateway
+storage dependency. A host application can implement the public, versioned `MemoryProvider`
+contract and inject it at the composition root:
+
+```js
+import { MEMORY_PROVIDER_PROTOCOL_VERSION } from 'qwen-audio-agent/memory-provider'
+import { createGatewayApplication } from 'qwen-audio-agent/gateway-application'
+
+const memoryProvider = {
+  describe: () => ({
+    protocolVersion: MEMORY_PROVIDER_PROTOCOL_VERSION,
+    key: 'company-memory',
+    label: 'Company Memory',
+  }),
+  list(ownerId, options) {
+    return []
+  },
+  async apply(ownerId, changes, context) {
+    return { changed: 0, documents: [] }
+  },
+  health: () => ({ ok: true }),
+  async close() {},
+}
+
+const gateway = createGatewayApplication({ memoryProvider })
+```
+
+`list()` must return a synchronous, bounded Realtime context snapshot. Remote providers should
+maintain a local cache inside their adapter. `apply()` may be asynchronous. Its Gateway-owned
+`context` identifies the source, Session, Turn, and Trace separately from model-controlled
+changes. Returned documents are bounded, their scopes are normalized, and invalid or duplicate
+documents are discarded.
+
+Realtime, automatic extraction, and tool handling depend only on `FrontendMemoryRuntime`; they
+never access a vendor SDK, database, or Markdown file. Without an injected provider, the existing
+Markdown provider remains active, so current configuration and data require no migration.
+Third-party adapters own remote authentication, tenant mapping, cache refresh, and translation
+into the public `user` and `memory` document semantics.
+
 ## Logs
 
 Logs use JSON Lines format. API Keys, Tokens, Authorization headers, Cookies, passwords,

--- a/docs/reference/memory.zh.md
+++ b/docs/reference/memory.zh.md
@@ -84,6 +84,44 @@ Realtime 与自动整理都通过同一个记忆服务提交受限 Markdown 变�
 一句话包含多项持久修改时，Realtime 可在同一轮逐项调用，Gateway 只生成一次
 后续回应。写入前会重新读取最新文档，精确替换找不到或匹配多处时安全失败。
 
+## 替换记忆 Provider
+
+内置的 `USER.md` 和 `MEMORY.md` 是默认实现，不是 Gateway 的固定存储依赖。宿主应用
+可以从公开入口实现版本化的 `MemoryProvider`，并在 Composition Root 注入：
+
+```js
+import { MEMORY_PROVIDER_PROTOCOL_VERSION } from 'qwen-audio-agent/memory-provider'
+import { createGatewayApplication } from 'qwen-audio-agent/gateway-application'
+
+const memoryProvider = {
+  describe: () => ({
+    protocolVersion: MEMORY_PROVIDER_PROTOCOL_VERSION,
+    key: 'company-memory',
+    label: 'Company Memory',
+  }),
+  list(ownerId, options) {
+    return []
+  },
+  async apply(ownerId, changes, context) {
+    return { changed: 0, documents: [] }
+  },
+  health: () => ({ ok: true }),
+  async close() {},
+}
+
+const gateway = createGatewayApplication({ memoryProvider })
+```
+
+`list()` 必须返回同步、有界的 Realtime 上下文快照；远程 Provider 应在 Adapter 内维护
+本地缓存。`apply()` 可以异步，`context` 中的来源、Session、Turn 和 Trace 由 Gateway
+提供，不属于模型可控的修改内容。Provider 返回的文档会统一限制长度、规范 scope，并
+丢弃重复或无效文档。
+
+Realtime、自动整理器和工具处理器只依赖 `FrontendMemoryRuntime`，不会访问供应商 SDK、
+数据库或 Markdown 文件。未注入 Provider 时继续使用现有 Markdown 实现，现有配置和数据
+无需迁移。第三方 Adapter 自行负责远程认证、租户映射、缓存刷新和底层记录到 `user`、
+`memory` 两种公开文档语义的转换。
+
 ## 日志
 
 日志采用 JSON Lines 格式，API Key、Token、Authorization、Cookie、密码和

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "./a2a-backend-adapter": "./server/src/backend/a2a-backend-adapter.mjs",
     "./realtime-provider": "./server/src/voice/realtime-provider-extension.mjs",
     "./knowledge-provider": "./server/src/frontend/knowledge/retrieval-provider.mjs",
+    "./memory-provider": "./server/src/conversation/memory-provider.mjs",
     "./settings": "./desktop/src/settings-store.mjs",
     "./skin-store": "./desktop/src/skin-store.mjs",
     "./orb/main": "./desktop/src/orb-shell.mjs",

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -18,6 +18,7 @@ import {
 } from '../conversation/memory-extractor.mjs'
 import { FrontendMemoryService } from '../conversation/frontend-memory-service.mjs'
 import { MarkdownContextStore } from '../conversation/markdown-context-store.mjs'
+import { FrontendMemoryRuntime } from '../conversation/memory-runtime.mjs'
 import { enforceSameOrigin } from '../core/request-security.mjs'
 import {
   GATEWAY_CAPABILITIES,
@@ -79,6 +80,8 @@ export function createGatewayApplication({
   webSearchProvider = undefined,
   urlFetcher = undefined,
   frontendRetrieval = null,
+  memoryProvider = undefined,
+  frontendMemory = null,
   knowledgeProvider = null,
   // Compatibility alias for embedders that adopted the original injection name.
   knowledgeRetrievalProvider = null,
@@ -211,26 +214,38 @@ conversationSync.configureRetention({
   sessionTtlMs: config.conversationSessionTtlMs,
   maxSessions: config.maxConversationSessions,
 })
-const userDocuments = new MarkdownContextStore({
-  filePath: config.userModelPath,
-  scope: 'user',
-  personalOwnerId: config.personalOwnerId,
-  maxChars: 6000,
-  template: '# USER',
-  onWarning: warning => logger.warn('user_model.persistence_warning', { warning }),
-})
-const memoryDocuments = new MarkdownContextStore({
-  filePath: config.frontendMemoryPath,
-  scope: 'memory',
-  personalOwnerId: config.personalOwnerId,
-  maxChars: 8000,
-  template: '# MEMORY',
-  onWarning: warning => logger.warn('memory.persistence_warning', { warning }),
-})
-const frontendMemoryService = new FrontendMemoryService({
-  userStore: userDocuments,
-  memoryStore: memoryDocuments,
-})
+// The built-in Markdown provider preserves the existing USER.md/MEMORY.md
+// behaviour. Embedders can replace the entire persistence boundary without
+// changing Realtime, extraction, or tool handling code.
+let defaultMemoryProvider = null
+if (memoryProvider === undefined && !frontendMemory) {
+  const userDocuments = new MarkdownContextStore({
+    filePath: config.userModelPath,
+    scope: 'user',
+    personalOwnerId: config.personalOwnerId,
+    maxChars: 6000,
+    template: '# USER',
+    onWarning: warning => logger.warn('user_model.persistence_warning', { warning }),
+  })
+  const memoryDocuments = new MarkdownContextStore({
+    filePath: config.frontendMemoryPath,
+    scope: 'memory',
+    personalOwnerId: config.personalOwnerId,
+    maxChars: 8000,
+    template: '# MEMORY',
+    onWarning: warning => logger.warn('memory.persistence_warning', { warning }),
+  })
+  defaultMemoryProvider = new FrontendMemoryService({
+    userStore: userDocuments,
+    memoryStore: memoryDocuments,
+  })
+}
+const memoryProviderRuntime = memoryProvider === undefined
+  ? defaultMemoryProvider
+  : memoryProvider
+const frontendMemoryRuntime = frontendMemory || (memoryProviderRuntime
+  ? new FrontendMemoryRuntime({ provider: memoryProviderRuntime })
+  : null)
 // Restored scheduled tasks submit the same self-contained Work input as live
 // requests. Frontend conversation history and memory stay at the frontend.
 taskManager.configureScheduledTaskRunner(
@@ -269,7 +284,7 @@ const notesStore = new FrontendNotesStore({
 // and the extractor stays silently disabled; explicit memories are
 // unaffected. ASSISTANT.md is never exposed as a writable document.
 const memoryExtractor = new MemoryExtractor({
-  memoryService: frontendMemoryService,
+  memoryService: frontendMemoryRuntime,
   conversationSync,
   audit: new MemoryAudit({
     filePath: config.memoryAuditPath,
@@ -361,7 +376,11 @@ app.get('/api/health', (req, res) => {
     resultContextMaxChars: config.resultContextMaxChars,
     announcementBatchMs: config.announcementBatchMs,
     announcementQuietMs: config.announcementQuietMs,
-    frontendMemory: frontendMemoryService.health(),
+    frontendMemory: frontendMemoryRuntime?.health() || {
+      ok: true,
+      configured: false,
+      provider: null,
+    },
     frontendProfile: config.frontendProfile || {
       configured: false,
       name: 'default',
@@ -631,7 +650,7 @@ const backendAvailability = new BackendAvailability({
 backendAvailability.refresh()
 realtimeGateway = attachRealtimeGateway(server, {
   identityManager,
-  memoryService: frontendMemoryService,
+  memoryService: frontendMemoryRuntime,
   memoryExtractor,
   notesStore,
   backendRuntime: workBackend,
@@ -689,6 +708,7 @@ const close = () => {
     await frontendMcpRuntime?.close?.()
     await frontendOpenApiRuntime?.close?.()
     await frontendKnowledgeRuntime?.close?.()
+    await frontendMemoryRuntime?.close?.()
     unsubscribeSessionTaskJournal?.()
     await sessionJournalRuntime.flush()
     await taskStore?.flush?.()
@@ -715,7 +735,11 @@ return {
     backendAvailability,
     conversationSync,
     backendRuntime: workBackend,
-    frontendMemoryService,
+    // Preserve the original service handle for embedders using the built-in
+    // synchronous Markdown API. New integrations should use frontendMemory.
+    frontendMemoryService: memoryProviderRuntime,
+    frontendMemory: frontendMemoryRuntime,
+    memoryProvider: memoryProviderRuntime,
     frontendRetrieval: retrievalRuntime,
     frontendKnowledge: frontendKnowledgeRuntime,
     frontendMcp: frontendMcpRuntime,

--- a/server/src/conversation/frontend-memory-service.mjs
+++ b/server/src/conversation/frontend-memory-service.mjs
@@ -3,6 +3,9 @@ import {
   MEMORY_DOCUMENTS,
   canonicalScope,
 } from '../core/memory-scopes.mjs'
+import {
+  MEMORY_PROVIDER_PROTOCOL_VERSION,
+} from './memory-provider.mjs'
 
 function normalizeScope(value, fallback = ALL_SCOPE) {
   const scope = canonicalScope(String(value || fallback))
@@ -15,6 +18,14 @@ function normalizeScope(value, fallback = ALL_SCOPE) {
 export class FrontendMemoryService {
   constructor({ userStore = null, memoryStore = null } = {}) {
     this.stores = { user: userStore, memory: memoryStore }
+  }
+
+  describe() {
+    return {
+      protocolVersion: MEMORY_PROVIDER_PROTOCOL_VERSION,
+      key: 'markdown',
+      label: 'Local Markdown memory',
+    }
   }
 
   list(ownerId, { scope = null } = {}) {

--- a/server/src/conversation/memory-extractor.mjs
+++ b/server/src/conversation/memory-extractor.mjs
@@ -314,7 +314,9 @@ export class MemoryExtractor {
       expectedRevision: documents.get(change.document)?.revision || '',
     }))
     try {
-      const result = this.memoryService.apply(ownerId, prepared)
+      const result = await this.memoryService.apply(ownerId, prepared, {
+        source: 'automatic-extraction',
+      })
       this.audit?.record({
         op: 'patch',
         ownerId,

--- a/server/src/conversation/memory-provider.mjs
+++ b/server/src/conversation/memory-provider.mjs
@@ -1,0 +1,73 @@
+export const MEMORY_PROVIDER_PROTOCOL_VERSION = 1
+
+const PROVIDER_KEY = /^[a-z0-9][a-z0-9-]*$/u
+
+function clean(value, maxChars) {
+  return [...String(value || '').replace(/\s+/g, ' ').trim()]
+    .slice(0, maxChars)
+    .join('')
+}
+
+export function describeMemoryProvider(provider) {
+  const description = provider?.describe?.()
+  if (
+    !description
+    || Number(description.protocolVersion) !== MEMORY_PROVIDER_PROTOCOL_VERSION
+    || !PROVIDER_KEY.test(String(description.key || ''))
+    || !String(description.label || '').trim()
+  ) {
+    throw new TypeError(
+      'MemoryProvider describe() returned an invalid identity or protocol version',
+    )
+  }
+  return {
+    protocolVersion: MEMORY_PROVIDER_PROTOCOL_VERSION,
+    key: String(description.key),
+    label: clean(description.label, 120),
+  }
+}
+
+/**
+ * Provider-neutral persistence port for frontend memory.
+ *
+ * Required methods:
+ *   describe() -> { protocolVersion, key, label }
+ *   list(ownerId, options) -> MemoryDocument[]
+ *   apply(ownerId, changes, context) -> MemoryApplyResult | Promise<...>
+ *
+ * list() is deliberately synchronous because it supplies the latency-sensitive
+ * Realtime prompt. Remote providers should keep a bounded local snapshot and
+ * refresh it after apply(). Writes may be asynchronous.
+ *
+ * Optional lifecycle methods:
+ *   health() -> { ok, ... }
+ *   close()
+ */
+export function assertMemoryProvider(value, { name = 'MemoryProvider' } = {}) {
+  if (!value || typeof value !== 'object') {
+    throw new TypeError(`${name} must be an object`)
+  }
+  const missing = ['describe', 'list', 'apply']
+    .filter(method => typeof value[method] !== 'function')
+  if (missing.length) {
+    throw new TypeError(`${name} is missing required methods: ${missing.join(', ')}`)
+  }
+  if (value.health != null && typeof value.health !== 'function') {
+    throw new TypeError(`${name} health must be a function when provided`)
+  }
+  if (value.close != null && typeof value.close !== 'function') {
+    throw new TypeError(`${name} close must be a function when provided`)
+  }
+  describeMemoryProvider(value)
+  return value
+}
+
+export function normalizeMemoryProviderHealth(value) {
+  const health = value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : {}
+  return {
+    ...health,
+    ok: health.ok !== false,
+  }
+}

--- a/server/src/conversation/memory-runtime.mjs
+++ b/server/src/conversation/memory-runtime.mjs
@@ -1,0 +1,97 @@
+import {
+  assertMemoryProvider,
+  describeMemoryProvider,
+  normalizeMemoryProviderHealth,
+} from './memory-provider.mjs'
+import {
+  canonicalScope,
+  isMemoryDocument,
+} from '../core/memory-scopes.mjs'
+
+function clean(value, maxChars) {
+  return [...String(value || '').replaceAll('\0', '').trim()]
+    .slice(0, maxChars)
+    .join('')
+}
+
+function normalizeDocuments(value) {
+  if (!Array.isArray(value)) {
+    throw new TypeError('MemoryProvider documents must be an array')
+  }
+  const documents = []
+  const scopes = new Set()
+  for (const candidate of value.slice(0, 8)) {
+    const scope = canonicalScope(candidate?.scope)
+    const content = clean(candidate?.content, 8_000)
+    if (!isMemoryDocument(scope) || !content || scopes.has(scope)) continue
+    scopes.add(scope)
+    documents.push({
+      id: clean(candidate?.id, 160) || `${scope}_document`,
+      scope,
+      content,
+      format: candidate?.format === 'text' ? 'text' : 'markdown',
+      revision: clean(candidate?.revision, 160),
+      editable: candidate?.editable !== false,
+    })
+  }
+  return documents
+}
+
+export class FrontendMemoryRuntime {
+  constructor({ provider } = {}) {
+    this.provider = assertMemoryProvider(provider)
+    this.closePromise = null
+  }
+
+  describe() {
+    return {
+      configured: true,
+      provider: describeMemoryProvider(this.provider),
+    }
+  }
+
+  list(ownerId, options = {}) {
+    const documents = this.provider.list(ownerId, options)
+    if (documents && typeof documents.then === 'function') {
+      throw new TypeError(
+        'MemoryProvider list() must return a synchronous Realtime snapshot',
+      )
+    }
+    return normalizeDocuments(documents)
+  }
+
+  async apply(ownerId, changes = [], context = {}) {
+    const result = await this.provider.apply(ownerId, changes, context)
+    if (!result || typeof result !== 'object' || !Array.isArray(result.documents)) {
+      throw new TypeError(
+        'MemoryProvider apply() must return changed and documents',
+      )
+    }
+    return {
+      ...result,
+      changed: Math.max(0, Math.trunc(Number(result.changed) || 0)),
+      documents: normalizeDocuments(result.documents),
+    }
+  }
+
+  health() {
+    const health = typeof this.provider.health === 'function'
+      ? this.provider.health()
+      : { ok: true }
+    if (health && typeof health.then === 'function') {
+      throw new TypeError('MemoryProvider health() must return a synchronous snapshot')
+    }
+    return {
+      ...normalizeMemoryProviderHealth(health),
+      configured: true,
+      provider: describeMemoryProvider(this.provider),
+    }
+  }
+
+  async close() {
+    if (!this.closePromise) {
+      this.closePromise = Promise.resolve().then(() => this.provider.close?.())
+    }
+    await this.closePromise
+  }
+}

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -1493,7 +1493,12 @@ export class ToolCallHandler {
           append: action === 'append' ? content : '',
         }
         const changes = [change]
-        const result = this.memoryService.apply(this.ownerId, changes)
+        const result = await this.memoryService.apply(this.ownerId, changes, {
+          source: 'realtime-tool',
+          sessionId: this.sessionId,
+          turnId,
+          traceId: callId,
+        })
         if (result.changed) this.notifyMemoryChanged()
         output = {
           status: result.changed ? 'updated' : 'unchanged',

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -190,3 +190,87 @@ test('enables knowledge only when an external provider is injected', async () =>
   await application.close()
   assert.equal(closed, true)
 })
+
+test('replaces Markdown memory through the public provider boundary', async () => {
+  let closed = false
+  const memoryProvider = {
+    describe: () => ({
+      protocolVersion: 1,
+      key: 'external-memory',
+      label: 'External Memory',
+    }),
+    list: ownerId => [{
+      id: `memory_${ownerId}`,
+      scope: 'memory',
+      content: '- External fact',
+      format: 'markdown',
+      revision: 'revision-one',
+    }],
+    apply: async () => ({ changed: 0, documents: [] }),
+    health: () => ({ ok: true, external: true }),
+    close: async () => { closed = true },
+  }
+  const application = createGatewayApplication({
+    config: {
+      ...config,
+      port: 0,
+      webSearchProvider: 'none',
+      webSearchMcpUrl: '',
+    },
+    parentPort: null,
+    autoStart: false,
+    agent: disabledBackend(),
+    memoryProvider,
+    frontendMcp: null,
+    frontendOpenApi: null,
+  })
+
+  assert.equal(application.services.memoryProvider, memoryProvider)
+  assert.equal(application.services.frontendMemoryService, memoryProvider)
+  assert.deepEqual(application.services.frontendMemory.describe(), {
+    configured: true,
+    provider: {
+      protocolVersion: 1,
+      key: 'external-memory',
+      label: 'External Memory',
+    },
+  })
+  assert.match(
+    application.services.frontendMemory.list('owner')[0].content,
+    /External fact/,
+  )
+  assert.deepEqual(application.services.frontendMemory.health(), {
+    ok: true,
+    external: true,
+    configured: true,
+    provider: {
+      protocolVersion: 1,
+      key: 'external-memory',
+      label: 'External Memory',
+    },
+  })
+  await application.close()
+  assert.equal(closed, true)
+})
+
+test('can disable memory without constructing the default provider', async () => {
+  const application = createGatewayApplication({
+    config: {
+      ...config,
+      port: 0,
+      webSearchProvider: 'none',
+      webSearchMcpUrl: '',
+    },
+    parentPort: null,
+    autoStart: false,
+    agent: disabledBackend(),
+    memoryProvider: null,
+    frontendMcp: null,
+    frontendOpenApi: null,
+  })
+
+  assert.equal(application.services.memoryProvider, null)
+  assert.equal(application.services.frontendMemory, null)
+  assert.equal(application.services.frontendMemoryService, null)
+  await application.close()
+})

--- a/server/test/memory-provider.test.mjs
+++ b/server/test/memory-provider.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  MEMORY_PROVIDER_PROTOCOL_VERSION,
+  assertMemoryProvider,
+  describeMemoryProvider,
+  normalizeMemoryProviderHealth,
+} from '../src/conversation/memory-provider.mjs'
+
+function provider(overrides = {}) {
+  return {
+    describe: () => ({
+      protocolVersion: MEMORY_PROVIDER_PROTOCOL_VERSION,
+      key: 'custom-memory',
+      label: 'Custom Memory',
+    }),
+    list: () => [],
+    apply: async () => ({ changed: 0, documents: [] }),
+    ...overrides,
+  }
+}
+
+test('validates one versioned provider-neutral memory contract', () => {
+  assert.throws(
+    () => assertMemoryProvider({ describe: () => ({}) }),
+    /list, apply/,
+  )
+  assert.throws(
+    () => assertMemoryProvider(provider({
+      describe: () => ({ protocolVersion: 2, key: 'future', label: 'Future' }),
+    })),
+    /protocol version/,
+  )
+  assert.throws(
+    () => assertMemoryProvider(provider({ close: true })),
+    /close must be a function/,
+  )
+  const fixture = provider()
+  assert.equal(assertMemoryProvider(fixture), fixture)
+  assert.deepEqual(describeMemoryProvider(fixture), {
+    protocolVersion: 1,
+    key: 'custom-memory',
+    label: 'Custom Memory',
+  })
+  assert.deepEqual(normalizeMemoryProviderHealth({ ok: false, warning: 'offline' }), {
+    ok: false,
+    warning: 'offline',
+  })
+})

--- a/server/test/memory-runtime.test.mjs
+++ b/server/test/memory-runtime.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { FrontendMemoryRuntime } from '../src/conversation/memory-runtime.mjs'
+
+function provider(overrides = {}) {
+  return {
+    describe: () => ({
+      protocolVersion: 1,
+      key: 'fixture',
+      label: 'Fixture Memory',
+    }),
+    list: () => [],
+    apply: async () => ({ changed: 0, documents: [] }),
+    ...overrides,
+  }
+}
+
+test('keeps trusted mutation context separate from model changes', async () => {
+  let received
+  const runtime = new FrontendMemoryRuntime({
+    provider: provider({
+      apply: async (ownerId, changes, context) => {
+        received = { ownerId, changes, context }
+        return { changed: 1, documents: [{ scope: 'memory', content: 'fact' }] }
+      },
+    }),
+  })
+  const changes = [{ document: 'memory', append: '- fact' }]
+  const context = { source: 'realtime-tool', sessionId: 'session-private' }
+  const result = await runtime.apply('owner-private', changes, context)
+  assert.deepEqual(received, { ownerId: 'owner-private', changes, context })
+  assert.equal(result.changed, 1)
+})
+
+test('requires a synchronous Realtime snapshot and closes once', async () => {
+  let closed = 0
+  const runtime = new FrontendMemoryRuntime({
+    provider: provider({
+      list: () => Promise.resolve([]),
+      close: async () => { closed += 1 },
+    }),
+  })
+  assert.throws(() => runtime.list('owner'), /synchronous Realtime snapshot/)
+  await runtime.close()
+  await runtime.close()
+  assert.equal(closed, 1)
+})
+
+test('normalizes provider health and rejects malformed writes', async () => {
+  const runtime = new FrontendMemoryRuntime({
+    provider: provider({
+      health: () => ({ ok: false, warning: 'offline' }),
+      apply: async () => null,
+    }),
+  })
+  assert.deepEqual(runtime.health(), {
+    ok: false,
+    warning: 'offline',
+    configured: true,
+    provider: {
+      protocolVersion: 1,
+      key: 'fixture',
+      label: 'Fixture Memory',
+    },
+  })
+  await assert.rejects(() => runtime.apply('owner', []), /changed and documents/)
+})

--- a/test/memory-provider-package-export.test.mjs
+++ b/test/memory-provider-package-export.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  MEMORY_PROVIDER_PROTOCOL_VERSION,
+  assertMemoryProvider,
+  describeMemoryProvider,
+  normalizeMemoryProviderHealth,
+} from 'qwen-audio-agent/memory-provider'
+
+test('exports one stable optional Memory Provider contract', () => {
+  assert.equal(MEMORY_PROVIDER_PROTOCOL_VERSION, 1)
+  assert.equal(typeof assertMemoryProvider, 'function')
+  assert.equal(typeof describeMemoryProvider, 'function')
+  assert.equal(typeof normalizeMemoryProviderHealth, 'function')
+})


### PR DESCRIPTION
## Summary
- add a public, versioned Memory Provider contract and normalized runtime
- preserve the existing Markdown memory implementation as the default
- allow custom providers or explicit memory disablement at the Gateway composition root
- route Realtime memory writes and automatic extraction through the provider-neutral runtime
- document the extension contract and add package, runtime, lifecycle, and injection tests

## Verification
- npm test
- npm run lint
- node scripts/verify-package.mjs
- git diff --check