### PR TITLE
fix(acp): declare builtin computer-use MCP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- 修复内置 `open-computer-use` MCP 描述缺少 `stdio` 传输类型的问题，兼容严格校验
+  MCP 描述的后台 Agent（例如 Kimi Code 0.38）。
 - 新增 Pi 后台支持：通过社区 `pi-acp` 适配器接入，并支持一键安装。Pi 没有
   内置沙箱与权限审批机制，始终等效于 `full` 权限，请仅在可信环境中使用。
 

--- a/server/src/agent/builtin-mcp.mjs
+++ b/server/src/agent/builtin-mcp.mjs
@@ -59,6 +59,7 @@ export function computerUseMcpServer(env = process.env) {
   if (!binPath) return null
   const descriptor = {
     name: 'open-computer-use',
+    type: 'stdio',
     command: process.execPath,
     args: [binPath, 'mcp'],
     // The bin is a Node script; when the Gateway runs inside Electron the

--- a/server/test/builtin-mcp.test.mjs
+++ b/server/test/builtin-mcp.test.mjs
@@ -10,6 +10,7 @@ test('computer-use MCP server resolves as stdio descriptor by default', () => {
   const descriptor = computerUseMcpServer({})
   assert.ok(descriptor, 'expected descriptor when package is installed')
   assert.equal(descriptor.name, 'open-computer-use')
+  assert.equal(descriptor.type, 'stdio')
   assert.equal(descriptor.command, process.execPath)
   assert.equal(descriptor.args.length, 2)
   assert.match(descriptor.args[0], /open-computer-use/)


### PR DESCRIPTION
## Summary

- Add the required type: "stdio" field to the built-in open-computer-use MCP descriptor.
- Prevent strict ACP backends such as Kimi Code 0.38 from rejecting session/new.
- Add a regression assertion and an Unreleased changelog entry.

Closes #176.

## Validation

- [x] node --test server/test/builtin-mcp.test.mjs (7 tests passed)
- [x] node --check server/src/agent/builtin-mcp.mjs
- [x] node --check server/test/builtin-mcp.test.mjs
- [x] git diff --check
- [ ] npm test (not run locally because dependency installation was unavailable; CI should run the full suite)
- [ ] npm run lint (not run locally because dependencies were unavailable)
- [ ] npm run build (not run locally because dependencies were unavailable)

## Compatibility and security

- No credentials, user data, logs, or network endpoints are included.
- The descriptor remains a stdio MCP server; this only declares its transport type for strict ACP validation.