### PR TITLE
feat: restore recent conversation history

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "./session-events": "./shared/session-events.mjs",
     "./session-journal": "./server/src/session/session-journal.mjs",
     "./session-replay": "./server/src/session/session-replay.mjs",
+    "./conversation-history": "./shared/conversation-history.mjs",
     "./gateway-client-state": "./shared/gateway-client-state.mjs",
     "./gateway-application": "./server/src/app/gateway-application.mjs",
     "./backend-adapter-sdk": "./server/src/backend/backend-adapter-sdk.mjs",

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -19,6 +19,7 @@ import {
 import { FrontendMemoryService } from '../conversation/frontend-memory-service.mjs'
 import { MarkdownContextStore } from '../conversation/markdown-context-store.mjs'
 import { FrontendMemoryRuntime } from '../conversation/memory-runtime.mjs'
+import { SessionConversationHistory } from './session-conversation-history.mjs'
 import { enforceSameOrigin } from '../core/request-security.mjs'
 import {
   GATEWAY_CAPABILITIES,
@@ -89,29 +90,21 @@ export function createGatewayApplication({
   frontendMcp = undefined,
   frontendOpenApi = undefined,
   sessionJournal = null,
+  conversationHistory = null,
 } = {}) {
 const workBackend = backendRuntime || new BackendWorkRuntime({ backend: agent })
 const sessionJournalRuntime = sessionJournal || defaultTaskSessionJournal
-conversationSync.setRecordObserver?.((message, context = {}) => {
-  if (!context.ownerId || !message?.id) return
-  sessionJournalRuntime.append({
-    ownerId: context.ownerId,
-    sessionId: context.sessionId || 'main',
-    event: {
-      type: message.role === 'user' ? 'user/message' : 'assistant/message',
-      turnId: message.turnId || null,
-      taskId: message.taskId || null,
-      source: message.source || 'conversation-sync',
-      payload: {
-        messageId: message.id,
-        content: message.content,
-        inputs: message.inputs || [],
-        taskIds: message.taskIds || [],
-        citations: message.citations || [],
-      },
-    },
-  })
+const conversationHistoryRuntime = conversationHistory || new SessionConversationHistory({
+  conversationSync,
+  sessionJournal: sessionJournalRuntime,
+  logger,
 })
+const restoredConversationMessages = conversationHistoryRuntime.start?.() || 0
+if (restoredConversationMessages) {
+  logger.info('conversation_history.restored', {
+    messages: restoredConversationMessages,
+  })
+}
 const inputAssetRegistry = inputAssets || new InputAssetRegistry({
   sessionTtlMs: config.conversationSessionTtlMs,
   maxSessions: config.maxConversationSessions,
@@ -516,6 +509,20 @@ app.get('/api/sessions/:sessionId/replay', async (req, res, next) => {
   }
 })
 
+// Stable, bounded UI projection. Clients never depend on Session Journal
+// records or diagnostic logs, and Realtime consumes this same projection.
+app.get('/api/conversations/:sessionId/messages', async (req, res, next) => {
+  try {
+    const messages = await conversationHistoryRuntime.messages({
+      ownerId: req.identity.ownerId,
+      sessionId: req.params.sessionId,
+    })
+    res.json({ messages })
+  } catch (error) {
+    next(error)
+  }
+})
+
 app.get('/api/tasks/:id', (req, res) => {
   const task = taskManager.get(req.params.id, { ownerId: req.identity.ownerId })
   if (!task) return res.status(404).json({ error: 'task not found' })
@@ -710,6 +717,7 @@ const close = () => {
     await frontendKnowledgeRuntime?.close?.()
     await frontendMemoryRuntime?.close?.()
     unsubscribeSessionTaskJournal?.()
+    conversationHistoryRuntime.close?.()
     await sessionJournalRuntime.flush()
     await taskStore?.flush?.()
     if (!server.listening) return
@@ -734,6 +742,7 @@ return {
     agent,
     backendAvailability,
     conversationSync,
+    conversationHistory: conversationHistoryRuntime,
     backendRuntime: workBackend,
     // Preserve the original service handle for embedders using the built-in
     // synchronous Markdown API. New integrations should use frontendMemory.

--- a/server/src/app/session-conversation-history.mjs
+++ b/server/src/app/session-conversation-history.mjs
@@ -1,0 +1,102 @@
+import { replaySession } from '../session/session-replay.mjs'
+import { projectFrontendConversation } from '../conversation/frontend-conversation-projection.mjs'
+
+/**
+ * Adapts the durable, domain-neutral Session Journal to the in-memory
+ * conversation projection. Neither the Realtime runtime nor UI clients need
+ * to understand the journal's JSONL representation.
+ */
+export class SessionConversationHistory {
+  constructor({
+    conversationSync,
+    sessionJournal,
+    logger = null,
+    limit,
+  } = {}) {
+    if (!conversationSync) throw new TypeError('conversationSync is required')
+    if (!sessionJournal) throw new TypeError('sessionJournal is required')
+    this.conversationSync = conversationSync
+    this.sessionJournal = sessionJournal
+    this.logger = logger
+    this.limit = limit
+    this.started = false
+  }
+
+  start() {
+    if (this.started) return 0
+    this.started = true
+    const restored = this.restoreAll()
+    this.conversationSync.setRecordObserver?.((message, context) => {
+      this.append(message, context)
+    })
+    return restored
+  }
+
+  restoreAll() {
+    if (typeof this.sessionJournal.readAllSync !== 'function') return 0
+    let restored = 0
+    for (const entry of this.sessionJournal.readAllSync()) {
+      try {
+        const replay = replaySession(entry.records)
+        const ownerId = String(replay.header.ownerId || '')
+        const sessionId = String(replay.header.sessionId || '')
+        if (!ownerId || !sessionId) continue
+        const messages = projectFrontendConversation(replay.messages, {
+          limit: this.limit,
+        })
+        this.conversationSync.restore?.({ ownerId, sessionId, messages })
+        restored += messages.length
+      } catch (error) {
+        this.logger?.warn('conversation_history.restore_failed', {
+          path: entry.path,
+          error,
+        })
+      }
+    }
+    return restored
+  }
+
+  append(message, context = {}) {
+    if (!context.ownerId || !message?.id) return
+    const pending = this.sessionJournal.append({
+      ownerId: context.ownerId,
+      sessionId: context.sessionId || 'main',
+      event: {
+        type: message.role === 'user' ? 'user/message' : 'assistant/message',
+        turnId: message.turnId || null,
+        taskId: message.taskId || null,
+        source: message.source || 'conversation-sync',
+        payload: {
+          messageId: message.id,
+          content: message.content,
+          inputs: message.inputs || [],
+          taskIds: message.taskIds || [],
+          citations: message.citations || [],
+        },
+      },
+    })
+    pending?.catch?.(error => {
+      this.logger?.warn('conversation_history.append_failed', {
+        ownerId: context.ownerId,
+        sessionId: context.sessionId || 'main',
+        error,
+      })
+    })
+  }
+
+  async messages({ ownerId, sessionId }) {
+    if (typeof this.sessionJournal.read !== 'function') {
+      return this.conversationSync.frontendContext({ ownerId, sessionId })
+    }
+    const records = await this.sessionJournal.read(ownerId, sessionId)
+    return projectFrontendConversation(
+      replaySession(records, { sessionId }).messages,
+      { limit: this.limit },
+    )
+  }
+
+  close() {
+    this.conversationSync.setRecordObserver?.(null)
+    this.started = false
+  }
+}

--- a/server/src/conversation/conversation-sync.mjs
+++ b/server/src/conversation/conversation-sync.mjs
@@ -1,3 +1,5 @@
+import { projectFrontendConversation } from './frontend-conversation-projection.mjs'
+
 function sessionKey(ownerId, sessionId) {
   return `${ownerId}\u0000${sessionId}`
 }
@@ -95,7 +97,7 @@ export class ConversationSync {
     }
   }
 
-  record({
+  upsert({
     ownerId,
     sessionId,
     id,
@@ -107,7 +109,8 @@ export class ConversationSync {
     taskIds = [],
     inputs = [],
     citations = [],
-  }) {
+    createdAt = null,
+  }, { notify = true } = {}) {
     const normalized = clean(content)
     if (!id || !normalized) return null
     const state = this.state(ownerId, sessionId)
@@ -126,7 +129,9 @@ export class ConversationSync {
         existing.citations = citations.map(citation => ({ ...citation }))
       }
       const snapshot = { ...existing }
-      try { this.onRecord?.(snapshot, { ownerId, sessionId }) } catch { /* observers must not affect sync */ }
+      if (notify) {
+        try { this.onRecord?.(snapshot, { ownerId, sessionId }) } catch { /* observers must not affect sync */ }
+      }
       return snapshot
     }
     const message = {
@@ -142,7 +147,7 @@ export class ConversationSync {
       ...(citations?.length
         ? { citations: citations.map(citation => ({ ...citation })) }
         : {}),
-      createdAt: Date.now(),
+      createdAt: Number(createdAt) || Date.now(),
     }
     state.messages.push(message)
     state.byId.set(id, message)
@@ -151,8 +156,21 @@ export class ConversationSync {
       state.byId.delete(removed.id)
     }
     const snapshot = { ...message }
-    try { this.onRecord?.(snapshot, { ownerId, sessionId }) } catch { /* observers must not affect sync */ }
+    if (notify) {
+      try { this.onRecord?.(snapshot, { ownerId, sessionId }) } catch { /* observers must not affect sync */ }
+    }
     return snapshot
+  }
+
+  record(message) {
+    return this.upsert(message)
+  }
+
+  restore({ ownerId, sessionId, messages = [] }) {
+    for (const message of messages) {
+      this.upsert({ ownerId, sessionId, ...message }, { notify: false })
+    }
+    return this.frontendContext({ ownerId, sessionId })
   }
 
   list({ ownerId, sessionId }) {
@@ -183,27 +201,7 @@ export class ConversationSync {
   }
 
   frontendContext({ ownerId, sessionId }) {
-    const messages = this.list({ ownerId, sessionId })
-    const presentedTaskIds = new Set()
-    messages
-      .filter(message => message.source === 'agent-presentation')
-      .forEach(message => {
-        if (message.taskId) presentedTaskIds.add(message.taskId)
-        message.taskIds?.forEach(taskId => presentedTaskIds.add(taskId))
-      })
-    return messages.filter(message => (
-      [
-        'voice-user',
-        'text-user',
-        'realtime-direct',
-        'agent-presentation',
-      ].includes(message.source)
-      || (
-        message.source === 'agent-result'
-        && message.taskId
-        && !presentedTaskIds.has(message.taskId)
-      )
-    ))
+    return projectFrontendConversation(this.list({ ownerId, sessionId }))
   }
 
 }

--- a/server/src/conversation/frontend-agent-context.mjs
+++ b/server/src/conversation/frontend-agent-context.mjs
@@ -2,12 +2,12 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { config } from '../core/config.mjs'
 import { canonicalScope, isDirectiveScope } from '../core/memory-scopes.mjs'
+import { recentConversationMessages } from '../../../shared/conversation-history.mjs'
 
 const PROMPT_FILE = 'PROMPT.md'
 const ASSISTANT_FILE = 'ASSISTANT.md'
 const MAX_PROMPT_CHARS = 16000
 const MAX_ASSISTANT_CHARS = 4000
-const MAX_RECENT_MESSAGES = 10
 const MAX_RECENT_CHARS = 3500
 
 function clean(value) {
@@ -111,7 +111,7 @@ function memorySection(memories = []) {
 }
 
 export function buildRecentConversationContext(messages = []) {
-  const candidates = messages.slice(-MAX_RECENT_MESSAGES)
+  const candidates = recentConversationMessages(messages)
   const selected = []
   let used = 0
   for (const message of candidates.toReversed()) {

--- a/server/src/conversation/frontend-conversation-projection.mjs
+++ b/server/src/conversation/frontend-conversation-projection.mjs
@@ -1,0 +1,37 @@
+import {
+  RECENT_CONVERSATION_MESSAGE_LIMIT,
+  recentConversationMessages,
+} from '../../../shared/conversation-history.mjs'
+
+const FRONTEND_MESSAGE_SOURCES = new Set([
+  'voice-user',
+  'text-user',
+  'realtime-direct',
+  'agent-presentation',
+])
+
+/**
+ * The single projection shared by Realtime context restoration and visible
+ * frontend history. Internal task results stay hidden when a user-facing
+ * presentation for the same task already exists.
+ */
+export function projectFrontendConversation(
+  messages = [],
+  { limit = RECENT_CONVERSATION_MESSAGE_LIMIT } = {},
+) {
+  const presentedTaskIds = new Set()
+  messages
+    .filter(message => message.source === 'agent-presentation')
+    .forEach(message => {
+      if (message.taskId) presentedTaskIds.add(message.taskId)
+      message.taskIds?.forEach(taskId => presentedTaskIds.add(taskId))
+    })
+  return recentConversationMessages(messages.filter(message => (
+    FRONTEND_MESSAGE_SOURCES.has(message.source)
+    || (
+      message.source === 'agent-result'
+      && message.taskId
+      && !presentedTaskIds.has(message.taskId)
+    )
+  )), limit)
+}

--- a/server/src/session/session-journal-registry.mjs
+++ b/server/src/session/session-journal-registry.mjs
@@ -58,6 +58,7 @@ export class SessionJournalRegistry {
 
   async read(ownerId, sessionId = 'main') {
     const journal = this.get(ownerId, sessionId)
+    await journal.flush()
     await journal.open()
     return journal.list()
   }

--- a/server/src/session/session-replay.mjs
+++ b/server/src/session/session-replay.mjs
@@ -8,18 +8,32 @@ import { validateSessionLog } from '../../../shared/session-events.mjs'
 export function replaySession(records, { sessionId } = {}) {
   const { header, events } = validateSessionLog(records, { sessionId })
   const messages = []
+  const messageIndexes = new Map()
   const tasks = new Map()
   const deliveries = []
   for (const event of events) {
     if (event.type === 'user/message' || event.type === 'assistant/message') {
-      messages.push({
+      const messageId = String(event.payload?.messageId || '')
+      const message = {
+        id: messageId || `journal:${event.seq}`,
         role: event.type === 'user/message' ? 'user' : 'assistant',
+        source: event.source || 'conversation-sync',
         ...(event.turnId ? { turnId: event.turnId } : {}),
         ...(event.taskId ? { taskId: event.taskId } : {}),
         ...(event.payload || {}),
         seq: event.seq,
         time: event.time,
-      })
+        createdAt: Number.isFinite(Date.parse(event.time))
+          ? Date.parse(event.time)
+          : 0,
+      }
+      const existingIndex = messageId ? messageIndexes.get(messageId) : undefined
+      if (existingIndex === undefined) {
+        if (messageId) messageIndexes.set(messageId, messages.length)
+        messages.push(message)
+      } else {
+        messages[existingIndex] = { ...messages[existingIndex], ...message }
+      }
     }
     if (event.type === 'qwaudio/task/event' && event.taskId && event.payload?.task) {
       tasks.set(event.taskId, {

--- a/server/test/conversation-sync.test.mjs
+++ b/server/test/conversation-sync.test.mjs
@@ -29,6 +29,45 @@ test('keeps recent voice context isolated by owner and voice session', () => {
   )
 })
 
+test('uses the same bounded ten-message projection for frontend history and Realtime', () => {
+  const sync = new ConversationSync()
+  for (let index = 1; index <= 12; index += 1) {
+    sync.record({
+      ownerId: 'owner',
+      sessionId: 'voice',
+      id: `message-${index}`,
+      role: index % 2 ? 'user' : 'assistant',
+      content: `message ${index}`,
+      source: index % 2 ? 'voice-user' : 'realtime-direct',
+    })
+  }
+
+  assert.deepEqual(
+    sync.frontendContext({ ownerId: 'owner', sessionId: 'voice' })
+      .map(message => message.content),
+    Array.from({ length: 10 }, (_, index) => `message ${index + 3}`),
+  )
+})
+
+test('restores messages without writing them back through the record observer', () => {
+  const observed = []
+  const sync = new ConversationSync({ onRecord: message => observed.push(message) })
+  sync.restore({
+    ownerId: 'owner',
+    sessionId: 'voice',
+    messages: [{
+      id: 'restored',
+      role: 'user',
+      content: 'persisted message',
+      source: 'voice-user',
+      createdAt: 123,
+    }],
+  })
+
+  assert.equal(observed.length, 0)
+  assert.equal(sync.frontendContext({ ownerId: 'owner', sessionId: 'voice' })[0].createdAt, 123)
+})
+
 test('deduplicates the same message id and retains agent presentations', () => {
   const sync = new ConversationSync()
   const input = {

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -149,6 +149,59 @@ test('constructs an injectable Gateway without binding a port on import', async 
   assert.equal(openApiClosed, true)
 })
 
+test('serves the bounded conversation projection without exposing journal records', async () => {
+  const calls = []
+  let closed = false
+  const conversationHistory = {
+    start: () => 0,
+    messages: async context => {
+      calls.push(context)
+      return [{
+        id: 'message-1',
+        role: 'user',
+        content: 'restored',
+        source: 'voice-user',
+      }]
+    },
+    close: () => { closed = true },
+  }
+  const application = createGatewayApplication({
+    config: {
+      ...config,
+      port: 0,
+      webSearchProvider: 'none',
+      webSearchMcpUrl: '',
+    },
+    parentPort: null,
+    autoStart: false,
+    agent: disabledBackend(),
+    conversationHistory,
+    frontendMcp: null,
+    frontendOpenApi: null,
+  })
+  application.start()
+  if (!application.server.listening) await once(application.server, 'listening')
+  const { port } = application.server.address()
+  const response = await fetch(
+    `http://127.0.0.1:${port}/api/conversations/desktop-session/messages`,
+  )
+  assert.equal(response.status, 200)
+  assert.deepEqual(await response.json(), {
+    messages: [{
+      id: 'message-1',
+      role: 'user',
+      content: 'restored',
+      source: 'voice-user',
+    }],
+  })
+  assert.deepEqual(calls, [{
+    ownerId: config.personalOwnerId,
+    sessionId: 'desktop-session',
+  }])
+  await application.close()
+  assert.equal(closed, true)
+})
+
 test('enables knowledge only when an external provider is injected', async () => {
   let closed = false
   const knowledgeProvider = {

--- a/server/test/session-conversation-history.test.mjs
+++ b/server/test/session-conversation-history.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { ConversationSync } from '../src/conversation/conversation-sync.mjs'
+import { SessionConversationHistory } from '../src/app/session-conversation-history.mjs'
+import { SessionJournalRegistry } from '../src/session/session-journal-registry.mjs'
+
+test('restores the same recent messages for the UI and Realtime after restart', async t => {
+  const directory = await mkdtemp(join(tmpdir(), 'qwaudio-conversation-history-'))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  const firstRegistry = new SessionJournalRegistry({ directory })
+  const firstSync = new ConversationSync()
+  const firstHistory = new SessionConversationHistory({
+    conversationSync: firstSync,
+    sessionJournal: firstRegistry,
+  })
+  firstHistory.start()
+
+  for (let index = 1; index <= 12; index += 1) {
+    firstSync.record({
+      ownerId: 'owner',
+      sessionId: 'desktop',
+      id: `message-${index}`,
+      role: index % 2 ? 'user' : 'assistant',
+      content: `message ${index}`,
+      source: index % 2 ? 'voice-user' : 'realtime-direct',
+    })
+  }
+  await firstRegistry.flush()
+  firstHistory.close()
+
+  const restoredSync = new ConversationSync()
+  const restoredHistory = new SessionConversationHistory({
+    conversationSync: restoredSync,
+    sessionJournal: new SessionJournalRegistry({ directory }),
+  })
+  assert.equal(restoredHistory.start(), 10)
+
+  const realtimeMessages = restoredSync.frontendContext({
+    ownerId: 'owner',
+    sessionId: 'desktop',
+  })
+  const visibleMessages = await restoredHistory.messages({
+    ownerId: 'owner',
+    sessionId: 'desktop',
+  })
+  const expected = Array.from({ length: 10 }, (_, index) => `message ${index + 3}`)
+  assert.deepEqual(realtimeMessages.map(message => message.content), expected)
+  assert.deepEqual(visibleMessages.map(message => message.content), expected)
+  assert.deepEqual(
+    visibleMessages.map(message => message.id),
+    realtimeMessages.map(message => message.id),
+  )
+  restoredHistory.close()
+})
+
+test('keeps internal task results out of the durable frontend projection', async t => {
+  const directory = await mkdtemp(join(tmpdir(), 'qwaudio-conversation-projection-'))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  const registry = new SessionJournalRegistry({ directory })
+  const sync = new ConversationSync()
+  const history = new SessionConversationHistory({
+    conversationSync: sync,
+    sessionJournal: registry,
+  })
+  history.start()
+  sync.record({
+    ownerId: 'owner', sessionId: 'desktop', id: 'raw-result',
+    role: 'assistant', content: 'internal result', source: 'agent-result', taskId: 'task-1',
+  })
+  sync.record({
+    ownerId: 'owner', sessionId: 'desktop', id: 'presentation',
+    role: 'assistant', content: 'visible result', source: 'agent-presentation', taskId: 'task-1',
+  })
+  await registry.flush()
+
+  assert.deepEqual(
+    (await history.messages({ ownerId: 'owner', sessionId: 'desktop' }))
+      .map(message => message.content),
+    ['visible result'],
+  )
+  history.close()
+})

--- a/server/test/session-journal.test.mjs
+++ b/server/test/session-journal.test.mjs
@@ -68,3 +68,22 @@ test('replays messages and latest task projection without side effects', async (
   assert.equal(replay.tasks[0].status, 'completed')
   assert.equal(replay.lastSeq, 3)
 })
+
+test('replay collapses repeated snapshots of the same visible message', async () => {
+  const journal = await journalFixture()
+  await journal.append({
+    type: SessionEventType.USER_MESSAGE,
+    source: 'voice-user',
+    payload: { messageId: 'user-1', content: 'preview' },
+  })
+  await journal.append({
+    type: SessionEventType.USER_MESSAGE,
+    source: 'voice-user',
+    payload: { messageId: 'user-1', content: 'final' },
+  })
+
+  const replay = replaySession(journal.list(), { sessionId: 'session-1' })
+  assert.equal(replay.messages.length, 1)
+  assert.equal(replay.messages[0].id, 'user-1')
+  assert.equal(replay.messages[0].content, 'final')
+})

--- a/shared/conversation-history.mjs
+++ b/shared/conversation-history.mjs
@@ -1,0 +1,12 @@
+export const RECENT_CONVERSATION_MESSAGE_LIMIT = 10
+
+export function recentConversationMessages(
+  messages = [],
+  limit = RECENT_CONVERSATION_MESSAGE_LIMIT,
+) {
+  const boundedLimit = Number.isInteger(limit) && limit >= 0
+    ? limit
+    : RECENT_CONVERSATION_MESSAGE_LIMIT
+  if (boundedLimit === 0) return []
+  return messages.slice(-boundedLimit)
+}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -10,6 +10,7 @@ import {
   buildConversationTurns,
   discardUserTranscript,
   insertByTurn,
+  mergeConversationHistory,
   upsertAssistantTranscript,
   upsertUserTranscript,
 } from './message-order.js'
@@ -221,6 +222,8 @@ export default function App() {
   const lastWakeAtRef = useRef(0)
   const orbVisualStateRef = useRef('idle')
   const previousDesktopLifecycle = useRef('active')
+  const sessionIdRef = useRef(sessionId)
+  sessionIdRef.current = sessionId
   const spriteAnimationCue = spriteAnimationCues[0] || null
 
   const noteInteraction = useCallback(() => {
@@ -485,6 +488,13 @@ export default function App() {
       window.qwenAudioAgentDesktop?.wake()
     }
     if (event.type === 'gateway.connected') {
+      fetch(`api/conversations/${encodeURIComponent(sessionId)}/messages`)
+        .then(response => response.ok ? response.json() : Promise.reject())
+        .then(payload => {
+          if (sessionIdRef.current !== sessionId) return
+          setMessages(items => mergeConversationHistory(items, payload.messages))
+        })
+        .catch(() => {})
       fetch(`api/tasks?sessionId=${encodeURIComponent(sessionId)}`)
         .then(response => response.ok ? response.json() : Promise.reject())
         .then(payload => {

--- a/web/src/message-order.js
+++ b/web/src/message-order.js
@@ -1,3 +1,8 @@
+import {
+  RECENT_CONVERSATION_MESSAGE_LIMIT,
+  recentConversationMessages,
+} from '../../shared/conversation-history.mjs'
+
 export function normalizeTranscript(content) {
   return String(content || '').replace(/\s+/g, ' ').trim()
 }
@@ -13,7 +18,9 @@ function turnTimestamp(turnId) {
 }
 
 export function insertByTurn(items, message) {
-  if (!message.turnId) return [...items, message]
+  if (!message.turnId) {
+    return recentConversationMessages([...items, message])
+  }
   const matching = items
     .map((item, index) => item.turnId === message.turnId ? index : -1)
     .filter(index => index >= 0)
@@ -35,7 +42,38 @@ export function insertByTurn(items, message) {
   }
   const next = [...items]
   next.splice(insertAt, 0, message)
-  return next
+  return recentConversationMessages(next)
+}
+
+export function mergeConversationHistory(items, history = []) {
+  const currentIds = new Set(items.map(message => message.id))
+  const restored = history.flatMap(message => {
+    const id = String(message.id || message.messageId || '')
+    const content = String(message.content || '').trim()
+    if (!id || !content || currentIds.has(id)) return []
+    return [{
+      id,
+      role: message.role === 'user' ? 'user' : 'assistant',
+      content,
+      turnId: message.turnId || '',
+      taskId: message.taskId || null,
+      taskIds: message.taskIds || [],
+      inputs: message.inputs || [],
+      citations: message.citations || [],
+      source: message.source || 'conversation-history',
+      ...(message.source === 'agent-presentation'
+        ? { origin: 'announcement' }
+        : {}),
+      createdAt: Number(message.createdAt) || 0,
+      voice: message.source === 'voice-user',
+      final: true,
+      live: false,
+    }]
+  })
+  return recentConversationMessages(
+    [...restored, ...items],
+    RECENT_CONVERSATION_MESSAGE_LIMIT,
+  )
 }
 
 export function upsertUserTranscript(items, {

--- a/web/test/message-order.test.js
+++ b/web/test/message-order.test.js
@@ -6,10 +6,35 @@ import {
   discardUserTranscript,
   finalAssistantContent,
   insertByTurn,
+  mergeConversationHistory,
   normalizeTranscript,
   upsertAssistantTranscript,
   upsertUserTranscript,
 } from '../src/message-order.js'
+
+test('hydrates only the recent ten persisted messages and keeps live duplicates', () => {
+  const history = Array.from({ length: 12 }, (_, index) => ({
+    id: `message-${index + 1}`,
+    role: index % 2 ? 'assistant' : 'user',
+    content: `persisted ${index + 1}`,
+    source: index % 2 ? 'realtime-direct' : 'voice-user',
+    createdAt: index + 1,
+  }))
+  const current = [{
+    id: 'message-12',
+    role: 'assistant',
+    content: 'live 12',
+    live: false,
+  }]
+
+  const messages = mergeConversationHistory(current, history)
+  assert.equal(messages.length, 10)
+  assert.deepEqual(
+    messages.map(message => message.id),
+    Array.from({ length: 10 }, (_, index) => `message-${index + 3}`),
+  )
+  assert.equal(messages.at(-1).content, 'live 12')
+})
 
 test('normalizes hard line breaks in final ASR text', () => {
   assert.equal(normalizeTranscript('查看下载目录\n下面有哪些文件  '), '查看下载目录 下面有哪些文件')


### PR DESCRIPTION
## Summary

- restore the latest 10 visible conversation messages after an app or Gateway restart
- use one bounded projection for both frontend history and Realtime context
- keep Session Journal persistence, conversation projection, app composition, and UI hydration decoupled
- deduplicate restored and live messages by stable message ID

## Validation

- `npm test`
- `npm run lint -- --no-warn-ignored`
- `npm run build --workspace web --no-global`