### PR TITLE
docs(gateway): define client protocol and roadmap

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -18,6 +18,14 @@ a feature then degrades instead of failing.
 Versioning follows SemVer: the minor rises for an additive capability, the
 major for a breaking change to any endpoint or event named below.
 
+The proposed 6.0 northbound boundary is documented in the draft
+[Gateway Client Protocol](gateway-protocol.md) and its
+[roadmap](roadmap/gateway-client-protocol.md), tracked by
+[GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251).
+Those documents are design targets, not current 5.x promises; this contract
+index remains authoritative until each capability is implemented and locked by
+a named test.
+
 The current version is `5.0.0`. The `5.0` line removes the backend-controlled
 Task `presentation` envelope. A backend returns factual `content` plus optional
 typed `artifacts`; the foreground Chatbot decides how to speak, while each

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -19,8 +19,8 @@ Versioning follows SemVer: the minor rises for an additive capability, the
 major for a breaking change to any endpoint or event named below.
 
 The proposed 6.0 northbound boundary is documented in the draft
-[Gateway Client Protocol](gateway-protocol.md) and its
-[roadmap](roadmap/gateway-client-protocol.md), tracked by
+[Gateway Client Protocol](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/gateway-protocol.md) and its
+[roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/gateway-client-protocol.md), tracked by
 [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251).
 Those documents are design targets, not current 5.x promises; this contract
 index remains authoritative until each capability is implemented and locked by

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -15,8 +15,8 @@
 变更升 major。
 
 拟议中的 6.0 北向边界记录在草案
-[Gateway Client Protocol](gateway-protocol.zh.md) 与
-[Roadmap](roadmap/gateway-client-protocol.zh.md) 中，并由
+[Gateway Client Protocol](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/gateway-protocol.zh.md) 与
+[Roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/gateway-client-protocol.zh.md) 中，并由
 [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)
 跟踪。它们是设计目标，不是当前 5.x 承诺；只有能力完成实现并由下文点名的测试锁定后，
 才进入本契约索引。

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -14,6 +14,13 @@
 版本号遵循 SemVer：新增能力升 minor；下文点名的任一端点或事件发生破坏性
 变更升 major。
 
+拟议中的 6.0 北向边界记录在草案
+[Gateway Client Protocol](gateway-protocol.zh.md) 与
+[Roadmap](roadmap/gateway-client-protocol.zh.md) 中，并由
+[GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)
+跟踪。它们是设计目标，不是当前 5.x 承诺；只有能力完成实现并由下文点名的测试锁定后，
+才进入本契约索引。
+
 当前版本为 `5.0.0`。`5.0` 删除由后台控制的 Task `presentation` 包装：后台只返回
 事实性 `content` 与可选的类型化 `artifacts`，前台 Chatbot 决定如何播报，各个对话
 客户端决定如何呈现。同一版本同时将现有 `WS /api/realtime` 事件模型正式发布为

--- a/docs/gateway-protocol.md
+++ b/docs/gateway-protocol.md
@@ -1,6 +1,6 @@
 # Gateway Client Protocol
 
-> Status: **Draft 0.3**<br>
+> Status: **Draft 0.4**<br>
 > Target wire version: **6.0.0**<br>
 > Roadmap: [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)<br>
 > Current 5.x sources of truth: `shared/realtime-events.mjs`, `shared/protocol/gateway-events.mjs`, and `server/src/core/gateway-protocol.mjs`
@@ -34,7 +34,7 @@ TUI, WebUI, and Desktop Orb are first-party reference clients. OpenCode, Qwen Co
 5. Realtime Tool Calls are model-facing. `ClientActionPort` maps applicable Tool Calls to Client Actions.
 6. Gateway decides whether an event is handled deterministically, added to model context, answered later, or answered immediately.
 7. Client events cannot spoof Gateway, Task, permission, or backend lifecycle events.
-8. Realtime-provider and backend-protocol objects never cross this boundary.
+8. Realtime-provider and backend-protocol wire objects never cross this boundary. The Gateway owns every public type, while deliberately aligning familiar field names and shapes with external standards where semantics match.
 9. Local mute, window layout, wake mechanism, and rendering remain client concerns unless they affect shared Gateway state.
 10. Existing behavior remains available through compatibility aliases until every first-party client has migrated and conformance coverage exists.
 
@@ -57,6 +57,9 @@ The Client connects to `ws://<gateway>/api/realtime`. The first message is `sess
     "input.text",
     "input.image",
     "playback.receipts",
+    "tasks.commands",
+    "permissions.respond",
+    "conversation.history",
     "client.events",
     "client.actions.desktop.presence.enter_sleep",
     "session.replay"
@@ -80,6 +83,9 @@ Gateway returns the selected version and capability intersection:
     "input.text",
     "input.image",
     "playback.receipts",
+    "tasks.commands",
+    "permissions.respond",
+    "conversation.history",
     "client.events",
     "client.actions.desktop.presence.enter_sleep",
     "session.replay"
@@ -94,6 +100,7 @@ Rules:
 - No takeover, kick, concurrent observer, or multi-client arbitration exists in 6.0.
 - The Client must branch on negotiated capabilities, not product versions.
 - Protocol version, Client identity, and capabilities cannot change without reconnecting.
+- Version 6.0 defines no `context_source`, `integration`, or observer connection role. Vehicle buses, CRM feeds, sensors, and other context sources attach to the active Client Environment through client-side adapters; that Client validates and relays registered semantic events.
 
 ## 4. Common event envelope
 
@@ -117,6 +124,8 @@ Gateway follows the flat OpenAI Realtime envelope style:
 | `occurred_at` | Semantic events when known | Millisecond timestamp at the event source; Gateway records receipt time separately |
 
 Immediate results and errors are not replayed. Media deltas, incremental transcripts, heartbeat traffic, and `session.replay.result` are also not replayed.
+
+The naming resemblance is intentional, but the schemas in this specification are authoritative. Reusing a standard's field name or compatible shape does not import that standard's object type or claim wire compatibility.
 
 All control messages are UTF-8 JSON text frames. Version 6.0 carries PCM audio as base64 in JSON; a future binary media capability may replace that without changing semantic event routing.
 
@@ -217,7 +226,26 @@ client.action.result
 
 Client Action is not a replacement for MCP, OpenAPI, ACP, or A2A. It covers capabilities owned by the connected Client Environment. Other external systems continue to use the appropriate tool or backend adapter.
 
-### 5.4 Gateway state and presentation
+### 5.4 Runtime commands and queries
+
+The active Client uses the same WebSocket for runtime commands and queries. Each command carries an `event_id`; its immediate `<command>.result` carries `request_event_id`. Later lifecycle changes remain ordinary replayable server pushes rather than being hidden inside the command result.
+
+| Command | Direction | Meaning |
+|---|---|---|
+| `task.create` | C→G | Explicitly create an asynchronous Task without impersonating conversational user input |
+| `task.get` / `task.list` | C→G | Read one Task or a bounded filtered Task snapshot |
+| `task.cancel` | C→G | Request cancellation of one Task; subsequent lifecycle events report the final state |
+| `permission.respond` | C→G | Resolve the currently pending authorization request |
+| `conversation.history` | C→G | Read the bounded, client-safe conversation projection |
+| `session.replay` | C→G | Replay eligible server pushes after a sequence cursor |
+
+`task.create` carries an A2A-aligned `message.parts` value rather than a second plain-text-only objective field, so an explicit integration may submit text, file, or structured parts without importing an A2A Message object.
+
+This is the Client runtime control plane. Equivalent internal REST/SSE routes remain migration aliases until every first-party Client uses the WebSocket commands and replay path. REST remains appropriate for startup discovery, health, static configuration, and host-management operations that are not part of an active Client session.
+
+`task.create` is an explicit integration command, not the normal voice-chat path. Conversational requests still reach Task creation through the frontend Agent's tools, preserving its routing and acknowledgement behavior.
+
+### 5.5 Gateway state and presentation
 
 Gateway publishes normalized state; the Client renders it without reconstructing Gateway internals:
 
@@ -229,9 +257,30 @@ Gateway publishes normalized state; the Client renders it without reconstructing
 
 Every public Task keeps one Gateway `task_id`. ACP Session IDs, A2A remote Task IDs, and custom-adapter identifiers remain private to `BackendPort` adapters.
 
+Task snapshots and updates use a Gateway-owned wrapper with deliberately A2A-aligned nested shapes:
+
+```jsonc
+{
+  "type": "task.updated",
+  "event_id": "evt_gateway_88",
+  "sequence": 41,
+  "task_id": "task_42",
+  "status": {
+    "state": "working",
+    "message": {
+      "role": "agent",
+      "parts": [{ "text": "正在检查磁盘空间。" }]
+    }
+  },
+  "artifacts": []
+}
+```
+
+The Gateway owns the state vocabulary and event lifecycle. The nested `status.state`, `status.message.parts`, and `artifacts[].parts` shapes aid adapter and UI reuse but are not native A2A objects.
+
 Task progress may be pushed to the Client without being sent to the Realtime model. Gateway's event policy selects only meaningful progress, permission, completion, and failure events for model delivery.
 
-### 5.5 Receipts and decisions
+### 5.6 Receipts and decisions
 
 | Event | Direction | Meaning |
 |---|---|---|
@@ -243,7 +292,7 @@ Task progress may be pushed to the Client without being sent to the Realtime mod
 
 `response.done` means generation finished, not that the user heard the response. Delivery workflows that require audible confirmation use playback receipts.
 
-### 5.6 Local mute and external capture ownership
+### 5.7 Local mute and external capture ownership
 
 Local mute stops microphone input at the Client and does not disconnect, cancel Tasks, or suppress output. It does not need a Gateway event.
 
@@ -366,28 +415,30 @@ Event definitions impose payload, rate, retention, and coalescing limits. Latest
 - Built-in actions are capability-gated. Extension actions require an installed and trusted Client/host extension.
 - One active Client may aggregate many local sensors or environment sources without opening more Gateway sockets.
 
-The base API is the existing WebSocket. A future authenticated HTTP or in-process ingestion adapter may translate the same event into `ClientEventIngress`; it must not define a second semantic protocol or consume the active Client slot.
+The base API is the existing WebSocket. Version 6.0 does not expose an independent HTTP, `context_source`, or integration connection that bypasses the active Client. A future deployment that needs direct machine-to-Gateway event ingestion requires an explicit protocol decision; it cannot silently become a second Client role.
 
 ## 10. Relationship to external standards
 
-| Standard | Use | Boundary |
+The Gateway protocol defines its own types. The following alignment is deliberate and non-normative: it helps implementers recognize familiar semantics without importing foreign wire objects.
+
+| Gateway concept or shape | Semantic alignment | Boundary |
 |---|---|---|
-| OpenAI Realtime | Common media, conversation, response, and cancellation vocabulary | Gateway extensions and negotiation are not claimed to be wire-compatible |
-| A2A | Task, state, artifact, and message semantics | A2A transport and native objects remain in its Backend adapter |
-| ACP | Stateful local-agent Backend adapter | ACP Session, Tool Call, and Update objects never enter the Client protocol |
-| AG-UI | Optional read-only projection where useful | Not the 6.0 base transport |
-| MCP / OpenAPI | Frontend tools and external services | Not a substitute for Client Event or Client Action |
+| `input_audio_buffer.*`, `conversation.item.create`, response and audio event names | [OpenAI Realtime](https://platform.openai.com/docs/api-reference/realtime-client-events) media, conversation, response, and cancellation vocabulary | Gateway schemas, handshake, extensions, and lifecycle remain authoritative; full wire compatibility is not claimed |
+| `task_id`, `status.state`, `status.message.parts`, `artifacts[].parts` | [A2A](https://a2a-protocol.org/latest/specification/) Task, status, Message, and Artifact semantics | A2A transport, JSON-RPC objects, remote Task IDs, and Agent Card objects remain inside the A2A Backend adapter |
+| normalized authorization and backend activity | ACP permission, Session update, Tool Call, and plan semantics | ACP request/update objects and Session IDs remain inside the ACP Backend adapter |
+| optional read-only activity projection | AG-UI activity semantics | AG-UI is not the 6.0 base transport or command plane |
+| frontend tools and external services | MCP / OpenAPI tool semantics | They do not replace Client Event, Client Action, or the Gateway runtime command plane |
 
 ## 11. Migration from 5.x
 
 1. Freeze this specification and add characterization tests for current clients.
 2. Add the 6.0 envelope, handshake, capabilities, and parsers while still accepting 5.x aliases.
-3. Add `GatewayEventRouter`, the Client Event registry, and `client.event.publish/result`.
+3. Add `GatewayEventRouter`, the Client Event registry, `client.event.publish/result`, and the WebSocket runtime command/query plane.
 4. Add provider-neutral Agent Delivery and reuse current Task announcement reliability.
 5. Add `ClientActionPort` and `client.action.request/result`; migrate `enter_sleep` first.
 6. Migrate WebUI, TUI, and Desktop through the shared reference Client SDK.
-7. Add replay and full conformance coverage.
-8. Stop emitting 5.x aliases, then remove them only after an announced deprecation release.
+7. Add replay and full conformance coverage; migrate Task, permission, and conversation runtime calls away from internal REST/SSE aliases.
+8. Stop emitting 5.x and REST/SSE runtime aliases, then remove them only after an announced deprecation release.
 
 Health checks, static assets, installation, and settings remain host/operations APIs and are not forced onto the business WebSocket.
 

--- a/docs/gateway-protocol.md
+++ b/docs/gateway-protocol.md
@@ -1,0 +1,420 @@
+# Gateway Client Protocol
+
+> Status: **Draft 0.3**<br>
+> Target wire version: **6.0.0**<br>
+> Roadmap: [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)<br>
+> Current 5.x sources of truth: `shared/realtime-events.mjs`, `shared/protocol/gateway-events.mjs`, and `server/src/core/gateway-protocol.mjs`
+
+This specification defines the northbound boundary between qwen-audio-agent's Gateway and one active Client Environment. It is the target contract for the next protocol major and does not claim that the current 5.x implementation already implements every event below.
+
+## 1. Product boundary
+
+```text
+Client Environment
+        ↕ Gateway Client Protocol
+Gateway Core + Realtime Frontend Agent
+        ↕ BackendPort
+Backend Agent
+```
+
+The three roles are intentionally independent:
+
+- **Gateway Core** owns the Realtime frontend agent, conversation, tools, Task lifecycle, authorization, routing, presentation, and recovery.
+- **Backend Agent** is the user's execution environment. Gateway reaches it only through `BackendPort`, implemented by ACP, A2A, or a custom adapter.
+- **Client Environment** owns I/O, rendering, playback, local UX, sensors, client state, user behavior, and actions available in the surrounding environment.
+
+TUI, WebUI, and Desktop Orb are first-party reference clients. OpenCode, Qwen Code, Pi, OpenClaw, remote A2A agents, and other integrations are reference backends. Neither list limits the framework.
+
+## 2. Invariants
+
+1. One Gateway instance accepts only one active Client connection at a time.
+2. One WebSocket carries the Client's business traffic. A second context or observer socket is not introduced.
+3. Raw audio stays on the media fast path. Only committed semantic inputs enter semantic routing.
+4. Client **Events** describe what happened. Client **Actions** request that the environment do something and return a result.
+5. Realtime Tool Calls are model-facing. `ClientActionPort` maps applicable Tool Calls to Client Actions.
+6. Gateway decides whether an event is handled deterministically, added to model context, answered later, or answered immediately.
+7. Client events cannot spoof Gateway, Task, permission, or backend lifecycle events.
+8. Realtime-provider and backend-protocol objects never cross this boundary.
+9. Local mute, window layout, wake mechanism, and rendering remain client concerns unless they affect shared Gateway state.
+10. Existing behavior remains available through compatibility aliases until every first-party client has migrated and conformance coverage exists.
+
+## 3. Connection and negotiation
+
+The Client connects to `ws://<gateway>/api/realtime`. The first message is `session.hello`.
+
+```jsonc
+{
+  "type": "session.hello",
+  "event_id": "evt_client_1",
+  "protocol": { "min": "6.0.0", "max": "6.0.0" },
+  "client": {
+    "type": "desktop",
+    "version": "1.12.0",
+    "instance_id": "desktop_7f3a"
+  },
+  "capabilities": [
+    "input.audio",
+    "input.text",
+    "input.image",
+    "playback.receipts",
+    "client.events",
+    "client.actions.desktop.presence.enter_sleep",
+    "session.replay"
+  ],
+  "locale": "zh-CN",
+  "time_zone": "Asia/Shanghai"
+}
+```
+
+Gateway returns the selected version and capability intersection:
+
+```jsonc
+{
+  "type": "session.ready",
+  "event_id": "evt_gateway_1",
+  "request_event_id": "evt_client_1",
+  "protocol_version": "6.0.0",
+  "session_id": "session_01",
+  "capabilities": [
+    "input.audio",
+    "input.text",
+    "input.image",
+    "playback.receipts",
+    "client.events",
+    "client.actions.desktop.presence.enter_sleep",
+    "session.replay"
+  ]
+}
+```
+
+Rules:
+
+- With an active Client, a new connection receives `client_occupied` and is closed.
+- The owner is released when the socket closes or its heartbeat expires.
+- No takeover, kick, concurrent observer, or multi-client arbitration exists in 6.0.
+- The Client must branch on negotiated capabilities, not product versions.
+- Protocol version, Client identity, and capabilities cannot change without reconnecting.
+
+## 4. Common event envelope
+
+Gateway follows the flat OpenAI Realtime envelope style:
+
+```jsonc
+{
+  "type": "client.event.publish",
+  "event_id": "evt_client_42",
+  "name": "user.object.touched",
+  "data": { "object_id": "cup" }
+}
+```
+
+| Field | Requirement | Meaning |
+|---|---|---|
+| `type` | Always | Protocol event type |
+| `event_id` | Every JSON event | Stable logical-event identity; replay preserves it |
+| `request_event_id` | Command results and command errors | Identifies the initiating command |
+| `sequence` | Replayable server pushes | Strictly increasing within one Gateway session |
+| `occurred_at` | Semantic events when known | Millisecond timestamp at the event source; Gateway records receipt time separately |
+
+Immediate results and errors are not replayed. Media deltas, incremental transcripts, heartbeat traffic, and `session.replay.result` are also not replayed.
+
+All control messages are UTF-8 JSON text frames. Version 6.0 carries PCM audio as base64 in JSON; a future binary media capability may replace that without changing semantic event routing.
+
+## 5. Protocol planes
+
+### 5.1 User input and media
+
+Use OpenAI Realtime terminology where the semantics match:
+
+| Event | Direction | Meaning |
+|---|---|---|
+| `input_audio_buffer.append` | C→G | Append input audio |
+| `conversation.item.create` | C→G | Submit text, image, file, or mixed user input |
+| `response.cancel` | C→G | Interrupt the current response |
+| `response.created` | G→C | Response generation started |
+| `response.output_audio.delta` / `.done` | G→C | Audio output |
+| `response.output_audio_transcript.delta` / `.done` | G→C | Assistant transcript |
+| `response.done` | G→C | Final response state; cancellation is `response.status = "cancelled"` |
+
+Gateway extensions include `turn.started`, `transcript.discard`, `playback.clear`, and playback receipts. `input_file` is a Gateway content-part extension, not an OpenAI Realtime standard part.
+
+User input is authoritative user intent and opens or supersedes a user turn. Client semantic events never impersonate user input.
+
+### 5.2 Client semantic events
+
+The public, extensible Client-to-Gateway API is:
+
+```text
+client.event.publish
+client.event.publish.result
+```
+
+```jsonc
+{
+  "type": "client.event.publish",
+  "event_id": "evt_client_17",
+  "occurred_at": 1787880000000,
+  "name": "user.object.touched",
+  "data": {
+    "object_id": "cup",
+    "object_name": "水杯"
+  }
+}
+```
+
+```jsonc
+{
+  "type": "client.event.publish.result",
+  "event_id": "evt_gateway_31",
+  "request_event_id": "evt_client_17",
+  "accepted": true
+}
+```
+
+`name` must be registered by the Gateway protocol or an installed extension. Registration defines:
+
+- payload schema and size limits;
+- transient or latest-value retention;
+- deduplication or coalescing key when needed;
+- default routing policy;
+- deterministic handler, if any;
+- provider-neutral model projection, if any;
+- replay and client-presentation behavior.
+
+Suggested namespaces include `desktop.*`, `environment.*`, `vehicle.*`, `hardware.*`, and an extension-owned prefix. Unknown names return `client_event_unsupported`; malformed data returns `client_event_invalid`.
+
+The caller does not choose the final model behavior. An optional `delivery_hint` may be accepted for an event definition that permits it, but Gateway may downgrade and never upgrades the requested urgency.
+
+### 5.3 Client actions
+
+Gateway-to-Client operations use a request/result pair:
+
+```text
+client.action.request
+client.action.result
+```
+
+```jsonc
+{
+  "type": "client.action.request",
+  "event_id": "evt_gateway_51",
+  "name": "desktop.presence.enter_sleep",
+  "arguments": {}
+}
+```
+
+```jsonc
+{
+  "type": "client.action.result",
+  "event_id": "evt_client_52",
+  "request_event_id": "evt_gateway_51",
+  "status": "completed",
+  "output": null
+}
+```
+
+`status` is `completed`, `failed`, or `unsupported`. Failure includes a bounded `{code, message}` object. Gateway exposes an action-derived Realtime tool only when the active Client negotiated the corresponding capability.
+
+Client Action is not a replacement for MCP, OpenAPI, ACP, or A2A. It covers capabilities owned by the connected Client Environment. Other external systems continue to use the appropriate tool or backend adapter.
+
+### 5.4 Gateway state and presentation
+
+Gateway publishes normalized state; the Client renders it without reconstructing Gateway internals:
+
+- `gateway.*` and `voice.*` for connection and frontend state;
+- `response.*`, transcript, and audio events for conversation output;
+- `task.*` for Task lifecycle, activity, artifacts, and notification state;
+- `task.permission.*` for authorization state;
+- `playback.clear` and other explicit presentation controls.
+
+Every public Task keeps one Gateway `task_id`. ACP Session IDs, A2A remote Task IDs, and custom-adapter identifiers remain private to `BackendPort` adapters.
+
+Task progress may be pushed to the Client without being sent to the Realtime model. Gateway's event policy selects only meaningful progress, permission, completion, and failure events for model delivery.
+
+### 5.5 Receipts and decisions
+
+| Event | Direction | Meaning |
+|---|---|---|
+| `playback.started` | C→G | Audible playback started |
+| `playback.ended` | C→G | Audible playback completed |
+| `playback.cancelled` | C→G | Playback was discarded or interrupted |
+| `client.action.result` | C→G | Client action completed or failed |
+| `permission.respond` | C→G | User authorization decision |
+
+`response.done` means generation finished, not that the user heard the response. Delivery workflows that require audible confirmation use playback receipts.
+
+### 5.6 Local mute and external capture ownership
+
+Local mute stops microphone input at the Client and does not disconnect, cancel Tasks, or suppress output. It does not need a Gateway event.
+
+External capture ownership is stronger and remains a shared control workflow:
+
+```text
+input.capture.suspend / input.capture.suspended
+input.capture.resume  / input.capture.resumed
+```
+
+Suspension has a TTL. A trusted Host Contract may request it without creating another Gateway Client connection.
+
+## 6. Internal semantic routing
+
+Public wire types remain distinct, but committed semantic inputs enter one in-process router:
+
+```text
+committed user input ─┐
+Client Event ─────────┤
+Task event ───────────┼→ GatewayEventRouter
+Gateway trigger ──────┘        ├─ deterministic handler
+                               ├─ state/replay projection
+                               ├─ Client presentation
+                               └─ optional AgentDelivery
+```
+
+This router is an in-process registry and dispatcher, not a message broker. Raw audio frames and output deltas bypass it.
+
+An optional provider-neutral `AgentDelivery` records how the Realtime frontend agent should perceive the event:
+
+```js
+{
+  id: 'delivery_123',
+  causeEventId: 'evt_client_17',
+  origin: 'client',
+  text: '用户触摸了桌面上的水杯。',
+  mode: 'context',
+  correlation: { eventName: 'user.object.touched' }
+}
+```
+
+Routing modes are:
+
+- `handle`: deterministic Gateway handling; no `AgentDelivery` is produced;
+- `context`: update model context without creating a response;
+- `respond`: update context and schedule a response at a safe boundary;
+- `interrupt`: interrupt the current response, update context, and request a response.
+
+`AgentDeliveryRuntime` owns user-speech blocking, response serialization, sleep deferral, retry, and playback acknowledgement. Realtime Provider adapters translate the delivery into their own wire protocol. Raw Client JSON is never pasted into a model prompt.
+
+## 7. Presence and sleep
+
+Both sleep modes converge on the same model tool and Client Action path.
+
+### User-requested sleep
+
+```text
+user input → Realtime → optional acknowledgement → enter_sleep
+           → PresenceController → ClientActionPort
+           → desktop.presence.enter_sleep → Client action result
+           → Gateway enters sleeping
+```
+
+The model may speak before the Tool Call or call it directly. The protocol does not mandate farewell text or a playback gate.
+
+### Client automatic sleep
+
+```text
+client.event.publish(desktop.presence.sleep_requested)
+           → GatewayEventRouter → AgentDelivery(respond)
+           → Realtime → optional acknowledgement → enter_sleep
+           → the same PresenceController and ClientActionPort
+```
+
+The Client request may carry a bounded deadline. If the Realtime provider is unavailable, generation fails, or the model does not call `enter_sleep` by that deadline, Gateway invokes the same idempotent `PresenceController` as a fallback. This is not a second sleep implementation.
+
+The state machine is:
+
+```text
+active → sleep_requested → sleeping
+```
+
+Only the first transition issues a Client Action. Concurrent model and timeout requests return `pending` or `already_sleeping`. Gateway marks the state `sleeping` only after a successful Client action result. Sleep does not cancel backend Tasks or discard pending results.
+
+Wake mechanism is a Client concern. A wake event restores presence and lets Gateway reconnect the Realtime provider and deliver pending notifications.
+
+## 8. Replay, errors, and limits
+
+`session.replay` pages replayable pushes by `sequence`; default page size is 50 and maximum is 200. A stale session or sequence returns an explicit error. Reliable replay must exist before equivalent REST/SSE recovery endpoints are removed.
+
+Base error codes include:
+
+```text
+client_occupied
+protocol_version_unsupported
+capability_unsupported
+bad_event
+unknown_type
+client_event_unsupported
+client_event_invalid
+client_action_unsupported
+session_expired
+sequence_expired
+task_not_found
+payload_too_large
+rate_limited
+internal
+```
+
+Errors never expose credentials, backend-native objects, stack traces, or sensitive local paths.
+
+Event definitions impose payload, rate, retention, and coalescing limits. Latest-value state must replace an existing key rather than append indefinitely. High-frequency sensors publish semantic changes, not raw sample or pointer streams.
+
+## 9. Trust and extension model
+
+- Gateway stamps the authenticated Client identity; a caller cannot claim an arbitrary trusted source.
+- `client.event.publish` cannot publish a top-level `task.*`, `permission.*`, `gateway.*`, or `response.*` event.
+- Model projections mark Client Event content as an observation or environment event, not a system instruction or user command.
+- Extensions register names, schemas, projectors, and policies at Gateway composition time.
+- Built-in actions are capability-gated. Extension actions require an installed and trusted Client/host extension.
+- One active Client may aggregate many local sensors or environment sources without opening more Gateway sockets.
+
+The base API is the existing WebSocket. A future authenticated HTTP or in-process ingestion adapter may translate the same event into `ClientEventIngress`; it must not define a second semantic protocol or consume the active Client slot.
+
+## 10. Relationship to external standards
+
+| Standard | Use | Boundary |
+|---|---|---|
+| OpenAI Realtime | Common media, conversation, response, and cancellation vocabulary | Gateway extensions and negotiation are not claimed to be wire-compatible |
+| A2A | Task, state, artifact, and message semantics | A2A transport and native objects remain in its Backend adapter |
+| ACP | Stateful local-agent Backend adapter | ACP Session, Tool Call, and Update objects never enter the Client protocol |
+| AG-UI | Optional read-only projection where useful | Not the 6.0 base transport |
+| MCP / OpenAPI | Frontend tools and external services | Not a substitute for Client Event or Client Action |
+
+## 11. Migration from 5.x
+
+1. Freeze this specification and add characterization tests for current clients.
+2. Add the 6.0 envelope, handshake, capabilities, and parsers while still accepting 5.x aliases.
+3. Add `GatewayEventRouter`, the Client Event registry, and `client.event.publish/result`.
+4. Add provider-neutral Agent Delivery and reuse current Task announcement reliability.
+5. Add `ClientActionPort` and `client.action.request/result`; migrate `enter_sleep` first.
+6. Migrate WebUI, TUI, and Desktop through the shared reference Client SDK.
+7. Add replay and full conformance coverage.
+8. Stop emitting 5.x aliases, then remove them only after an announced deprecation release.
+
+Health checks, static assets, installation, and settings remain host/operations APIs and are not forced onto the business WebSocket.
+
+## 12. Conformance requirements
+
+Before 6.0 becomes stable, tests must cover:
+
+- global single-Client ownership, release, and heartbeat expiry;
+- version and capability negotiation;
+- `event_id`, `request_event_id`, and replay `sequence` semantics;
+- user input versus Client Event authority;
+- registered, unknown, malformed, duplicated, rate-limited, and coalesced Client Events;
+- all four routing modes without duplicate model delivery;
+- provider-neutral context-only and response delivery on every Realtime provider;
+- Client Action capability gating, results, failures, timeout, and reconnect behavior;
+- active and automatic sleep converging on one idempotent state machine;
+- model failure fallback for Client-requested automatic sleep;
+- local mute versus external capture suspension;
+- Task and permission projections without backend protocol leakage;
+- first-party WebUI, TUI, and Desktop behavior through one contract suite.
+
+## 13. Non-goals
+
+- Multi-user or multi-Client concurrency, observers, takeover, and kick semantics.
+- Exposing Electron, React, CoreAudio, or a specific Client implementation in Gateway Core.
+- Treating ACP as the only backend protocol.
+- Allowing arbitrary Client data to become model instructions.
+- Requiring every Client Event or Task progress update to reach the model or produce speech.
+- Implementing wake-word detection, window layout, or local mute in Gateway Core.
+- Removing recovery APIs before replay is proven reliable.

--- a/docs/gateway-protocol.zh.md
+++ b/docs/gateway-protocol.zh.md
@@ -1,0 +1,420 @@
+# Gateway Client Protocol
+
+> 状态：**Draft 0.3**<br>
+> 目标线协议版本：**6.0.0**<br>
+> Roadmap：[GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)<br>
+> 当前 5.x 实现事实源：`shared/realtime-events.mjs`、`shared/protocol/gateway-events.mjs` 与 `server/src/core/gateway-protocol.mjs`
+
+本文档定义 qwen-audio-agent Gateway 与唯一活动 Client Environment 之间的北向协议。它描述的是下一主版本的目标契约，不代表当前 5.x 已经实现全部事件。
+
+## 1. 产品边界
+
+```text
+Client Environment
+        ↕ Gateway Client Protocol
+Gateway Core + Realtime Frontend Agent
+        ↕ BackendPort
+Backend Agent
+```
+
+三个角色相互独立：
+
+- **Gateway Core** 管理 Realtime 前台 Agent、对话、工具、Task 生命周期、权限、路由、Presentation 与恢复。
+- **Backend Agent** 是用户提供的执行环境。Gateway 只通过 `BackendPort` 访问，由 ACP、A2A 或自定义 Adapter 实现。
+- **Client Environment** 负责 I/O、显示、播放、本地 UX、传感器、客户端状态、用户行为和外部环境动作。
+
+TUI、WebUI 和桌面悬浮球是第一方参考客户端；OpenCode、Qwen Code、Pi、OpenClaw、远程 A2A Agent 等是参考后台。两者都不限制框架可接入的实现。
+
+## 2. 架构不变量
+
+1. 同一个 Gateway 实例同一时刻只接受一个活动 Client 连接。
+2. Client 的业务流量使用一条 WebSocket，不额外建立 context 或 observer 连接。
+3. 原始音频走媒体快速路径，只有已经提交的语义输入进入语义路由。
+4. Client **Event** 描述发生了什么；Client **Action** 要求环境执行操作并返回结果。
+5. Realtime Tool Call 是模型接口；适用的 Tool Call 由 `ClientActionPort` 映射为 Client Action。
+6. Gateway 决定事件是确定性处理、只进入模型上下文、稍后回复还是立即回复。
+7. Client Event 不能伪造 Gateway、Task、权限或后台生命周期事件。
+8. Realtime Provider 与后台协议的原生对象不能跨越本边界。
+9. 本地静音、窗口布局、唤醒手段和渲染属于 Client；只有影响共享状态的部分进入协议。
+10. 在全部第一方客户端完成迁移并具备 conformance coverage 前，现有行为通过兼容别名继续可用。
+
+## 3. 连接与能力协商
+
+Client 连接 `ws://<gateway>/api/realtime`，第一条消息必须是 `session.hello`。
+
+```jsonc
+{
+  "type": "session.hello",
+  "event_id": "evt_client_1",
+  "protocol": { "min": "6.0.0", "max": "6.0.0" },
+  "client": {
+    "type": "desktop",
+    "version": "1.12.0",
+    "instance_id": "desktop_7f3a"
+  },
+  "capabilities": [
+    "input.audio",
+    "input.text",
+    "input.image",
+    "playback.receipts",
+    "client.events",
+    "client.actions.desktop.presence.enter_sleep",
+    "session.replay"
+  ],
+  "locale": "zh-CN",
+  "time_zone": "Asia/Shanghai"
+}
+```
+
+Gateway 返回协商后的版本与能力交集：
+
+```jsonc
+{
+  "type": "session.ready",
+  "event_id": "evt_gateway_1",
+  "request_event_id": "evt_client_1",
+  "protocol_version": "6.0.0",
+  "session_id": "session_01",
+  "capabilities": [
+    "input.audio",
+    "input.text",
+    "input.image",
+    "playback.receipts",
+    "client.events",
+    "client.actions.desktop.presence.enter_sleep",
+    "session.replay"
+  ]
+}
+```
+
+规则：
+
+- 已有活动 Client 时，新连接收到 `client_occupied` 后关闭。
+- WebSocket 关闭或心跳超时后释放连接所有权。
+- 6.0 不提供接管、踢出、并发观察或多 Client 仲裁。
+- Client 必须依据协商后的 capabilities 判断能力，不能只比较产品版本。
+- 协议版本、Client 身份和能力不能在当前连接中改变；需要改变时重连。
+
+## 4. 通用事件信封
+
+Gateway 采用扁平的 OpenAI Realtime 风格信封：
+
+```jsonc
+{
+  "type": "client.event.publish",
+  "event_id": "evt_client_42",
+  "name": "user.object.touched",
+  "data": { "object_id": "cup" }
+}
+```
+
+| 字段 | 要求 | 语义 |
+|---|---|---|
+| `type` | 始终必填 | 协议事件类型 |
+| `event_id` | 每个 JSON 事件 | 稳定的逻辑事件标识；回放保持原值 |
+| `request_event_id` | 命令结果与命令错误 | 指向发起命令 |
+| `sequence` | 可回放的服务端推送 | 在同一 Gateway Session 内严格递增 |
+| `occurred_at` | 已知发生时间的语义事件 | 事件源的毫秒时间戳；Gateway 另记接收时间 |
+
+即时命令结果和错误不回放。媒体增量、转写增量、心跳以及 `session.replay.result` 也不回放。
+
+所有控制消息使用 UTF-8 JSON 文本帧。6.0 在 JSON 中以 base64 承载 PCM 音频；未来可以通过能力协商增加二进制媒体帧，而不改变语义事件路由。
+
+## 5. 协议面
+
+### 5.1 用户输入与媒体
+
+语义相同时采用 OpenAI Realtime 词汇：
+
+| 事件 | 方向 | 语义 |
+|---|---|---|
+| `input_audio_buffer.append` | C→G | 追加输入音频 |
+| `conversation.item.create` | C→G | 提交文本、图片、文件或混合用户输入 |
+| `response.cancel` | C→G | 打断当前回复 |
+| `response.created` | G→C | 回复开始生成 |
+| `response.output_audio.delta` / `.done` | G→C | 音频输出 |
+| `response.output_audio_transcript.delta` / `.done` | G→C | 助手转写 |
+| `response.done` | G→C | 回复最终状态；取消使用 `response.status = "cancelled"` |
+
+Gateway 扩展包括 `turn.started`、`transcript.discard`、`playback.clear` 和播放回执。`input_file` 是 Gateway content part 扩展，不属于 OpenAI Realtime 标准字段。
+
+用户输入代表明确的用户意图，会开启或替代用户轮次。Client 语义事件不能伪装成用户输入。
+
+### 5.2 Client 语义事件
+
+公开、可扩展的 Client-to-Gateway API：
+
+```text
+client.event.publish
+client.event.publish.result
+```
+
+```jsonc
+{
+  "type": "client.event.publish",
+  "event_id": "evt_client_17",
+  "occurred_at": 1787880000000,
+  "name": "user.object.touched",
+  "data": {
+    "object_id": "cup",
+    "object_name": "水杯"
+  }
+}
+```
+
+```jsonc
+{
+  "type": "client.event.publish.result",
+  "event_id": "evt_gateway_31",
+  "request_event_id": "evt_client_17",
+  "accepted": true
+}
+```
+
+`name` 必须由 Gateway 协议或已安装扩展注册。注册定义：
+
+- payload Schema 与大小限制；
+- 一次性或最新值保存策略；
+- 必要时的去重或合并键；
+- 默认路由策略；
+- 可选的确定性 Handler；
+- 可选的 Provider 无关模型投影；
+- 回放和客户端展示行为。
+
+建议命名空间包括 `desktop.*`、`environment.*`、`vehicle.*`、`hardware.*` 和扩展自己的前缀。未知名称返回 `client_event_unsupported`，不合法数据返回 `client_event_invalid`。
+
+调用方不能决定最终模型行为。事件定义可以选择接受 `delivery_hint`，但 Gateway 只能降级紧急程度，不能升级。
+
+### 5.3 Client Action
+
+Gateway-to-Client 操作使用请求/结果事件：
+
+```text
+client.action.request
+client.action.result
+```
+
+```jsonc
+{
+  "type": "client.action.request",
+  "event_id": "evt_gateway_51",
+  "name": "desktop.presence.enter_sleep",
+  "arguments": {}
+}
+```
+
+```jsonc
+{
+  "type": "client.action.result",
+  "event_id": "evt_client_52",
+  "request_event_id": "evt_gateway_51",
+  "status": "completed",
+  "output": null
+}
+```
+
+`status` 为 `completed`、`failed` 或 `unsupported`。失败包含有界的 `{code, message}`。只有活动 Client 协商了相应 capability，Gateway 才向 Realtime 暴露由该 Action 派生的工具。
+
+Client Action 不替代 MCP、OpenAPI、ACP 或 A2A。它只用于当前 Client Environment 自己拥有的能力；其他外部系统继续使用适合的工具或 Backend Adapter。
+
+### 5.4 Gateway 状态与 Presentation
+
+Gateway 发布规范化状态，Client 不需要反向推导内部状态机：
+
+- `gateway.*`、`voice.*`：连接和前台状态；
+- `response.*`、转写和音频事件：对话输出；
+- `task.*`：Task 生命周期、活动、Artifact 与通知状态；
+- `task.permission.*`：权限状态；
+- `playback.clear` 等明确的展示控制。
+
+每个公开 Task 只有一个 Gateway `task_id`。ACP Session ID、A2A 远程 Task ID 和自定义 Adapter ID 留在 `BackendPort` Adapter 内部。
+
+Task 进展可以推送给 Client，但不一定进入 Realtime 模型。Gateway Event Policy 只选择有意义的进展、权限、完成和失败事件进行模型投递。
+
+### 5.5 回执与决策
+
+| 事件 | 方向 | 语义 |
+|---|---|---|
+| `playback.started` | C→G | 实际播放已经开始 |
+| `playback.ended` | C→G | 实际播放已经完成 |
+| `playback.cancelled` | C→G | 播放被丢弃或打断 |
+| `client.action.result` | C→G | Client Action 完成或失败 |
+| `permission.respond` | C→G | 用户授权决策 |
+
+`response.done` 只表示生成完成，不表示用户已经听到。确实需要可听送达确认的工作流使用播放回执。
+
+### 5.6 本地静音与外部采集占用
+
+本地静音只在 Client 停止麦克风输入，不断开连接、不取消 Task、不抑制输出，不需要 Gateway 事件。
+
+外部采集占用更强，仍然是共享控制工作流：
+
+```text
+input.capture.suspend / input.capture.suspended
+input.capture.resume  / input.capture.resumed
+```
+
+暂停必须有 TTL。可信 Host Contract 可以请求暂停，而不建立第二个 Gateway Client 连接。
+
+## 6. 内部语义路由
+
+公开线协议保留类型，提交后的语义输入进入同一个进程内 Router：
+
+```text
+已提交用户输入 ─┐
+Client Event ────┤
+Task Event ──────┼→ GatewayEventRouter
+Gateway Trigger ─┘        ├─ 确定性 Handler
+                          ├─ 状态/回放投影
+                          ├─ Client Presentation
+                          └─ 可选 AgentDelivery
+```
+
+它是进程内 Registry 与 Dispatcher，不是消息中间件。原始音频帧和输出增量绕过它。
+
+可选的 Provider 无关 `AgentDelivery` 描述 Realtime 前台 Agent 如何感知事件：
+
+```js
+{
+  id: 'delivery_123',
+  causeEventId: 'evt_client_17',
+  origin: 'client',
+  text: '用户触摸了桌面上的水杯。',
+  mode: 'context',
+  correlation: { eventName: 'user.object.touched' }
+}
+```
+
+路由模式：
+
+- `handle`：Gateway 确定性处理，不产生 `AgentDelivery`；
+- `context`：更新模型上下文，不创建回复；
+- `respond`：更新上下文，在安全边界安排回复；
+- `interrupt`：打断当前回复、更新上下文并请求回复。
+
+`AgentDeliveryRuntime` 管理用户说话阻塞、回复串行化、休眠暂存、重试和播放确认。Realtime Provider Adapter 再转换成自己的线协议。不能把 Client 原始 JSON 直接粘贴进模型 Prompt。
+
+## 7. Presence 与休眠
+
+两种休眠最终进入同一个模型工具和 Client Action 链路。
+
+### 用户主动休眠
+
+```text
+用户输入 → Realtime → 可选承接语 → enter_sleep
+         → PresenceController → ClientActionPort
+         → desktop.presence.enter_sleep → Client Action Result
+         → Gateway 进入 sleeping
+```
+
+模型可以先说话，也可以直接调用工具。协议不强制告别话术，也不强制等待播放结束。
+
+### Client 自动休眠
+
+```text
+client.event.publish(desktop.presence.sleep_requested)
+         → GatewayEventRouter → AgentDelivery(respond)
+         → Realtime → 可选承接语 → enter_sleep
+         → 同一个 PresenceController 与 ClientActionPort
+```
+
+Client 请求可以携带有界 deadline。Realtime Provider 不可用、生成失败，或模型在 deadline 前没有调用 `enter_sleep` 时，Gateway 以同一个幂等 `PresenceController` 执行兜底。这不是第二套休眠实现。
+
+状态机：
+
+```text
+active → sleep_requested → sleeping
+```
+
+只有第一次转换发出 Client Action。模型调用与超时兜底并发时，重复请求返回 `pending` 或 `already_sleeping`。只有 Client Action 成功后，Gateway 才标记为 `sleeping`。休眠不会取消后台 Task，也不会丢弃待播报结果。
+
+唤醒手段属于 Client。唤醒事件恢复 Presence，Gateway 重连 Realtime Provider 并投递暂存通知。
+
+## 8. 回放、错误与限制
+
+`session.replay` 按 `sequence` 分页回放服务端推送，默认 50、最大 200。过期 Session 或 sequence 返回明确错误。在可靠回放完成前，不能删除等价的 REST/SSE 恢复接口。
+
+基础错误码：
+
+```text
+client_occupied
+protocol_version_unsupported
+capability_unsupported
+bad_event
+unknown_type
+client_event_unsupported
+client_event_invalid
+client_action_unsupported
+session_expired
+sequence_expired
+task_not_found
+payload_too_large
+rate_limited
+internal
+```
+
+错误不能暴露凭据、后台原生对象、堆栈或敏感本机路径。
+
+事件定义负责 payload、频率、保存和合并限制。最新状态必须覆盖原有 key，不能无限追加。高频传感器应发布语义变化，不能直接发布原始采样或鼠标移动流。
+
+## 9. 信任与扩展
+
+- Gateway 根据连接身份填写可信 Client 来源，调用方不能自称任意可信 source。
+- `client.event.publish` 不能发布顶层 `task.*`、`permission.*`、`gateway.*` 或 `response.*` 事件。
+- 模型投影将 Client Event 标记为观察或环境事件，而不是系统指令或用户命令。
+- 扩展在 Gateway 组合时注册名称、Schema、Projector 和 Policy。
+- 内置 Action 需要 capability；扩展 Action 需要已安装且可信的 Client/Host 扩展。
+- 一个活动 Client 可以聚合多个本地传感器和环境来源，不需要增加 Gateway Socket。
+
+基础 API 使用现有 WebSocket。未来可增加带认证的 HTTP 或进程内 Ingress Adapter，将同一事件转换到 `ClientEventIngress`；它不能定义第二套语义协议，也不能占用活动 Client 槽位。
+
+## 10. 与外部标准的关系
+
+| 标准 | 使用方式 | 边界 |
+|---|---|---|
+| OpenAI Realtime | 常见媒体、对话、回复和取消词汇 | Gateway 扩展与握手不宣称完整线兼容 |
+| A2A | Task、状态、Artifact 与消息语义 | A2A 传输和原生对象留在 Backend Adapter |
+| ACP | 有状态本地 Agent Backend Adapter | ACP Session、Tool Call 与 Update 不进入 Client 协议 |
+| AG-UI | 可选的只读投影 | 不作为 6.0 基线传输 |
+| MCP / OpenAPI | 前台工具与外部服务 | 不替代 Client Event 或 Client Action |
+
+## 11. 从 5.x 迁移
+
+1. 固化本文档，为当前客户端增加 characterization tests。
+2. 增加 6.0 信封、握手、capabilities 和 Parser，同时继续接受 5.x 别名。
+3. 增加 `GatewayEventRouter`、Client Event Registry 和 `client.event.publish/result`。
+4. 增加 Provider 无关 Agent Delivery，复用当前 Task 播报可靠性。
+5. 增加 `ClientActionPort` 和 `client.action.request/result`，首先迁移 `enter_sleep`。
+6. WebUI、TUI、Desktop 依次迁移到共享参考 Client SDK。
+7. 增加回放与完整 conformance coverage。
+8. 停止写出 5.x 别名，并在明确的废弃版本之后删除。
+
+健康检查、静态资源、安装和设置仍是 Host/运维 API，不强制迁移到业务 WebSocket。
+
+## 12. Conformance 要求
+
+6.0 稳定前至少覆盖：
+
+- 全局单 Client 占用、释放和心跳超时；
+- 版本与 capability 协商；
+- `event_id`、`request_event_id` 和回放 `sequence`；
+- 用户输入与 Client Event 的权限差异；
+- 已注册、未知、不合法、重复、限流和合并 Client Event；
+- 四种路由模式且不重复投递模型；
+- 所有 Realtime Provider 的 Provider 无关 context-only 与 response 投递；
+- Client Action capability、结果、失败、超时与重连；
+- 主动休眠与自动休眠进入同一个幂等状态机；
+- Client 自动休眠时的模型失败兜底；
+- 本地静音与外部采集暂停；
+- Task、权限投影不泄漏后台协议；
+- WebUI、TUI 和 Desktop 通过同一套契约测试。
+
+## 13. 明确不做
+
+- 多用户、多 Client 并发、Observer、接管或踢出。
+- 在 Gateway Core 中依赖 Electron、React、CoreAudio 或具体 Client。
+- 将 ACP 规定为唯一后台协议。
+- 允许任意 Client 数据成为模型指令。
+- 强制每个 Client Event 或 Task 进展进入模型或产生播报。
+- 在 Gateway Core 实现唤醒词、窗口布局或本地静音。
+- 在可靠回放完成前删除恢复接口。

--- a/docs/gateway-protocol.zh.md
+++ b/docs/gateway-protocol.zh.md
@@ -1,6 +1,6 @@
 # Gateway Client Protocol
 
-> 状态：**Draft 0.3**<br>
+> 状态：**Draft 0.4**<br>
 > 目标线协议版本：**6.0.0**<br>
 > Roadmap：[GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)<br>
 > 当前 5.x 实现事实源：`shared/realtime-events.mjs`、`shared/protocol/gateway-events.mjs` 与 `server/src/core/gateway-protocol.mjs`
@@ -34,7 +34,7 @@ TUI、WebUI 和桌面悬浮球是第一方参考客户端；OpenCode、Qwen Code
 5. Realtime Tool Call 是模型接口；适用的 Tool Call 由 `ClientActionPort` 映射为 Client Action。
 6. Gateway 决定事件是确定性处理、只进入模型上下文、稍后回复还是立即回复。
 7. Client Event 不能伪造 Gateway、Task、权限或后台生命周期事件。
-8. Realtime Provider 与后台协议的原生对象不能跨越本边界。
+8. Realtime Provider 与后台协议的原生协议对象不能跨越本边界。所有公开类型由 Gateway 定义；语义一致时，可以刻意对齐外部标准中熟悉的字段命名和形状。
 9. 本地静音、窗口布局、唤醒手段和渲染属于 Client；只有影响共享状态的部分进入协议。
 10. 在全部第一方客户端完成迁移并具备 conformance coverage 前，现有行为通过兼容别名继续可用。
 
@@ -57,6 +57,9 @@ Client 连接 `ws://<gateway>/api/realtime`，第一条消息必须是 `session.
     "input.text",
     "input.image",
     "playback.receipts",
+    "tasks.commands",
+    "permissions.respond",
+    "conversation.history",
     "client.events",
     "client.actions.desktop.presence.enter_sleep",
     "session.replay"
@@ -80,6 +83,9 @@ Gateway 返回协商后的版本与能力交集：
     "input.text",
     "input.image",
     "playback.receipts",
+    "tasks.commands",
+    "permissions.respond",
+    "conversation.history",
     "client.events",
     "client.actions.desktop.presence.enter_sleep",
     "session.replay"
@@ -94,6 +100,7 @@ Gateway 返回协商后的版本与能力交集：
 - 6.0 不提供接管、踢出、并发观察或多 Client 仲裁。
 - Client 必须依据协商后的 capabilities 判断能力，不能只比较产品版本。
 - 协议版本、Client 身份和能力不能在当前连接中改变；需要改变时重连。
+- 6.0 不定义 `context_source`、`integration` 或 Observer 连接角色。车辆总线、CRM、传感器等上下文来源通过客户端侧 Adapter 接入当前活动 Client Environment，再由该 Client 校验并转发已注册的语义事件。
 
 ## 4. 通用事件信封
 
@@ -117,6 +124,8 @@ Gateway 采用扁平的 OpenAI Realtime 风格信封：
 | `occurred_at` | 已知发生时间的语义事件 | 事件源的毫秒时间戳；Gateway 另记接收时间 |
 
 即时命令结果和错误不回放。媒体增量、转写增量、心跳以及 `session.replay.result` 也不回放。
+
+命名相似是有意为之，但本文定义的 Schema 才是权威契约。复用标准字段名或兼容形状，不代表引入该标准的对象类型，也不宣称线兼容。
 
 所有控制消息使用 UTF-8 JSON 文本帧。6.0 在 JSON 中以 base64 承载 PCM 音频；未来可以通过能力协商增加二进制媒体帧，而不改变语义事件路由。
 
@@ -217,7 +226,26 @@ client.action.result
 
 Client Action 不替代 MCP、OpenAPI、ACP 或 A2A。它只用于当前 Client Environment 自己拥有的能力；其他外部系统继续使用适合的工具或 Backend Adapter。
 
-### 5.4 Gateway 状态与 Presentation
+### 5.4 运行时命令与查询
+
+活动 Client 通过同一个 WebSocket 发起运行时命令与查询。每个命令携带 `event_id`；即时 `<command>.result` 通过 `request_event_id` 关联请求。后续生命周期变化仍作为普通、可回放的服务端推送发布，不能隐藏在命令结果中。
+
+| 命令 | 方向 | 语义 |
+|---|---|---|
+| `task.create` | C→G | 显式创建异步 Task，不伪装成对话中的用户输入 |
+| `task.get` / `task.list` | C→G | 查询一个 Task，或读取有界、可筛选的 Task 快照 |
+| `task.cancel` | C→G | 请求取消一个 Task；最终状态由后续生命周期事件报告 |
+| `permission.respond` | C→G | 处理当前等待中的授权请求 |
+| `conversation.history` | C→G | 读取有界、对 Client 安全的对话投影 |
+| `session.replay` | C→G | 从 sequence 游标回放符合条件的服务端推送 |
+
+`task.create` 使用与 A2A 语义对齐的 `message.parts`，而不是另设只能传纯文本的 objective 字段。这样显式集成可以提交文本、文件或结构化 Part，同时不引入 A2A Message 原生对象。
+
+这是 Client 的运行时控制面。等价的内部 REST/SSE 路由作为迁移别名保留，直到所有第一方 Client 都改用 WebSocket 命令和回放路径。REST 仍适合启动发现、健康检查、静态配置，以及不属于活动 Client Session 的 Host 管理操作。
+
+`task.create` 是显式集成命令，不是常规语音聊天路径。对话请求仍由前台 Agent 通过工具创建 Task，以保留它的路由判断和自然承接行为。
+
+### 5.5 Gateway 状态与 Presentation
 
 Gateway 发布规范化状态，Client 不需要反向推导内部状态机：
 
@@ -229,9 +257,30 @@ Gateway 发布规范化状态，Client 不需要反向推导内部状态机：
 
 每个公开 Task 只有一个 Gateway `task_id`。ACP Session ID、A2A 远程 Task ID 和自定义 Adapter ID 留在 `BackendPort` Adapter 内部。
 
+Task 快照和更新使用 Gateway 自己的包装，但嵌套形状刻意与 A2A 语义对齐：
+
+```jsonc
+{
+  "type": "task.updated",
+  "event_id": "evt_gateway_88",
+  "sequence": 41,
+  "task_id": "task_42",
+  "status": {
+    "state": "working",
+    "message": {
+      "role": "agent",
+      "parts": [{ "text": "正在检查磁盘空间。" }]
+    }
+  },
+  "artifacts": []
+}
+```
+
+状态词汇和事件生命周期由 Gateway 定义。嵌套的 `status.state`、`status.message.parts` 和 `artifacts[].parts` 便于复用 Adapter 与 UI，但不属于 A2A 原生对象。
+
 Task 进展可以推送给 Client，但不一定进入 Realtime 模型。Gateway Event Policy 只选择有意义的进展、权限、完成和失败事件进行模型投递。
 
-### 5.5 回执与决策
+### 5.6 回执与决策
 
 | 事件 | 方向 | 语义 |
 |---|---|---|
@@ -243,7 +292,7 @@ Task 进展可以推送给 Client，但不一定进入 Realtime 模型。Gateway
 
 `response.done` 只表示生成完成，不表示用户已经听到。确实需要可听送达确认的工作流使用播放回执。
 
-### 5.6 本地静音与外部采集占用
+### 5.7 本地静音与外部采集占用
 
 本地静音只在 Client 停止麦克风输入，不断开连接、不取消 Task、不抑制输出，不需要 Gateway 事件。
 
@@ -366,28 +415,30 @@ internal
 - 内置 Action 需要 capability；扩展 Action 需要已安装且可信的 Client/Host 扩展。
 - 一个活动 Client 可以聚合多个本地传感器和环境来源，不需要增加 Gateway Socket。
 
-基础 API 使用现有 WebSocket。未来可增加带认证的 HTTP 或进程内 Ingress Adapter，将同一事件转换到 `ClientEventIngress`；它不能定义第二套语义协议，也不能占用活动 Client 槽位。
+基础 API 使用现有 WebSocket。6.0 不提供绕过活动 Client 的独立 HTTP、`context_source` 或 Integration 连接。未来部署若需要机器直接向 Gateway 投递事件，必须重新做出明确协议决策，不能悄悄演变成第二种 Client 角色。
 
 ## 10. 与外部标准的关系
 
-| 标准 | 使用方式 | 边界 |
+Gateway 协议定义自己的类型。下表是刻意且非规范性的语义对齐：帮助实现者识别熟悉概念，但不引入外部标准的原生协议对象。
+
+| Gateway 概念或形状 | 语义对齐 | 边界 |
 |---|---|---|
-| OpenAI Realtime | 常见媒体、对话、回复和取消词汇 | Gateway 扩展与握手不宣称完整线兼容 |
-| A2A | Task、状态、Artifact 与消息语义 | A2A 传输和原生对象留在 Backend Adapter |
-| ACP | 有状态本地 Agent Backend Adapter | ACP Session、Tool Call 与 Update 不进入 Client 协议 |
-| AG-UI | 可选的只读投影 | 不作为 6.0 基线传输 |
-| MCP / OpenAPI | 前台工具与外部服务 | 不替代 Client Event 或 Client Action |
+| `input_audio_buffer.*`、`conversation.item.create`、回复与音频事件名 | [OpenAI Realtime](https://platform.openai.com/docs/api-reference/realtime-client-events) 的媒体、对话、回复与取消词汇 | Gateway Schema、握手、扩展和生命周期才是权威契约；不宣称完整线兼容 |
+| `task_id`、`status.state`、`status.message.parts`、`artifacts[].parts` | [A2A](https://a2a-protocol.org/latest/specification/) 的 Task、状态、Message 与 Artifact 语义 | A2A 传输、JSON-RPC 对象、远程 Task ID 和 Agent Card 留在 A2A Backend Adapter 内部 |
+| 规范化权限和后台活动 | ACP 的权限、Session Update、Tool Call 与计划语义 | ACP 请求/更新对象与 Session ID 留在 ACP Backend Adapter 内部 |
+| 可选的只读活动投影 | AG-UI 活动语义 | AG-UI 不作为 6.0 基线传输或命令面 |
+| 前台工具和外部服务 | MCP / OpenAPI 工具语义 | 不替代 Client Event、Client Action 或 Gateway 运行时命令面 |
 
 ## 11. 从 5.x 迁移
 
 1. 固化本文档，为当前客户端增加 characterization tests。
 2. 增加 6.0 信封、握手、capabilities 和 Parser，同时继续接受 5.x 别名。
-3. 增加 `GatewayEventRouter`、Client Event Registry 和 `client.event.publish/result`。
+3. 增加 `GatewayEventRouter`、Client Event Registry、`client.event.publish/result` 和 WebSocket 运行时命令/查询面。
 4. 增加 Provider 无关 Agent Delivery，复用当前 Task 播报可靠性。
 5. 增加 `ClientActionPort` 和 `client.action.request/result`，首先迁移 `enter_sleep`。
 6. WebUI、TUI、Desktop 依次迁移到共享参考 Client SDK。
-7. 增加回放与完整 conformance coverage。
-8. 停止写出 5.x 别名，并在明确的废弃版本之后删除。
+7. 增加回放与完整 conformance coverage；把 Task、权限和对话运行时调用从内部 REST/SSE 别名迁走。
+8. 停止写出 5.x 与 REST/SSE 运行时别名，并在明确的废弃版本之后删除。
 
 健康检查、静态资源、安装和设置仍是 Host/运维 API，不强制迁移到业务 WebSocket。
 

--- a/docs/roadmap/gateway-client-protocol.md
+++ b/docs/roadmap/gateway-client-protocol.md
@@ -1,0 +1,122 @@
+# Gateway Client Protocol Roadmap
+
+> Status: proposal
+>
+> Tracking: [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)
+>
+> Spec: [Gateway Client Protocol](../gateway-protocol.md)
+
+## Goal
+
+Complete qwen-audio-agent's remaining public architecture boundary. `BackendPort` already isolates Gateway from ACP, A2A, and custom Backend Agents. This roadmap isolates Gateway Core from TUI, WebUI, Desktop Orb, and future Client Environments.
+
+The resulting framework has three replaceable edges:
+
+```text
+Client Environment
+        ↕ Gateway Client Protocol / ClientPort
+Gateway Core
+        ├─ RealtimeProvider
+        ↕ BackendPort
+Backend Agent
+```
+
+## Current baseline
+
+The repository already has:
+
+- one WebSocket carrying voice, text, playback receipts, Task events, and state;
+- shared event constants and Zod message schemas;
+- a dedicated user-input runtime;
+- normalized BackendPort events and Task projections;
+- provider-neutral result and permission injection primitives;
+- Task announcement queuing, retry, and playback acknowledgement;
+- first-party WebUI, TUI, and Desktop clients.
+
+The remaining gaps are:
+
+- Client dispatch is still concentrated in `realtime-gateway.mjs`;
+- desktop capabilities and sleep behavior still appear as special cases;
+- no generic Client-to-Gateway semantic event API exists;
+- no generic Gateway-to-Client action/result contract exists;
+- user input, Task announcements, permissions, and Gateway triggers do not yet share one semantic event/delivery boundary;
+- no 6.0 handshake, event correlation, or complete Client conformance suite exists.
+
+## Architectural rules
+
+1. Keep one active Client per Gateway.
+2. Keep raw media off the semantic event router.
+3. Keep user input, Client Event, Task event, and Client Action authority distinct.
+4. Let Gateway policy decide model visibility and response timing.
+5. Project semantic events into provider-neutral Agent Delivery values before provider encoding.
+6. Derive model-visible Client tools from negotiated Client Action capabilities.
+7. Keep every stage backward compatible until all first-party clients have migrated.
+8. Land every stage as a separately reviewable PR linked to issue #251.
+
+## GCP0 — Freeze the contract
+
+- [ ] Merge the bilingual protocol spec and this roadmap.
+- [ ] Record current 5.x aliases and characterization coverage.
+- [ ] Add the protocol documents to the public contract index.
+
+Exit criteria: terminology, single-Client ownership, Event versus Action semantics, routing modes, sleep convergence, and migration policy are reviewable in one place.
+
+## GCP1 — Envelope, handshake, and capabilities
+
+- [ ] Add 6.0 envelope schemas for `event_id`, `request_event_id`, and replay `sequence`.
+- [ ] Add `session.hello` / `session.ready` negotiation.
+- [ ] Add capability constants for Client Event, Client Action, and replay.
+- [ ] Keep 5.x `connect` and event aliases working through a normalization layer.
+- [ ] Publish shared parser and Client SDK helpers.
+
+Exit criteria: a 5.x and a 6.0 reference Client can connect to the same Gateway without divergent business logic.
+
+## GCP2 — Client Event ingress
+
+- [ ] Add the Client Event definition registry.
+- [ ] Add `GatewayEventRouter` and `client.event.publish/result`.
+- [ ] Stamp trusted source identity at the connection boundary.
+- [ ] Enforce schema, size, rate, retention, deduplication, and coalescing policy.
+- [ ] Add `desktop.presence.sleep_requested` as the first end-to-end event.
+
+Exit criteria: a Client can publish a registered environment or user-behavior event without pretending it is user text or adding a new Gateway branch.
+
+## GCP3 — Agent Delivery
+
+- [ ] Define provider-neutral `AgentDelivery` and the `handle`, `context`, `respond`, and `interrupt` routing modes.
+- [ ] Add context-only injection to each Realtime Provider.
+- [ ] Extract reusable delivery serialization, blocking, retry, and playback acknowledgement from the current Task announcement path.
+- [ ] Route meaningful Task, permission, Gateway, and Client events through the shared delivery runtime.
+- [ ] Keep high-frequency progress and media off the model path.
+
+Exit criteria: one event can update Gateway/UI only, update model context silently, or produce exactly one safe Realtime response without provider-specific Gateway code.
+
+## GCP4 — Client Action port
+
+- [ ] Add `ClientActionPort` and `client.action.request/result`.
+- [ ] Advertise Client Action capabilities during handshake.
+- [ ] Expose action-derived Realtime tools only when supported.
+- [ ] Migrate `enter_sleep` from `requestClientState()` to the shared action path.
+- [ ] Add one idempotent `PresenceController` for user-requested, automatic, timeout, and duplicate sleep requests.
+- [ ] Mark sleeping only after a successful Client Action result.
+
+Exit criteria: Realtime Tool Calls and Gateway fallbacks use one action/state machine, and Gateway Core no longer knows how Desktop hides its window.
+
+## GCP5 — Reference clients, replay, and stabilization
+
+- [ ] Migrate WebUI, TUI, and Desktop to the shared reference Client SDK.
+- [ ] Add bounded replay and reconnect recovery.
+- [ ] Run one conformance suite against all first-party clients.
+- [ ] Update `docs/contract.md` and its Chinese counterpart with locked capabilities and tests.
+- [ ] Deprecate old aliases for at least one announced release before removal.
+- [ ] Mark the 6.0 specification stable only after the replacement path is proven.
+
+Exit criteria: first-party clients contain presentation and environment behavior but no reconstructed Gateway state machine; Gateway contains no first-party Client implementation branch.
+
+## PR policy
+
+- Do not combine protocol-version migration, Event ingress, Agent Delivery, and Client Action migration in one PR.
+- Every PR links issue #251 and identifies its GCP stage.
+- Every new public event ships with Schema, parser, negative tests, capability behavior, and documentation.
+- Existing first-party behavior remains green before compatibility aliases are removed.
+- No stage may leak Realtime-provider, ACP, A2A, Electron, React, or CoreAudio objects across a public port.

--- a/docs/roadmap/gateway-client-protocol.md
+++ b/docs/roadmap/gateway-client-protocol.md
@@ -25,7 +25,7 @@ Backend Agent
 
 The repository already has:
 
-- one WebSocket carrying voice, text, playback receipts, Task events, and state;
+- one WebSocket carrying voice, text, playback receipts, Task events, and state, while some runtime commands still use internal REST/SSE routes;
 - shared event constants and Zod message schemas;
 - a dedicated user-input runtime;
 - normalized BackendPort events and Task projections;
@@ -39,6 +39,7 @@ The remaining gaps are:
 - desktop capabilities and sleep behavior still appear as special cases;
 - no generic Client-to-Gateway semantic event API exists;
 - no generic Gateway-to-Client action/result contract exists;
+- Task control, permission decisions, conversation history, and recovery are still split between WebSocket and internal REST/SSE routes;
 - user input, Task announcements, permissions, and Gateway triggers do not yet share one semantic event/delivery boundary;
 - no 6.0 handshake, event correlation, or complete Client conformance suite exists.
 
@@ -50,14 +51,18 @@ The remaining gaps are:
 4. Let Gateway policy decide model visibility and response timing.
 5. Project semantic events into provider-neutral Agent Delivery values before provider encoding.
 6. Derive model-visible Client tools from negotiated Client Action capabilities.
-7. Keep every stage backward compatible until all first-party clients have migrated.
-8. Land every stage as a separately reviewable PR linked to issue #251.
+7. Use one WebSocket runtime control plane; keep REST for discovery, health, static configuration, and host management.
+8. Own every public Gateway type while deliberately aligning familiar field names and payload shapes with external standards where semantics match.
+9. Keep context sources behind the single active Client instead of adding a second connection role.
+10. Keep every stage backward compatible until all first-party clients have migrated.
+11. Land every stage as a separately reviewable PR linked to issue #251.
 
 ## GCP0 — Freeze the contract
 
 - [ ] Merge the bilingual protocol spec and this roadmap.
 - [ ] Record current 5.x aliases and characterization coverage.
 - [ ] Add the protocol documents to the public contract index.
+- [ ] Freeze the standard-alignment mapping, WebSocket runtime command plane, and single-Client context-source decision.
 
 Exit criteria: terminology, single-Client ownership, Event versus Action semantics, routing modes, sleep convergence, and migration policy are reviewable in one place.
 
@@ -66,20 +71,23 @@ Exit criteria: terminology, single-Client ownership, Event versus Action semanti
 - [ ] Add 6.0 envelope schemas for `event_id`, `request_event_id`, and replay `sequence`.
 - [ ] Add `session.hello` / `session.ready` negotiation.
 - [ ] Add capability constants for Client Event, Client Action, and replay.
+- [ ] Add capability constants for Task commands, permission decisions, and conversation history.
 - [ ] Keep 5.x `connect` and event aliases working through a normalization layer.
 - [ ] Publish shared parser and Client SDK helpers.
 
 Exit criteria: a 5.x and a 6.0 reference Client can connect to the same Gateway without divergent business logic.
 
-## GCP2 — Client Event ingress
+## GCP2 — Client Event ingress and runtime commands
 
 - [ ] Add the Client Event definition registry.
 - [ ] Add `GatewayEventRouter` and `client.event.publish/result`.
+- [ ] Add WebSocket schemas and handlers for `task.create/get/list/cancel`, `permission.respond`, and `conversation.history`.
+- [ ] Keep each immediate command result correlated by `request_event_id`; publish later Task and permission changes through the normal replayable event stream.
 - [ ] Stamp trusted source identity at the connection boundary.
 - [ ] Enforce schema, size, rate, retention, deduplication, and coalescing policy.
 - [ ] Add `desktop.presence.sleep_requested` as the first end-to-end event.
 
-Exit criteria: a Client can publish a registered environment or user-behavior event without pretending it is user text or adding a new Gateway branch.
+Exit criteria: a Client can publish a registered environment or user-behavior event without pretending it is user text or adding a new Gateway branch, and first-party runtime commands have a WebSocket replacement for their internal REST path.
 
 ## GCP3 — Agent Delivery
 
@@ -106,6 +114,7 @@ Exit criteria: Realtime Tool Calls and Gateway fallbacks use one action/state ma
 
 - [ ] Migrate WebUI, TUI, and Desktop to the shared reference Client SDK.
 - [ ] Add bounded replay and reconnect recovery.
+- [ ] Migrate Task control, permission decisions, conversation history, and Task event recovery away from internal REST/SSE aliases.
 - [ ] Run one conformance suite against all first-party clients.
 - [ ] Update `docs/contract.md` and its Chinese counterpart with locked capabilities and tests.
 - [ ] Deprecate old aliases for at least one announced release before removal.
@@ -119,4 +128,4 @@ Exit criteria: first-party clients contain presentation and environment behavior
 - Every PR links issue #251 and identifies its GCP stage.
 - Every new public event ships with Schema, parser, negative tests, capability behavior, and documentation.
 - Existing first-party behavior remains green before compatibility aliases are removed.
-- No stage may leak Realtime-provider, ACP, A2A, Electron, React, or CoreAudio objects across a public port.
+- No stage may leak Realtime-provider, ACP, A2A, Electron, React, or CoreAudio wire objects across a public port. Semantic field-name and payload-shape alignment documented by the Gateway specification is allowed.

--- a/docs/roadmap/gateway-client-protocol.zh.md
+++ b/docs/roadmap/gateway-client-protocol.zh.md
@@ -1,0 +1,122 @@
+# Gateway Client Protocol Roadmap
+
+> 状态：提案
+>
+> GitHub 跟踪：[#251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)
+>
+> 协议：[Gateway Client Protocol](../gateway-protocol.zh.md)
+
+## 目标
+
+完成 qwen-audio-agent 尚未固化的公开架构边界。`BackendPort` 已经把 Gateway 与 ACP、A2A、自定义 Backend Agent 隔离；本 Roadmap 继续把 Gateway Core 与 TUI、WebUI、桌面悬浮球及未来 Client Environment 隔离。
+
+最终形成三个可替换边界：
+
+```text
+Client Environment
+        ↕ Gateway Client Protocol / ClientPort
+Gateway Core
+        ├─ RealtimeProvider
+        ↕ BackendPort
+Backend Agent
+```
+
+## 当前基础
+
+仓库已经具备：
+
+- 一条 WebSocket 承载语音、文本、播放回执、Task 与状态；
+- 共享事件常量和 Zod 消息 Schema；
+- 独立用户输入 Runtime；
+- 规范化 BackendPort Event 与 Task Projection；
+- Provider 无关的结果和权限注入基础；
+- Task 播报排队、重试和播放确认；
+- 第一方 WebUI、TUI 和 Desktop Client。
+
+尚未解决：
+
+- Client 分发仍集中在 `realtime-gateway.mjs`；
+- Desktop capability 与休眠仍然存在特殊分支；
+- 缺少通用 Client-to-Gateway 语义事件 API；
+- 缺少通用 Gateway-to-Client Action/Result 契约；
+- 用户输入、Task 播报、权限和 Gateway Trigger 尚未共享统一语义 Event/Delivery 边界；
+- 缺少 6.0 握手、事件关联和完整 Client conformance suite。
+
+## 架构规则
+
+1. 每个 Gateway 只保留一个活动 Client。
+2. 原始媒体不进入语义 Event Router。
+3. 用户输入、Client Event、Task Event 与 Client Action 保持不同权限语义。
+4. 模型是否感知、何时回复由 Gateway Policy 决定。
+5. 语义事件先投影成 Provider 无关 Agent Delivery，再编码成 Provider 协议。
+6. 模型可见的 Client 工具来自协商后的 Client Action capability。
+7. 所有第一方 Client 完成迁移前，每个阶段保持向后兼容。
+8. 每个阶段使用独立可审查 PR，并关联 issue #251。
+
+## GCP0 — 固化契约
+
+- [ ] 合并中英文协议和本 Roadmap。
+- [ ] 记录当前 5.x 别名与 characterization coverage。
+- [ ] 将协议文档加入公开契约索引。
+
+完成条件：术语、单 Client 所有权、Event/Action 语义、路由模式、休眠汇合与迁移策略可以在一个位置完整评审。
+
+## GCP1 — 信封、握手与能力
+
+- [ ] 增加包含 `event_id`、`request_event_id`、回放 `sequence` 的 6.0 Schema。
+- [ ] 增加 `session.hello` / `session.ready` 协商。
+- [ ] 增加 Client Event、Client Action 和回放 capability。
+- [ ] 通过归一化层继续支持 5.x `connect` 和旧事件别名。
+- [ ] 发布共享 Parser 与 Client SDK Helper。
+
+完成条件：5.x 与 6.0 参考 Client 可以连接同一个 Gateway，且不分叉业务逻辑。
+
+## GCP2 — Client Event Ingress
+
+- [ ] 增加 Client Event Definition Registry。
+- [ ] 增加 `GatewayEventRouter` 与 `client.event.publish/result`。
+- [ ] 在连接边界填写可信来源身份。
+- [ ] 执行 Schema、大小、频率、保存、去重与合并 Policy。
+- [ ] 以 `desktop.presence.sleep_requested` 完成首个端到端事件。
+
+完成条件：Client 可以发布已注册的环境或用户行为事件，不需要伪装成用户文本，也不需要给 Gateway 增加新的条件分支。
+
+## GCP3 — Agent Delivery
+
+- [ ] 定义 Provider 无关 `AgentDelivery` 以及 `handle`、`context`、`respond`、`interrupt`。
+- [ ] 为全部 Realtime Provider 增加 context-only 注入。
+- [ ] 从当前 Task 播报链路抽取可复用的串行化、阻塞、重试和播放确认。
+- [ ] 让有意义的 Task、权限、Gateway 与 Client Event 使用共享 Delivery Runtime。
+- [ ] 高频进展和媒体不进入模型路径。
+
+完成条件：同一个事件可以只更新 Gateway/UI、静默更新模型上下文，或只产生一次安全的 Realtime 回复，并且 Gateway 不包含 Provider 专属逻辑。
+
+## GCP4 — Client Action Port
+
+- [ ] 增加 `ClientActionPort` 与 `client.action.request/result`。
+- [ ] 在握手中声明 Client Action capability。
+- [ ] 只有 Client 支持时才暴露 Action 派生的 Realtime 工具。
+- [ ] 将 `enter_sleep` 从 `requestClientState()` 迁移到共享 Action 链路。
+- [ ] 以一个幂等 `PresenceController` 处理用户主动、自动、超时与重复休眠请求。
+- [ ] Client Action 成功后才标记 sleeping。
+
+完成条件：Realtime Tool Call 与 Gateway 兜底共用一个 Action/状态机，Gateway Core 不再知道 Desktop 如何隐藏窗口。
+
+## GCP5 — 参考 Client、回放与稳定
+
+- [ ] WebUI、TUI、Desktop 迁移到共享参考 Client SDK。
+- [ ] 增加有界回放与重连恢复。
+- [ ] 对所有第一方 Client 运行同一套 conformance suite。
+- [ ] 在 `docs/contract.md` 及中文版记录有测试锁定的 capability。
+- [ ] 旧别名至少经过一个明确废弃版本后再删除。
+- [ ] 替代链路验证完成后，才将 6.0 Spec 标记为稳定。
+
+完成条件：第一方 Client 只包含 Presentation 与环境行为，不自行重建 Gateway 状态机；Gateway 不包含第一方 Client 实现分支。
+
+## PR 规则
+
+- 协议版本迁移、Event Ingress、Agent Delivery 与 Client Action 不能合并成一个 PR。
+- 每个 PR 关联 issue #251，并注明所属 GCP 阶段。
+- 每个公开事件同时提交 Schema、Parser、反例测试、capability 行为与文档。
+- 删除兼容别名前，现有第一方行为必须持续通过测试。
+- 任何阶段都不能让 Realtime Provider、ACP、A2A、Electron、React 或 CoreAudio 对象跨越公开 Port。

--- a/docs/roadmap/gateway-client-protocol.zh.md
+++ b/docs/roadmap/gateway-client-protocol.zh.md
@@ -25,7 +25,7 @@ Backend Agent
 
 仓库已经具备：
 
-- 一条 WebSocket 承载语音、文本、播放回执、Task 与状态；
+- 一条 WebSocket 承载语音、文本、播放回执、Task 与状态，但部分运行时命令仍使用内部 REST/SSE 路由；
 - 共享事件常量和 Zod 消息 Schema；
 - 独立用户输入 Runtime；
 - 规范化 BackendPort Event 与 Task Projection；
@@ -39,6 +39,7 @@ Backend Agent
 - Desktop capability 与休眠仍然存在特殊分支；
 - 缺少通用 Client-to-Gateway 语义事件 API；
 - 缺少通用 Gateway-to-Client Action/Result 契约；
+- Task 控制、权限决策、对话历史和恢复仍分散在 WebSocket 与内部 REST/SSE 路由；
 - 用户输入、Task 播报、权限和 Gateway Trigger 尚未共享统一语义 Event/Delivery 边界；
 - 缺少 6.0 握手、事件关联和完整 Client conformance suite。
 
@@ -50,14 +51,18 @@ Backend Agent
 4. 模型是否感知、何时回复由 Gateway Policy 决定。
 5. 语义事件先投影成 Provider 无关 Agent Delivery，再编码成 Provider 协议。
 6. 模型可见的 Client 工具来自协商后的 Client Action capability。
-7. 所有第一方 Client 完成迁移前，每个阶段保持向后兼容。
-8. 每个阶段使用独立可审查 PR，并关联 issue #251。
+7. 使用一条 WebSocket 作为运行时控制面；REST 只保留发现、健康检查、静态配置和 Host 管理。
+8. 所有公开 Gateway 类型由本协议定义；语义一致时，可以刻意对齐外部标准中熟悉的字段名和 payload 形状。
+9. 上下文来源放在单一活动 Client 后面，不增加第二种连接角色。
+10. 所有第一方 Client 完成迁移前，每个阶段保持向后兼容。
+11. 每个阶段使用独立可审查 PR，并关联 issue #251。
 
 ## GCP0 — 固化契约
 
 - [ ] 合并中英文协议和本 Roadmap。
 - [ ] 记录当前 5.x 别名与 characterization coverage。
 - [ ] 将协议文档加入公开契约索引。
+- [ ] 固化标准对齐映射、WebSocket 运行时命令面和单 Client 上下文来源决策。
 
 完成条件：术语、单 Client 所有权、Event/Action 语义、路由模式、休眠汇合与迁移策略可以在一个位置完整评审。
 
@@ -66,20 +71,23 @@ Backend Agent
 - [ ] 增加包含 `event_id`、`request_event_id`、回放 `sequence` 的 6.0 Schema。
 - [ ] 增加 `session.hello` / `session.ready` 协商。
 - [ ] 增加 Client Event、Client Action 和回放 capability。
+- [ ] 增加 Task 命令、权限决策和对话历史 capability。
 - [ ] 通过归一化层继续支持 5.x `connect` 和旧事件别名。
 - [ ] 发布共享 Parser 与 Client SDK Helper。
 
 完成条件：5.x 与 6.0 参考 Client 可以连接同一个 Gateway，且不分叉业务逻辑。
 
-## GCP2 — Client Event Ingress
+## GCP2 — Client Event Ingress 与运行时命令
 
 - [ ] 增加 Client Event Definition Registry。
 - [ ] 增加 `GatewayEventRouter` 与 `client.event.publish/result`。
+- [ ] 增加 `task.create/get/list/cancel`、`permission.respond` 与 `conversation.history` 的 WebSocket Schema 和 Handler。
+- [ ] 即时命令结果通过 `request_event_id` 关联；后续 Task 与权限变化继续通过普通、可回放事件流发布。
 - [ ] 在连接边界填写可信来源身份。
 - [ ] 执行 Schema、大小、频率、保存、去重与合并 Policy。
 - [ ] 以 `desktop.presence.sleep_requested` 完成首个端到端事件。
 
-完成条件：Client 可以发布已注册的环境或用户行为事件，不需要伪装成用户文本，也不需要给 Gateway 增加新的条件分支。
+完成条件：Client 可以发布已注册的环境或用户行为事件，不需要伪装成用户文本，也不需要给 Gateway 增加新的条件分支；第一方运行时命令都有内部 REST 路径的 WebSocket 替代方案。
 
 ## GCP3 — Agent Delivery
 
@@ -106,6 +114,7 @@ Backend Agent
 
 - [ ] WebUI、TUI、Desktop 迁移到共享参考 Client SDK。
 - [ ] 增加有界回放与重连恢复。
+- [ ] 将 Task 控制、权限决策、对话历史和 Task 事件恢复从内部 REST/SSE 别名迁走。
 - [ ] 对所有第一方 Client 运行同一套 conformance suite。
 - [ ] 在 `docs/contract.md` 及中文版记录有测试锁定的 capability。
 - [ ] 旧别名至少经过一个明确废弃版本后再删除。
@@ -119,4 +128,4 @@ Backend Agent
 - 每个 PR 关联 issue #251，并注明所属 GCP 阶段。
 - 每个公开事件同时提交 Schema、Parser、反例测试、capability 行为与文档。
 - 删除兼容别名前，现有第一方行为必须持续通过测试。
-- 任何阶段都不能让 Realtime Provider、ACP、A2A、Electron、React 或 CoreAudio 对象跨越公开 Port。
+- 任何阶段都不能让 Realtime Provider、ACP、A2A、Electron、React 或 CoreAudio 原生协议对象跨越公开 Port；Gateway 规范明确记录的语义字段名和 payload 形状对齐除外。


### PR DESCRIPTION
## Summary

- define the target 6.0 Gateway Client Protocol in English and Chinese
- formalize the single-Client boundary, Client Event ingress, Client Action egress, and provider-neutral Agent Delivery
- make user-requested and automatic sleep converge on one `enter_sleep` / `ClientActionPort` path with idempotent fallback
- add a staged GCP0-GCP5 migration roadmap and link it from the current 5.x contract index

## Review decisions in Draft 0.4

- Gateway owns every public protocol type, while field names and payload shapes deliberately align with OpenAI Realtime and A2A semantics where useful; a non-normative mapping table documents the boundary
- the active WebSocket becomes the single runtime command/query plane for Task control, permission decisions, conversation history, and replay; REST/SSE runtime routes remain migration aliases only
- 6.0 keeps one active Client connection and adds no `context_source` role; vehicle, CRM, sensor, and other context sources attach through client-side adapters and publish registered Client Events

## Scope

This is GCP0 only. It freezes terminology and migration constraints; it does not change the current 5.x wire protocol or runtime behavior.

## Validation

- `npm run lint`
- Markdown relative-link, code-fence, and whitespace checks
- full CI matrix on the rebased branch

Part of #251
