### PR TITLE
标题：fix(memory): 摘掉落不了地的 edit，保住同批里正确的追加

### DIFF
--- a/server/src/conversation/memory-extractor.mjs
+++ b/server/src/conversation/memory-extractor.mjs
@@ -52,6 +52,11 @@ const EXTRACTOR_SYSTEM_PROMPT = [
   '规则：',
   '- user 只保存用户本人明确提出、会直接改变未来交互方式的长期指令：称呼、关系、助手在该用户面前的名称、语言、表达风格和默认做法。不得推测。',
   '- memory 只保存用户本人明确陈述、稳定且具有跨会话价值的非交互事实与决定：所在地、习惯、兴趣、人际关系事实、项目、长期目标或计划。不得推测。',
+  // 别在这条规则上再加「不要把对话原话当 old_text」之类的强调 —— 试过了，
+  // A/B 各 15 轮同时段交替发起：edit 误用率 73% → 73%，一点没降，只是把写入
+  // 成功率从 MEMORY 挪到了 USER（60%→20% / 13%→47%），总量还少 1。
+  // 模型误用 edits 这件事靠 prompt 管不住，已改为在 pruneUnappliableEdits 里
+  // 结构性兜住。
   '- edits 用于更正或删除已有内容；old_text 必须逐字来自对应的现有文档且只出现一次。删除时 new_text 为空。',
   '- append 是追加到对应文档的完整 Markdown 块，可包含多项信息并使用合适的小标题；没有新增时为空字符串。',
   '- 保持文档简洁、自然、可直接由人阅读，不添加 ID、时间戳、来源或 JSON 字段。',
@@ -61,6 +66,52 @@ const EXTRACTOR_SYSTEM_PROMPT = [
   '- 同一文档的修改合并为一个 change，每个 document 最多出现一次。',
   '- 没有值得修改的内容时输出 {"changes":[]}。',
 ].join('\n')
+
+// 与 markdown-context-store 的 old_text 判定同口径：不重叠计数，必须恰好一次。
+// 两处口径必须一致，否则这里放行的 edit 会在 prepareEdit 里再次被拒。
+function countOccurrences(content, needle) {
+  if (!needle) return 0
+  let count = 0
+  let offset = 0
+  while ((offset = content.indexOf(needle, offset)) >= 0) {
+    count += 1
+    offset += needle.length
+  }
+  return count
+}
+
+// 摘掉落不了地的 edit。
+//
+// 模型很容易把【对话里的原话】当成 old_text，而 old_text 必须是【现有文档里】的
+// 原文；文档还是空模板时更是必错。这类 edit 在 prepareEdit 里会抛错，而 apply 是
+// 整批原子的 —— 一条坏 edit 会连带丢掉同一批里完全正确的 append。
+//
+// 这里按顺序在副本上模拟替换（edits 是顺序应用的，后一条可能依赖前一条的结果），
+// 找不到或出现多次的单独摘出去，保住其余部分。
+//
+// 已知限制：这里用的是 memoryService.list() 给出的内容，与喂给模型的是同一份，
+// 因此和模型的视角一致；但 prepareEdit 用的是未截断的原文。文档超过注入预算时，
+// 被截断部分若含重复文本，仍可能在 prepareEdit 处判为 ambiguous 而整批失败。
+// 那种情况下 read 侧本来就有截断告警，属可接受的窄边界。
+function pruneUnappliableEdits(edits = [], currentContent = '') {
+  let working = String(currentContent || '')
+  const kept = []
+  const dropped = []
+  for (const edit of edits) {
+    const oldText = String(edit?.old_text || '').trim()
+    const matches = countOccurrences(working, oldText)
+    if (matches !== 1) {
+      dropped.push({
+        reason: oldText ? (matches ? 'ambiguous' : 'not_found') : 'empty',
+        old_text: oldText.slice(0, 40),
+      })
+      continue
+    }
+    working = working.replace(oldText, String(edit?.new_text || ''))
+    kept.push(edit)
+  }
+  return { kept, dropped }
+}
 
 function containsSensitiveContent(value) {
   return SENSITIVE_PATTERNS.some(pattern => pattern.test(value))
@@ -288,7 +339,34 @@ export class MemoryExtractor {
       this.audit?.record({ op: 'skip', ownerId, reason: 'sensitive' })
       return
     }
-    const invalidBoundary = changes.some(change => {
+    // 摘掉落不了地的 edit —— 见 pruneUnappliableEdits 的注释。必须排在边界校验
+    // 之前：被摘掉的 new_text 不会写入，不该再参与「该进哪个文档」的判断。
+    const droppedEdits = []
+    const applicable = []
+    for (const change of changes) {
+      const current = documents.get(change.document)?.content || ''
+      const { kept, dropped } = pruneUnappliableEdits(change.edits, current)
+      for (const item of dropped) {
+        droppedEdits.push({ document: change.document, ...item })
+      }
+      // edits 全被摘掉、又没有 append 的 change 整个不要
+      if (kept.length || change.append) {
+        applicable.push({ ...change, edits: kept })
+      }
+    }
+    if (droppedEdits.length) {
+      this.audit?.record({
+        op: 'skip',
+        ownerId,
+        reason: 'edit_not_applicable',
+        detail: droppedEdits,
+      })
+    }
+    if (!applicable.length) {
+      this.audit?.record({ op: 'skip', ownerId, reason: 'no_applicable_change' })
+      return
+    }
+    const invalidBoundary = applicable.some(change => {
       const additions = [
         ...change.edits.map(edit => edit.new_text),
         change.append,
@@ -303,13 +381,13 @@ export class MemoryExtractor {
       return
     }
     if (
-      changes.some(change => change.document === 'user')
+      applicable.some(change => change.document === 'user')
       && !hasExplicitUserDirective(lines)
     ) {
       this.audit?.record({ op: 'skip', ownerId, reason: 'user_directive_not_explicit' })
       return
     }
-    const prepared = changes.map(change => ({
+    const prepared = applicable.map(change => ({
       ...change,
       expectedRevision: documents.get(change.document)?.revision || '',
     }))

--- a/server/test/memory-extractor.test.mjs
+++ b/server/test/memory-extractor.test.mjs
@@ -95,6 +95,89 @@ test('can correct existing Markdown with an exact edit', async () => {
   assert.doesNotMatch(memoryStore.read(OWNER), /每天晚上跑步/)
 })
 
+test('keeps a valid append when a sibling edit cannot be applied', async () => {
+  // 真实模型 15 轮里有 11 轮这么错：把【对话里的原话】当成 old_text，而 old_text
+  // 必须来自现有文档。apply 是整批原子的，所以修复前这一条坏 edit 会连带丢掉
+  // 同批里完全正确的 append —— 实测下来两个文档全空。
+  const events = []
+  const { instance, userStore, memoryStore } = extractor({
+    userText: '以后都叫我老张吧',
+    audit: { record: event => events.push(event) },
+    llmCall: async () => JSON.stringify({
+      changes: [
+        {
+          document: 'user',
+          // 这句在对话里有，在空的 USER.md 里没有
+          edits: [{ old_text: '以后都叫我老张吧', new_text: '以后都叫我老张' }],
+          append: '',
+        },
+        {
+          document: 'memory',
+          edits: [],
+          append: '## 所在地\n\n- 用户住在杭州西湖区。',
+        },
+      ],
+    }),
+  })
+  await instance.maybeRun({ ownerId: OWNER, sessionId: SESSION })
+  // 正确的那条落地了
+  assert.match(memoryStore.read(OWNER), /杭州西湖区/)
+  // 落不了地的 edit 没有被硬写进去
+  assert.doesNotMatch(userStore.read(OWNER), /老张/)
+  const dropped = events.find(event => event.reason === 'edit_not_applicable')
+  assert.ok(dropped, '摘掉无效 edit 必须留下审计记录')
+  assert.deepEqual(dropped.detail, [
+    { document: 'user', reason: 'not_found', old_text: '以后都叫我老张吧' },
+  ])
+  assert.equal(events.at(-1).op, 'patch')
+})
+
+test('drops the whole change when every edit is unappliable and nothing is appended', async () => {
+  const events = []
+  const { instance, memoryStore } = extractor({
+    audit: { record: event => events.push(event) },
+    llmCall: async () => JSON.stringify({
+      changes: [{
+        document: 'memory',
+        edits: [{ old_text: '文档里根本没有这句', new_text: '替换后' }],
+        append: '',
+      }],
+    }),
+  })
+  await instance.maybeRun({ ownerId: OWNER, sessionId: SESSION })
+  assert.equal(memoryStore.read(OWNER).includes('替换后'), false)
+  assert.equal(events.at(-1).reason, 'no_applicable_change')
+})
+
+test('drops an ambiguous edit but keeps the unique one in the same batch', async () => {
+  // edits 是顺序应用的，所以判定必须在副本上模拟：第一条替换掉唯一那处之后，
+  // 第二条才轮到。这里刻意让「跑步」在文档里出现两次。
+  const events = []
+  const { instance, memoryStore } = extractor({
+    audit: { record: event => events.push(event) },
+    llmCall: async () => JSON.stringify({
+      changes: [{
+        document: 'memory',
+        edits: [
+          { old_text: '游泳', new_text: '骑车' },
+          { old_text: '跑步', new_text: '快走' },
+        ],
+        append: '',
+      }],
+    }),
+  })
+  memoryStore.edit(OWNER, { append: '- 早上跑步\n- 晚上跑步\n- 周末游泳' })
+  await instance.maybeRun({ ownerId: OWNER, sessionId: SESSION })
+  const content = memoryStore.read(OWNER)
+  assert.match(content, /骑车/, '唯一命中的那条应当落地')
+  assert.doesNotMatch(content, /快走/, '出现两次的 old_text 必须被摘掉')
+  assert.match(content, /早上跑步[\s\S]*晚上跑步/, '原文不被破坏')
+  const dropped = events.find(event => event.reason === 'edit_not_applicable')
+  assert.deepEqual(dropped.detail, [
+    { document: 'memory', reason: 'ambiguous', old_text: '跑步' },
+  ])
+})
+
 test('reconciles a misplaced directive across both documents atomically', async () => {
   const { instance, userStore, memoryStore } = extractor({
     userText: '以后每次回复都加一句爱你哟',


### PR DESCRIPTION
[模型很容易把【对话里的原话】当成 old_text，而 old_text 必须来自【现有文档】；
文档还是空模板时更是必错。这类 edit 在 prepareEdit 里会抛错，而 apply 是整批 原子的 —— 一条坏 edit 会连带丢掉同一批里完全正确的 append。

真实模型实测 12 轮：10 轮出现这种误用，修复前这 10 轮的写入全部整批丢弃，
USER.md 与 MEMORY.md 双双为空；audit 只留一句 old_text was not found， 看不出还有正确的部分被连带丢掉。

改为调 apply 前按顺序在副本上模拟替换，找不到或出现多次的单独摘出去、
保住其余。修复后同样 12 轮里有 8 轮成功写入。

几个实现要点：

- 必须模拟而不是各自独立判断：edits 是顺序应用的，后一条可能依赖前一条的 替换结果。测试里刻意让同一个词出现两次来锁住这一点。
- 计数与 markdown-context-store 的 old_text 判定同口径（不重叠、恰好一次）， 否则这里放行的 edit 会在 prepareEdit 里再次被拒。
- 摘除必须排在文档边界校验之前：被摘掉的 new_text 不会写入， 不该再参与「该进哪个文档」的判断。
- 摘除与「整个 change 都不可用」分别留审计记录，便于事后区分。

另外记下一条被否证的路：在 prompt 里加「不要把对话原话当 old_text」的强调
无效。A/B 各 15 轮同时段交替发起，edit 误用率 73% → 73% 一点没降，只是把
写入成功率从 MEMORY 挪到了 USER，总量还少 1。所以这里用结构性防护而不是
prompt 叮嘱，注释里也写明了免得再试一遍。

验证：npm test 全绿，lint 干净。反证过三条测试都能抓到 bug：
让 prune 不摘任何东西 → 三条全红。

## 变更说明

<!-- 说明问题、解决方式以及为何需要这项变更。 -->

## 验证

<!-- 列出实际运行的测试、构建或手工验证。 -->

- [ ] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 行为变化已补充测试或说明无法自动测试的原因

## 兼容性与安全

- [ ] 未提交密钥、用户数据、日志或内部地址
- [ ] 配置、用户可见行为和依赖变化已同步更新文档
- [ ] 已说明网络、权限、隐私、持久化或发布流程影响；不适用时请注明
](https://github.com/QwenAudio/qwen-audio-agent/compare/main...usionkong:qwen-audio-agent:fix/prune-unappliable-memory-edits)