### PR TITLE
标题：fix(realtime): 允许只更新 agentContext 而不重发 session.update

### DIFF
--- a/server/src/voice/realtime-provider-session.mjs
+++ b/server/src/voice/realtime-provider-session.mjs
@@ -117,8 +117,11 @@ export class RealtimeProviderSession {
     this.frontend?.cancel()
   }
 
-  updateAgentContext(context) {
-    return this.frontend?.updateAgentContext(context)
+  // options 必须一并转发：底层靠 { refreshSession: false } 决定是否重发
+  // session.update。这一层若吞掉第二个参数，调用方的意图会被静默丢弃 ——
+  // 不报错、测试也照样绿，只是前缀缓存白白失效。
+  updateAgentContext(context, options) {
+    return this.frontend?.updateAgentContext(context, options)
   }
 
   appendAudio(audio) {

--- a/server/src/voice/realtime-provider.mjs
+++ b/server/src/voice/realtime-provider.mjs
@@ -271,8 +271,13 @@ export class RealtimeFrontend {
     this.send(this.protocol.conversationItemCreate({ id, ...item }))
   }
 
-  updateAgentContext(patch = {}) {
+  // refreshSession 为 false 时只更新 agentContext 缓存，不重发 session.update。
+  // instructions 是 prompt 前缀的一部分，重发等于换前缀，会让整场会话已经建立的
+  // 前缀缓存失效。所以「更新了上下文但不需要本轮就生效」的调用方（例如后台写入
+  // 长期记忆）应当传 false，让新内容在下一次自然的 session.update 时带上去。
+  updateAgentContext(patch = {}, { refreshSession = true } = {}) {
     this.agentContext = { ...this.agentContext, ...patch }
+    if (!refreshSession) return
     if (!this.ready) return
     const refresh = async () => {
       await this.whenIdle()

--- a/server/test/realtime-provider-session.test.mjs
+++ b/server/test/realtime-provider-session.test.mjs
@@ -60,7 +60,9 @@ function harness({
       appendAudio: audio => calls.push(['appendAudio', audio]),
       cancel: () => calls.push(['cancel']),
       close: () => calls.push(['close', options.providerName]),
-      updateAgentContext: context => calls.push(['updateAgentContext', context]),
+      // 记下第二个参数：这一层曾经只转发 context，把 options 静默吞掉，
+      // 而 stub 当时也只记录第一个参数，于是那个断点在测试里完全隐形。
+      updateAgentContext: (context, options) => calls.push(['updateAgentContext', context, options]),
       triggerError: error => options.onError(error),
       triggerClose: () => {
         frontend.ready = false
@@ -214,4 +216,18 @@ test('explicit close can notify disconnection without a duplicate close callback
     calls.filter(([name]) => name === 'onDisconnected').length,
     1,
   )
+})
+
+test('forwards agent context options down to the frontend', async () => {
+  // 底层靠 { refreshSession: false } 决定要不要重发 session.update。这一层
+  // 若只转发第一个参数，调用方的意图会被静默丢弃 —— 不报错，测试也照样绿，
+  // 只是整场会话的前缀缓存白白失效。
+  const { runtime, calls } = harness({ connectMode: 'resolve' })
+  await runtime.ensure()
+
+  runtime.updateAgentContext({ memories: [] }, { refreshSession: false })
+
+  const [, context, options] = calls.find(([name]) => name === 'updateAgentContext')
+  assert.deepEqual(context, { memories: [] })
+  assert.deepEqual(options, { refreshSession: false }, 'options 必须原样到底层')
 })

--- a/server/test/realtime-provider.test.mjs
+++ b/server/test/realtime-provider.test.mjs
@@ -951,6 +951,37 @@ test('refreshes live session instructions after frontend context changes', async
   assert.doesNotMatch(sent[0].session.instructions, /只在恢复连接时注入的历史/)
 })
 
+test('keeps the live session untouched when refreshSession is false', async () => {
+  // instructions 是 prompt 前缀的一部分，重发 session.update 等于换前缀，会让
+  // 整场会话已经建立的前缀缓存失效。所以「更新了上下文但不需要本轮就生效」的
+  // 调用方要能只写缓存、不动会话。
+  const frontend = createQwenFrontend({
+    agentContext: {
+      client: { timeZone: 'Asia/Shanghai', locale: 'zh-CN' },
+      memories: [{ scope: 'profile', content: '旧的记忆' }],
+    },
+  })
+  const sent = []
+  frontend.ready = true
+  frontend.sessionConfigured = true
+  frontend.send = payload => sent.push(payload)
+
+  frontend.updateAgentContext(
+    { memories: [{ scope: 'profile', content: '新的记忆' }] },
+    { refreshSession: false },
+  )
+  await frontend.outputQueue
+
+  assert.deepEqual(sent, [], '不该重发 session.update')
+  // 缓存要更新到位：下一次自然的 session.update 必须带上新内容，
+  // 否则这个开关就变成了「丢掉这次更新」。
+  frontend.updateAgentContext({})
+  await frontend.outputQueue
+  assert.equal(sent[0].type, 'session.update')
+  assert.match(sent[0].session.instructions, /新的记忆/)
+  assert.doesNotMatch(sent[0].session.instructions, /旧的记忆/)
+})
+
 test('restores recent conversation once after configuring a fresh session', () => {
   const frontend = createQwenFrontend({
     agentContext: {


### PR DESCRIPTION
从 #245 拆出的独立修复。

`instructions` 是 prompt 前缀的一部分，重发 `session.update` 等于换前缀，会让
整场会话已经建立的前缀缓存失效。但有些上下文更新并不需要本轮就生效 —— 例如
后台写入长期记忆，内容在下一次自然的 `session.update` 时带上去就够了。

给 `updateAgentContext` 加第二个参数 `{ refreshSession }`，默认 `true` 保持原
行为。

`realtime-provider-session` 这一层必须一并转发 —— 它原来只转发第一个参数，
调用方的 options 会被静默吞掉，不报错、测试也照样绿。这类跨层参数断点在评审里
很难看出来，所以两侧各锁一条测试，并且修了测试 stub（它原来也只记录第一个
参数，正是这一点让断点在测试里完全隐形）。

反证过：还原中间层转发 → session 那条红；还原底层判断 → provider 那条红。