### PR TITLE
refactor: formalize frontend chatbot boundaries

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,8 +232,8 @@ Activity never produces spoken status updates and never affects the queue.
 The backend Agent returns a standard ACP turn. Text arrives in
 `agent_message_chunk` updates, while images, audio, and resources remain native
 `ContentBlock` values; the turn ends with the `session/prompt`
-`PromptResponse`. The ACP adapter no longer flattens these values and then asks
-the model to reconstruct `state` or `presentation` JSON. It projects text and
+`PromptResponse`. The ACP adapter no longer flattens these values or asks the
+model to reconstruct a proprietary result envelope. It projects text and
 non-text content into the BackendPort `content` and `artifacts` fields, and the
 Gateway accepts only `stopReason=end_turn` as a successfully completed turn.
 Cancellation, refusal, and token or agent-request limits enter the Gateway's
@@ -342,8 +342,8 @@ Qwen Code ACP, Kimi Code ACP, or another ACP Agent
 ```
 
 Backend-specific API details belong only in `server/src/agent`. Realtime tools
-must not import backend adapters. The UI consumes only public Task events and
-final timeline content. Package-level `shared` modules are foundational runtime
+must not import backend adapters. The UI consumes only public Task and
+conversation events. Package-level `shared` modules are foundational runtime
 utilities; server `core` and `process` may depend on them, but they must not
 depend on server layers.
 
@@ -352,6 +352,13 @@ convenience, but this is static hosting only. Gateway source must not import UI
 components, presentation text, styling, terminal behavior, or desktop behavior.
 All three UIs own their rendering and map structured protocol fields to their
 own labels and interaction patterns.
+
+Background Task announcement behaviour has one code-level composition seam:
+an embedder may pass `taskAnnouncementFactory` to `createGatewayApplication`.
+The default factory keeps the existing final-result and low-frequency progress
+managers unchanged; a scenario may replace both together. This is dependency
+injection for product code, not a user setting, strategy registry, or new wire
+protocol.
 
 ## 10. Process ownership
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -188,8 +188,8 @@ UI 将此映射为稳定的任务说明或短语，如"搜索中"、"读取中"�
 
 后端 Agent 通过标准 ACP 回合返回结果：正文来自 `agent_message_chunk`，图片、音频和
 资源保留为原生 `ContentBlock`，回合以 `session/prompt` 的 `PromptResponse` 结束。
-ACP Adapter 不再把这些内容压成一段文本，也不要求模型补写 `state` 或
-`presentation` JSON；它将文本和非文本内容分别投射为 BackendPort 的 `content` 与
+ACP Adapter 不再把这些内容压成一段文本，也不要求模型补写专有结果 JSON；
+它将文本和非文本内容分别投射为 BackendPort 的 `content` 与
 `artifacts`。只有 `stopReason=end_turn` 代表回合成功完成；取消、拒绝、Token 或
 Agent 请求次数耗尽分别进入 Gateway 的取消或失败路径。Gateway 再根据客户端能力
 决定对话展示、资源卡片和语音表达。
@@ -274,12 +274,17 @@ Qwen Code ACP, Kimi Code ACP, or another ACP Agent
 ```
 
 后端特定的 API 细节仅属于 `server/src/agent`。实时工具不得导入后端适配器。
-UI 仅消费公共 Task 事件和最终时间线内容。包级别的 `shared` 模块是基础运行时
+UI 仅消费公共 Task 与对话事件。包级别的 `shared` 模块是基础运行时
 工具；server `core` 和 `process` 可以依赖它们，但它们不得依赖 server 层。
 
 Gateway 可以将不可变的 `web/dist` 产物作为部署便利来提供，但这仅是静态托管。
 Gateway 源码不得导入 UI 组件、呈现文本、样式、终端行为或桌面行为。
 所有三个 UI 拥有自己的渲染，并将结构化协议字段映射到各自的标签和交互模式。
+
+后台 Task 播报只保留一个代码级装配接缝：嵌入方可以向
+`createGatewayApplication` 传入 `taskAnnouncementFactory`。默认 factory 原样组合
+现有的最终结果播报与低频进度播报管理器；场景方也可以整体替换两者。这是产品代码的
+依赖注入点，不是用户设置、策略注册表或新的线上协议。
 
 ## 10. 进程所有权
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -18,13 +18,18 @@ a feature then degrades instead of failing.
 Versioning follows SemVer: the minor rises for an additive capability, the
 major for a breaking change to any endpoint or event named below.
 
-The current version is `4.0.0`. The `4.0` line replaces the former
+The current version is `5.0.0`. The `5.0` line removes the backend-controlled
+Task `presentation` envelope. A backend returns factual `content` plus optional
+typed `artifacts`; the foreground Chatbot decides how to speak, while each
+Conversation Client decides how to render. The same line publishes the existing
+`WS /api/realtime` event model as the replaceable Conversation Client boundary.
+The `4.0` line replaces the former
 `workId` / `jobId` pair with one short Task `id` (`task_id` in model tool
 results) and adds incremental `task.updated` snapshots. This changes the Task
 event shape and therefore raises the major version. The `3.1` line adds bounded citations to final
 assistant transcript events. The `3.0` line gives native Task events
 A2A-aligned `submitted`, `working`, and `auth_required` states together with
-typed artifact, presentation, and authorization values. It replaces the `2.x`
+typed artifact and authorization values. It replaces the `2.x`
 `active` state and opaque result metadata, so event consumers must check the
 capability table below. The `2.1` line added the optional AG-UI Task event
 projection without changing its default event stream. The `2.x` line succeeds the `1.x` line of the
@@ -48,9 +53,10 @@ below instead of assuming the old list.
 | `input.suspend-ttl` | A suspension expires on its own when the holder never resumes | `server/test/input-arbitration.test.mjs` |
 | `input.suspend-ack` | Clients confirm a suspension with `input.suspend.ack` (status display only — never wait for it) | `server/test/input-suspend-protocol.test.mjs` |
 | `tasks.ag-ui-event-stream` | `GET /api/tasks/:id/events?format=ag-ui` projects the existing Task stream into AG-UI `ACTIVITY_SNAPSHOT` events; omitting `format` preserves the native stream | `server/test/agui-event-projector.test.mjs` |
-| `tasks.work-artifacts-authorization` | Native Task events use A2A-aligned work states and expose typed `artifacts`, `presentation`, and `authorization` values | `test/gateway-event-schema.test.mjs`, `server/test/task-state.test.mjs` |
+| `tasks.structured-results-authorization` | Native Task events use A2A-aligned work states and expose factual `result`, typed `artifacts`, and `authorization`, without prescribing speech or UI | `test/gateway-event-schema.test.mjs`, `server/test/task-state.test.mjs` |
 | `tasks.unified-id-updates` | A Task exposes one short `id`; `task.updated` carries adapter-normalized incremental messages and artifacts | `test/gateway-event-schema.test.mjs`, `server/test/task-manager.test.mjs` |
 | `messages.citations` | Final assistant `transcript.final` events may carry normalized citations collected from frontend retrieval in the same turn | `test/gateway-event-schema.test.mjs`, `server/test/realtime-presentation-runtime.test.mjs` |
+| `realtime.conversation-client-v1` | `WS /api/realtime`, published event constants, and message schemas form the replaceable text/audio/multimodal Conversation Client boundary | `test/gateway-event-schema.test.mjs`, `test/custom-conversation-client.test.mjs` |
 | `desktop.orb-shell` | The orb form's main-process contract ships: `bindOrbShell` answers the channels the shipped preload sends | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` owns the orb window recipe; its `destroy()` is the host's synchronous teardown path (renderer exit is what releases the microphone) | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` covers the default anchor, display clamping and drop persistence | `desktop/test/orb-placement.test.mjs` |
@@ -153,14 +159,42 @@ endpoint. Each Task keeps one stable `messageId`; every lifecycle update
 replaces its `qwen.audio.task` activity content. The native Task stream remains
 the default and existing clients receive no additional events.
 
-Endpoints not listed here (`/api/tasks`, `/api/timeline`, `/api/backend/ui`,
-`/api/permissions/:id`, `WS /api/realtime` payloads beyond the events below)
-are used by our own front ends and carry no stability promise.
+Endpoints not listed here (`/api/tasks`, `/api/backend/ui`, and
+`/api/permissions/:id`) are used by our own front ends and carry no stability
+promise.
 
 ## Realtime events
 
-Event names ship as constants in `shared/realtime-events.mjs`; a client that
-spells them by hand is on its own.
+`WS /api/realtime?sessionId=<id>` is the public Conversation Client boundary.
+Event names ship through `qwen-audio-agent/realtime-events`, and message
+schemas/parsers through `qwen-audio-agent/gateway-events`; clients should use
+those package entries rather than internal module paths.
+`gateway.connected` and `gateway.disconnected` are client-side lifecycle
+helpers used by the shared state reducer; they are not WebSocket wire events.
+
+After the socket opens, send `connect` first. It declares input/output mode,
+client identity, locale/time zone, and supported input kinds. Audio input is
+base64 PCM16 mono at the `inputSampleRate` reported by `voice.ready`; audio
+output uses the `sampleRate` carried by each `audio.delta`. A text or multimodal
+turn uses `input.message` with ordered `parts` (`text` or `file`). Task events
+share the same socket but are optional for a client that only needs the
+conversation surface.
+
+| Direction | Event group | Meaning |
+| --- | --- | --- |
+| client → server | `connect` | Declare the client and its voice/input capabilities before submitting input |
+| client → server | `input.message`, `text.message` | Submit one text or multimodal conversation turn |
+| client → server | `audio.append` | Append one base64 PCM16 mono input chunk |
+| client → server | `unmute`, `mute`, `input.unmute`, `input.mute` | Control voice participation or only microphone capture |
+| client → server | `interrupt`, `sleep`, `wake` | Interrupt the foreground response or control explicit sleep |
+| client → server | `playback.started`, `playback.ended`, `playback.cancelled` | Report client-side playback lifecycle by `responseId` |
+| server → client | `voice.ready`, `voice.connection`, `voice.ownership`, `voice.deactivated`, `voice.sleep` | Voice connection, ownership, and sleep lifecycle |
+| server → client | `turn.started`, `voice.state` | Foreground conversation-turn identity and state |
+| server → client | `audio.delta`, `audio.done`, `playback.clear` | Audio playback stream and cancellation |
+| server → client | `response.started`, `response.interrupted` | Response lifecycle keyed by `responseId` |
+| server → client | `transcript.delta`, `transcript.final`, `transcript.discard` | User and assistant transcript lifecycle |
+| server → client | `task.*` | Optional background Task snapshots, progress, authorization, and completion |
+| server → client | `agent.activity`, `client.state`, `error` | Foreground activity hints, supported client-state requests, and errors |
 
 | Direction | Event | Meaning |
 | --- | --- | --- |

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -14,11 +14,14 @@
 版本号遵循 SemVer：新增能力升 minor；下文点名的任一端点或事件发生破坏性
 变更升 major。
 
-当前版本为 `4.0.0`。`4.0` 将原来的 `workId` / `jobId` 双重身份收敛为 Task 的唯一短
+当前版本为 `5.0.0`。`5.0` 删除由后台控制的 Task `presentation` 包装：后台只返回
+事实性 `content` 与可选的类型化 `artifacts`，前台 Chatbot 决定如何播报，各个对话
+客户端决定如何呈现。同一版本同时将现有 `WS /api/realtime` 事件模型正式发布为
+可替换的对话客户端边界。`4.0` 将原来的 `workId` / `jobId` 双重身份收敛为 Task 的唯一短
 `id`（模型工具结果中为 `task_id`），并增加 `task.updated` 增量快照。该字段变更会影响
 读取 Task 事件的客户端，因此升 major。`3.1` 在最终助手转写事件中增加有界 Citation。`3.0` 为原生
 Task 事件提供与 A2A 对齐的 `submitted`、
-`working`、`auth_required` 状态，以及类型明确的产物、呈现与授权对象。它替换了
+`working`、`auth_required` 状态，以及类型明确的产物与授权对象。它替换了
 `2.x` 的 `active` 状态与不透明结果元数据，因此事件消费者必须检查下方能力位。
 `2.1` 新增了可选的 AG-UI Task 事件投射，且未改变默认事件流。`2.x` 接替
 `feat/embedded-gateway-host-contract` 分支的 `1.x`
@@ -40,9 +43,10 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `input.suspend-ttl` | 持有者不主动释放时抢占自行过期 | `server/test/input-arbitration.test.mjs` |
 | `input.suspend-ack` | 客户端以 `input.suspend.ack` 确认抢占生效（仅用于状态展示——不要等待它） | `server/test/input-suspend-protocol.test.mjs` |
 | `tasks.ag-ui-event-stream` | `GET /api/tasks/:id/events?format=ag-ui` 将现有 Task 事件流投射为 AG-UI `ACTIVITY_SNAPSHOT`；不传 `format` 时仍为原生事件流 | `server/test/agui-event-projector.test.mjs` |
-| `tasks.work-artifacts-authorization` | 原生 Task 事件使用与 A2A 对齐的工作状态，并暴露类型明确的 `artifacts`、`presentation` 与 `authorization` 对象 | `test/gateway-event-schema.test.mjs`、`server/test/task-state.test.mjs` |
+| `tasks.structured-results-authorization` | 原生 Task 事件使用与 A2A 对齐的工作状态，并暴露事实性 `result`、类型化 `artifacts` 与 `authorization`，不规定播报或 UI | `test/gateway-event-schema.test.mjs`、`server/test/task-state.test.mjs` |
 | `tasks.unified-id-updates` | Task 只公开一个短 `id`；`task.updated` 携带 Adapter 归一化后的增量消息与产物 | `test/gateway-event-schema.test.mjs`、`server/test/task-manager.test.mjs` |
 | `messages.citations` | 最终助手 `transcript.final` 可以携带同一轮前台检索产生的规范化 Citation | `test/gateway-event-schema.test.mjs`、`server/test/realtime-presentation-runtime.test.mjs` |
+| `realtime.conversation-client-v1` | `WS /api/realtime`、公开事件常量与消息 Schema 共同构成可替换的文本/音频/多模态对话客户端边界 | `test/gateway-event-schema.test.mjs`、`test/custom-conversation-client.test.mjs` |
 | `desktop.orb-shell` | 悬浮球形态的主进程契约随包发布：`bindOrbShell` 应答随包 preload 发出的全部通道 | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` 持有悬浮球窗口配方；其 `destroy()` 是宿主的同步销毁路径（渲染进程退出才能确定性释放麦克风） | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` 覆盖默认锚点、显示器夹取与拖放持久化 | `desktop/test/orb-placement.test.mjs` |
@@ -140,14 +144,38 @@ await orb.load()
 稳定的 `messageId`，每次生命周期更新都会替换对应的 `qwen.audio.task` activity
 内容。原生 Task 事件流仍是默认格式，现有客户端不会收到任何新增事件。
 
-未在此列出的接口（`/api/tasks`、`/api/timeline`、`/api/backend/ui`、
-`/api/permissions/:id`，以及 `WS /api/realtime` 中除下文事件之外的负载）
-是我们自己前端在用的，不承诺稳定。
+未在此列出的接口（`/api/tasks`、`/api/backend/ui` 与
+`/api/permissions/:id`）是我们自己前端在用的，不承诺稳定。
 
 ## Realtime 事件
 
-事件名以常量形式发布在 `shared/realtime-events.mjs`；自行拼写字符串的客户端
-后果自负。
+`WS /api/realtime?sessionId=<id>` 是公开的对话客户端边界。事件名通过
+`qwen-audio-agent/realtime-events` 发布，消息 Schema 与解析器通过
+`qwen-audio-agent/gateway-events` 发布；客户端应使用这些包入口，不依赖内部路径。
+`gateway.connected` 与 `gateway.disconnected` 是共享状态 reducer 使用的客户端本地
+生命周期辅助事件，不会通过 WebSocket 下发。
+
+WebSocket 打开后先发送 `connect`，声明输入/输出模式、客户端身份、语言/时区与
+支持的输入类型。音频输入为 base64 PCM16 单声道，采样率取 `voice.ready` 返回的
+`inputSampleRate`；音频输出按每个 `audio.delta` 携带的 `sampleRate` 播放。文本或
+多模态轮次使用 `input.message`，按顺序提交 `text` / `file` 类型的 `parts`。Task
+事件与对话事件共用同一连接，但只做对话的客户端可以忽略它们。
+
+| 方向 | 事件组 | 含义 |
+| --- | --- | --- |
+| 客户端 → 服务端 | `connect` | 在提交输入前声明客户端及其语音/输入能力 |
+| 客户端 → 服务端 | `input.message`、`text.message` | 提交一轮文本或多模态对话输入 |
+| 客户端 → 服务端 | `audio.append` | 追加一段 base64 PCM16 单声道音频 |
+| 客户端 → 服务端 | `unmute`、`mute`、`input.unmute`、`input.mute` | 控制语音参与，或只控制麦克风采集 |
+| 客户端 → 服务端 | `interrupt`、`sleep`、`wake` | 打断前台回复，或控制显式休眠 |
+| 客户端 → 服务端 | `playback.started`、`playback.ended`、`playback.cancelled` | 按 `responseId` 回报客户端播放生命周期 |
+| 服务端 → 客户端 | `voice.ready`、`voice.connection`、`voice.ownership`、`voice.deactivated`、`voice.sleep` | 语音连接、占用权与休眠生命周期 |
+| 服务端 → 客户端 | `turn.started`、`voice.state` | 前台对话轮次标识与状态 |
+| 服务端 → 客户端 | `audio.delta`、`audio.done`、`playback.clear` | 播放音频流及清除指令 |
+| 服务端 → 客户端 | `response.started`、`response.interrupted` | 以 `responseId` 标识的回复生命周期 |
+| 服务端 → 客户端 | `transcript.delta`、`transcript.final`、`transcript.discard` | 用户与助手转写生命周期 |
+| 服务端 → 客户端 | `task.*` | 可选的后台 Task 快照、进度、授权与完成事件 |
+| 服务端 → 客户端 | `agent.activity`、`client.state`、`error` | 前台活动提示、客户端状态请求与错误 |
 
 | 方向 | 事件 | 含义 |
 | --- | --- | --- |

--- a/docs/promo/articles/full-duplex-voice-frontend.md
+++ b/docs/promo/articles/full-duplex-voice-frontend.md
@@ -47,27 +47,18 @@ qwen-audio-agent 把系统切成两层：
 - **需要工具或长时间处理** → 打包成任务委派给后台 Agent，前台先用一句话
   确认（"我去查一下，你先忙别的"），对话不断线。
 
-这个"路由"决策由一个轻量的协调器完成（`server/src/agent/coordinator.mjs`），
-它的输出是一个强 schema 约束的决策对象：
+这个路由决策由前台模型完成。需要后台处理时，它调用结构化的
+`spawn_thinking`：
 
 ```js
-// 两种决策：respond（前台直接回答）/ delegate（委派后台）
 {
-  task_id: '…',
-  state: 'delegated',
-  mode: 'delegate',
-  delegation_id: '…',
-  target_session_id: '…',
-  presentation: {
-    speech: '我让后台去跑这个任务，你可以继续问我别的。',
-    inline: { title: '任务详情', format: 'markdown', content: '…' }
-  }
+  instruction: '用户希望后台完成的事情',
+  input_refs: []
 }
 ```
 
-注意 `presentation` 被拆成 **speech（说出来）** 和 **inline（展示出来）**
-两部分。语音通道信息密度低，长内容不该念出来；同一份结果，
-耳朵收摘要，眼睛收全文。这是语音前台和聊天窗口最大的交互差异。
+后台以 `content` 返回供前台理解和自然转述的事实结果，以 `artifacts`
+返回可选文件、图片和结构化内容；后台不指定前台的播报话术或 UI 表现。
 
 ## 关键设计二：打断是状态机，不是一个事件
 

--- a/docs/reference/backend-adapter-sdk.md
+++ b/docs/reference/backend-adapter-sdk.md
@@ -3,7 +3,7 @@
 The Backend Adapter SDK connects non-ACP action systems to qwen-audio-agent.
 A phone agent, hardware agent, HTTP service, or other task runtime implements
 the protocol-neutral `BackendPort`; voice interaction, the Task queue,
-authorization relay, and result presentation remain unchanged.
+authorization relay, and result delivery remain unchanged.
 
 ## Import
 
@@ -61,9 +61,13 @@ The final `submit` result contains at least:
 {
   content: 'Factual material for the frontend',
   artifacts: [],
-  presentation: { speech: 'Material for natural expression', inline: null },
 }
 ```
+
+`content` is the sole factual text that the frontend Chatbot understands,
+summarizes, and expresses naturally. An adapter must not prescribe separate
+spoken wording. Files, images, and structured output use `artifacts`;
+BackendPort does not prescribe a Conversation Client presentation.
 
 Do not return raw protocol objects, session IDs, tokens, or credentials.
 Progress is published through `subscribe` as backend events correlated by
@@ -90,7 +94,7 @@ Incremental messages and artifacts use `backend.message` and
 callbacks must be normalized inside the adapter; raw protocol payloads never
 reach TaskManager or the frontend.
 
-`kind` is extensible. Common presentation fields include `status`, `message`,
+`kind` is extensible. Common display fields include `status`, `message`,
 `label`, `detail`, `category`, `tool`, `title`, `updatedAt`, `mode`, `completed`,
 and `total`; adapter-specific fields may be added. Reusing an activity `id`
 updates that observation and makes it the most recent one. Never put raw

--- a/docs/reference/backend-adapter-sdk.zh.md
+++ b/docs/reference/backend-adapter-sdk.zh.md
@@ -2,7 +2,7 @@
 
 Backend Adapter SDK 用于把非 ACP 办事系统接到 qwen-audio-agent。手机 Agent、硬件
 Agent、HTTP 服务或其他任务运行时只需实现统一 `BackendPort`；前台语音、Task 队列、
-权限转述和结果播报不需要修改。
+权限转述和结果交付不需要修改。
 
 ## 导入
 
@@ -57,9 +57,12 @@ Adapter 必须实现全部方法：
 {
   content: '供前台理解的事实结果',
   artifacts: [],
-  presentation: { speech: '可自然表达的结果材料', inline: null },
 }
 ```
+
+`content` 是前台 Chatbot 理解、概括和自然播报结果的唯一事实文本。Adapter
+不得另行指定播报话术。文件、图片和结构化结果使用 `artifacts`；BackendPort
+不规定 Conversation Client 的具体展示方式。
 
 不要返回原始协议对象、Session ID、Token 或凭据。运行进度通过 `subscribe` 发布
 `taskId`、`ownerId` 关联的标准后台事件；监听器异常不能中断任务。

--- a/docs/roadmap/frontend-chatbot-runtime.md
+++ b/docs/roadmap/frontend-chatbot-runtime.md
@@ -107,7 +107,7 @@ receipt (`spawn_thinking`); `control` tools query or change existing work.
 
 Task records use one short `task_id` across intake, query, cancellation, events,
 and result delivery. They carry owner, conversation, turn, objective,
-multimodal inputs, state, activity, authorization, artifacts, presentation,
+multimodal inputs, state, activity, authorization, artifacts,
 and timestamps. Public states align
 with A2A Task semantics: `submitted`, `working`, `auth_required`, `completed`,
 `failed`, and `cancelled`. Gateway-specific phases remain internal.

--- a/examples/backend-adapter/in-memory-backend.mjs
+++ b/examples/backend-adapter/in-memory-backend.mjs
@@ -86,7 +86,6 @@ export class InMemoryBackendAdapter {
       return {
         content,
         artifacts: [],
-        presentation: { speech: content, inline: null },
       }
     } finally {
       this.active.delete(taskId)

--- a/examples/custom-conversation-client/README.md
+++ b/examples/custom-conversation-client/README.md
@@ -1,0 +1,21 @@
+# Custom Conversation Client
+
+This minimal text client demonstrates the replaceable UI boundary. It connects
+to the public `WS /api/realtime` endpoint and imports only published package
+entries—no WebUI, desktop, or Gateway internals.
+
+```bash
+node examples/custom-conversation-client/client.mjs \
+  http://127.0.0.1:18888 \
+  "你好，请介绍一下自己。"
+```
+
+Use the same event contract to add microphone PCM input, `audio.delta`
+playback, multimodal `file` parts, or Task cards. The Gateway remains the
+foreground Chatbot; the client owns only conversation I/O and presentation.
+
+这个最小文本客户端用于演示可替换 UI 边界：它连接公开的
+`WS /api/realtime`，且只导入发布包入口，不依赖 WebUI、桌面版或 Gateway 内部代码。
+座舱面板、客服工作台等自定义 UI 可以在同一协议上增加麦克风 PCM 输入、
+`audio.delta` 播放、多模态 `file` part 与 Task 卡片；Gateway 仍负责前台对话，
+客户端只负责对话输入输出与呈现。

--- a/examples/custom-conversation-client/client.mjs
+++ b/examples/custom-conversation-client/client.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url'
+import WebSocket from 'ws'
+import {
+  GatewayClientEvent,
+  GatewayServerEvent,
+} from 'qwen-audio-agent/realtime-events'
+import { parseGatewayServerMessage } from 'qwen-audio-agent/gateway-events'
+
+export function conversationSocketUrl(origin, sessionId = 'custom-client') {
+  const url = new URL('/api/realtime', origin)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  url.searchParams.set('sessionId', sessionId)
+  return url.toString()
+}
+
+export function createConnectionMessage({
+  clientLabel = 'Custom Conversation Client',
+  locale = 'zh-CN',
+  timeZone = 'Asia/Shanghai',
+} = {}) {
+  return {
+    type: GatewayClientEvent.CONNECT,
+    clientType: 'web',
+    clientLabel,
+    textOnly: true,
+    inputEnabled: false,
+    outputEnabled: true,
+    locale,
+    timeZone,
+    inputCapabilities: {
+      text: true,
+      audio: false,
+      image: true,
+      resource: true,
+    },
+  }
+}
+
+export function createTextInputMessage(text) {
+  return {
+    type: GatewayClientEvent.INPUT_MESSAGE,
+    parts: [{ type: 'text', text: String(text || '').trim() }],
+  }
+}
+
+export function displayServerMessage(value, write = console.log) {
+  const event = parseGatewayServerMessage(value)
+  if (
+    event.type === GatewayServerEvent.TRANSCRIPT_DELTA
+    || event.type === GatewayServerEvent.TRANSCRIPT_FINAL
+  ) {
+    write(`${event.role}: ${event.content}`)
+  } else if (event.type === GatewayServerEvent.ERROR) {
+    write(`error: ${event.message}`)
+  } else if (event.type.startsWith('task.')) {
+    write(`${event.type}: ${event.task.status}`)
+  }
+  return event
+}
+
+export function run({ origin, text, sessionId = 'custom-client' }) {
+  const socket = new WebSocket(conversationSocketUrl(origin, sessionId))
+  socket.on('open', () => {
+    socket.send(JSON.stringify(createConnectionMessage()))
+    socket.send(JSON.stringify(createTextInputMessage(text)))
+  })
+  socket.on('message', raw => {
+    try {
+      displayServerMessage(JSON.parse(raw.toString()))
+    } catch (error) {
+      console.error(`invalid Gateway event: ${error.message}`)
+    }
+  })
+  socket.on('error', error => console.error(error.message))
+  return socket
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const origin = process.argv[2] || 'http://127.0.0.1:18888'
+  const text = process.argv.slice(3).join(' ') || '你好，请介绍一下自己。'
+  run({ origin, text })
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "config/deepseek-harness/cordis.yml",
     "config/codebuddy/workspace/.codebuddy/models.json",
     "examples/backend-adapter/",
+    "examples/custom-conversation-client/",
     "docs/architecture.md",
     "docs/architecture.zh.md",
     "docs/architecture-overview.png",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -112,6 +112,8 @@ if (isMain) {
     'config/codebuddy/workspace/.codebuddy/models.json',
     'examples/backend-adapter/README.md',
     'examples/backend-adapter/in-memory-backend.mjs',
+    'examples/custom-conversation-client/README.md',
+    'examples/custom-conversation-client/client.mjs',
     'CONTRIBUTING.md',
     'docs/architecture.md',
     'docs/architecture-overview.png',

--- a/server/src/agent/acp-backend-adapter.mjs
+++ b/server/src/agent/acp-backend-adapter.mjs
@@ -1449,7 +1449,6 @@ export class AcpBackendAdapter {
       return {
         content: clean(result?.content),
         artifacts,
-        presentation: null,
       }
     } finally {
       if (this.workControllers.get(taskId) === controller) {
@@ -1591,7 +1590,6 @@ export class AcpBackendAdapter {
         sessionId: delegation.sessionId,
         title: delegation.title,
         directory: delegation.directory,
-        presentation: saved.presentation || null,
       },
     })
     try {
@@ -1711,7 +1709,7 @@ export class AcpBackendAdapter {
       latest?.detail || latest?.tool || latest?.kind,
       240,
     )
-    const speech = status.status === 'completed'
+    const answer = status.status === 'completed'
       ? `这项工作已经完成：${clean(status.result)}`
       : status.status === 'failed'
         ? `这项工作已经失败：${clean(status.error)}`
@@ -1725,7 +1723,7 @@ export class AcpBackendAdapter {
         task_id: clean(record.taskId) || clean(taskId),
         state: 'completed',
         mode: 'respond',
-        presentation: { speech, inline: null },
+        result: answer,
       }),
       protocol: this.protocol,
       metadata: {

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -91,6 +91,7 @@ export function createGatewayApplication({
   frontendOpenApi = undefined,
   sessionJournal = null,
   conversationHistory = null,
+  taskAnnouncementFactory = undefined,
 } = {}) {
 const workBackend = backendRuntime || new BackendWorkRuntime({ backend: agent })
 const sessionJournalRuntime = sessionJournal || defaultTaskSessionJournal
@@ -466,25 +467,9 @@ app.get('/api/tasks', (req, res) => {
   })
 })
 
-app.get('/api/timeline', (req, res) => {
-  const items = taskManager.list({
-    ownerId: req.identity.ownerId,
-    sessionId: req.query.sessionId,
-  })
-    .filter(task => task.presentation?.inline?.content)
-    .map(task => ({
-      id: `inline_${task.id}`,
-      taskId: task.id,
-      createdAt: task.completedAt || task.createdAt,
-      ...task.presentation.inline,
-    }))
-    .sort((left, right) => left.createdAt - right.createdAt)
-  res.json({ items })
-})
-
-// Durable session facts are intentionally exposed separately from the UI
-// timeline. Clients may use this for reconnect/recovery; projections should
-// not need to understand the on-disk JSONL format.
+// Durable session facts are intentionally exposed separately from UI state.
+// Clients may use this for reconnect/recovery; projections should not need to
+// understand the on-disk JSONL format.
 app.get('/api/sessions/:sessionId/events', async (req, res, next) => {
   try {
     const events = await sessionJournalRuntime.read(
@@ -673,6 +658,7 @@ realtimeGateway = attachRealtimeGateway(server, {
   frontendRetrieval: retrievalRuntime,
   frontendKnowledge: frontendKnowledgeRuntime,
   frontendToolSources,
+  taskAnnouncementFactory,
 })
 const start = ({ host = config.host, port = config.port } = {}) => {
   if (server.listening) return server

--- a/server/src/backend/a2a-backend-adapter.mjs
+++ b/server/src/backend/a2a-backend-adapter.mjs
@@ -288,7 +288,7 @@ function taskSummary(task) {
   const lines = uniqueLines([status, ...history, ...artifactText])
   return {
     content: bounded(lines.join('\n\n'), MAX_TEXT_CHARS),
-    speech: status || history.at(-1) || '',
+    fallback: status || history.at(-1) || '',
   }
 }
 
@@ -646,22 +646,21 @@ export class A2ABackendAdapter {
   }
 
   outcomeFromMessage(message) {
-    const content = messageText(message)
-    const speech = bounded(content) || '后台工作已经完成。'
+    const content = bounded(messageText(message)) || '后台工作已经完成。'
     return {
-      content: content || speech,
+      content,
       artifacts: messageArtifact(message),
-      presentation: { speech, inline: null },
     }
   }
 
   outcomeFromTask(task) {
     const summary = taskSummary(task)
-    const speech = bounded(summary.speech) || '后台工作已经完成。'
+    const content = summary.content
+      || bounded(summary.fallback)
+      || '后台工作已经完成。'
     return {
-      content: summary.content || speech,
+      content,
       artifacts: taskArtifacts(task),
-      presentation: { speech, inline: null },
     }
   }
 

--- a/server/src/backend/backend-adapter-conformance.mjs
+++ b/server/src/backend/backend-adapter-conformance.mjs
@@ -17,10 +17,7 @@ async function usingFixture(createFixture, options, operation) {
 function assertOutcome(outcome) {
   assert.equal(typeof outcome?.content, 'string')
   assert.ok(Array.isArray(outcome?.artifacts))
-  assert.ok(
-    outcome?.presentation == null
-      || typeof outcome.presentation === 'object',
-  )
+  assert.equal('presentation' in outcome, false)
   for (const privateField of [
     'metadata',
     'raw',

--- a/server/src/core/gateway-protocol.mjs
+++ b/server/src/core/gateway-protocol.mjs
@@ -10,12 +10,17 @@
 // Every capability listed here is locked by a test (see docs/contract.md);
 // anything not listed is internal and may change in any release.
 //
+// 5.0.0 removes the backend-controlled Task presentation envelope. Backend
+// outcomes now expose factual `content` plus optional typed `artifacts`; the
+// frontend Chatbot owns spoken expression and each Conversation Client owns
+// rendering. It also publishes the existing Realtime event model as the
+// replaceable Conversation Client boundary.
 // 4.0.0 replaces the dual workId/jobId Task identity with one short `id`
 // (`task_id` in model tool results) and adds task.updated snapshots for
 // normalized backend messages and artifacts.
 // 3.1.0 adds bounded citations to final assistant transcript events.
-// 3.0.0 gives public Tasks A2A-aligned work states and first-class artifact,
-// presentation and authorization values. This replaces the 2.x `active`
+// 3.0.0 gives public Tasks A2A-aligned work states and first-class artifact
+// and authorization values. This replaces the 2.x `active`
 // state and opaque result metadata, so event consumers must branch on the
 // capability below before reading the new fields.
 // 2.1.0 adds an opt-in AG-UI projection while preserving the native stream.
@@ -25,7 +30,7 @@
 // desktop.settings-window, …) are not part of this contract, and a removed
 // capability is a breaking change. Hosts migrating from the fork must branch
 // on the capability list below, never on the version number.
-export const GATEWAY_PROTOCOL_VERSION = '4.0.0'
+export const GATEWAY_PROTOCOL_VERSION = '5.0.0'
 
 export const GATEWAY_CAPABILITIES = Object.freeze([
   // The Gateway statically hosts web/dist at its own origin, so a client may
@@ -69,14 +74,18 @@ export const GATEWAY_CAPABILITIES = Object.freeze([
   // unchanged.
   'tasks.ag-ui-event-stream',
   // Native Task events expose A2A-aligned submitted/working/auth_required
-  // states plus typed artifact, presentation and authorization values.
-  'tasks.work-artifacts-authorization',
+  // states plus factual results, typed artifacts and authorization values.
+  'tasks.structured-results-authorization',
   // Every public Task has one short `id`; task.updated carries incremental
   // backend messages and artifacts without exposing adapter protocol objects.
   'tasks.unified-id-updates',
   // Final assistant transcript events may carry bounded, normalized citations
   // collected from frontend retrieval tools during the same user turn.
   'messages.citations',
+  // WS /api/realtime plus the published event constants and schemas form the
+  // replaceable Conversation Client boundary for audio, text, multimodal
+  // input, transcripts, playback receipts, voice state and Task projections.
+  'realtime.conversation-client-v1',
   // The orb shell contract ships: qwen-audio-agent/orb/preload plus
   // orb/main's bindOrbShell, so a host may run the floating orb form.
   'desktop.orb-shell',

--- a/server/src/task/task-artifact.mjs
+++ b/server/src/task/task-artifact.mjs
@@ -145,28 +145,8 @@ export function mergeArtifacts(current, incoming) {
   return normalizeArtifacts([...byId.values()])
 }
 
-export function artifactFromInlinePresentation(presentation) {
-  const inline = presentation?.inline
-  const content = clean(inline?.content, MAX_TEXT_CHARS)
-  if (!content) return null
-  const format = ['markdown', 'code', 'link'].includes(inline.format)
-    ? inline.format
-    : 'markdown'
-  return {
-    artifactId: 'artifact_inline',
-    ...(clean(inline.title, 240) ? { name: clean(inline.title, 240) } : {}),
-    parts: [{
-      text: content,
-      mediaType: format === 'link' ? 'text/uri-list' : 'text/markdown',
-    }],
-  }
-}
-
-export function artifactsFromOutcome(outcome, presentation = null) {
-  const supplied = normalizeArtifacts(
+export function artifactsFromOutcome(outcome) {
+  return normalizeArtifacts(
     outcome?.artifacts || outcome?.metadata?.artifacts,
   )
-  if (supplied.length) return supplied
-  const inline = artifactFromInlinePresentation(presentation)
-  return inline ? [inline] : []
 }

--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -22,7 +22,6 @@ import {
   isTaskTerminal,
   isUserWork,
   normalizeTaskScope,
-  normalizeTaskPresentation,
   persistedTask,
   publicTask,
   TaskScope,
@@ -152,9 +151,8 @@ export class TaskManager {
         saved.parentTaskId = saved.parentWorkId
       }
       delete saved.parentWorkId
-      saved.presentation = normalizeTaskPresentation(
-        saved.presentation || saved.resultMetadata || null,
-      )
+      delete saved.presentation
+      delete saved.resultMetadata
       saved.artifacts = normalizeArtifacts(saved.artifacts)
       saved.authorization = normalizeAuthorization(saved.authorization, {
         taskId: saved.id,
@@ -169,10 +167,7 @@ export class TaskManager {
           ...saved,
           status: 'scheduled',
           runner: saved.kind === 'reminder'
-            ? async (obj) => ({
-                content: obj,
-                metadata: { presentation: { speech: obj } },
-              })
+            ? async obj => ({ content: obj })
             : null, // scheduled_task runner set from scheduledTaskRunner in start()
           resolve: null,
           promise: null,
@@ -449,7 +444,6 @@ export class TaskManager {
       error: null,
       message: null,
       artifacts: [],
-      presentation: null,
       activity: [],
       delegation: null,
       cancellation: null,
@@ -507,7 +501,6 @@ export class TaskManager {
       error: null,
       message: null,
       artifacts: [],
-      presentation: null,
       activity: [],
       delegation: null,
       cancellation: null,
@@ -515,10 +508,7 @@ export class TaskManager {
       notificationStatus: 'none',
       notificationClaimantId: null,
       notificationClaimedAt: null,
-      runner: runner || (async (obj) => ({
-        content: obj,
-        metadata: { presentation: { speech: obj } },
-      })),
+      runner: runner || (async obj => ({ content: obj })),
       canceler: null,
       cancelPromise: null,
       terminalHandled: false,
@@ -600,7 +590,8 @@ export class TaskManager {
       if (['cancelling', 'cancelled'].includes(task.status)) return
       if (event?.type === BackendEventType.DELEGATED && event.delegation) {
         transitionTask(task, TaskStatus.DELEGATED)
-        task.delegation = { ...event.delegation }
+        const { presentation: _presentation, ...delegation } = event.delegation
+        task.delegation = delegation
         this.releaseScheduler(task)
         this.emit(TaskDomainEvent.DELEGATED, task)
         this.drain()
@@ -705,12 +696,9 @@ export class TaskManager {
         this.flushProgress(task)
         transitionTask(task, TaskStatus.COMPLETED)
         task.result = String(outcome?.content ?? outcome ?? '').trim()
-        task.presentation = normalizeTaskPresentation(
-          outcome?.presentation || outcome?.metadata || null,
-        )
         task.artifacts = mergeArtifacts(
           task.artifacts,
-          artifactsFromOutcome(outcome, task.presentation),
+          artifactsFromOutcome(outcome),
         )
       })
       .catch(error => {

--- a/server/src/task/task-state.mjs
+++ b/server/src/task/task-state.mjs
@@ -1,7 +1,4 @@
-import {
-  artifactFromInlinePresentation,
-  normalizeArtifacts,
-} from './task-artifact.mjs'
+import { normalizeArtifacts } from './task-artifact.mjs'
 import { publicAuthorization } from '../core/work-authorization.mjs'
 
 export const TaskStatus = Object.freeze({
@@ -118,43 +115,7 @@ export function transitionTask(task, nextStatus) {
   return task
 }
 
-export function normalizeTaskPresentation(value) {
-  if (!value || typeof value !== 'object') return null
-  const source = value.presentation || value.decision?.presentation || value
-  if (!source || typeof source !== 'object') return null
-  const inline = source.inline && typeof source.inline === 'object'
-    && typeof source.inline.content === 'string'
-    && source.inline.content.trim()
-    ? {
-        title: typeof source.inline.title === 'string'
-          ? source.inline.title.slice(0, 120)
-          : '',
-        format: ['markdown', 'code', 'link'].includes(source.inline.format)
-          ? source.inline.format
-          : 'markdown',
-        content: source.inline.content,
-      }
-    : null
-  const speech = typeof source.speech === 'string' ? source.speech : ''
-  if (!speech && !inline) return null
-  return { speech, inline }
-}
-
-function taskPresentation(task) {
-  return normalizeTaskPresentation(
-    task.presentation || task.resultMetadata || null,
-  )
-}
-
-function taskArtifacts(task, presentation) {
-  const normalized = normalizeArtifacts(task.artifacts)
-  if (normalized.length) return normalized
-  const legacy = artifactFromInlinePresentation(presentation)
-  return legacy ? [legacy] : []
-}
-
 export function publicTask(task, { now = Date.now() } = {}) {
-  const presentation = taskPresentation(task)
   return {
     id: task.id,
     workState: publicWorkState(task),
@@ -175,21 +136,12 @@ export function publicTask(task, { now = Date.now() } = {}) {
     result: task.result,
     error: task.error,
     message: task.message || null,
-    artifacts: taskArtifacts(task, presentation),
-    presentation,
+    artifacts: normalizeArtifacts(task.artifacts),
     activity: [...(task.activity || [])],
     delegation: task.delegation
       ? {
           status: task.delegation.status || 'running',
           title: String(task.delegation.title || '').slice(0, 160),
-          presentation: task.delegation.presentation
-            ? {
-                speech: String(
-                  task.delegation.presentation.speech || '',
-                ).slice(0, 1200),
-                inline: task.delegation.presentation.inline || null,
-              }
-            : null,
         }
       : null,
     authorization: publicAuthorization(task.authorization, { taskId: task.id }),
@@ -208,12 +160,7 @@ export function persistedTask(task) {
   }
   saved.submissionKey = task.submissionKey || null
   saved.delegation = task.delegation
-    ? {
-        ...task.delegation,
-        presentation: task.delegation.presentation
-          ? { ...task.delegation.presentation }
-          : null,
-      }
+    ? { ...task.delegation }
     : null
   return saved
 }

--- a/server/src/voice/announcement/task-announcement-runtime.mjs
+++ b/server/src/voice/announcement/task-announcement-runtime.mjs
@@ -1,0 +1,61 @@
+import { AnnouncementManager } from './announcement-manager.mjs'
+import {
+  ProgressAnnouncementManager,
+} from './progress-announcement-manager.mjs'
+
+const RESULT_METHODS = Object.freeze([
+  'completed',
+  'failed',
+  'dismissActive',
+  'confirmMany',
+  'retryMany',
+  'flush',
+  'pause',
+  'close',
+])
+
+const PROGRESS_METHODS = Object.freeze([
+  'offer',
+  'remove',
+  'clear',
+  'flush',
+  'close',
+])
+
+function assertMethods(value, methods, label) {
+  if (!value || typeof value !== 'object') {
+    throw new TypeError(`${label} must be an object`)
+  }
+  for (const method of methods) {
+    if (typeof value[method] !== 'function') {
+      throw new TypeError(`${label}.${method} must be a function`)
+    }
+  }
+}
+
+/**
+ * Default code-level composition for background Task announcements.
+ *
+ * A scenario may replace this factory at the Gateway composition root. The
+ * supplied options are live runtime dependencies, not user configuration;
+ * protocol and default product behaviour remain owned by these managers.
+ */
+export function createTaskAnnouncementRuntime({
+  resultOptions,
+  progressOptions,
+} = {}) {
+  return {
+    results: new AnnouncementManager(resultOptions || {}),
+    progress: new ProgressAnnouncementManager(progressOptions),
+  }
+}
+
+export function resolveTaskAnnouncementRuntime(factory, options) {
+  if (typeof factory !== 'function') {
+    throw new TypeError('taskAnnouncementFactory must be a function')
+  }
+  const runtime = factory(options)
+  assertMethods(runtime?.results, RESULT_METHODS, 'Task announcement results')
+  assertMethods(runtime?.progress, PROGRESS_METHODS, 'Task announcement progress')
+  return runtime
+}

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -5,11 +5,11 @@ import {
   GatewayServerEvent,
   isGatewayClientEvent,
 } from '../../../shared/realtime-events.mjs'
-import { AnnouncementManager } from './announcement/announcement-manager.mjs'
 import { AnnouncementWindow } from './announcement/announcement-window.mjs'
 import {
-  ProgressAnnouncementManager,
-} from './announcement/progress-announcement-manager.mjs'
+  createTaskAnnouncementRuntime,
+  resolveTaskAnnouncementRuntime,
+} from './announcement/task-announcement-runtime.mjs'
 import { config } from '../core/config.mjs'
 import { logger } from '../core/logger.mjs'
 import { conversationSync } from '../conversation/conversation-sync.mjs'
@@ -117,6 +117,7 @@ export function attachRealtimeGateway(server, {
   frontendRetrieval = null,
   frontendKnowledge = null,
   frontendToolSources = [],
+  taskAnnouncementFactory = createTaskAnnouncementRuntime,
 }) {
   const wss = new WebSocketServer({ noServer: true, maxPayload: 20 * 1024 * 1024 })
   const activeVoiceClients = new ActiveVoiceClients()
@@ -279,52 +280,64 @@ export function attachRealtimeGateway(server, {
       }
       activeTasks.forEach(announcePermission)
     }
-    const announcements = new AnnouncementManager({
-      getFrontend: () => realtimeSession?.frontend,
-      isDeliveryBlocked: () => sleeping || waking || !outputEnabled || announcementWindow.isBlocked(),
-      announceIntoContext: config.announceIntoContext,
-      resultContextMaxChars: config.resultContextMaxChars,
-      maxBatchItems: config.announcementMaxBatchItems,
-      batchWindowMs: config.announcementBatchMs,
-      acknowledgementTimeoutMs: config.announcementAcknowledgementTimeoutMs,
-      maxRetryAttempts: config.announcementMaxRetryAttempts,
-      leaseRenewIntervalMs: Math.max(
-        1000,
-        Math.floor(config.taskNotificationClaimTtlMs / 3),
-      ),
-      onDelivered: taskIds => taskManager.markNotificationsDelivered(taskIds, {
-        claimantId: notificationClaimantId,
-      }),
-      onLeaseRenew: taskIds => taskManager.renewNotificationClaims(taskIds, {
-        claimantId: notificationClaimantId,
-      }),
-      onRelease: taskIds => taskManager.releaseNotificationClaims(taskIds, {
-        claimantId: notificationClaimantId,
-      }),
-      onError: error => send(ws, {
-        type: 'error',
-        message: `后台结果暂时无法播报，正在自动重试：${error.message}`,
-      }),
-    })
-    const progressAnnouncements = new ProgressAnnouncementManager({
-      getFrontend: () => realtimeSession?.frontend,
-      isDeliveryBlocked: () => (
-        sleeping
-        || waking
-        || !outputEnabled
-        || !realtimeSession?.ready
-        || turns.userSpeaking
-        || announcementWindow.isBlocked()
-      ),
-      isTaskActive: taskId => activeSessionTasks().some(task => (
-        task.id === taskId
-      )),
-      intervalMs: 60_000,
-      quietMs: config.announcementQuietMs,
-      onError: error => connectionLogger.warn('progress.injection_failed', {
-        error: error.message,
-      }),
-    })
+    const taskAnnouncements = resolveTaskAnnouncementRuntime(
+      taskAnnouncementFactory,
+      {
+        resultOptions: {
+          getFrontend: () => realtimeSession?.frontend,
+          isDeliveryBlocked: () => (
+            sleeping
+            || waking
+            || !outputEnabled
+            || announcementWindow.isBlocked()
+          ),
+          announceIntoContext: config.announceIntoContext,
+          resultContextMaxChars: config.resultContextMaxChars,
+          maxBatchItems: config.announcementMaxBatchItems,
+          batchWindowMs: config.announcementBatchMs,
+          acknowledgementTimeoutMs: config.announcementAcknowledgementTimeoutMs,
+          maxRetryAttempts: config.announcementMaxRetryAttempts,
+          leaseRenewIntervalMs: Math.max(
+            1000,
+            Math.floor(config.taskNotificationClaimTtlMs / 3),
+          ),
+          onDelivered: taskIds => taskManager.markNotificationsDelivered(taskIds, {
+            claimantId: notificationClaimantId,
+          }),
+          onLeaseRenew: taskIds => taskManager.renewNotificationClaims(taskIds, {
+            claimantId: notificationClaimantId,
+          }),
+          onRelease: taskIds => taskManager.releaseNotificationClaims(taskIds, {
+            claimantId: notificationClaimantId,
+          }),
+          onError: error => send(ws, {
+            type: 'error',
+            message: `后台结果暂时无法播报，正在自动重试：${error.message}`,
+          }),
+        },
+        progressOptions: {
+          getFrontend: () => realtimeSession?.frontend,
+          isDeliveryBlocked: () => (
+            sleeping
+            || waking
+            || !outputEnabled
+            || !realtimeSession?.ready
+            || turns.userSpeaking
+            || announcementWindow.isBlocked()
+          ),
+          isTaskActive: taskId => activeSessionTasks().some(task => (
+            task.id === taskId
+          )),
+          intervalMs: 60_000,
+          quietMs: config.announcementQuietMs,
+          onError: error => connectionLogger.warn('progress.injection_failed', {
+            error: error.message,
+          }),
+        },
+      },
+    )
+    const announcements = taskAnnouncements.results
+    const progressAnnouncements = taskAnnouncements.progress
     const reportFrontendError = error => {
       if (error?.realtimeConnectionReported) return
       if (error) error.realtimeConnectionReported = true
@@ -678,6 +691,10 @@ export function attachRealtimeGateway(server, {
       }
       if (event.type === TaskDomainEvent.PERMISSION_RESOLVED) {
         const authorizationId = event.permission?.id
+        // A permission confirmation already tells the user that work resumes.
+        // Drop progress queued before the decision so it cannot immediately
+        // repeat the same “still working” information after that confirmation.
+        progressAnnouncements.remove(task.id)
         if (authorizationId) {
           // 已进入对话的权限询问被其它通道（如 WebUI 按钮）处理后，把结果
           // 静默回注模型上下文：避免模型不知情而重复追问，或把用户随后的
@@ -697,19 +714,6 @@ export function attachRealtimeGateway(server, {
           presentationRuntime.cancelPermission(authorizationId)
         }
       }
-      if (event.type === TaskDomainEvent.DELEGATED) {
-        const presentation = task.delegation?.presentation
-        if (presentation?.inline?.content) {
-          send(ws, {
-            type: 'timeline.inline',
-            item: {
-              id: `inline_${task.id}_delegated`,
-              taskId: task.id,
-              ...presentation.inline,
-            },
-          })
-        }
-      }
       if ([
         TaskDomainEvent.COMPLETED,
         TaskDomainEvent.FAILED,
@@ -722,17 +726,6 @@ export function attachRealtimeGateway(server, {
         TaskDomainEvent.FAILED,
       ].includes(event.type)) {
         recordResult(task)
-        const inline = task.presentation?.inline
-        if (inline?.content) {
-          send(ws, {
-            type: 'timeline.inline',
-            item: {
-              id: `inline_${task.id}`,
-              taskId: task.id,
-              ...inline,
-            },
-          })
-        }
         claimPendingNotifications([task.id])
       }
     })

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -170,8 +170,8 @@ export class ToolCallHandler {
       [NOTES_TOOL_NAME]: ({ callId, turnId, args }) => (
         this.notes(callId, turnId, args)
       ),
-      [RESPOND_AGENT_PERMISSION_TOOL_NAME]: ({ callId, turnId, args }) => (
-        this.respondAgentPermission(callId, turnId, args)
+      [RESPOND_AGENT_PERMISSION_TOOL_NAME]: context => (
+        this.respondAgentPermission(context)
       ),
       [RESPOND_FRONTEND_TOOL_PERMISSION_NAME]: ({ callId, turnId, args }) => (
         this.respondFrontendToolPermission(callId, turnId, args)
@@ -190,6 +190,8 @@ export class ToolCallHandler {
     this.cancelResponseByTurn = new Map()
     this.terminalToolResponses = new Set()
     this.deferredToolResponses = new Map()
+    this.pendingBackendPermissions = new Map()
+    this.submittedBackendPermissions = new Set()
     this.pendingExternalAuthorizations = new Map()
   }
 
@@ -468,6 +470,13 @@ export class ToolCallHandler {
     if (
       event?.type === BackendEventType.AUTHORIZATION_RESOLVED
       && permission?.id
+    ) {
+      this.pendingBackendPermissions.delete(permission.id)
+      this.submittedBackendPermissions.delete(permission.id)
+    }
+    if (
+      event?.type === BackendEventType.AUTHORIZATION_RESOLVED
+      && permission?.id
       && this.gatewayApprovedPermissions.delete(permission.id)
     ) return
     if (
@@ -479,6 +488,15 @@ export class ToolCallHandler {
         this.sessionId,
       )
     ) {
+      if (
+        event?.type === BackendEventType.AUTHORIZATION_REQUESTED
+        && permission?.id
+      ) {
+        this.pendingBackendPermissions.set(permission.id, {
+          taskId,
+          permission,
+        })
+      }
       onEvent(event)
       return
     }
@@ -521,17 +539,25 @@ export class ToolCallHandler {
       laneKey: `backend:${this.ownerId}`,
       laneLimit: 1,
       runner: async (_ignored, { onEvent, signal }) => {
-        return this.backendRuntime.run({
-          objective,
-          inputParts,
-        }, {
-          ownerId: this.ownerId,
-          sessionId: this.sessionId,
-          turnId,
-          taskId,
-          signal,
-          onEvent: event => this.forwardBackendEvent(taskId, event, onEvent),
-        })
+        try {
+          return await this.backendRuntime.run({
+            objective,
+            inputParts,
+          }, {
+            ownerId: this.ownerId,
+            sessionId: this.sessionId,
+            turnId,
+            taskId,
+            signal,
+            onEvent: event => this.forwardBackendEvent(taskId, event, onEvent),
+          })
+        } finally {
+          for (const [id, entry] of this.pendingBackendPermissions) {
+            if (entry.taskId !== taskId) continue
+            this.pendingBackendPermissions.delete(id)
+            this.submittedBackendPermissions.delete(id)
+          }
+        }
       },
       canceler: async ({ previousStatus, abort }) => {
         const result = await this.backendRuntime.cancel(
@@ -1179,70 +1205,144 @@ export class ToolCallHandler {
     }
   }
 
-  async respondAgentPermission(callId, turnId, args) {
+  async respondAgentPermission({
+    callId,
+    turnId,
+    generation,
+    args,
+    callContext,
+  }) {
     const authorizationId = String(args.authorization_id || '').trim()
     const decision = String(args.decision || '').trim()
-    const transcript = String(await this.transcripts.transcript(turnId)).trim()
-    if (
-      !authorizationId
-      || !['always', 'reject'].includes(decision)
-      || !transcript
-    ) {
-      await this.sendOutput(
-        callId,
-        failure('invalid_permission_response', '没有找到有效的权限请求或决定。'),
-        turnId,
+    const responseId = String(
+      callContext?.responseId || callContext?.event?.response_id || '',
+    ).trim()
+    const response = ['always', 'reject'].includes(decision)
+      ? {
+          instructions: decision === 'always'
+            ? [
+                '权限决定已提交，并在本会话立即生效。',
+                '只用一句简短自然口语确认“已允许，后台继续执行”。',
+                '不要重述操作，不要再次询问或调用工具。',
+              ].join(' ')
+            : [
+                '权限决定已提交。',
+                '只用一句简短自然口语确认“已拒绝，后台不会执行这项操作”。',
+                '不要重述操作，不要再次询问或调用工具。',
+              ].join(' '),
+        }
+      : null
+    const deferred = this.beginDeferredToolResponse(responseId, {
+      turnId,
+      turnGeneration: generation,
+    }, response)
+    const outputOptions = deferred
+      ? { createResponse: false }
+      : { response }
+    let failed = false
+    try {
+      const transcript = String(await this.transcripts.transcript(turnId)).trim()
+      if (!authorizationId || !response || !transcript) {
+        await this.sendOutput(
+          callId,
+          failure('invalid_permission_response', '没有找到有效的权限请求或决定。'),
+          turnId,
+          null,
+          deferred ? { createResponse: false } : undefined,
+        )
+        return
+      }
+      const trackedPermission = this.pendingBackendPermissions.get(authorizationId)
+      const pendingTask = trackedPermission
+        ? this.taskManager.getByTaskId(trackedPermission.taskId, {
+            ownerId: this.ownerId,
+          })
+        : this.taskManager.list({
+            ownerId: this.ownerId,
+            sessionId: this.sessionId,
+            active: true,
+          }).find(task => task.authorization?.id === authorizationId)
+      if (!pendingTask) {
+        await this.sendOutput(
+          callId,
+          failure(
+            'permission_not_pending',
+            '这项权限请求已经处理过或不属于当前任务；若用户刚在界面上确认过，'
+            + '无需重复回应，直接继续即可。',
+            { retryable: false },
+          ),
+          turnId,
+          null,
+          deferred ? { createResponse: false } : undefined,
+        )
+        return
+      }
+      if (!this.respondAuthorization) {
+        await this.sendOutput(
+          callId,
+          failure('permission_unavailable', '当前后台无法接收权限决定。'),
+          turnId,
+          null,
+          deferred ? { createResponse: false } : undefined,
+        )
+        return
+      }
+      if (this.submittedBackendPermissions.has(authorizationId)) {
+        await this.sendOutput(callId, {
+          status: 'already_submitted',
+          authorization_id: authorizationId,
+        }, turnId, pendingTask.id, deferred ? { createResponse: false } : undefined)
+        return
+      }
+      const previousPermissionMode = this.permissionPolicy?.mode(
+        this.ownerId,
+        this.sessionId,
       )
-      return
-    }
-    const pendingTask = this.taskManager.list({
-      ownerId: this.ownerId,
-      sessionId: this.sessionId,
-      active: true,
-    }).find(task => task.authorization?.id === authorizationId)
-    if (!pendingTask) {
-      await this.sendOutput(
-        callId,
-        failure(
-          'permission_not_pending',
-          '这项权限请求已经处理过或不属于当前任务；若用户刚在界面上确认过，'
-          + '无需重复回应，直接继续即可。',
-          { retryable: false },
-        ),
-        turnId,
-      )
-      return
-    }
-    if (!this.respondAuthorization) {
-      await this.sendOutput(
-        callId,
-        failure('permission_unavailable', '当前后台无法接收权限决定。'),
-        turnId,
-      )
-      return
-    }
-    const previousPermissionMode = this.permissionPolicy?.mode(
-      this.ownerId,
-      this.sessionId,
-    )
-    this.permissionPolicy?.applyDecision(
-      this.ownerId,
-      this.sessionId,
-      decision,
-    )
-    // Receipt-based: the local policy takes effect immediately and the backend
-    // round trip must not delay the spoken confirmation. On delivery failure
-    // the policy rolls back and the authorization is still pending on the
-    // backend, so the gateway can re-announce it through the existing
-    // pending-permission retry path.
-    Promise.resolve()
-      .then(() => this.respondAuthorization(
-        pendingTask.id,
-        authorizationId,
+      this.permissionPolicy?.applyDecision(
+        this.ownerId,
+        this.sessionId,
         decision,
-        { ownerId: this.ownerId },
-      ))
-      .catch(error => {
+      )
+      // Receipt-based: the local policy takes effect immediately and the backend
+      // round trip must not delay the spoken confirmation. An "always" decision
+      // also settles permissions that arrived concurrently for this same task.
+      const permissions = decision === 'always'
+        ? [...this.pendingBackendPermissions.entries()]
+            .filter(([id, entry]) => (
+              entry.taskId === pendingTask.id
+              && !this.submittedBackendPermissions.has(id)
+            ))
+            .map(([id, entry]) => ({ id, taskId: entry.taskId }))
+        : [{ id: authorizationId, taskId: pendingTask.id }]
+      if (!permissions.some(permission => permission.id === authorizationId)) {
+        permissions.push({ id: authorizationId, taskId: pendingTask.id })
+      }
+      permissions.forEach(permission => {
+        this.submittedBackendPermissions.add(permission.id)
+      })
+      Promise.all(permissions.map(async permission => {
+        try {
+          await this.respondAuthorization(
+            permission.taskId,
+            permission.id,
+            decision,
+            { ownerId: this.ownerId },
+          )
+        } catch (error) {
+          this.submittedBackendPermissions.delete(permission.id)
+          try {
+            this.onPermissionDeliveryFailed({
+              authorizationId: permission.id,
+              decision,
+              taskId: permission.taskId,
+              error: String(error?.message || error),
+            })
+          } catch {
+            // Delivery diagnostics must not break the voice session.
+          }
+          throw error
+        }
+      })).catch(() => {
         if (previousPermissionMode) {
           this.permissionPolicy?.setMode(
             this.ownerId,
@@ -1250,35 +1350,17 @@ export class ToolCallHandler {
             previousPermissionMode,
           )
         }
-        try {
-          this.onPermissionDeliveryFailed({
-            authorizationId,
-            decision,
-            taskId: pendingTask.id,
-            error: String(error?.message || error),
-          })
-        } catch {
-          // Delivery diagnostics must not break the voice session.
-        }
       })
-    await this.sendOutput(callId, {
-      status: 'submitted',
-      authorization_id: authorizationId,
-    }, turnId, pendingTask.id, {
-      response: {
-        instructions: decision === 'always'
-          ? [
-              '权限决定已提交，并在本会话立即生效。',
-              '只用一句简短自然口语确认“已允许，后台继续执行”。',
-              '不要重述操作，不要再次询问或调用工具。',
-            ].join(' ')
-          : [
-              '权限决定已提交。',
-              '只用一句简短自然口语确认“已拒绝，后台不会执行这项操作”。',
-              '不要重述操作，不要再次询问或调用工具。',
-            ].join(' '),
-      },
-    })
+      await this.sendOutput(callId, {
+        status: 'submitted',
+        authorization_id: authorizationId,
+      }, turnId, pendingTask.id, outputOptions)
+    } catch (error) {
+      failed = true
+      throw error
+    } finally {
+      await this.completeDeferredToolResponse(deferred, { failed })
+    }
   }
 
   async cancelAgentTask(callId, turnId, args, responseOptions) {

--- a/server/test/a2a-backend-adapter.test.mjs
+++ b/server/test/a2a-backend-adapter.test.mjs
@@ -226,7 +226,7 @@ test('projects A2A messages and task artifacts into public outcomes', async () =
   })
 
   const outcome = await backend.submit(work())
-  assert.equal(outcome.presentation.speech, '报告已经完成。')
+  assert.equal(outcome.presentation, undefined)
   assert.match(outcome.content, /分析过程/)
   assert.match(outcome.content, /# 结果/)
   assert.deepEqual(outcome.artifacts, [{
@@ -351,7 +351,8 @@ test('normalizes A2A streaming status messages and artifacts into Task updates',
   const outcome = await backend.submit(work())
 
   assert.equal(requests[0].configuration.returnImmediately, false)
-  assert.equal(outcome.presentation.speech, '已经完成。')
+  assert.match(outcome.content, /已经完成/)
+  assert.equal(outcome.presentation, undefined)
   assert.equal(outcome.artifacts[0].artifactId, 'stream-report')
   assert.ok(events.some(event => (
     event.type === 'backend.message'
@@ -463,7 +464,8 @@ test('interoperates with an A2A 1.0 HTTP+JSON agent through official discovery',
     assert.equal(backend.describe().transport, 'HTTP+JSON')
     assert.equal(received.message.parts[0].text, '回环测试')
     assert.equal(received.configuration.returnImmediately, true)
-    assert.equal(outcome.presentation.speech, '回环任务已经完成。')
+    assert.equal(outcome.content, '回环任务已经完成。')
+    assert.equal(outcome.presentation, undefined)
   } finally {
     await backend.close()
     await new Promise(resolve => server.close(resolve))

--- a/server/test/acp-backend-adapter.test.mjs
+++ b/server/test/acp-backend-adapter.test.mjs
@@ -1485,7 +1485,7 @@ test('delegated status and cancellation bypass the coordinator', async () => {
     '做到哪了',
     { ownerId: 'owner-one' },
   )
-  assert.equal(JSON.parse(status.content).presentation.speech,
+  assert.equal(JSON.parse(status.content).result,
     '这项工作仍在执行中，当前没有新的详细进展。')
   assert.equal(status.metadata.statusSource, 'gateway')
   const cancelled = await adapter.cancelWork('work-one', {
@@ -1740,7 +1740,7 @@ test('busy-coordinator status query returns Gateway-known state immediately', as
   )
   adapter.activeCoordinatorTurns.delete('coordinator-session')
   assert.equal(client.calls.length, before)
-  assert.equal(JSON.parse(status.content).presentation.speech,
+  assert.equal(JSON.parse(status.content).result,
     '这项工作仍在执行中，当前没有新的详细进展。')
   assert.equal(status.metadata.statusSource, 'gateway')
   await adapter.cancelWork('work-one', { ownerId: 'owner-one' })

--- a/server/test/acp-backend-port.test.mjs
+++ b/server/test/acp-backend-port.test.mjs
@@ -112,7 +112,6 @@ test('ACP submit exposes Work values while Session details stay private', async 
   assert.deepEqual(outcome, {
     content: '已经完成。',
     artifacts: [],
-    presentation: null,
   })
   assert.equal('metadata' in outcome, false)
   assert.equal('sessionId' in outcome, false)
@@ -141,7 +140,7 @@ test('ACP submit preserves non-text output as standard artifacts', async () => {
   })
 
   assert.equal(outcome.content, '')
-  assert.equal(outcome.presentation, null)
+  assert.equal('presentation' in outcome, false)
   assert.deepEqual(outcome.artifacts, [{
     artifactId: 'acp_content_1',
     name: 'result.png',

--- a/server/test/backend-adapter-conformance.test.mjs
+++ b/server/test/backend-adapter-conformance.test.mjs
@@ -57,7 +57,7 @@ function fakeClient({ hold }) {
           task_id: 'job',
           state: 'completed',
           mode: 'respond',
-          presentation: { speech: '已经完成。', inline: null },
+          result: '已经完成。',
         }),
         response: { stopReason: 'end_turn' },
       }

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
 import test from 'node:test'
+import WebSocket from 'ws'
 import { createGatewayApplication } from '../src/app/gateway-application.mjs'
 import { config } from '../src/core/config.mjs'
 import { createRealtimeProviderRegistry } from '../src/voice/providers/provider-registry.mjs'
@@ -28,6 +29,61 @@ function disabledBackend() {
     recoverDelegatedWork: async () => null,
   }
 }
+
+function customTaskAnnouncementRuntime() {
+  const methods = names => Object.fromEntries(
+    names.map(name => [name, () => {}]),
+  )
+  return {
+    results: methods([
+      'completed',
+      'failed',
+      'dismissActive',
+      'confirmMany',
+      'retryMany',
+      'flush',
+      'pause',
+      'close',
+    ]),
+    progress: methods(['offer', 'remove', 'clear', 'flush', 'close']),
+  }
+}
+
+test('passes the Task announcement factory through the application composition root', async () => {
+  const calls = []
+  const application = createGatewayApplication({
+    config: {
+      ...config,
+      port: 0,
+      webSearchProvider: 'none',
+      webSearchMcpUrl: '',
+    },
+    parentPort: null,
+    autoStart: false,
+    agent: disabledBackend(),
+    frontendMcp: null,
+    frontendOpenApi: null,
+    taskAnnouncementFactory: options => {
+      calls.push(options)
+      return customTaskAnnouncementRuntime()
+    },
+  })
+  application.start()
+  if (!application.server.listening) await once(application.server, 'listening')
+  const { port } = application.server.address()
+  const socket = new WebSocket(
+    `ws://127.0.0.1:${port}/api/realtime?sessionId=announcement-factory`,
+  )
+  try {
+    await once(socket, 'open')
+    assert.equal(calls.length, 1)
+    assert.equal(typeof calls[0].resultOptions.getFrontend, 'function')
+    assert.equal(typeof calls[0].progressOptions.isTaskActive, 'function')
+  } finally {
+    socket.close()
+    await application.close()
+  }
+})
 
 test('constructs an injectable Gateway without binding a port on import', async () => {
   const inputAssets = { kind: 'test-input-assets' }

--- a/server/test/reminder-scheduler.test.mjs
+++ b/server/test/reminder-scheduler.test.mjs
@@ -100,7 +100,6 @@ test('reschedule re-arms when a scheduled task is cancelled', async () => {
   const manager = new TaskManager()
   const runner = async objective => ({
     content: objective,
-    metadata: { presentation: { speech: objective } },
   })
 
   const future = Date.now() + 60_000

--- a/server/test/result-delivery.test.mjs
+++ b/server/test/result-delivery.test.mjs
@@ -4,30 +4,18 @@ import { TaskManager } from '../src/task/task-manager.mjs'
 import { AnnouncementManager } from '../src/voice/announcement/announcement-manager.mjs'
 import { recordTaskResult } from '../src/conversation/task-result-projector.mjs'
 
-const OPEN = 1 // WebSocket.OPEN
-
 /**
  * Simulates the realtime-gateway subscriber for task completion delivery.
  *
  * In production this logic lives inside `attachRealtimeGateway`'s
  * `wss.on('connection')` handler.  The harness extracts only the
- * delivery-relevant paths so we can verify the two independent channels:
- *
- *   1. inline  → timeline.inline  via WebSocket (Realtime model NOT involved)
- *   2. speech  → AnnouncementManager → frontend.injectResult (Realtime model)
- *
- * Each path must fire exactly once per task — never duplicated by the
+ * delivery-relevant path so we can verify that a factual Task result reaches
+ * AnnouncementManager → frontend.injectResult exactly once — never duplicated by the
  * subsequent `task.notification.pending` event.
  */
 function createDeliveryHarness() {
-  const wsMessages = []
   const injectCalls = []
   const speakCalls = []
-
-  const ws = {
-    readyState: OPEN,
-    send(data) { wsMessages.push(JSON.parse(data)) },
-  }
 
   const frontend = {
     ready: true,
@@ -59,10 +47,6 @@ function createDeliveryHarness() {
     onDelivered: taskIds =>
       taskManager.markNotificationsDelivered(taskIds, { claimantId: 'test' }),
   })
-
-  const send = (socket, event) => {
-    if (socket.readyState === OPEN) socket.send(JSON.stringify(event))
-  }
 
   const recordResult = task =>
     recordTaskResult({ conversationSync, ownerId, sessionId, task })
@@ -96,39 +80,8 @@ function createDeliveryHarness() {
 
     if (task.sessionId !== sessionId) return
 
-    send(ws, {
-      type: event.type,
-      task,
-      ...(event.permission ? { permission: event.permission } : {}),
-    })
-
-    if (event.type === 'task.delegated') {
-      const inline = task.delegation?.presentation?.inline
-      if (inline?.content) {
-        send(ws, {
-          type: 'timeline.inline',
-          item: {
-            id: `inline_${task.id}_delegated`,
-            taskId: task.id,
-            ...inline,
-          },
-        })
-      }
-    }
-
     if (['task.completed', 'task.failed'].includes(event.type)) {
       recordResult(task)
-      const inline = task.presentation?.inline
-      if (inline?.content) {
-        send(ws, {
-          type: 'timeline.inline',
-          item: {
-            id: `inline_${task.id}`,
-            taskId: task.id,
-            ...inline,
-          },
-        })
-      }
       claimPendingNotifications([task.id])
     }
   })
@@ -136,8 +89,6 @@ function createDeliveryHarness() {
   return {
     taskManager,
     announcements,
-    ws,
-    wsMessages,
     injectCalls,
     speakCalls,
     ownerId,
@@ -150,7 +101,7 @@ async function flush() {
   await new Promise(resolve => setTimeout(resolve, 10))
 }
 
-test('delegation updates the timeline without producing a second voice announcement', async () => {
+test('delegation does not produce a premature voice announcement', async () => {
   const h = createDeliveryHarness()
   let release
   const { id: taskId } = h.taskManager.create({
@@ -164,14 +115,6 @@ test('delegation updates the timeline without producing a second voice announcem
           id: 'delegation-one',
           sessionId: 'project-session-one',
           title: '贪吃蛇小游戏',
-          presentation: {
-            speech: '贪吃蛇小游戏已经开始开发。',
-            inline: {
-              title: '项目正在执行',
-              format: 'text',
-              content: '正在开发贪吃蛇小游戏',
-            },
-          },
         },
       })
       return new Promise(resolve => { release = resolve })
@@ -180,13 +123,6 @@ test('delegation updates the timeline without producing a second voice announcem
 
   await new Promise(resolve => setImmediate(resolve))
 
-  const inline = h.wsMessages.find(message => (
-    message.type === 'timeline.inline'
-    && message.item.id === `inline_${taskId}_delegated`
-  ))
-  assert.ok(inline, 'delegation presentation should update the timeline')
-  assert.equal(inline.item.content, '正在开发贪吃蛇小游戏')
-  assert.equal('turnId' in inline.item, false)
   assert.equal(h.speakCalls.length, 0, 'delegation must not speak again')
   assert.equal(h.injectCalls.length, 0, 'delegation must not announce as a result')
 
@@ -200,7 +136,7 @@ test('delegation updates the timeline without producing a second voice announcem
 // Test scenarios
 // ---------------------------------------------------------------------------
 
-test('programming task: inline code goes to timeline.inline, speech goes to injectResult, each exactly once', async () => {
+test('programming task delivers its factual result exactly once', async () => {
   const h = createDeliveryHarness()
 
   // create() auto-starts the task via queueMicrotask(() => drain())
@@ -210,33 +146,12 @@ test('programming task: inline code goes to timeline.inline, speech goes to inje
     sessionId: h.sessionId,
     runner: async () => ({
       content: '快速排序已实现',
-      metadata: {
-        presentation: {
-          speech: '快速排序已实现，使用了经典的分治策略。',
-          inline: {
-            title: '快速排序实现',
-            format: 'code',
-            content: 'function quicksort(arr) {\n  if (arr.length <= 1) return arr\n  const [pivot, ...rest] = arr\n  return [...quicksort(rest.filter(x => x < pivot)), pivot, ...quicksort(rest.filter(x => x >= pivot))]\n}',
-          },
-        },
-      },
     }),
   })
 
   await h.taskManager.wait(taskId)
   await flush()
 
-  // --- inline path: timeline.inline sent via WebSocket ---
-  const inlineMsg = h.wsMessages.find(m => m.type === 'timeline.inline')
-  assert.ok(inlineMsg, 'timeline.inline message should be sent')
-  assert.equal(inlineMsg.item.taskId, taskId)
-  assert.equal('turnId' in inlineMsg.item, false)
-  assert.equal(inlineMsg.item.title, '快速排序实现')
-  assert.equal(inlineMsg.item.format, 'code')
-  assert.match(inlineMsg.item.content, /function quicksort/)
-  assert.match(inlineMsg.item.content, /pivot/)
-
-  // --- speech path: injectResult called exactly once ---
   assert.equal(h.injectCalls.length, 1, 'injectResult must be called exactly once')
   assert.match(h.injectCalls[0].text, /你先前异步执行工作的最终更新/)
   assert.match(h.injectCalls[0].text, /快速排序已实现/)
@@ -245,14 +160,10 @@ test('programming task: inline code goes to timeline.inline, speech goes to inje
   // --- speak should not be used (announcement uses injectResult) ---
   assert.equal(h.speakCalls.length, 0, 'speak should not be called for announcements')
 
-  // --- no duplicate timeline.inline ---
-  const inlineCount = h.wsMessages.filter(m => m.type === 'timeline.inline').length
-  assert.equal(inlineCount, 1, 'timeline.inline must not be duplicated')
-
   h.announcements.close()
 })
 
-test('task with inline=null: no timeline.inline sent, injectResult still called once', async () => {
+test('result-only task injects its factual result once', async () => {
   const h = createDeliveryHarness()
 
   const { id: taskId } = h.taskManager.create({
@@ -261,24 +172,14 @@ test('task with inline=null: no timeline.inline sent, injectResult still called 
     sessionId: h.sessionId,
     runner: async () => ({
       content: '今天晴，25度。',
-      metadata: {
-        presentation: {
-          speech: '今天晴，25度。',
-          inline: null,
-        },
-      },
     }),
   })
 
   await h.taskManager.wait(taskId)
   await flush()
 
-  // No inline content → no timeline.inline message
-  const inlineMsg = h.wsMessages.find(m => m.type === 'timeline.inline')
-  assert.equal(inlineMsg, undefined, 'no timeline.inline when inline is null')
-
-  // Speech still delivered via announcement system
-  assert.equal(h.injectCalls.length, 1, 'injectResult called once for speech-only task')
+  // The factual result is still delivered through the announcement system.
+  assert.equal(h.injectCalls.length, 1, 'injectResult called once for result-only task')
   assert.match(h.injectCalls[0].text, /今天晴/)
 
   h.announcements.close()
@@ -293,16 +194,6 @@ test('no duplication: task.completed and task.notification.pending both fire but
     sessionId: h.sessionId,
     runner: async () => ({
       content: '快速排序已实现',
-      metadata: {
-        presentation: {
-          speech: '快速排序已实现。',
-          inline: {
-            title: '代码',
-            format: 'code',
-            content: 'function qs() {}',
-          },
-        },
-      },
     }),
   })
 
@@ -316,14 +207,10 @@ test('no duplication: task.completed and task.notification.pending both fire but
   assert.equal(h.injectCalls.length, 1,
     'injectResult must be called exactly once despite two events')
 
-  // timeline.inline also sent exactly once
-  const inlineCount = h.wsMessages.filter(m => m.type === 'timeline.inline').length
-  assert.equal(inlineCount, 1, 'timeline.inline must not be duplicated')
-
   h.announcements.close()
 })
 
-test('multiple programming tasks: each gets one inline and one injectResult', async () => {
+test('multiple programming tasks each get one injected result', async () => {
   const h = createDeliveryHarness()
 
   // maxBatchItems=1 in the harness forces separate deliveries.
@@ -335,13 +222,6 @@ test('multiple programming tasks: each gets one inline and one injectResult', as
     sessionId: h.sessionId,
     runner: async () => ({
       content: '冒泡排序已实现',
-      metadata: {
-        presentation: {
-          speech: '冒泡排序已实现。',
-          inline: { title: '冒泡排序', format: 'code',
-            content: 'function bubble(arr) { /* bubble sort */ }' },
-        },
-      },
     }),
   })
 
@@ -358,24 +238,11 @@ test('multiple programming tasks: each gets one inline and one injectResult', as
     sessionId: h.sessionId,
     runner: async () => ({
       content: '归并排序已实现',
-      metadata: {
-        presentation: {
-          speech: '归并排序已实现。',
-          inline: { title: '归并排序', format: 'code',
-            content: 'function merge(arr) { /* merge sort */ }' },
-        },
-      },
     }),
   })
 
   await h.taskManager.wait(id2)
   await flush()
-
-  // --- Two timeline.inline messages, one per task ---
-  const inlineMsgs = h.wsMessages.filter(m => m.type === 'timeline.inline')
-  assert.equal(inlineMsgs.length, 2, 'two inline messages for two tasks')
-  assert.match(inlineMsgs[0].item.content, /bubble/)
-  assert.match(inlineMsgs[1].item.content, /merge/)
 
   // --- Two injectResult calls, one per task ---
   assert.equal(h.injectCalls.length, 2, 'two injectResult calls for two tasks')
@@ -385,11 +252,9 @@ test('multiple programming tasks: each gets one inline and one injectResult', as
   h.announcements.close()
 })
 
-test('failed task: no inline shown, error delivered via injectResult once', async () => {
+test('failed task delivers its error via injectResult once', async () => {
   const h = createDeliveryHarness()
 
-  // Runner throws — TaskManager sets task.error, presentation stays null,
-  // so no inline content is available for timeline.inline.
   const { id: taskId } = h.taskManager.create({
     objective: '编写一个快速排序',
     ownerId: h.ownerId,
@@ -399,10 +264,6 @@ test('failed task: no inline shown, error delivered via injectResult once', asyn
 
   await h.taskManager.wait(taskId)
   await flush()
-
-  // Failed tasks have no presentation → no timeline.inline
-  const inlineMsg = h.wsMessages.find(m => m.type === 'timeline.inline')
-  assert.equal(inlineMsg, undefined, 'no timeline.inline for failed task')
 
   // But the error is still announced via injectResult
   assert.equal(h.injectCalls.length, 1, 'injectResult called once for failed task')

--- a/server/test/task-announcement-runtime.test.mjs
+++ b/server/test/task-announcement-runtime.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { AnnouncementManager } from '../src/voice/announcement/announcement-manager.mjs'
+import { ProgressAnnouncementManager } from '../src/voice/announcement/progress-announcement-manager.mjs'
+import {
+  createTaskAnnouncementRuntime,
+  resolveTaskAnnouncementRuntime,
+} from '../src/voice/announcement/task-announcement-runtime.mjs'
+
+function resultRuntime() {
+  return Object.fromEntries([
+    'completed',
+    'failed',
+    'dismissActive',
+    'confirmMany',
+    'retryMany',
+    'flush',
+    'pause',
+    'close',
+  ].map(method => [method, () => {}]))
+}
+
+function progressRuntime() {
+  return Object.fromEntries([
+    'offer',
+    'remove',
+    'clear',
+    'flush',
+    'close',
+  ].map(method => [method, () => {}]))
+}
+
+test('composes the existing announcement managers by default', () => {
+  const runtime = createTaskAnnouncementRuntime({
+    resultOptions: {
+      getFrontend: () => null,
+      isDeliveryBlocked: () => true,
+    },
+    progressOptions: {
+      getFrontend: () => null,
+      isDeliveryBlocked: () => true,
+    },
+  })
+  assert.equal(runtime.results instanceof AnnouncementManager, true)
+  assert.equal(runtime.progress instanceof ProgressAnnouncementManager, true)
+  runtime.results.close()
+  runtime.progress.close()
+})
+
+test('accepts one code-level factory for replacing the whole Task announcement runtime', () => {
+  const expected = {
+    results: resultRuntime(),
+    progress: progressRuntime(),
+  }
+  const options = { resultOptions: {}, progressOptions: {} }
+  let received
+  const actual = resolveTaskAnnouncementRuntime(value => {
+    received = value
+    return expected
+  }, options)
+  assert.equal(received, options)
+  assert.equal(actual, expected)
+})
+
+test('rejects incomplete scenario announcement implementations at composition time', () => {
+  assert.throws(
+    () => resolveTaskAnnouncementRuntime(() => ({
+      results: {},
+      progress: progressRuntime(),
+    }), {}),
+    /results\.completed must be a function/u,
+  )
+  assert.throws(
+    () => resolveTaskAnnouncementRuntime(null, {}),
+    /taskAnnouncementFactory must be a function/u,
+  )
+})

--- a/server/test/task-artifact.test.mjs
+++ b/server/test/task-artifact.test.mjs
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
-  artifactFromInlinePresentation,
   artifactsFromOutcome,
   normalizeArtifacts,
 } from '../src/task/task-artifact.mjs'
@@ -54,23 +53,7 @@ test('drops duplicate artifacts and unsafe or malformed parts', () => {
   }])
 })
 
-test('adapts the legacy inline presentation into one stable artifact', () => {
-  const presentation = {
-    speech: '报告已完成。',
-    inline: { title: '报告', format: 'code', content: 'const done = true' },
-  }
-  const artifact = artifactFromInlinePresentation(presentation)
-  assert.deepEqual(artifactsFromOutcome({ metadata: {} }, presentation), [
-    artifact,
-  ])
-  assert.deepEqual(artifact, {
-    artifactId: 'artifact_inline',
-    name: '报告',
-    parts: [{ text: 'const done = true', mediaType: 'text/markdown' }],
-  })
-})
-
-test('prefers backend artifacts over the inline compatibility projection', () => {
+test('normalizes artifacts supplied by a backend outcome', () => {
   const artifacts = artifactsFromOutcome({
     artifacts: [{
       artifactId: 'image',
@@ -79,9 +62,19 @@ test('prefers backend artifacts over the inline compatibility projection', () =>
         mediaType: 'image/png',
       }],
     }],
-  }, {
-    inline: { title: 'ignored', format: 'markdown', content: 'ignored' },
   })
   assert.equal(artifacts.length, 1)
   assert.equal(artifacts[0].artifactId, 'image')
+})
+
+test('accepts the legacy metadata location without a presentation fallback', () => {
+  const artifacts = artifactsFromOutcome({
+    metadata: {
+      artifacts: [{ artifactId: 'report', parts: [{ text: '# Report' }] }],
+    },
+  })
+  assert.deepEqual(artifacts, [{
+    artifactId: 'report',
+    parts: [{ text: '# Report', mediaType: 'text/plain' }],
+  }])
 })

--- a/server/test/task-journal-recovery.test.mjs
+++ b/server/test/task-journal-recovery.test.mjs
@@ -22,7 +22,6 @@ test('journal snapshot supersedes a stale compact task projection', () => {
     error: null,
     message: null,
     artifacts: [],
-    presentation: null,
     activity: [],
     delegation: null,
     authorization: null,

--- a/server/test/task-manager-scheduled.test.mjs
+++ b/server/test/task-manager-scheduled.test.mjs
@@ -4,7 +4,6 @@ import { TaskManager } from '../src/task/task-manager.mjs'
 
 const trivialRunner = async objective => ({
   content: objective,
-  metadata: { presentation: { speech: objective } },
 })
 
 function persistedReminder(status, id = `work_${status}_reminder`) {
@@ -27,7 +26,6 @@ function persistedReminder(status, id = `work_${status}_reminder`) {
     elapsedMs: 0,
     result: null,
     error: null,
-    resultMetadata: null,
     activity: [],
     delegation: null,
     cancellation: null,
@@ -181,7 +179,6 @@ test('restore recovers scheduled tasks with reminder runner rebuilt', () => {
     elapsedMs: 0,
     result: null,
     error: null,
-    resultMetadata: null,
     activity: [],
     delegation: null,
     cancellation: null,
@@ -223,7 +220,6 @@ test('restored scheduled_task receives its complete persisted execution context'
     elapsedMs: 0,
     result: null,
     error: null,
-    resultMetadata: null,
     activity: [],
     delegation: null,
     cancellation: null,

--- a/server/test/task-manager.test.mjs
+++ b/server/test/task-manager.test.mjs
@@ -251,8 +251,11 @@ test('keeps delegated work active while releasing its coordinator lane', async (
           title: '已有项目',
           directory: '/project',
           presentation: {
-            speech: '项目已经接着做了。',
-            inline: null,
+            inline: {
+              title: '已有项目',
+              format: 'markdown',
+              content: '项目已经接着做了。',
+            },
           },
         },
       })
@@ -277,10 +280,7 @@ test('keeps delegated work active while releasing its coordinator lane', async (
   assert.equal(delegated.workState, 'working')
   assert.equal(delegated.delegation.status, 'running')
   assert.equal(delegated.delegation.title, '已有项目')
-  assert.equal(
-    delegated.delegation.presentation.speech,
-    '项目已经接着做了。',
-  )
+  assert.equal('presentation' in delegated.delegation, false)
   assert.ok(events.some(event => event.type === 'task.delegated'))
   assert.equal(secondStarted, true)
   assert.equal(manager.get(second.id).status, 'completed')
@@ -525,7 +525,7 @@ test('listing tasks does not rewrite unchanged persistent state', async () => {
   assert.equal(saves, before)
 })
 
-test('publishes presentation and standard artifacts from a completed result', async () => {
+test('publishes standard artifacts from a completed result', async () => {
   const events = []
   const manager = new TaskManager()
   manager.subscribe(event => events.push(event))
@@ -535,15 +535,12 @@ test('publishes presentation and standard artifacts from a completed result', as
     sessionId: 'voice',
     runner: async () => ({
       content: '报告已经生成',
+      artifacts: [{
+        artifactId: 'report',
+        name: '报告',
+        parts: [{ text: '# 完成', mediaType: 'text/markdown' }],
+      }],
       metadata: {
-        presentation: {
-          speech: '报告已经生成。',
-          inline: {
-            title: '报告',
-            format: 'markdown',
-            content: '# 完成',
-          },
-        },
         backendRef: {
           sessionId: 'backend-session',
           directory: '/private/project',
@@ -557,16 +554,9 @@ test('publishes presentation and standard artifacts from a completed result', as
   })
 
   const completed = await manager.wait(task.id)
-  assert.deepEqual(completed.presentation, {
-    speech: '报告已经生成。',
-    inline: {
-      title: '报告',
-      format: 'markdown',
-      content: '# 完成',
-    },
-  })
+  assert.equal('presentation' in completed, false)
   assert.deepEqual(completed.artifacts, [{
-    artifactId: 'artifact_inline',
+    artifactId: 'report',
     name: '报告',
     parts: [{ text: '# 完成', mediaType: 'text/markdown' }],
   }])
@@ -577,7 +567,7 @@ test('publishes presentation and standard artifacts from a completed result', as
   )
 })
 
-test('projects legacy decision presentation when restoring a task', () => {
+test('drops legacy presentation while preserving standard artifacts on restore', () => {
   let saved = []
   const manager = new TaskManager({
     store: {
@@ -588,10 +578,13 @@ test('projects legacy decision presentation when restoring a task', () => {
         ownerId: 'owner',
         sessionId: 'voice',
         result: '旧结果',
+        artifacts: [{
+          artifactId: 'legacy-result',
+          parts: [{ text: 'const done = true', mediaType: 'text/plain' }],
+        }],
         resultMetadata: {
           decision: {
             presentation: {
-              speech: '旧任务已经完成。',
               inline: {
                 title: '旧结果',
                 format: 'code',
@@ -610,16 +603,9 @@ test('projects legacy decision presentation when restoring a task', () => {
   })
 
   const restored = manager.get('task_92')
-  assert.deepEqual(restored.presentation, {
-    speech: '旧任务已经完成。',
-    inline: {
-      title: '旧结果',
-      format: 'code',
-      content: 'const done = true',
-    },
-  })
+  assert.equal('presentation' in restored, false)
   manager.persist()
-  assert.deepEqual(saved[0].presentation, restored.presentation)
   assert.deepEqual(saved[0].artifacts, restored.artifacts)
+  assert.equal('presentation' in saved[0], false)
   assert.equal('resultMetadata' in saved[0], false)
 })

--- a/server/test/task-state.test.mjs
+++ b/server/test/task-state.test.mjs
@@ -51,7 +51,7 @@ test('accepts valid transitions and rejects backwards or terminal transitions', 
   )
 })
 
-test('projects an active task into presentation and standard artifacts', () => {
+test('projects an active task into standard artifacts without legacy result metadata', () => {
   const projected = publicTask({
     id: 'work-one',
     taskId: 'job_1',
@@ -63,9 +63,13 @@ test('projects an active task into presentation and standard artifacts', () => {
     startedAt: 40,
     elapsedMs: 0,
     activity: [],
+    artifacts: [{
+      artifactId: 'report',
+      name: '报告',
+      parts: [{ text: '# 完成', mediaType: 'text/markdown' }],
+    }],
     resultMetadata: {
       presentation: {
-        speech: '报告已完成。',
         inline: { title: '报告', format: 'markdown', content: '# 完成' },
       },
       backendRef: { sessionId: 'private-session' },
@@ -75,12 +79,9 @@ test('projects an active task into presentation and standard artifacts', () => {
 
   assert.equal(projected.workState, 'working')
   assert.equal(projected.elapsedMs, 60)
-  assert.deepEqual(projected.presentation, {
-    speech: '报告已完成。',
-    inline: { title: '报告', format: 'markdown', content: '# 完成' },
-  })
+  assert.equal('presentation' in projected, false)
   assert.deepEqual(projected.artifacts, [{
-    artifactId: 'artifact_inline',
+    artifactId: 'report',
     name: '报告',
     parts: [{ text: '# 完成', mediaType: 'text/markdown' }],
   }])

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -1457,6 +1457,77 @@ test('auto-allows later permissions in the Gateway without publishing them', asy
   )
 })
 
+test('batches concurrent backend permissions into one confirmation and one delivery each', async () => {
+  const permissionIds = ['auth-news-1', 'auth-news-2', 'auth-news-3', 'auth-news-4']
+  const approvals = []
+  let release
+  const kit = harness({
+    permissionPolicy: new SessionPermissionPolicy(),
+    respondPermission: async (id, decision, options) => {
+      approvals.push({ id, decision, options })
+      return { id, status: 'approved' }
+    },
+    coordinator: {
+      run: async (_input, { onEvent }) => {
+        permissionIds.forEach(id => onEvent({
+          type: 'backend.permission.requested',
+          permission: {
+            id,
+            status: 'pending',
+            category: 'search',
+            summary: `Allow search ${id}`,
+          },
+        }))
+        return new Promise(resolve => { release = resolve })
+      },
+    },
+  })
+  kit.transcripts.record('turn-one', '搜索新闻')
+  await kit.handler.handle({
+    call_id: 'spawn-news',
+    name: 'spawn_thinking',
+    arguments: '{"objective":"搜索最新新闻"}',
+  }, { turnId: 'turn-one', turnGeneration: 1 })
+  await new Promise(resolve => setImmediate(resolve))
+
+  kit.transcripts.record('turn-one', '我同意')
+  const decisions = permissionIds.map((authorizationId, index) => (
+    kit.handler.handle({
+      call_id: `allow-news-${index}`,
+      response_id: 'permission-response',
+      name: 'respond_agent_permission',
+      arguments: JSON.stringify({
+        authorization_id: authorizationId,
+        decision: 'always',
+      }),
+    }, {
+      turnId: 'turn-one',
+      turnGeneration: 1,
+      responseId: 'permission-response',
+    })
+  ))
+  await kit.handler.finishToolResponse('permission-response')
+  await Promise.all(decisions)
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.deepEqual(
+    approvals.map(call => call.id).sort(),
+    [...permissionIds].sort(),
+  )
+  assert.ok(approvals.every(call => call.decision === 'always'))
+  assert.ok(kit.outputs.slice(1).every(output => output[3].createResponse === false))
+  assert.equal(kit.ensuredResponses.length, 1)
+  assert.match(
+    kit.ensuredResponses[0][1].response.instructions,
+    /已允许，后台继续执行/,
+  )
+
+  release({ content: '完成' })
+  await Promise.all(kit.manager.list({ ownerId: 'owner' }).map(task => (
+    kit.manager.wait(task.id)
+  )))
+})
+
 test('accepts a semantic permission decision without an evidence field', async () => {
   const calls = []
   const kit = await permissionHarness({

--- a/shared/protocol/gateway-events.mjs
+++ b/shared/protocol/gateway-events.mjs
@@ -45,15 +45,6 @@ export const GatewayArtifactSchema = z.object({
   parts: z.array(GatewayArtifactPartSchema).min(1),
 })
 
-export const GatewayPresentationSchema = z.object({
-  speech: z.string(),
-  inline: z.object({
-    title: z.string(),
-    format: z.enum(['markdown', 'code', 'link']),
-    content: z.string(),
-  }).nullable(),
-})
-
 const GatewayCitationUrlSchema = z.string().max(2048).url().refine(value => {
   const url = new URL(value)
   return ['http:', 'https:'].includes(url.protocol) && !url.username && !url.password
@@ -91,7 +82,7 @@ export const GatewayAuthorizationSchema = z.object({
   resolvedAt: z.number().nullable(),
 })
 
-// Adapter implementations may add presentation hints, but every activity
+// Adapter implementations may add display hints, but every activity
 // crosses the Gateway through these protocol-neutral common fields. ACP event
 // names and A2A Task payloads stay private to their adapters.
 export const GatewayActivitySchema = z.object({
@@ -135,7 +126,6 @@ export const GatewayTaskSchema = z.object({
   error: z.string().nullable().optional(),
   message: z.string().nullable().optional(),
   artifacts: z.array(GatewayArtifactSchema).optional(),
-  presentation: GatewayPresentationSchema.nullable().optional(),
   activity: z.array(GatewayActivitySchema).optional(),
   delegation: z.unknown().optional(),
   authorization: GatewayAuthorizationSchema.nullable().optional(),
@@ -149,18 +139,152 @@ export const GatewayClientEventTypeSchema = z.enum(GATEWAY_CLIENT_EVENT_NAMES)
 export const GatewayServerEventTypeSchema = z.enum(GATEWAY_SERVER_EVENT_NAMES)
 export const GatewayTaskEventTypeSchema = z.enum(GATEWAY_TASK_EVENT_NAMES)
 
-// The first protocol boundary deliberately validates the stable envelope and
-// event namespace while preserving provider/client extension fields. Payload
-// schemas can now be tightened one event at a time without inventing a second
-// event registry or breaking compatible clients.
+export const GatewayInputPartSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('text'),
+    text: z.string().min(1),
+  }).passthrough(),
+  z.object({
+    type: z.literal('file'),
+    mime: z.string().min(3).refine(value => value.includes('/'), 'invalid MIME type'),
+    filename: z.string().min(1).optional(),
+    url: z.string().min(1),
+  }).passthrough(),
+])
+
+const GatewayInputMessagePayloadSchema = z.object({
+  text: z.string().min(1).optional(),
+  parts: z.array(GatewayInputPartSchema).min(1).max(16).optional(),
+}).passthrough().refine(value => value.text || value.parts, {
+  message: 'a text or parts payload is required',
+})
+
+const GatewayClientPayloadSchemas = Object.freeze({
+  [GatewayClientEvent.CONNECT]: z.object({
+    voiceEnabled: z.boolean().optional(),
+    inputEnabled: z.boolean().optional(),
+    outputEnabled: z.boolean().optional(),
+    textOnly: z.boolean().optional(),
+    takeover: z.boolean().optional(),
+    provider: z.string().min(1).optional(),
+    clientType: z.string().min(1).optional(),
+    clientLabel: z.string().min(1).optional(),
+    clientInstanceId: z.string().min(1).optional(),
+    timeZone: z.string().min(1).optional(),
+    locale: z.string().min(1).optional(),
+    workingDirectory: z.string().min(1).optional(),
+    inputCapabilities: z.object({
+      text: z.boolean().optional(),
+      audio: z.boolean().optional(),
+      image: z.boolean().optional(),
+      resource: z.boolean().optional(),
+    }).passthrough().optional(),
+    clientStates: z.array(z.string().min(1)).optional(),
+  }).passthrough(),
+  [GatewayClientEvent.AUDIO_APPEND]: z.object({
+    audio: z.string().min(1),
+  }).passthrough(),
+  [GatewayClientEvent.TEXT_MESSAGE]: GatewayInputMessagePayloadSchema,
+  [GatewayClientEvent.INPUT_MESSAGE]: GatewayInputMessagePayloadSchema,
+  [GatewayClientEvent.PLAYBACK_STARTED]: z.object({
+    responseId: z.string().min(1),
+  }).passthrough(),
+  [GatewayClientEvent.PLAYBACK_ENDED]: z.object({
+    responseId: z.string().min(1),
+  }).passthrough(),
+  [GatewayClientEvent.PLAYBACK_CANCELLED]: z.object({
+    responseId: z.string().min(1),
+    reason: z.string().optional(),
+  }).passthrough(),
+})
+
+const GatewayVoicePayloadSchemas = Object.freeze({
+  [GatewayServerEvent.VOICE_READY]: z.object({
+    inputSampleRate: z.number().int().positive(),
+    provider: z.string().min(1).optional(),
+    providerLabel: z.string().min(1).optional(),
+  }).passthrough(),
+  [GatewayServerEvent.VOICE_CONNECTION]: z.object({
+    state: z.string().min(1),
+  }).passthrough(),
+  [GatewayServerEvent.VOICE_STATE]: z.object({
+    state: z.enum(['idle', 'listening', 'processing', 'speaking']),
+    turnId: z.string().min(1).nullable().optional(),
+  }).passthrough(),
+  [GatewayServerEvent.VOICE_OWNERSHIP]: z.object({
+    state: z.enum(['active', 'busy', 'available']),
+    holder: z.unknown().nullable().optional(),
+  }).passthrough(),
+  [GatewayServerEvent.VOICE_DEACTIVATED]: z.object({
+    holder: z.unknown().nullable().optional(),
+  }).passthrough(),
+  [GatewayServerEvent.VOICE_SLEEP]: z.object({
+    state: z.enum(['preparing', 'enabled', 'sleeping', 'detected', 'awake', 'disabled']),
+  }).passthrough(),
+  [GatewayServerEvent.TURN_STARTED]: z.object({
+    turnId: z.string().min(1),
+  }).passthrough(),
+  [GatewayServerEvent.INPUT_SUSPEND]: z.object({
+    owner: z.string().min(1),
+    reason: z.string().optional(),
+    expiresAt: z.number().optional(),
+  }).passthrough(),
+  [GatewayServerEvent.AUDIO_DELTA]: z.object({
+    audio: z.string().min(1),
+    sampleRate: z.number().int().positive(),
+    responseId: z.string().min(1),
+  }).passthrough(),
+  [GatewayServerEvent.AUDIO_DONE]: z.object({
+    responseId: z.string().min(1),
+  }).passthrough(),
+  [GatewayServerEvent.RESPONSE_STARTED]: z.object({
+    responseId: z.string().min(1),
+  }).passthrough(),
+  [GatewayServerEvent.RESPONSE_INTERRUPTED]: z.object({
+    responseId: z.string().min(1),
+  }).passthrough(),
+  [GatewayServerEvent.TRANSCRIPT_DELTA]: z.object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string(),
+  }).passthrough(),
+  [GatewayServerEvent.TRANSCRIPT_FINAL]: z.object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string(),
+  }).passthrough(),
+  [GatewayServerEvent.TRANSCRIPT_DISCARD]: z.object({
+    role: z.enum(['user', 'assistant']),
+  }).passthrough(),
+  [GatewayServerEvent.AGENT_ACTIVITY]: z.object({
+    activity: z.string().min(1),
+  }).passthrough(),
+  [GatewayServerEvent.CLIENT_STATE]: z.object({
+    state: z.string().min(1),
+  }).passthrough(),
+  [GatewayServerEvent.ERROR]: z.object({
+    message: z.string().min(1),
+  }).passthrough(),
+})
+
+function validatePayload(schema, event, context) {
+  if (!schema) return
+  const result = schema.safeParse(event)
+  if (result.success) return
+  for (const issue of result.error.issues) context.addIssue(issue)
+}
+
+// Stable fields are validated per event while passthrough preserves optional
+// client/provider extensions. The constants remain the single event registry.
 export const GatewayClientMessageSchema = GatewayEventEnvelopeSchema.extend({
   type: GatewayClientEventTypeSchema,
+}).superRefine((event, context) => {
+  validatePayload(GatewayClientPayloadSchemas[event.type], event, context)
 })
 
 export const GatewayVoiceMessageSchema = GatewayEventEnvelopeSchema.extend({
   type: GatewayServerEventTypeSchema,
   citations: z.array(GatewayCitationSchema).max(16).optional(),
 }).superRefine((event, context) => {
+  validatePayload(GatewayVoicePayloadSchemas[event.type], event, context)
   if (
     event.citations
     && (

--- a/shared/realtime-events.mjs
+++ b/shared/realtime-events.mjs
@@ -43,7 +43,6 @@ export const GatewayServerEvent = Object.freeze({
   TRANSCRIPT_DELTA: 'transcript.delta',
   TRANSCRIPT_FINAL: 'transcript.final',
   TRANSCRIPT_DISCARD: 'transcript.discard',
-  TIMELINE_INLINE: 'timeline.inline',
   AGENT_ACTIVITY: 'agent.activity',
   CLIENT_STATE: 'client.state',
   ERROR: 'error',

--- a/test/custom-conversation-client.test.mjs
+++ b/test/custom-conversation-client.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import {
+  conversationSocketUrl,
+  createConnectionMessage,
+  createTextInputMessage,
+  displayServerMessage,
+} from '../examples/custom-conversation-client/client.mjs'
+import {
+  parseGatewayClientMessage,
+  parseGatewayServerMessage,
+} from 'qwen-audio-agent/gateway-events'
+
+test('custom client builds messages accepted by the public Gateway schemas', () => {
+  assert.equal(
+    conversationSocketUrl('https://voice.example.com/base', 'cockpit'),
+    'wss://voice.example.com/api/realtime?sessionId=cockpit',
+  )
+  assert.equal(parseGatewayClientMessage(createConnectionMessage()).type, 'connect')
+  assert.deepEqual(
+    parseGatewayClientMessage(createTextInputMessage('打开空调')).parts,
+    [{ type: 'text', text: '打开空调' }],
+  )
+  assert.throws(() => parseGatewayClientMessage(createTextInputMessage('')))
+})
+
+test('custom client consumes public conversation and Task events', () => {
+  const output = []
+  displayServerMessage({
+    type: 'transcript.final',
+    role: 'assistant',
+    content: '空调已打开。',
+  }, value => output.push(value))
+  assert.deepEqual(output, ['assistant: 空调已打开。'])
+
+  assert.equal(parseGatewayServerMessage({
+    type: 'voice.ready',
+    inputSampleRate: 16_000,
+    provider: 'dashscope',
+  }).type, 'voice.ready')
+  assert.equal(parseGatewayServerMessage({
+    type: 'task.running',
+    task: {
+      id: 'task_1',
+      workState: 'working',
+      status: 'running',
+      kind: 'work',
+      objective: '检查车辆状态',
+      createdAt: 1,
+      elapsedMs: 0,
+    },
+  }).task.id, 'task_1')
+})
+
+test('custom client imports only public package entries', async () => {
+  const source = await readFile(
+    new URL('../examples/custom-conversation-client/client.mjs', import.meta.url),
+    'utf8',
+  )
+  assert.match(source, /from 'qwen-audio-agent\/realtime-events'/)
+  assert.match(source, /from 'qwen-audio-agent\/gateway-events'/)
+  assert.doesNotMatch(source, /(?:server|shared|web|desktop|tui)\/(?:src|protocol)/)
+})

--- a/test/gateway-event-schema.test.mjs
+++ b/test/gateway-event-schema.test.mjs
@@ -40,6 +40,29 @@ test('validates client event envelopes and preserves extension fields', () => {
     false,
   )
   assert.equal(GatewayClientMessageSchema.safeParse(null).success, false)
+
+  assert.equal(parseGatewayClientMessage({
+    type: 'input.message',
+    parts: [
+      { type: 'text', text: '检查前方天气' },
+      {
+        type: 'file',
+        mime: 'image/jpeg',
+        filename: 'road.jpg',
+        url: 'data:image/jpeg;base64,YQ==',
+      },
+    ],
+  }).parts.length, 2)
+  assert.equal(GatewayClientMessageSchema.safeParse({
+    type: 'input.message',
+    parts: [],
+  }).success, false)
+  assert.equal(GatewayClientMessageSchema.safeParse({
+    type: 'audio.append',
+  }).success, false)
+  assert.equal(GatewayClientMessageSchema.safeParse({
+    type: 'playback.ended',
+  }).success, false)
 })
 
 test('validates voice and task messages in the server direction', () => {
@@ -64,6 +87,21 @@ test('validates voice and task messages in the server direction', () => {
     GatewayServerMessageSchema.safeParse({
       type: 'task.accepted',
       task: { id: 'task_1' },
+    }).success,
+    false,
+  )
+  assert.equal(
+    GatewayServerMessageSchema.safeParse({
+      type: 'voice.ready',
+      inputSampleRate: 0,
+    }).success,
+    false,
+  )
+  assert.equal(
+    GatewayServerMessageSchema.safeParse({
+      type: 'audio.delta',
+      audio: 'YQ==',
+      sampleRate: 24_000,
     }).success,
     false,
   )
@@ -138,6 +176,7 @@ test('preserves protocol-neutral backend observations and safe permission detail
     message.task.authorization.operation.command,
     'sysctl -n hw.memsize',
   )
+  assert.equal('presentation' in message.task, false)
 })
 
 test('validates the supported AG-UI activity event surface', () => {

--- a/tui/src/index.mjs
+++ b/tui/src/index.mjs
@@ -1429,10 +1429,6 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
       playback.done(event.responseId)
     }
     transcriptDisplay.handle(event)
-    if (event.type === 'timeline.inline') {
-      const content = event.item?.content || event.item?.markdown || ''
-      if (content) print(`${style('── 执行结果 ──', 'cyan')}\n${content}`)
-    }
     if (event.type === 'task.running') {
       turnStatusDisplay.status(
         event,

--- a/tui/src/text-cli.mjs
+++ b/tui/src/text-cli.mjs
@@ -9,7 +9,6 @@ import { isExitCommand } from './terminal-commands.mjs'
 
 const ESC = ''
 const DIM = `${ESC}[90m`
-const CYAN = `${ESC}[36m`
 const YELLOW = `${ESC}[33m`
 const RED = `${ESC}[31m`
 const BOLD = `${ESC}[1m`
@@ -152,9 +151,6 @@ export async function runCli(options = parseArguments(process.argv.slice(2))) {
         const citations = formatCitationLines(event.citations)
         if (citations) print(`${DIM}${citations}${RST}`)
       }
-    } else if (event.type === 'timeline.inline') {
-      const content = event.item?.content || event.item?.markdown || ''
-      if (content) print(`${CYAN}── 时间线 ──${RST}\n${content}`)
     } else if (event.type === 'error') {
       if (streaming) {
         process.stdout.write('\n')

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -9,7 +9,6 @@ import {
 import {
   buildConversationTurns,
   discardUserTranscript,
-  insertByTurn,
   mergeConversationHistory,
   upsertAssistantTranscript,
   upsertUserTranscript,
@@ -422,30 +421,6 @@ export default function App() {
     }))
   }, [])
 
-  const updateTimelineItem = useCallback(item => {
-    if (!item?.content) return
-    setMessages(items => {
-      const id = `inline:${item.id || item.taskId || crypto.randomUUID()}`
-      const existing = items.findIndex(message => message.id === id)
-      const message = {
-        id,
-        role: 'assistant',
-        content: item.content,
-        title: item.title,
-        // Backend presentation is a new timeline item. taskId preserves the
-        // work relation; no user turn is inferred from current UI state.
-        turnId: item.turnId || '',
-        taskId: item.taskId,
-        companion: true,
-        final: true,
-      }
-      if (existing < 0) return insertByTurn(items, message)
-      const next = [...items]
-      next[existing] = message
-      return next
-    })
-  }, [])
-
   const onRealtimeEvent = useCallback(event => {
     const animationEvent = spriteAnimationEventForGatewayEvent(event)
     if (animationEvent) {
@@ -523,12 +498,6 @@ export default function App() {
           })
         })
         .catch(() => {})
-      fetch(`api/timeline?sessionId=${encodeURIComponent(sessionId)}`)
-        .then(response => response.ok ? response.json() : Promise.reject())
-        .then(payload => {
-          for (const item of payload.items || []) updateTimelineItem(item)
-        })
-        .catch(() => {})
     }
     if (event.type === 'voice.deactivated') {
       setVoiceEnabled(false)
@@ -575,9 +544,6 @@ export default function App() {
     }
     if (event.type === 'transcript.discard' && event.role === 'user') {
       setMessages(items => discardUserTranscript(items, event.turnId))
-    }
-    if (event.type === 'timeline.inline' && event.item?.content) {
-      updateTimelineItem(event.item)
     }
     if (event.type === 'response.started') {
       activeVoiceResponse.current = event.responseId
@@ -777,7 +743,6 @@ export default function App() {
     }
   }, [
     sessionId,
-    updateTimelineItem,
     updateUserTranscript,
     updateVoiceMessage,
     noteInteraction,


### PR DESCRIPTION
## Summary

- formalize the headless conversation client contract and validate Gateway event envelopes
- remove unused legacy presentation fields and keep UI/backend integrations behind stable boundaries
- isolate task announcement composition behind a small code-level DI seam
- batch concurrent backend permission decisions into one realtime confirmation and clear stale progress announcements
- add a custom conversation client example and protocol/conformance coverage

## Verification

- `npm test`
- `npm run lint`
- `npm run build`
- regression coverage for four concurrent permission requests producing one spoken confirmation