### PR TITLE
fix(desktop): persist conversation session across restarts

### DIFF
--- a/desktop/src/main.mjs
+++ b/desktop/src/main.mjs
@@ -160,6 +160,7 @@ const desktopSettingsStore = createSettingsStore({
   configDir: runtimeEnvironment.dataDirectory,
   uiStateDir: runtimeEnvironment.configDirectory,
 })
+let desktopConversationSessionId = desktopSettingsStore.conversationSession.load()
 const orbPlacement = createOrbPlacement({
   getDisplays: () => screen.getAllDisplays(),
   orbSize: { width: DESKTOP_ORB_WIDTH, height: DESKTOP_ORB_HEIGHT },
@@ -484,6 +485,7 @@ async function loadQwenAudioAgent(window) {
       wakeWordEnabled: settings.wakeWordEnabled,
       language: effectiveDesktopLanguage(settings.language, app.getLocale()),
       surfaceMode: desktopSurfaceMode,
+      sessionId: desktopConversationSessionId,
     }))
     clearTimeout(reconnectTimer)
     reconnectTimer = null
@@ -679,6 +681,10 @@ const orbShell = bindOrbShell({
     const selected = setDesktopSurfaceMode(mode)
     if (selected === 'panel') desktopPresence.wake('panel')
     return selected
+  },
+  onSetConversationSession: sessionId => {
+    desktopConversationSessionId = desktopSettingsStore.conversationSession.save(sessionId)
+    return desktopConversationSessionId
   },
   onQuit: () => app.quit(),
   onDragEnd: () => {

--- a/desktop/src/orb-shell.mjs
+++ b/desktop/src/orb-shell.mjs
@@ -21,6 +21,7 @@ export const ORB_CHANNELS = Object.freeze({
   taskCardPlacement: 'qwen-audio-agent:task-card-placement',
   surfaceLoad: 'qwen-audio-agent:surface-load',
   surfaceSet: 'qwen-audio-agent:surface-set',
+  conversationSessionSet: 'qwen-audio-agent:conversation-session-set',
   quit: 'qwen-audio-agent:quit',
 })
 
@@ -61,6 +62,7 @@ export function bindOrbShell({
   onOpenSettings = null,
   onLoadSurface = null,
   onSetSurface = null,
+  onSetConversationSession = null,
   onQuit = null,
   onDragEnd = null,
 } = {}) {
@@ -161,6 +163,13 @@ export function bindOrbShell({
     }
     const mode = requestedMode === 'panel' ? 'panel' : 'orb'
     return { mode: onSetSurface?.(mode) === 'panel' ? 'panel' : 'orb' }
+  })
+
+  handle(ORB_CHANNELS.conversationSessionSet, (event, sessionId) => {
+    if (!fromOrbWindow(event)) {
+      throw new Error('无权修改桌面对话会话')
+    }
+    return { sessionId: onSetConversationSession?.(sessionId) || '' }
   })
 
   on(ORB_CHANNELS.wake, event => {

--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -35,6 +35,10 @@ contextBridge.exposeInMainWorld('qwenAudioAgentDesktop', {
     'qwen-audio-agent:surface-set',
     mode,
   ),
+  setConversationSession: sessionId => ipcRenderer.invoke(
+    'qwen-audio-agent:conversation-session-set',
+    sessionId,
+  ),
   enterHide: () => ipcRenderer.invoke('qwen-audio-agent:enter-hide'),
   wake: () => ipcRenderer.send('qwen-audio-agent:wake'),
   lifecycleReady: () => ipcRenderer.send('qwen-audio-agent:lifecycle-ready'),

--- a/desktop/src/security.mjs
+++ b/desktop/src/security.mjs
@@ -2,6 +2,7 @@ import {
   isBuiltinOrbSkin,
   normalizeOrbSkinId,
 } from '../../shared/orb-skin-catalog.mjs'
+import { normalizeConversationSessionId } from '../../shared/conversation-session.mjs'
 
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '[::1]'])
 
@@ -46,6 +47,7 @@ export function desktopOrbUrl(value, {
   wakeWordEnabled = false,
   language = '',
   surfaceMode = 'orb',
+  sessionId = '',
 } = {}) {
   const url = new URL(value)
   url.searchParams.set('desktop', 'orb')
@@ -61,5 +63,7 @@ export function desktopOrbUrl(value, {
   if (wakeWordEnabled) url.searchParams.set('wakeWordEnabled', 'true')
   if (language) url.searchParams.set('lang', language)
   if (surfaceMode === 'panel') url.searchParams.set('surface', 'panel')
+  const normalizedSessionId = normalizeConversationSessionId(sessionId)
+  if (normalizedSessionId) url.searchParams.set('session', normalizedSessionId)
   return url.href
 }

--- a/desktop/src/settings-store.mjs
+++ b/desktop/src/settings-store.mjs
@@ -30,6 +30,7 @@ import {
   parseSettings,
   updateSettingsContent,
 } from './settings-config.mjs'
+import { normalizeConversationSessionId } from '../../shared/conversation-session.mjs'
 
 export const SETTINGS_FILE = 'config.env'
 export const UI_STATE_FILE = 'ui-state.json'
@@ -96,6 +97,7 @@ function writePrivateFile(path, content) {
  *   loadUiState: () => object,
  *   saveUiState: (patch: object) => object,
  *   orbPosition: { load: () => object|null, save: (state: object) => object },
+ *   conversationSession: { load: () => string, save: (sessionId: string) => string },
  * }}
  */
 export function createSettingsStore({
@@ -181,6 +183,26 @@ export function createSettingsStore({
         return loadUiState().orbPosition || null
       },
       save: state => saveUiState({ orbPosition: state }),
+    },
+
+    conversationSession: {
+      load() {
+        const current = normalizeConversationSessionId(
+          loadUiState().conversationSessionId,
+        )
+        if (current) return current
+        const created = randomUUID()
+        saveUiState({ conversationSessionId: created })
+        return created
+      },
+      save(value) {
+        const sessionId = normalizeConversationSessionId(value)
+        if (!sessionId) throw new TypeError('conversation session id is invalid')
+        if (loadUiState().conversationSessionId !== sessionId) {
+          saveUiState({ conversationSessionId: sessionId })
+        }
+        return sessionId
+      },
     },
   }
 }

--- a/desktop/test/orb-shell.test.mjs
+++ b/desktop/test/orb-shell.test.mjs
@@ -79,6 +79,10 @@ function shellHarness({
       dragEnds.push(`surface:${mode}`)
       return mode
     },
+    onSetConversationSession: sessionId => {
+      dragEnds.push(`session:${sessionId}`)
+      return sessionId
+    },
     onQuit: () => dragEnds.push('quit'),
     onDragEnd: () => dragEnds.push('drag-end'),
   })
@@ -150,6 +154,23 @@ test('surface channels keep orb and panel in one authorized window', () => {
   assert.deepEqual(calls, ['surface:panel'])
   assert.throws(
     () => ipc.invoke(ORB_CHANNELS.surfaceSet, { sender: {} }, 'panel'),
+    /无权/,
+  )
+})
+
+test('conversation session changes cross the authorized orb host boundary', () => {
+  const { ipc, event, calls } = shellHarness()
+  assert.deepEqual(
+    ipc.invoke(ORB_CHANNELS.conversationSessionSet, event, 'session-2'),
+    { sessionId: 'session-2' },
+  )
+  assert.deepEqual(calls, ['session:session-2'])
+  assert.throws(
+    () => ipc.invoke(
+      ORB_CHANNELS.conversationSessionSet,
+      { sender: {} },
+      'foreign-session',
+    ),
     /无权/,
   )
 })

--- a/desktop/test/security.test.mjs
+++ b/desktop/test/security.test.mjs
@@ -76,3 +76,16 @@ test('restores the desktop conversation panel without changing the client route'
     'http://127.0.0.1:3101/?desktop=orb&surface=panel',
   )
 })
+
+test('carries one validated persistent conversation session across renderer origins', () => {
+  assert.equal(
+    desktopOrbUrl('http://127.0.0.1:3101/', {
+      sessionId: 'desktop session',
+    }),
+    'http://127.0.0.1:3101/?desktop=orb&session=desktop+session',
+  )
+  assert.equal(
+    desktopOrbUrl('http://127.0.0.1:3101/', { sessionId: 'bad\nsession' }),
+    'http://127.0.0.1:3101/?desktop=orb',
+  )
+})

--- a/desktop/test/settings-store.test.mjs
+++ b/desktop/test/settings-store.test.mjs
@@ -92,6 +92,24 @@ test('orbPosition matches the placement storage contract', t => {
   assert.equal(store.loadUiState().theme, 'dark')
 })
 
+test('conversation session survives restart and changes only when explicitly replaced', t => {
+  const root = temporaryRoot(t)
+  const directory = join(root, 'data')
+  const first = createSettingsStore({ configDir: directory, env: {} })
+  const initial = first.conversationSession.load()
+  assert.match(initial, /^[0-9a-f-]{36}$/)
+  assert.equal(first.conversationSession.load(), initial)
+
+  const restarted = createSettingsStore({ configDir: directory, env: {} })
+  assert.equal(restarted.conversationSession.load(), initial)
+  assert.equal(restarted.conversationSession.save('next-session'), 'next-session')
+  assert.equal(first.conversationSession.load(), 'next-session')
+  assert.throws(
+    () => first.conversationSession.save('bad\nsession'),
+    /invalid/,
+  )
+})
+
 test('splits ui state into its own directory when uiStateDir is given', t => {
   const root = temporaryRoot(t)
   const store = createSettingsStore({

--- a/shared/conversation-session.mjs
+++ b/shared/conversation-session.mjs
@@ -1,0 +1,11 @@
+export const MAX_CONVERSATION_SESSION_ID_LENGTH = 200
+
+export function normalizeConversationSessionId(value) {
+  const sessionId = String(value || '').trim()
+  if (
+    !sessionId
+    || sessionId.length > MAX_CONVERSATION_SESSION_ID_LENGTH
+    || /[\u0000-\u001f\u007f]/.test(sessionId)
+  ) return ''
+  return sessionId
+}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -226,6 +226,12 @@ export default function App() {
   sessionIdRef.current = sessionId
   const spriteAnimationCue = spriteAnimationCues[0] || null
 
+  useEffect(() => {
+    const persistSession = window.qwenAudioAgentDesktop?.setConversationSession
+    if (!desktopOrbMode || typeof persistSession !== 'function') return
+    void persistSession(sessionId).catch(() => {})
+  }, [sessionId])
+
   const noteInteraction = useCallback(() => {
     setLastInteractionAt(Date.now())
   }, [])

--- a/web/src/session.js
+++ b/web/src/session.js
@@ -1,6 +1,7 @@
+import { normalizeConversationSessionId } from '../../shared/conversation-session.mjs'
+
 export function requestedSessionId(search) {
-  const value = String(
+  return normalizeConversationSessionId(
     new URLSearchParams(search).get('session') || '',
-  ).trim()
-  return value && value.length <= 200 ? value : ''
+  )
 }

--- a/web/test/session.test.mjs
+++ b/web/test/session.test.mjs
@@ -12,4 +12,5 @@ test('reads an explicit CLI session from the WebUI address', () => {
 test('rejects empty or unreasonably long session identifiers', () => {
   assert.equal(requestedSessionId('?session=%20'), '')
   assert.equal(requestedSessionId(`?session=${'x'.repeat(201)}`), '')
+  assert.equal(requestedSessionId('?session=bad%0Asession'), '')
 })


### PR DESCRIPTION
## Summary

- persist the active desktop conversation session in Electron UI state
- pass the stable session through the desktop URL and synchronize explicit new-session changes over an authorized IPC boundary
- share session ID validation between the web and desktop runtimes

This keeps the existing readable Session Journal format unchanged while allowing the desktop card and Realtime context to restore the same recent 10 messages after an app restart.

## Validation

- 27 focused desktop/web tests
- ESLint on changed files
- Web production build
- two real desktop restarts with the same session ID
- desktop card verified to render all 10 restored messages