### PR TITLE
fix(desktop): disambiguate application translation

### DIFF
--- a/desktop/src/i18n.mjs
+++ b/desktop/src/i18n.mjs
@@ -7,7 +7,7 @@ const ENGLISH = {
   '后台 Agent': 'Backend Agent',
   '设置分类': 'Settings categories',
   '语音前台': 'Voice Frontend',
-  '应用': 'App',
+  '应用程序': 'Application',
   '选择实时语音引擎': 'Select realtime voice engine',
   '服务地址': 'Service URL',
   '获取 API Key': 'Get API Key',

--- a/desktop/src/settings.html
+++ b/desktop/src/settings.html
@@ -74,7 +74,7 @@
             aria-selected="false"
             aria-controls="app-settings"
             data-settings-tab="app"
-          >应用</button>
+          >应用程序</button>
         </nav>
         <div class="settings-groups">
           <section

--- a/desktop/test/i18n.test.mjs
+++ b/desktop/test/i18n.test.mjs
@@ -32,6 +32,8 @@ test('translates desktop settings text while preserving product names', () => {
   const english = desktopTranslator('en')
   assert.equal(english('设置'), 'Settings')
   assert.equal(english('后台 Agent'), 'Backend Agent')
+  assert.equal(english('应用程序'), 'Application')
+  assert.equal(english('应用'), 'Apply')
   assert.equal(english('Qwen Audio'), 'Qwen Audio')
   assert.equal(desktopTranslator('zh-CN')('设置'), '设置')
 })


### PR DESCRIPTION
## Summary
- translate the settings category as Application
- keep the settings action translated as Apply
- add a regression assertion for both meanings

## Validation
- npm test --workspace desktop
- npm run lint
- npm run build
- git diff --check