### PR TITLE
chore(task): 终态任务保留期从 24 小时放宽到 3 天

### DIFF
--- a/server/src/task/task-manager.mjs
+++ b/server/src/task/task-manager.mjs
@@ -57,7 +57,12 @@ export class TaskManager {
     maxConcurrent = 4,
     maxConcurrentPerOwner = 2,
     systemMaxConcurrent = 2,
-    terminalTtlMs = 86_400_000,
+    // 终态任务保留 3 天而非 24 小时：语音场景里「周五派的活周一问」很常见，
+    // 24 小时会让隔天的查询就拿不到状态，用户只能重新派一次。
+    //
+    // 数量上限（maxTerminalTasksPerOwner）保持不变：prune() 按 createdAt 降序
+    // 保留最新的那一批，所以放宽时间窗不会让内存无界增长 —— 上限仍然是硬顶。
+    terminalTtlMs = 259_200_000,
     pendingNotificationTtlMs = 604_800_000,
     notificationClaimTtlMs = 60_000,
     maxTerminalTasksPerOwner = 100,

--- a/server/test/task-manager.test.mjs
+++ b/server/test/task-manager.test.mjs
@@ -463,6 +463,36 @@ test('does not evict pending notifications to satisfy delivered history limit', 
   assert.equal(manager.list({ ownerId: 'owner' }).length, 2)
 })
 
+test('keeps a delivered task reachable the next day but drops it after the window', async () => {
+  // 语音场景里「周五派的活周一问」很常见，隔天还能查到状态是这个 TTL 的用途。
+  // 这里不写死毫秒数，只锁「跨天仍在、超窗即走」这条语义。
+  const manager = new TaskManager()
+  const day = 86_400_000
+  const [next, expired] = await Promise.all(['隔天问', '很久以前'].map(async objective => {
+    const task = manager.create({
+      objective,
+      ownerId: 'owner',
+      sessionId: 'voice',
+      runner: async () => ({ content: '结果' }),
+    })
+    await manager.wait(task.id)
+    return task
+  }))
+  // 通知已送达才会走 terminalTtlMs；未送达的走 pendingNotificationTtlMs
+  for (const task of [next, expired]) {
+    manager.tasks.get(task.id).notificationStatus = 'delivered'
+  }
+  // 用 2 天前而不是 1 天前：判断是 age > ttl，1 天前正好卡在等号上，
+  // 24 小时与 3 天两种配置都不会删，那样这条测试就锁不住任何东西。
+  manager.tasks.get(next.id).completedAt = Date.now() - day * 2
+  manager.tasks.get(expired.id).completedAt = Date.now() - day * 4
+
+  manager.prune()
+  const ids = manager.list({ ownerId: 'owner' }).map(task => task.taskId ?? task.id)
+  assert.ok(ids.includes(next.id), '隔天的活必须还能查到状态')
+  assert.ok(!ids.includes(expired.id), '超出保留窗的活应当被清掉')
+})
+
 test('reuses a persisted submission key instead of running duplicate work', async () => {
   let saved = []
   let runs = 0


### PR DESCRIPTION
从 #245 拆出。**这一条动了默认值，如果你们定 24 小时有内存或 prune 上的考虑，
可以直接关掉这个 PR** —— 关掉之后功能仍然工作，只是隔天派的活答不出状态。

语音场景里「周五派的活周一问」很常见，24 小时会让隔天的查询就拿不到状态，
用户只能重新派一次。

`maxTerminalTasksPerOwner` 保持不变：`prune()` 按 `createdAt` 降序保留最新的
那一批，所以放宽时间窗不会让内存无界增长 —— 上限仍然是硬顶。

补一条测试锁住语义。**原先这个常量没有任何测试覆盖，改成任何数字都不会红。**
测试刻意用「2 天前」而不是「1 天前」：判断是 `age > ttl`，1 天前正好卡在等号
上，两种配置下都不删 —— 第一版正是这么写的，反证时才发现锁不住任何东西。