### PR TITLE
feat(gateway): add GCP2 client events and runtime commands

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -347,6 +347,12 @@ conversation events. Package-level `shared` modules are foundational runtime
 utilities; server `core` and `process` may depend on them, but they must not
 depend on server layers.
 
+`server/src/client` owns the northbound Client Event registry and runtime
+command application service. It may depend only on public `shared` protocol
+values and the protocol-neutral Task layer. The composition root in
+`server/src/app` injects those services into the Realtime transport; neither
+the voice path nor Client code imports their concrete implementation.
+
 Gateway may serve the immutable `web/dist` artifact as a deployment
 convenience, but this is static hosting only. Gateway source must not import UI
 components, presentation text, styling, terminal behavior, or desktop behavior.

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -277,6 +277,10 @@ Qwen Code ACP, Kimi Code ACP, or another ACP Agent
 UI 仅消费公共 Task 与对话事件。包级别的 `shared` 模块是基础运行时
 工具；server `core` 和 `process` 可以依赖它们，但它们不得依赖 server 层。
 
+`server/src/client` 管理北向 Client Event Registry 与运行时命令应用服务，只能依赖
+公开 `shared` 协议值和协议无关的 Task 层。`server/src/app` 组合根把这些服务注入
+Realtime Transport；语音链路与 Client 代码都不能导入其具体实现。
+
 Gateway 可以将不可变的 `web/dist` 产物作为部署便利来提供，但这仅是静态托管。
 Gateway 源码不得导入 UI 组件、呈现文本、样式、终端行为或桌面行为。
 所有三个 UI 拥有自己的渲染，并将结构化协议字段映射到各自的标签和交互模式。

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -22,12 +22,16 @@ The proposed 6.0 northbound boundary is documented in the draft
 [Gateway Client Protocol](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/gateway-protocol.md) and its
 [roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/gateway-client-protocol.md), tracked by
 [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251).
-Those documents remain the design target. GCP1 is now available as an opt-in
-6.0 handshake and envelope over the existing WebSocket; capabilities for later
-stages are vocabulary only and are not negotiated until their runtimes ship.
+Those documents remain the design target. GCP1 and GCP2 are now available as
+an opt-in 6.0 handshake, Client Event ingress, and runtime-command plane over
+the existing WebSocket; capabilities for later stages remain vocabulary only
+until their runtimes ship.
 This contract index remains authoritative for implemented behavior.
 
-The current health-contract version is `5.1.0`. The additive `5.1` line exposes
+The current health-contract version is `5.2.0`. The additive `5.2` line exposes
+registered Client Event ingress and Task, permission, and conversation-history
+commands on the negotiated 6.0 WebSocket while retaining REST compatibility
+aliases. The additive `5.1` line exposes
 the opt-in GCP 6.0 `session.hello` / `session.ready` handshake while preserving
 the 5.x `connect` path and business event aliases. The `5.0` line removes the backend-controlled
 Task `presentation` envelope. A backend returns factual `content` plus optional
@@ -69,6 +73,7 @@ below instead of assuming the old list.
 | `messages.citations` | Final assistant `transcript.final` events may carry normalized citations collected from frontend retrieval in the same turn | `test/gateway-event-schema.test.mjs`, `server/test/realtime-presentation-runtime.test.mjs` |
 | `realtime.conversation-client-v1` | `WS /api/realtime`, published event constants, and message schemas form the replaceable text/audio/multimodal Conversation Client boundary | `test/gateway-event-schema.test.mjs`, `test/custom-conversation-client.test.mjs` |
 | `realtime.gateway-client-protocol-v6-handshake` | The same WebSocket accepts an opt-in 6.0 `session.hello`, returns correlated `session.ready`, negotiates implemented capabilities, and normalizes 6.0 input aliases into the existing business path | `test/gateway-client-protocol.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
+| `realtime.gateway-client-protocol-v6-runtime-commands` | Negotiated 6.0 Clients can publish registered semantic Client Events and use correlated Task, permission, and conversation-history commands over the same WebSocket; existing REST routes call the same command service as compatibility aliases | `test/gateway-client-protocol.test.mjs`, `server/test/client-event-router.test.mjs`, `server/test/client-command-runtime.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
 | `desktop.orb-shell` | The orb form's main-process contract ships: `bindOrbShell` answers the channels the shipped preload sends | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` owns the orb window recipe; its `destroy()` is the host's synchronous teardown path (renderer exit is what releases the microphone) | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` covers the default anchor, display clamping and drop persistence | `desktop/test/orb-placement.test.mjs` |
@@ -89,6 +94,7 @@ is unsupported and breaks without notice.
 | `qwen-audio-agent/electron` | **CJS**: `load()` (every contract in one namespace), `PRELOAD_PATH` |
 | `qwen-audio-agent/gateway-protocol` | `GATEWAY_PROTOCOL_VERSION`, `GATEWAY_CAPABILITIES` |
 | `qwen-audio-agent/gateway-client-protocol` | GCP 6.0 envelope and handshake schemas, parsers, capability constants, and reference Client helpers |
+| `qwen-audio-agent/client-events` | Client Event definition registry, built-in definitions, routing policies, and `GatewayEventRouter` for Gateway extensions |
 | `qwen-audio-agent/gateway-setup` | `gatewaySetupStatus`, `assertGatewaySetup` |
 | `qwen-audio-agent/gateway-process` | `GatewayProcess`, `createGatewayProcess`, `GATEWAY_READY_MESSAGE`, `DEFAULT_GATEWAY_ENTRY`, `validateGatewayOrigin`, `portInUse` |
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`, `findRunningGateway`, `acquireGatewayLease` |

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -18,11 +18,14 @@
 [Gateway Client Protocol](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/gateway-protocol.zh.md) 与
 [Roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/gateway-client-protocol.zh.md) 中，并由
 [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)
-跟踪。它们仍是完整设计目标；GCP1 已以可选的 6.0 握手与信封形式落在现有 WebSocket
-上。后续阶段的 capability 目前只是已冻结词汇，在对应运行时实现前不会参与协商。
+跟踪。它们仍是完整设计目标；GCP1 与 GCP2 已以可选的 6.0 握手、Client Event Ingress
+与运行时命令面落在现有 WebSocket 上。后续阶段的 capability 仍是已冻结词汇，在对应
+运行时实现前不会参与协商。
 已实现行为仍以本契约索引为准。
 
-当前健康契约版本为 `5.1.0`。新增的 `5.1` 能力提供可选 GCP 6.0
+当前健康契约版本为 `5.2.0`。新增的 `5.2` 能力在协商后的 6.0 WebSocket 上提供已注册
+Client Event Ingress 与 Task、权限、对话历史命令，同时保留 REST 兼容别名。`5.1`
+能力提供可选 GCP 6.0
 `session.hello` / `session.ready` 握手，同时保留 5.x `connect` 路径与业务事件别名。
 `5.0` 删除由后台控制的 Task `presentation` 包装：后台只返回
 事实性 `content` 与可选的类型化 `artifacts`，前台 Chatbot 决定如何播报，各个对话
@@ -58,6 +61,7 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `messages.citations` | 最终助手 `transcript.final` 可以携带同一轮前台检索产生的规范化 Citation | `test/gateway-event-schema.test.mjs`、`server/test/realtime-presentation-runtime.test.mjs` |
 | `realtime.conversation-client-v1` | `WS /api/realtime`、公开事件常量与消息 Schema 共同构成可替换的文本/音频/多模态对话客户端边界 | `test/gateway-event-schema.test.mjs`、`test/custom-conversation-client.test.mjs` |
 | `realtime.gateway-client-protocol-v6-handshake` | 同一 WebSocket 可选择以 6.0 `session.hello` 接入，返回有关联关系的 `session.ready`，协商已实现能力，并把 6.0 输入别名归一化到现有业务路径 | `test/gateway-client-protocol.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
+| `realtime.gateway-client-protocol-v6-runtime-commands` | 协商后的 6.0 Client 可以通过同一 WebSocket 发布已注册的语义 Client Event，并使用有关联结果的 Task、权限和对话历史命令；现有 REST 路由调用同一命令服务作为兼容别名 | `test/gateway-client-protocol.test.mjs`、`server/test/client-event-router.test.mjs`、`server/test/client-command-runtime.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
 | `desktop.orb-shell` | 悬浮球形态的主进程契约随包发布：`bindOrbShell` 应答随包 preload 发出的全部通道 | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` 持有悬浮球窗口配方；其 `destroy()` 是宿主的同步销毁路径（渲染进程退出才能确定性释放麦克风） | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` 覆盖默认锚点、显示器夹取与拖放持久化 | `desktop/test/orb-placement.test.mjs` |
@@ -77,6 +81,7 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `qwen-audio-agent/electron` | **CJS**：`load()`（一个命名空间拿到全部契约）、`PRELOAD_PATH` |
 | `qwen-audio-agent/gateway-protocol` | `GATEWAY_PROTOCOL_VERSION`、`GATEWAY_CAPABILITIES` |
 | `qwen-audio-agent/gateway-client-protocol` | GCP 6.0 信封与握手 Schema、解析器、能力常量和参考 Client Helper |
+| `qwen-audio-agent/client-events` | 供 Gateway 扩展使用的 Client Event Definition Registry、内置定义、路由 Policy 与 `GatewayEventRouter` |
 | `qwen-audio-agent/gateway-setup` | `gatewaySetupStatus`、`assertGatewaySetup` |
 | `qwen-audio-agent/gateway-process` | `GatewayProcess`、`createGatewayProcess`、`GATEWAY_READY_MESSAGE`、`DEFAULT_GATEWAY_ENTRY`、`validateGatewayOrigin`、`portInUse` |
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`、`findRunningGateway`、`acquireGatewayLease` |

--- a/docs/gateway-protocol.md
+++ b/docs/gateway-protocol.md
@@ -1,9 +1,9 @@
 # Gateway Client Protocol
 
-> Status: **Draft 0.5**<br>
+> Status: **Draft 0.6**<br>
 > Target wire version: **6.0.0**<br>
 > Roadmap: [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)<br>
-> Current implementation sources of truth: `shared/gateway-client-protocol.mjs`, `shared/realtime-events.mjs`, `shared/protocol/gateway-events.mjs`, and `server/src/core/gateway-protocol.mjs`
+> Current implementation sources of truth: `shared/gateway-client-protocol.mjs`, `server/src/client/client-event-router.mjs`, `server/src/client/client-command-runtime.mjs`, `shared/realtime-events.mjs`, `shared/protocol/gateway-events.mjs`, and `server/src/core/gateway-protocol.mjs`
 
 This specification defines the northbound boundary between qwen-audio-agent's Gateway and one active Client Environment. It is the target contract for the next protocol major and does not claim that the current 5.x implementation already implements every event below.
 
@@ -109,9 +109,25 @@ logic. A 6.0 Client starts with `session.hello`; Gateway returns
 `session.ready`, adds `event_id` to subsequent outbound events, and normalizes
 6.0 input aliases into the existing internal event model. A 5.x Client may
 continue to start with `connect` and receives the unchanged legacy event shape.
-Only capabilities with working runtimes are negotiated. Names reserved for
-GCP2–GCP5 are published for extension interoperability but are not advertised
-as implemented.
+Only capabilities with working runtimes are negotiated. GCP2 Client Event and
+runtime-command capabilities are now implemented; names reserved for GCP3–GCP5
+remain vocabulary-only until their runtimes ship.
+
+### 3.2 GCP2 runtime rollout
+
+GCP2 adds `client.event.publish` and the Task, permission, and conversation
+history commands in section 5.4 to the negotiated WebSocket. Immediate results
+and errors correlate through `request_event_id`. Existing REST routes call the
+same runtime command service and remain temporary compatibility aliases.
+
+Client Event definitions are registered at Gateway composition time. The
+registry owns payload Schema, size, rate, retention, coalescing, maximum route,
+and an optional deterministic handler. Gateway stamps owner, Session, Client
+type, and Client instance from the authenticated connection; none of those
+trusted fields are accepted from event data. The first built-in definition is
+`desktop.presence.sleep_requested`. Its model delivery is intentionally deferred
+to GCP3, so GCP2 accepts, validates, retains, and handles the event without
+pretending it is user input.
 
 ## 4. Common event envelope
 
@@ -187,7 +203,8 @@ client.event.publish.result
   "type": "client.event.publish.result",
   "event_id": "evt_gateway_31",
   "request_event_id": "evt_client_17",
-  "accepted": true
+  "accepted": true,
+  "name": "user.object.touched"
 }
 ```
 
@@ -239,7 +256,7 @@ Client Action is not a replacement for MCP, OpenAPI, ACP, or A2A. It covers capa
 
 ### 5.4 Runtime commands and queries
 
-The active Client uses the same WebSocket for runtime commands and queries. Each command carries an `event_id`; its immediate `<command>.result` carries `request_event_id`. Later lifecycle changes remain ordinary replayable server pushes rather than being hidden inside the command result.
+The active Client uses the same WebSocket for runtime commands and queries. Each command carries an `event_id`; its immediate `<command>.result` carries `request_event_id`. Later lifecycle changes remain ordinary server pushes rather than being hidden inside the command result; bounded replay is added in GCP5.
 
 | Command | Direction | Meaning |
 |---|---|---|
@@ -400,6 +417,7 @@ Base error codes include:
 client_occupied
 protocol_version_unsupported
 capability_unsupported
+capability_not_negotiated
 bad_event
 unknown_type
 client_event_unsupported
@@ -408,6 +426,8 @@ client_action_unsupported
 session_expired
 sequence_expired
 task_not_found
+task_not_cancellable
+permission_not_found
 payload_too_large
 rate_limited
 internal

--- a/docs/gateway-protocol.zh.md
+++ b/docs/gateway-protocol.zh.md
@@ -1,9 +1,9 @@
 # Gateway Client Protocol
 
-> 状态：**Draft 0.5**<br>
+> 状态：**Draft 0.6**<br>
 > 目标线协议版本：**6.0.0**<br>
 > Roadmap：[GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)<br>
-> 当前实现事实源：`shared/gateway-client-protocol.mjs`、`shared/realtime-events.mjs`、`shared/protocol/gateway-events.mjs` 与 `server/src/core/gateway-protocol.mjs`
+> 当前实现事实源：`shared/gateway-client-protocol.mjs`、`server/src/client/client-event-router.mjs`、`server/src/client/client-command-runtime.mjs`、`shared/realtime-events.mjs`、`shared/protocol/gateway-events.mjs` 与 `server/src/core/gateway-protocol.mjs`
 
 本文档定义 qwen-audio-agent Gateway 与唯一活动 Client Environment 之间的北向协议。它描述的是下一主版本的目标契约，不代表当前 5.x 已经实现全部事件。
 
@@ -107,8 +107,22 @@ Gateway 返回协商后的版本与能力交集：
 GCP1 在不分叉 Gateway 业务逻辑的前提下实现信封与握手。6.0 Client 以
 `session.hello` 开始；Gateway 返回 `session.ready`，为后续下行事件补充
 `event_id`，并把 6.0 输入别名归一化到现有内部事件模型。5.x Client 仍可使用
-`connect`，收到的旧事件形状保持不变。握手只协商已有运行时实现的能力；为
-GCP2–GCP5 预留的名称用于统一扩展词汇，但不会被声明为已实现。
+`connect`，收到的旧事件形状保持不变。握手只协商已有运行时实现的能力。GCP2 的
+Client Event 与运行时命令 capability 已经实现；GCP3–GCP5 预留的名称仍只用于统一
+扩展词汇，在对应 Runtime 完成前不会被声明为已实现。
+
+### 3.2 GCP2 运行时落地
+
+GCP2 在协商后的同一条 WebSocket 上实现 `client.event.publish`，以及第 5.4 节的
+Task、权限和对话历史命令。即时结果与错误通过 `request_event_id` 关联。现有 REST
+路由调用同一个 Runtime Command Service，并暂时作为兼容别名保留。
+
+Client Event Definition 在 Gateway 组合阶段注册。Registry 统一定义 payload
+Schema、大小、频率、保存、合并、最大路由等级与可选确定性 Handler。Gateway 根据
+已认证连接填写 owner、Session、Client 类型与 Client 实例；这些可信字段不能由
+Event data 提供。首个内置定义是 `desktop.presence.sleep_requested`。它进入模型的
+Delivery 留到 GCP3，因此 GCP2 只负责接收、校验、保存和确定性处理，不会把它伪装成
+用户输入。
 
 ## 4. 通用事件信封
 
@@ -184,7 +198,8 @@ client.event.publish.result
   "type": "client.event.publish.result",
   "event_id": "evt_gateway_31",
   "request_event_id": "evt_client_17",
-  "accepted": true
+  "accepted": true,
+  "name": "user.object.touched"
 }
 ```
 
@@ -236,7 +251,7 @@ Client Action 不替代 MCP、OpenAPI、ACP 或 A2A。它只用于当前 Client 
 
 ### 5.4 运行时命令与查询
 
-活动 Client 通过同一个 WebSocket 发起运行时命令与查询。每个命令携带 `event_id`；即时 `<command>.result` 通过 `request_event_id` 关联请求。后续生命周期变化仍作为普通、可回放的服务端推送发布，不能隐藏在命令结果中。
+活动 Client 通过同一个 WebSocket 发起运行时命令与查询。每个命令携带 `event_id`；即时 `<command>.result` 通过 `request_event_id` 关联请求。后续生命周期变化仍作为普通服务端推送发布，不能隐藏在命令结果中；有界回放由 GCP5 补充。
 
 | 命令 | 方向 | 语义 |
 |---|---|---|
@@ -397,6 +412,7 @@ active → sleep_requested → sleeping
 client_occupied
 protocol_version_unsupported
 capability_unsupported
+capability_not_negotiated
 bad_event
 unknown_type
 client_event_unsupported
@@ -405,6 +421,8 @@ client_action_unsupported
 session_expired
 sequence_expired
 task_not_found
+task_not_cancellable
+permission_not_found
 payload_too_large
 rate_limited
 internal

--- a/docs/roadmap/gateway-client-protocol.md
+++ b/docs/roadmap/gateway-client-protocol.md
@@ -37,11 +37,10 @@ The remaining gaps are:
 
 - Client dispatch is still concentrated in `realtime-gateway.mjs`;
 - desktop capabilities and sleep behavior still appear as special cases;
-- no generic Client-to-Gateway semantic event API exists;
 - no generic Gateway-to-Client action/result contract exists;
-- Task control, permission decisions, conversation history, and recovery are still split between WebSocket and internal REST/SSE routes;
+- first-party Clients still use internal REST/SSE aliases for some Task control, permission, conversation-history, and recovery flows;
 - user input, Task announcements, permissions, and Gateway triggers do not yet share one semantic event/delivery boundary;
-- no 6.0 handshake, event correlation, or complete Client conformance suite exists.
+- replay, full first-party migration, and a complete Client conformance suite are not implemented yet.
 
 ## Architectural rules
 
@@ -79,13 +78,13 @@ Exit criteria: a 5.x and a 6.0 reference Client can connect to the same Gateway 
 
 ## GCP2 — Client Event ingress and runtime commands
 
-- [ ] Add the Client Event definition registry.
-- [ ] Add `GatewayEventRouter` and `client.event.publish/result`.
-- [ ] Add WebSocket schemas and handlers for `task.create/get/list/cancel`, `permission.respond`, and `conversation.history`.
-- [ ] Keep each immediate command result correlated by `request_event_id`; publish later Task and permission changes through the normal replayable event stream.
-- [ ] Stamp trusted source identity at the connection boundary.
-- [ ] Enforce schema, size, rate, retention, deduplication, and coalescing policy.
-- [ ] Add `desktop.presence.sleep_requested` as the first end-to-end event.
+- [x] Add the Client Event definition registry.
+- [x] Add `GatewayEventRouter` and `client.event.publish/result`.
+- [x] Add WebSocket schemas and handlers for `task.create/get/list/cancel`, `permission.respond`, and `conversation.history`.
+- [x] Keep each immediate command result correlated by `request_event_id`; publish later Task and permission changes through the normal event stream, which becomes replayable in GCP5.
+- [x] Stamp trusted source identity at the connection boundary.
+- [x] Enforce schema, size, rate, retention, deduplication, and coalescing policy.
+- [x] Add `desktop.presence.sleep_requested` as the first end-to-end event.
 
 Exit criteria: a Client can publish a registered environment or user-behavior event without pretending it is user text or adding a new Gateway branch, and first-party runtime commands have a WebSocket replacement for their internal REST path.
 

--- a/docs/roadmap/gateway-client-protocol.zh.md
+++ b/docs/roadmap/gateway-client-protocol.zh.md
@@ -37,11 +37,10 @@ Backend Agent
 
 - Client 分发仍集中在 `realtime-gateway.mjs`；
 - Desktop capability 与休眠仍然存在特殊分支；
-- 缺少通用 Client-to-Gateway 语义事件 API；
 - 缺少通用 Gateway-to-Client Action/Result 契约；
-- Task 控制、权限决策、对话历史和恢复仍分散在 WebSocket 与内部 REST/SSE 路由；
+- 第一方 Client 的部分 Task 控制、权限、对话历史与恢复流程仍在使用内部 REST/SSE 兼容别名；
 - 用户输入、Task 播报、权限和 Gateway Trigger 尚未共享统一语义 Event/Delivery 边界；
-- 缺少 6.0 握手、事件关联和完整 Client conformance suite。
+- 回放、完整第一方迁移与完整 Client conformance suite 尚未实现。
 
 ## 架构规则
 
@@ -79,13 +78,13 @@ Backend Agent
 
 ## GCP2 — Client Event Ingress 与运行时命令
 
-- [ ] 增加 Client Event Definition Registry。
-- [ ] 增加 `GatewayEventRouter` 与 `client.event.publish/result`。
-- [ ] 增加 `task.create/get/list/cancel`、`permission.respond` 与 `conversation.history` 的 WebSocket Schema 和 Handler。
-- [ ] 即时命令结果通过 `request_event_id` 关联；后续 Task 与权限变化继续通过普通、可回放事件流发布。
-- [ ] 在连接边界填写可信来源身份。
-- [ ] 执行 Schema、大小、频率、保存、去重与合并 Policy。
-- [ ] 以 `desktop.presence.sleep_requested` 完成首个端到端事件。
+- [x] 增加 Client Event Definition Registry。
+- [x] 增加 `GatewayEventRouter` 与 `client.event.publish/result`。
+- [x] 增加 `task.create/get/list/cancel`、`permission.respond` 与 `conversation.history` 的 WebSocket Schema 和 Handler。
+- [x] 即时命令结果通过 `request_event_id` 关联；后续 Task 与权限变化继续通过普通事件流发布，并在 GCP5 具备回放能力。
+- [x] 在连接边界填写可信来源身份。
+- [x] 执行 Schema、大小、频率、保存、去重与合并 Policy。
+- [x] 以 `desktop.presence.sleep_requested` 完成首个端到端事件。
 
 完成条件：Client 可以发布已注册的环境或用户行为事件，不需要伪装成用户文本，也不需要给 Gateway 增加新的条件分支；第一方运行时命令都有内部 REST 路径的 WebSocket 替代方案。
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "./realtime-events": "./shared/realtime-events.mjs",
     "./gateway-events": "./shared/protocol/gateway-events.mjs",
     "./gateway-client-protocol": "./shared/gateway-client-protocol.mjs",
+    "./client-events": "./server/src/client/client-event-router.mjs",
     "./ag-ui-events": "./shared/protocol/agui-events.mjs",
     "./session-events": "./shared/session-events.mjs",
     "./session-journal": "./server/src/session/session-journal.mjs",

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -77,6 +77,12 @@ import {
   projectGatewayTaskEventForFormat,
 } from '../transport/agui-event-projector.mjs'
 import { replaySession } from '../session/session-replay.mjs'
+import { GatewayClientCommandRuntime } from '../client/client-command-runtime.mjs'
+import {
+  BUILTIN_CLIENT_EVENT_DEFINITIONS,
+  ClientEventDefinitionRegistry,
+  GatewayEventRouter,
+} from '../client/client-event-router.mjs'
 
 export function createGatewayApplication({
   config = defaultConfig,
@@ -105,6 +111,9 @@ export function createGatewayApplication({
   sessionJournal = null,
   conversationHistory = null,
   taskAnnouncementFactory = undefined,
+  clientCommandRuntime = null,
+  clientEventRouter = null,
+  clientEventDefinitions = [],
 } = {}) {
 const workBackend = backendRuntime || new BackendWorkRuntime({ backend: agent })
 const sessionJournalRuntime = sessionJournal || defaultTaskSessionJournal
@@ -473,6 +482,24 @@ const permissionPolicy = new SessionPermissionPolicy({
   ttlMs: config.conversationSessionTtlMs,
   maxSessions: config.maxConversationSessions,
 })
+const runtimeCommands = clientCommandRuntime || new GatewayClientCommandRuntime({
+  taskManager,
+  backendRuntime: workBackend,
+  conversationHistory: conversationHistoryRuntime,
+  respondAuthorization: (taskId, id, decision, options) => (
+    agent.respondAuthorization(taskId, id, decision, options)
+  ),
+  permissionPolicy,
+  logger,
+})
+const gatewayEventRouter = clientEventRouter || new GatewayEventRouter({
+  registry: new ClientEventDefinitionRegistry({
+    definitions: [
+      ...BUILTIN_CLIENT_EVENT_DEFINITIONS,
+      ...clientEventDefinitions,
+    ],
+  }),
+})
 
 app.disable('x-powered-by')
 app.use(enforceSameOrigin)
@@ -634,11 +661,11 @@ app.get('/api/backend/ui', async (req, res, next) => {
 
 app.get('/api/tasks', (req, res) => {
   res.json({
-    tasks: taskManager.list({
-      ownerId: req.identity.ownerId,
-      sessionId: req.query.sessionId,
+    tasks: runtimeCommands.listTasks({
+      session_id: req.query.sessionId,
       active: req.query.active === 'true',
-    }),
+      limit: Number.MAX_SAFE_INTEGER,
+    }, { ownerId: req.identity.ownerId, allSessions: true }),
   })
 })
 
@@ -767,10 +794,9 @@ app.get('/api/sessions/:sessionId/replay', async (req, res, next) => {
 // records or diagnostic logs, and Realtime consumes this same projection.
 app.get('/api/conversations/:sessionId/messages', async (req, res, next) => {
   try {
-    const messages = await conversationHistoryRuntime.messages({
-      ownerId: req.identity.ownerId,
-      sessionId: req.params.sessionId,
-    })
+    const messages = await runtimeCommands.history({
+      session_id: req.params.sessionId,
+    }, { ownerId: req.identity.ownerId })
     res.json({ messages })
   } catch (error) {
     next(error)
@@ -778,26 +804,38 @@ app.get('/api/conversations/:sessionId/messages', async (req, res, next) => {
 })
 
 app.get('/api/tasks/:id', (req, res) => {
-  const task = taskManager.get(req.params.id, { ownerId: req.identity.ownerId })
-  if (!task) return res.status(404).json({ error: 'task not found' })
-  res.json(task)
+  try {
+    res.json(runtimeCommands.getTask(req.params.id, {
+      ownerId: req.identity.ownerId,
+    }))
+  } catch (error) {
+    if (error?.code === 'task_not_found') {
+      return res.status(404).json({ error: 'task not found' })
+    }
+    res.status(400).json({ error: error.message })
+  }
 })
 
-app.delete('/api/tasks/:id', async (req, res) => {
-  const existing = taskManager.get(req.params.id, {
-    ownerId: req.identity.ownerId,
-  })
-  if (!existing) return res.status(404).json({ error: 'task not found' })
-  const task = await taskManager.cancel(req.params.id, {
-    ownerId: req.identity.ownerId,
-  })
-  if (!task) {
-    return res.status(409).json({
-      error: 'task is no longer active',
-      task: existing,
-    })
+app.delete('/api/tasks/:id', async (req, res, next) => {
+  try {
+    const task = await runtimeCommands.cancelTask(req.params.id, {
+      ownerId: req.identity.ownerId,
+    }, { wait: true })
+    res.json(task)
+  } catch (error) {
+    if (error?.code === 'task_not_found') {
+      return res.status(404).json({ error: 'task not found' })
+    }
+    if (error?.code === 'task_not_cancellable') {
+      return res.status(409).json({
+        error: 'task is no longer active',
+        task: runtimeCommands.getTask(req.params.id, {
+          ownerId: req.identity.ownerId,
+        }),
+      })
+    }
+    next(error)
   }
-  res.json(task)
 })
 
 app.post('/api/permissions/:id', async (req, res, next) => {
@@ -805,39 +843,14 @@ app.post('/api/permissions/:id', async (req, res, next) => {
   if (!['always', 'reject'].includes(decision)) {
     return res.status(400).json({ error: 'decision must be always or reject' })
   }
-  const permissionTask = taskManager.list({
-    ownerId: req.identity.ownerId,
-    active: true,
-  }).find(task => task.authorization?.id === req.params.id)
-  if (!permissionTask) {
-    return res.status(404).json({ error: 'permission request not found' })
-  }
-  const previousPermissionMode = permissionPolicy.mode(
-    req.identity.ownerId,
-    permissionTask.sessionId,
-  )
-  permissionPolicy.applyDecision(
-    req.identity.ownerId,
-    permissionTask.sessionId,
-    decision,
-  )
   try {
-    const permission = await agent.respondAuthorization(
-      permissionTask.id,
-      req.params.id,
+    const permission = await runtimeCommands.respondPermission({
+      permission_id: req.params.id,
       decision,
-      { ownerId: req.identity.ownerId },
-    )
+    }, { ownerId: req.identity.ownerId })
     return res.json(permission)
   } catch (error) {
-    if (previousPermissionMode) {
-      permissionPolicy.setMode(
-        req.identity.ownerId,
-        permissionTask.sessionId,
-        previousPermissionMode,
-      )
-    }
-    if (error?.status === 404) {
+    if (error?.status === 404 || error?.code === 'permission_not_found') {
       return res.status(404).json({ error: error.message })
     }
     return next(error)
@@ -933,6 +946,8 @@ realtimeGateway = attachRealtimeGateway(server, {
   frontendKnowledge: frontendKnowledgeRuntime,
   frontendToolSources,
   taskAnnouncementFactory,
+  clientCommandRuntime: runtimeCommands,
+  clientEventRouter: gatewayEventRouter,
 })
 const start = ({ host = config.host, port = config.port } = {}) => {
   if (server.listening) return server
@@ -1013,6 +1028,8 @@ return {
     frontendKnowledge: frontendKnowledgeRuntime,
     frontendMcp: frontendMcpRuntime,
     frontendOpenApi: frontendOpenApiRuntime,
+    runtimeCommands,
+    gatewayEventRouter,
     knowledgeProvider: knowledgeProviderRuntime,
     identityManager,
     inputArbitration,

--- a/server/src/client/client-command-runtime.mjs
+++ b/server/src/client/client-command-runtime.mjs
@@ -1,0 +1,225 @@
+import { GatewayClientProtocolEvent } from '../../../shared/gateway-client-protocol.mjs'
+import { normalizeInputParts } from '../../../shared/input-parts.mjs'
+import { isTaskCancellable } from '../task/task-state.mjs'
+
+function clean(value) {
+  return String(value || '').trim()
+}
+
+function objectiveFromMessage(message = {}) {
+  const parts = Array.isArray(message.parts) ? message.parts : []
+  const text = parts
+    .filter(part => part?.type === 'text')
+    .map(part => clean(part.text))
+    .filter(Boolean)
+    .join('\n')
+  if (text) return text
+  const files = parts
+    .filter(part => part?.type === 'file')
+    .map((part, index) => clean(part.filename) || `附件 ${index + 1}`)
+    .filter(Boolean)
+  return files.length ? `处理客户端提交的文件：${files.join('、')}` : ''
+}
+
+function inputPartsFromMessage(message = {}) {
+  return (Array.isArray(message.parts) ? message.parts : [])
+    .filter(part => part?.type === 'file')
+    .map(part => ({ ...part }))
+}
+
+export class RuntimeCommandError extends Error {
+  constructor(code, message) {
+    super(message)
+    this.name = 'RuntimeCommandError'
+    this.code = code
+  }
+}
+
+export class GatewayClientCommandRuntime {
+  constructor({
+    taskManager,
+    backendRuntime,
+    conversationHistory,
+    respondAuthorization,
+    permissionPolicy,
+    logger = null,
+  } = {}) {
+    if (!taskManager) throw new TypeError('taskManager is required')
+    if (!backendRuntime) throw new TypeError('backendRuntime is required')
+    if (!conversationHistory) throw new TypeError('conversationHistory is required')
+    this.taskManager = taskManager
+    this.backendRuntime = backendRuntime
+    this.conversationHistory = conversationHistory
+    this.respondAuthorization = respondAuthorization
+    this.permissionPolicy = permissionPolicy
+    this.logger = logger
+  }
+
+  async execute(message, context = {}) {
+    const requestEventId = clean(message?.event_id)
+    const common = { request_event_id: requestEventId }
+    switch (message?.type) {
+      case GatewayClientProtocolEvent.TASK_CREATE:
+        return {
+          type: GatewayClientProtocolEvent.TASK_CREATE_RESULT,
+          ...common,
+          task: this.createTask(message, context),
+        }
+      case GatewayClientProtocolEvent.TASK_GET:
+        return {
+          type: GatewayClientProtocolEvent.TASK_GET_RESULT,
+          ...common,
+          task: this.getTask(message.task_id, context),
+        }
+      case GatewayClientProtocolEvent.TASK_LIST:
+        return {
+          type: GatewayClientProtocolEvent.TASK_LIST_RESULT,
+          ...common,
+          tasks: this.listTasks(message, context),
+        }
+      case GatewayClientProtocolEvent.TASK_CANCEL:
+        return {
+          type: GatewayClientProtocolEvent.TASK_CANCEL_RESULT,
+          ...common,
+          task: await this.cancelTask(message.task_id, context, { wait: false }),
+        }
+      case GatewayClientProtocolEvent.PERMISSION_RESPOND:
+        return {
+          type: GatewayClientProtocolEvent.PERMISSION_RESPOND_RESULT,
+          ...common,
+          permission: await this.respondPermission(message, context),
+        }
+      case GatewayClientProtocolEvent.CONVERSATION_HISTORY:
+        return {
+          type: GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT,
+          ...common,
+          messages: await this.history(message, context),
+        }
+      default:
+        throw new RuntimeCommandError(
+          'unknown_type',
+          `unsupported runtime command: ${clean(message?.type)}`,
+        )
+    }
+  }
+
+  createTask(message, { ownerId, sessionId = 'main' } = {}) {
+    let normalizedMessage
+    try {
+      normalizedMessage = {
+        parts: normalizeInputParts(message.message?.parts),
+      }
+    } catch (error) {
+      throw new RuntimeCommandError('bad_event', error.message)
+    }
+    const objective = objectiveFromMessage(normalizedMessage)
+    if (!objective) {
+      throw new RuntimeCommandError('bad_event', 'task.create requires content')
+    }
+    const inputParts = inputPartsFromMessage(normalizedMessage)
+    let taskId = ''
+    const task = this.taskManager.create({
+      objective,
+      ownerId,
+      sessionId,
+      submissionKey: clean(message.event_id),
+      laneKey: `backend:${clean(ownerId)}`,
+      laneLimit: 1,
+      runner: async (_ignored, { onEvent, signal }) => this.backendRuntime.run({
+        objective,
+        inputParts,
+      }, {
+        ownerId,
+        sessionId,
+        taskId,
+        signal,
+        onEvent,
+      }),
+      canceler: async ({ abort }) => {
+        const result = await this.backendRuntime.cancel(taskId, { ownerId })
+        abort()
+        return result
+      },
+    })
+    taskId = task.id
+    const publicTask = { ...task }
+    delete publicTask.reused
+    return publicTask
+  }
+
+  getTask(taskId, { ownerId } = {}) {
+    const task = this.taskManager.get(clean(taskId), { ownerId })
+    if (!task) throw new RuntimeCommandError('task_not_found', 'task not found')
+    return task
+  }
+
+  listTasks(message = {}, { ownerId, sessionId = 'main', allSessions = false } = {}) {
+    const limit = Number(message.limit) || 50
+    return this.taskManager.list({
+      ownerId,
+      sessionId: message.session_id || (allSessions ? undefined : sessionId),
+      active: message.active === true,
+    }).slice(0, limit)
+  }
+
+  async cancelTask(taskId, { ownerId } = {}, { wait = false } = {}) {
+    const id = clean(taskId)
+    const existing = this.getTask(id, { ownerId })
+    if (!isTaskCancellable(existing.status) && existing.status !== 'cancelling') {
+      throw new RuntimeCommandError('task_not_cancellable', 'task is no longer active')
+    }
+    const pending = this.taskManager.cancel(id, { ownerId })
+    if (wait) return pending
+    pending.catch(error => {
+      this.logger?.warn('task.cancel_async_failed', { taskId: id, error })
+    })
+    return this.taskManager.get(id, { ownerId }) || existing
+  }
+
+  async respondPermission(message, { ownerId } = {}) {
+    if (!this.respondAuthorization) {
+      throw new RuntimeCommandError('permission_not_found', 'permission runtime unavailable')
+    }
+    const permissionId = clean(message.permission_id)
+    const permissionTask = this.taskManager.list({
+      ownerId,
+      active: true,
+    }).find(task => task.authorization?.id === permissionId)
+    if (!permissionTask) {
+      throw new RuntimeCommandError('permission_not_found', 'permission request not found')
+    }
+    const previousPermissionMode = this.permissionPolicy?.mode(
+      ownerId,
+      permissionTask.sessionId,
+    )
+    this.permissionPolicy?.applyDecision(
+      ownerId,
+      permissionTask.sessionId,
+      message.decision,
+    )
+    try {
+      return await this.respondAuthorization(
+        permissionTask.id,
+        permissionId,
+        message.decision,
+        { ownerId },
+      )
+    } catch (error) {
+      if (previousPermissionMode) {
+        this.permissionPolicy?.setMode(
+          ownerId,
+          permissionTask.sessionId,
+          previousPermissionMode,
+        )
+      }
+      throw error
+    }
+  }
+
+  history(message = {}, { ownerId, sessionId = 'main' } = {}) {
+    return this.conversationHistory.messages({
+      ownerId,
+      sessionId: message.session_id || sessionId,
+    })
+  }
+}

--- a/server/src/client/client-event-router.mjs
+++ b/server/src/client/client-event-router.mjs
@@ -1,0 +1,234 @@
+import { z } from 'zod'
+
+const ROUTE_PRIORITY = Object.freeze({
+  handle: 0,
+  context: 1,
+  respond: 2,
+  interrupt: 3,
+})
+const RESERVED_NAMESPACES = new Set([
+  'client',
+  'conversation',
+  'gateway',
+  'permission',
+  'response',
+  'session',
+  'task',
+])
+
+function cleanName(value) {
+  return String(value || '').trim()
+}
+
+function sourceKey(source = {}) {
+  return [
+    source.ownerId,
+    source.sessionId,
+    source.clientInstanceId,
+  ].map(value => String(value || '')).join(':')
+}
+
+function boundedRoute(requested, maximum) {
+  if (!requested) return maximum
+  return ROUTE_PRIORITY[requested] <= ROUTE_PRIORITY[maximum]
+    ? requested
+    : maximum
+}
+
+export class ClientEventRoutingError extends Error {
+  constructor(code, message) {
+    super(message)
+    this.name = 'ClientEventRoutingError'
+    this.code = code
+  }
+}
+
+export const BUILTIN_CLIENT_EVENT_DEFINITIONS = Object.freeze([
+  Object.freeze({
+    name: 'desktop.presence.sleep_requested',
+    schema: z.object({
+      reason: z.string().trim().min(1).max(160).optional(),
+      idle_ms: z.number().int().nonnegative().max(86_400_000).optional(),
+    }).strict(),
+    maxBytes: 1_024,
+    rateLimit: Object.freeze({ max: 4, windowMs: 10_000 }),
+    retention: 'latest',
+    route: 'respond',
+  }),
+])
+
+export class ClientEventDefinitionRegistry {
+  constructor({ definitions = BUILTIN_CLIENT_EVENT_DEFINITIONS } = {}) {
+    this.definitions = new Map()
+    for (const definition of definitions) this.register(definition)
+  }
+
+  register(definition = {}) {
+    const name = cleanName(definition.name)
+    const namespace = name.split('.')[0]
+    if (!/^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$/.test(name)) {
+      throw new TypeError(`invalid Client Event name: ${name || '<empty>'}`)
+    }
+    if (RESERVED_NAMESPACES.has(namespace)) {
+      throw new TypeError(`reserved Client Event namespace: ${namespace}`)
+    }
+    if (this.definitions.has(name)) {
+      throw new TypeError(`duplicate Client Event definition: ${name}`)
+    }
+    if (!definition.schema?.safeParse) {
+      throw new TypeError(`Client Event ${name} requires a schema`)
+    }
+    const route = ROUTE_PRIORITY[definition.route] == null
+      ? 'handle'
+      : definition.route
+    const retention = definition.retention === 'latest' ? 'latest' : 'transient'
+    const normalized = Object.freeze({
+      name,
+      schema: definition.schema,
+      maxBytes: Math.max(128, Math.min(65_536, Number(definition.maxBytes) || 4_096)),
+      rateLimit: Object.freeze({
+        max: Math.max(1, Math.min(1_000, Number(definition.rateLimit?.max) || 20)),
+        windowMs: Math.max(
+          100,
+          Math.min(60_000, Number(definition.rateLimit?.windowMs) || 1_000),
+        ),
+      }),
+      retention,
+      route,
+      coalesceKey: typeof definition.coalesceKey === 'function'
+        ? definition.coalesceKey
+        : null,
+      handle: typeof definition.handle === 'function' ? definition.handle : null,
+    })
+    this.definitions.set(name, normalized)
+    return normalized
+  }
+
+  get(name) {
+    return this.definitions.get(cleanName(name)) || null
+  }
+
+  list() {
+    return [...this.definitions.values()]
+  }
+}
+
+export class GatewayEventRouter {
+  constructor({
+    registry = new ClientEventDefinitionRegistry(),
+    now = Date.now,
+    duplicateTtlMs = 300_000,
+    maxDuplicateIds = 1_024,
+  } = {}) {
+    this.registry = registry
+    this.now = now
+    this.duplicateTtlMs = duplicateTtlMs
+    this.maxDuplicateIds = maxDuplicateIds
+    this.seen = new Map()
+    this.rateBuckets = new Map()
+    this.latest = new Map()
+  }
+
+  async publish(message, { source = {} } = {}) {
+    const messageId = cleanName(message?.event_id)
+    if (!messageId) {
+      throw new ClientEventRoutingError(
+        'client_event_invalid',
+        'Client Event requires event_id',
+      )
+    }
+    const definition = this.registry.get(message?.name)
+    if (!definition) {
+      throw new ClientEventRoutingError(
+        'client_event_unsupported',
+        `unsupported Client Event: ${cleanName(message?.name)}`,
+      )
+    }
+
+    const now = this.now()
+    this.#pruneSeen(now)
+    const duplicateKey = `${sourceKey(source)}:${messageId}`
+    if (this.seen.has(duplicateKey)) {
+      return { accepted: true, duplicate: true, name: definition.name }
+    }
+
+    const bytes = Buffer.byteLength(JSON.stringify(message.data ?? null), 'utf8')
+    if (bytes > definition.maxBytes) {
+      throw new ClientEventRoutingError(
+        'payload_too_large',
+        `Client Event payload exceeds ${definition.maxBytes} bytes`,
+      )
+    }
+    const parsed = definition.schema.safeParse(message.data ?? {})
+    if (!parsed.success) {
+      throw new ClientEventRoutingError(
+        'client_event_invalid',
+        `invalid ${definition.name} payload`,
+      )
+    }
+    this.#admitRate(definition, source, now)
+
+    const trustedSource = Object.freeze({
+      ownerId: String(source.ownerId || ''),
+      sessionId: String(source.sessionId || 'main'),
+      clientType: String(source.clientType || 'web'),
+      clientInstanceId: String(source.clientInstanceId || ''),
+    })
+    const event = Object.freeze({
+      id: messageId,
+      name: definition.name,
+      data: Object.freeze(parsed.data),
+      occurredAt: Number(message.occurred_at) || now,
+      receivedAt: now,
+      source: trustedSource,
+      route: boundedRoute(message.delivery_hint, definition.route),
+    })
+    await definition.handle?.(event)
+    this.seen.set(duplicateKey, now)
+    this.#boundSeen()
+
+    if (definition.retention === 'latest') {
+      const suffix = definition.coalesceKey?.(parsed.data, trustedSource) || ''
+      this.latest.set(`${sourceKey(trustedSource)}:${definition.name}:${suffix}`, event)
+    }
+    return {
+      accepted: true,
+      duplicate: false,
+      name: definition.name,
+      event,
+    }
+  }
+
+  latestEvents() {
+    return [...this.latest.values()]
+  }
+
+  #admitRate(definition, source, now) {
+    const key = `${sourceKey(source)}:${definition.name}`
+    const current = this.rateBuckets.get(key)
+    const bucket = !current || now - current.startedAt >= definition.rateLimit.windowMs
+      ? { startedAt: now, count: 0 }
+      : current
+    bucket.count += 1
+    this.rateBuckets.set(key, bucket)
+    if (bucket.count > definition.rateLimit.max) {
+      throw new ClientEventRoutingError(
+        'rate_limited',
+        `Client Event rate limit exceeded: ${definition.name}`,
+      )
+    }
+  }
+
+  #pruneSeen(now) {
+    for (const [key, timestamp] of this.seen) {
+      if (now - timestamp <= this.duplicateTtlMs) continue
+      this.seen.delete(key)
+    }
+  }
+
+  #boundSeen() {
+    while (this.seen.size > this.maxDuplicateIds) {
+      this.seen.delete(this.seen.keys().next().value)
+    }
+  }
+}

--- a/server/src/core/gateway-protocol.mjs
+++ b/server/src/core/gateway-protocol.mjs
@@ -10,6 +10,9 @@
 // Every capability listed here is locked by a test (see docs/contract.md);
 // anything not listed is internal and may change in any release.
 //
+// 5.2.0 adds GCP2 Client Event ingress and WebSocket runtime commands for
+// Tasks, permissions, and conversation history while retaining the existing
+// REST paths as migration aliases.
 // 5.1.0 adds the opt-in 6.0 Gateway Client Protocol handshake and versioned
 // envelope while preserving every 5.x Client event as a compatibility alias.
 // 5.0.0 removes the backend-controlled Task presentation envelope. Backend
@@ -32,7 +35,7 @@
 // desktop.settings-window, …) are not part of this contract, and a removed
 // capability is a breaking change. Hosts migrating from the fork must branch
 // on the capability list below, never on the version number.
-export const GATEWAY_PROTOCOL_VERSION = '5.1.0'
+export const GATEWAY_PROTOCOL_VERSION = '5.2.0'
 
 export const GATEWAY_CAPABILITIES = Object.freeze([
   // The Gateway statically hosts web/dist at its own origin, so a client may
@@ -92,6 +95,10 @@ export const GATEWAY_CAPABILITIES = Object.freeze([
   // 5.x connect and event names remain compatibility aliases through one
   // normalization layer.
   'realtime.gateway-client-protocol-v6-handshake',
+  // Negotiated 6.0 clients can publish registered Client Events and execute
+  // Task, permission, and conversation-history runtime commands over the same
+  // WebSocket. Immediate results and errors correlate through request_event_id.
+  'realtime.gateway-client-protocol-v6-runtime-commands',
   // The orb shell contract ships: qwen-audio-agent/orb/preload plus
   // orb/main's bindOrbShell, so a host may run the floating orb form.
   'desktop.orb-shell',

--- a/server/src/transport/gateway-client-protocol-session.mjs
+++ b/server/src/transport/gateway-client-protocol-session.mjs
@@ -4,9 +4,12 @@ import {
   GATEWAY_CLIENT_PROTOCOL_VERSION,
   GatewayClientProtocolEvent,
   GatewaySessionHelloSchema,
+  gatewayClientProtocolCapabilityFor,
   gatewayHelloAsLegacyConnect,
+  isGatewayClientRuntimeMessage,
   negotiateGatewayClientCapabilities,
   normalizeGatewayClientProtocolMessage,
+  parseGatewayClientProtocolMessage,
   supportsGatewayClientProtocol,
 } from '../../../shared/gateway-client-protocol.mjs'
 import { parseGatewayClientMessage } from '../../../shared/protocol/gateway-events.mjs'
@@ -52,6 +55,24 @@ export class GatewayClientProtocolSession {
       return this.#error('bad_event', 'session.hello is only valid as the first message', {
         requestEventId: value?.event_id,
       })
+    }
+
+    if (isGatewayClientRuntimeMessage(value?.type)) {
+      const requiredCapability = gatewayClientProtocolCapabilityFor(value.type)
+      if (!this.capabilities.includes(requiredCapability)) {
+        return this.#error(
+          'capability_not_negotiated',
+          `${requiredCapability} was not negotiated`,
+          { requestEventId: value?.event_id },
+        )
+      }
+      try {
+        return { event: null, runtimeMessage: parseGatewayClientProtocolMessage(value) }
+      } catch (error) {
+        return this.#error('bad_event', error.message, {
+          requestEventId: value?.event_id,
+        })
+      }
     }
 
     try {

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -50,6 +50,11 @@ import {
 } from '../frontend/tools/frontend-tool-source.mjs'
 import { FRONTEND_RECALL_CAPABILITY } from './frontend-tools.mjs'
 import { GatewayClientProtocolSession } from '../transport/gateway-client-protocol-session.mjs'
+import {
+  GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES,
+  GatewayClientCapability,
+  GatewayClientProtocolEvent,
+} from '../../../shared/gateway-client-protocol.mjs'
 
 const MAX_PENDING_AUDIO_CHUNKS = 30
 const RESPONSE_START_WATCHDOG_MS = 12000
@@ -127,8 +132,22 @@ export function attachRealtimeGateway(server, {
   frontendKnowledge = null,
   frontendToolSources = [],
   taskAnnouncementFactory = createTaskAnnouncementRuntime,
+  clientCommandRuntime = null,
+  clientEventRouter = null,
 }) {
   const wss = new WebSocketServer({ noServer: true, maxPayload: 20 * 1024 * 1024 })
+  const supportedClientCapabilities = GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES
+    .filter(capability => {
+      if (capability === GatewayClientCapability.CLIENT_EVENTS) {
+        return Boolean(clientEventRouter)
+      }
+      if ([
+        GatewayClientCapability.TASK_COMMANDS,
+        GatewayClientCapability.PERMISSION_RESPOND,
+        GatewayClientCapability.CONVERSATION_HISTORY,
+      ].includes(capability)) return Boolean(clientCommandRuntime)
+      return true
+    })
   const activeVoiceClients = new ActiveVoiceClients()
   const voiceConnections = new Map()
   const frontendToolSourcesReady = Promise.all(
@@ -184,7 +203,10 @@ export function attachRealtimeGateway(server, {
   wss.on('connection', (ws, url, identity) => {
     const ownerId = identity.ownerId
     const sessionId = url.searchParams.get('sessionId') || 'main'
-    const clientProtocol = new GatewayClientProtocolSession({ sessionId })
+    const clientProtocol = new GatewayClientProtocolSession({
+      sessionId,
+      supportedCapabilities: supportedClientCapabilities,
+    })
     clientProtocolSessions.set(ws, clientProtocol)
     const connectionLogger = logger.child({
       subsystem: 'realtime',
@@ -218,6 +240,7 @@ export function attachRealtimeGateway(server, {
     const announcedPermissions = new Set()
     let permissionRetryTimer = null
     let realtimeSession
+    let runtimeMessageChain = Promise.resolve()
     const activeSessionTasks = () => taskManager.list({
       ownerId,
       sessionId,
@@ -1008,6 +1031,62 @@ export function attachRealtimeGateway(server, {
         expiresAt: status.expiresAt,
       })
     }
+    const runtimeSource = () => ({
+      ownerId,
+      sessionId,
+      clientType: descriptor.type,
+      clientInstanceId: descriptor.instanceId,
+    })
+    const sendRuntimeError = (message, error) => {
+      connectionLogger.warn('client_runtime.command_failed', {
+        type: String(message?.type || ''),
+        requestEventId: String(message?.event_id || ''),
+        code: String(error?.code || 'internal'),
+        error: String(error?.message || error),
+      })
+      send(ws, {
+        type: 'error',
+        ...(message?.event_id
+          ? { request_event_id: String(message.event_id) }
+          : {}),
+        error: {
+          code: String(error?.code || 'internal').slice(0, 80),
+          message: String(error?.message || error).slice(0, 500),
+        },
+      })
+    }
+    const handleRuntimeMessage = async message => {
+      if (message.type === GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH) {
+        if (!clientEventRouter) {
+          const error = new Error('Client Event runtime unavailable')
+          error.code = 'internal'
+          throw error
+        }
+        const result = await clientEventRouter.publish(message, {
+          source: runtimeSource(),
+        })
+        send(ws, {
+          type: GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH_RESULT,
+          request_event_id: message.event_id,
+          accepted: result.accepted === true,
+          name: result.name,
+          ...(result.duplicate ? { duplicate: true } : {}),
+        })
+        return
+      }
+      if (!clientCommandRuntime) {
+        const error = new Error('Gateway Client command runtime unavailable')
+        error.code = 'internal'
+        throw error
+      }
+      const result = await clientCommandRuntime.execute(message, {
+        ownerId,
+        sessionId,
+        source: runtimeSource(),
+      })
+      send(ws, result)
+    }
+
     ws.on('message', raw => {
       let event
       try {
@@ -1023,6 +1102,13 @@ export function attachRealtimeGateway(server, {
       }
       for (const pendingEvent of protocolOutcome.pending || []) {
         send(ws, pendingEvent)
+      }
+      if (protocolOutcome.runtimeMessage) {
+        const runtimeMessage = protocolOutcome.runtimeMessage
+        runtimeMessageChain = runtimeMessageChain
+          .then(() => handleRuntimeMessage(runtimeMessage))
+          .catch(error => sendRuntimeError(runtimeMessage, error))
+        return
       }
       event = protocolOutcome.event
       if (!event) return

--- a/server/test/client-command-runtime.test.mjs
+++ b/server/test/client-command-runtime.test.mjs
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  GatewayClientProtocolEvent,
+} from '../../shared/gateway-client-protocol.mjs'
+import {
+  GatewayClientCommandRuntime,
+  RuntimeCommandError,
+} from '../src/client/client-command-runtime.mjs'
+
+function task(overrides = {}) {
+  return {
+    id: 'task_1',
+    workState: 'working',
+    status: 'running',
+    kind: 'work',
+    objective: '查询本机内存',
+    ownerId: 'owner-1',
+    sessionId: 'voice-1',
+    createdAt: 1,
+    startedAt: 2,
+    completedAt: null,
+    elapsedMs: 3,
+    ...overrides,
+  }
+}
+
+function harness(overrides = {}) {
+  const records = new Map([['task_1', task()]])
+  const calls = { created: [], cancelled: [], backend: [] }
+  const taskManager = {
+    create(options) {
+      calls.created.push(options)
+      const created = task({
+        id: `task_${records.size + 1}`,
+        objective: options.objective,
+        sessionId: options.sessionId,
+      })
+      records.set(created.id, created)
+      return created
+    },
+    get(id, { ownerId } = {}) {
+      const value = records.get(id)
+      return value?.ownerId === ownerId ? value : null
+    },
+    list({ ownerId, sessionId, active } = {}) {
+      return [...records.values()].filter(item => (
+        item.ownerId === ownerId
+        && (!sessionId || item.sessionId === sessionId)
+        && (!active || ['queued', 'running', 'cancelling'].includes(item.status))
+      ))
+    },
+    async cancel(id) {
+      calls.cancelled.push(id)
+      const value = records.get(id)
+      Object.assign(value, {
+        status: 'cancelled',
+        workState: 'cancelled',
+        completedAt: 4,
+      })
+      return value
+    },
+  }
+  const runtime = new GatewayClientCommandRuntime({
+    taskManager,
+    backendRuntime: {
+      run: async (...args) => {
+        calls.backend.push(args)
+        return { content: 'ok' }
+      },
+      cancel: async () => ({ status: 'cancelled' }),
+    },
+    conversationHistory: {
+      messages: ({ ownerId, sessionId }) => [{ role: 'user', text: `${ownerId}:${sessionId}` }],
+    },
+    respondAuthorization: async () => ({ status: 'approved' }),
+    permissionPolicy: null,
+    ...overrides,
+  })
+  return { runtime, records, calls }
+}
+
+test('executes correlated task and conversation runtime commands', async () => {
+  const { runtime, calls } = harness()
+  const created = await runtime.execute({
+    type: GatewayClientProtocolEvent.TASK_CREATE,
+    event_id: 'evt-create-1',
+    message: {
+      parts: [
+        { type: 'text', text: '查询硬盘' },
+        {
+          type: 'file',
+          mime: 'text/plain',
+          url: 'data:text/plain;base64,YQ==',
+          filename: 'a.txt',
+        },
+      ],
+    },
+  }, { ownerId: 'owner-1', sessionId: 'voice-1' })
+  assert.equal(created.type, GatewayClientProtocolEvent.TASK_CREATE_RESULT)
+  assert.equal(created.request_event_id, 'evt-create-1')
+  assert.equal(created.task.objective, '查询硬盘')
+  assert.equal(calls.created[0].submissionKey, 'evt-create-1')
+
+  const listed = await runtime.execute({
+    type: GatewayClientProtocolEvent.TASK_LIST,
+    event_id: 'evt-list-1',
+    active: true,
+  }, { ownerId: 'owner-1', sessionId: 'voice-1' })
+  assert.equal(listed.tasks.length, 2)
+
+  const history = await runtime.execute({
+    type: GatewayClientProtocolEvent.CONVERSATION_HISTORY,
+    event_id: 'evt-history-1',
+  }, { ownerId: 'owner-1', sessionId: 'voice-1' })
+  assert.deepEqual(history.messages, [{ role: 'user', text: 'owner-1:voice-1' }])
+})
+
+test('cancels active tasks asynchronously and rejects terminal tasks', async () => {
+  const { runtime, records, calls } = harness()
+  const result = await runtime.execute({
+    type: GatewayClientProtocolEvent.TASK_CANCEL,
+    event_id: 'evt-cancel-1',
+    task_id: 'task_1',
+  }, { ownerId: 'owner-1' })
+  assert.equal(result.request_event_id, 'evt-cancel-1')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(calls.cancelled, ['task_1'])
+
+  records.set('task_2', task({
+    id: 'task_2',
+    status: 'completed',
+    workState: 'completed',
+  }))
+  await assert.rejects(
+    runtime.cancelTask('task_2', { ownerId: 'owner-1' }),
+    error => error instanceof RuntimeCommandError
+      && error.code === 'task_not_cancellable',
+  )
+})
+
+test('applies the shared attachment safety policy to explicit Task commands', async () => {
+  const { runtime } = harness()
+  await assert.rejects(runtime.execute({
+    type: GatewayClientProtocolEvent.TASK_CREATE,
+    event_id: 'evt-create-local-file',
+    message: {
+      parts: [{
+        type: 'file',
+        mime: 'text/plain',
+        filename: 'secret.txt',
+        url: 'file:///etc/passwd',
+      }],
+    },
+  }, { ownerId: 'owner-1', sessionId: 'voice-1' }), error => (
+    error instanceof RuntimeCommandError
+    && error.code === 'bad_event'
+    && /不支持的附件 URL 协议/u.test(error.message)
+  ))
+})
+
+test('rolls back session permission policy when the adapter rejects a response', async () => {
+  const permissionTask = task({
+    authorization: { id: 'permission-1' },
+  })
+  const taskManager = {
+    create: () => permissionTask,
+    get: () => permissionTask,
+    list: () => [permissionTask],
+    cancel: async () => permissionTask,
+  }
+  const changes = []
+  const runtime = new GatewayClientCommandRuntime({
+    taskManager,
+    backendRuntime: { run: async () => ({}), cancel: async () => ({}) },
+    conversationHistory: { messages: () => [] },
+    respondAuthorization: async () => {
+      throw new Error('adapter unavailable')
+    },
+    permissionPolicy: {
+      mode: () => 'ask',
+      applyDecision: (...args) => changes.push(['apply', ...args]),
+      setMode: (...args) => changes.push(['restore', ...args]),
+    },
+  })
+  await assert.rejects(runtime.execute({
+    type: GatewayClientProtocolEvent.PERMISSION_RESPOND,
+    event_id: 'evt-permission-1',
+    permission_id: 'permission-1',
+    decision: 'always',
+  }, { ownerId: 'owner-1' }), /adapter unavailable/u)
+  assert.deepEqual(changes.map(change => change[0]), ['apply', 'restore'])
+})

--- a/server/test/client-event-router.test.mjs
+++ b/server/test/client-event-router.test.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { z } from 'zod'
+import {
+  BUILTIN_CLIENT_EVENT_DEFINITIONS,
+  ClientEventDefinitionRegistry,
+  ClientEventRoutingError,
+  GatewayEventRouter,
+} from '../src/client/client-event-router.mjs'
+
+const source = Object.freeze({
+  ownerId: 'owner-1',
+  sessionId: 'voice-1',
+  clientType: 'desktop',
+  clientInstanceId: 'desktop-1',
+})
+
+function sleepEvent(overrides = {}) {
+  return {
+    type: 'client.event.publish',
+    event_id: 'evt-sleep-1',
+    name: 'desktop.presence.sleep_requested',
+    data: { reason: 'idle', idle_ms: 60_000 },
+    ...overrides,
+  }
+}
+
+test('registers built-in and extension Client Event definitions', () => {
+  const registry = new ClientEventDefinitionRegistry({
+    definitions: [
+      ...BUILTIN_CLIENT_EVENT_DEFINITIONS,
+      {
+        name: 'vehicle.control.button_pressed',
+        schema: z.object({ button: z.string().min(1) }).strict(),
+        route: 'context',
+      },
+    ],
+  })
+  assert.equal(registry.get('desktop.presence.sleep_requested')?.route, 'respond')
+  assert.equal(registry.get('vehicle.control.button_pressed')?.route, 'context')
+  assert.throws(() => registry.register({
+    name: 'task.changed',
+    schema: z.object({}),
+  }), /reserved Client Event namespace/u)
+})
+
+test('validates, rate-limits and bounds Client Event payloads', async () => {
+  let now = 1_000
+  const router = new GatewayEventRouter({ now: () => now })
+  await assert.rejects(
+    router.publish(sleepEvent({ name: 'desktop.unknown.event' }), { source }),
+    error => error instanceof ClientEventRoutingError
+      && error.code === 'client_event_unsupported',
+  )
+  await assert.rejects(
+    router.publish(sleepEvent({ data: { idle_ms: -1 } }), { source }),
+    error => error.code === 'client_event_invalid',
+  )
+  await assert.rejects(
+    router.publish(sleepEvent({ data: { reason: 'x'.repeat(2_000) } }), { source }),
+    error => ['payload_too_large', 'client_event_invalid'].includes(error.code),
+  )
+
+  for (let index = 0; index < 4; index += 1) {
+    await router.publish(sleepEvent({ event_id: `evt-rate-${index}` }), { source })
+  }
+  await assert.rejects(
+    router.publish(sleepEvent({ event_id: 'evt-rate-5' }), { source }),
+    error => error.code === 'rate_limited',
+  )
+  now += 10_001
+  assert.equal((await router.publish(sleepEvent({ event_id: 'evt-rate-6' }), {
+    source,
+  })).accepted, true)
+})
+
+test('deduplicates by trusted source and retains only the latest event', async () => {
+  let now = 1_000
+  const router = new GatewayEventRouter({ now: () => now })
+  const first = await router.publish(sleepEvent({
+    delivery_hint: 'context',
+    source: { ownerId: 'spoofed-owner', clientType: 'spoofed-client' },
+  }), { source })
+  assert.equal(first.event.route, 'context')
+  assert.deepEqual(first.event.source, source)
+  assert.equal(first.event.source.ownerId, 'owner-1')
+
+  const duplicate = await router.publish(sleepEvent({ data: { reason: 'changed' } }), {
+    source,
+  })
+  assert.equal(duplicate.duplicate, true)
+  assert.equal(router.latestEvents()[0].data.reason, 'idle')
+
+  now += 1
+  const next = await router.publish(sleepEvent({
+    event_id: 'evt-sleep-2',
+    data: { reason: 'new' },
+    // A client may request a quieter route, but never upgrade beyond the
+    // registered definition's maximum route.
+    delivery_hint: 'interrupt',
+  }), { source })
+  assert.equal(next.event.route, 'respond')
+  assert.equal(router.latestEvents().length, 1)
+  assert.equal(router.latestEvents()[0].data.reason, 'new')
+})
+
+test('does not acknowledge or retain a Client Event whose handler fails', async () => {
+  let attempts = 0
+  const registry = new ClientEventDefinitionRegistry({
+    definitions: [{
+      name: 'hardware.sensor.changed',
+      schema: z.object({ value: z.number() }).strict(),
+      retention: 'latest',
+      handle: () => {
+        attempts += 1
+        if (attempts === 1) throw new Error('temporary failure')
+      },
+    }],
+  })
+  const router = new GatewayEventRouter({ registry })
+  const message = {
+    event_id: 'evt-sensor-1',
+    name: 'hardware.sensor.changed',
+    data: { value: 1 },
+  }
+  await assert.rejects(router.publish(message, { source }), /temporary failure/u)
+  assert.deepEqual(router.latestEvents(), [])
+  assert.equal((await router.publish(message, { source })).duplicate, false)
+  assert.equal(attempts, 2)
+})

--- a/server/test/dependency-boundaries.test.mjs
+++ b/server/test/dependency-boundaries.test.mjs
@@ -12,6 +12,7 @@ const allowedDependencies = {
     'agent',
     'app',
     'backend',
+    'client',
     'conversation',
     'core',
     'domain',
@@ -28,6 +29,7 @@ const allowedDependencies = {
   providers: new Set(['core', 'frontend', 'providers', 'shared']),
   agent: new Set(['agent', 'backend', 'core', 'shared']),
   backend: new Set(['backend', 'core', 'shared']),
+  client: new Set(['client', 'shared', 'task']),
   conversation: new Set(['conversation', 'core', 'shared']),
   // 资料库刻意不依赖 conversation：它复用的落盘与敏感闸门都在 core，
   // 让「用户给的手册」去依赖「会话逻辑」是没有道理的耦合。

--- a/server/test/gateway-client-handshake.test.mjs
+++ b/server/test/gateway-client-handshake.test.mjs
@@ -4,11 +4,16 @@ import test from 'node:test'
 import WebSocket from 'ws'
 import {
   GatewayClientCapability,
+  GatewayClientProtocolEvent,
   createGatewaySessionHello,
 } from '../../shared/gateway-client-protocol.mjs'
+import {
+  ClientEventDefinitionRegistry,
+  GatewayEventRouter,
+} from '../src/client/client-event-router.mjs'
 import { attachRealtimeGateway } from '../src/voice/realtime-gateway.mjs'
 
-function gatewayHarness() {
+function gatewayHarness(overrides = {}) {
   const server = createServer()
   const gateway = attachRealtimeGateway(server, {
     identityManager: {
@@ -25,6 +30,7 @@ function gatewayHarness() {
       resolveDecision: () => null,
       rememberDecision: () => {},
     },
+    ...overrides,
   })
   return { server, gateway }
 }
@@ -81,7 +87,11 @@ test('5.x connect and 6.0 session.hello share one Gateway business path', async 
     eventId: 'evt_client_hello',
     clientType: 'web',
     clientInstanceId: 'web_protocol_test',
-    capabilities: [GatewayClientCapability.INPUT_TEXT],
+    capabilities: [
+      GatewayClientCapability.INPUT_TEXT,
+      GatewayClientCapability.CLIENT_EVENTS,
+      GatewayClientCapability.TASK_COMMANDS,
+    ],
   }))
   const ready = await waitFor(modern.received, event => event.type === 'session.ready')
   assert.equal(ready.request_event_id, 'evt_client_hello')
@@ -91,5 +101,106 @@ test('5.x connect and 6.0 session.hello share one Gateway business path', async 
   const state = await waitFor(modern.received, event => event.type === 'voice.state')
   assert.match(state.event_id, /^evt_gateway_/)
   assert.equal(modern.received[0].type, 'session.ready')
+  modern.socket.close()
+})
+
+test('routes negotiated GCP2 commands and Client Events with correlated results', async t => {
+  const commands = []
+  const routed = []
+  const registry = new ClientEventDefinitionRegistry()
+  const definition = registry.get('desktop.presence.sleep_requested')
+  registry.definitions.set(definition.name, Object.freeze({
+    ...definition,
+    handle: event => routed.push(event),
+  }))
+  const { server, gateway } = gatewayHarness({
+    clientEventRouter: new GatewayEventRouter({ registry }),
+    clientCommandRuntime: {
+      async execute(message, context) {
+        commands.push({ message, context })
+        return {
+          type: GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT,
+          request_event_id: message.event_id,
+          messages: [],
+        }
+      },
+    },
+  })
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  t.after(async () => {
+    await gateway.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const modern = await connect(server, createGatewaySessionHello({
+    eventId: 'evt-client-hello',
+    clientType: 'desktop',
+    clientInstanceId: 'desktop-runtime-test',
+    capabilities: [
+      GatewayClientCapability.CLIENT_EVENTS,
+      GatewayClientCapability.CONVERSATION_HISTORY,
+    ],
+  }))
+  await waitFor(modern.received, event => event.type === 'session.ready')
+
+  modern.socket.send(JSON.stringify({
+    type: GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH,
+    event_id: 'evt-client-sleep',
+    name: 'desktop.presence.sleep_requested',
+    data: { reason: 'idle' },
+  }))
+  const eventResult = await waitFor(
+    modern.received,
+    event => event.request_event_id === 'evt-client-sleep',
+  )
+  assert.equal(eventResult.type, GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH_RESULT)
+  assert.equal(eventResult.accepted, true)
+  assert.equal(routed[0].source.ownerId, 'owner-protocol-test')
+  assert.equal(routed[0].source.clientInstanceId, 'desktop-runtime-test')
+
+  modern.socket.send(JSON.stringify({
+    type: GatewayClientProtocolEvent.CONVERSATION_HISTORY,
+    event_id: 'evt-client-history',
+  }))
+  const history = await waitFor(
+    modern.received,
+    event => event.request_event_id === 'evt-client-history',
+  )
+  assert.equal(history.type, GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT)
+  assert.equal(commands[0].context.sessionId, 'protocol-test')
+  modern.socket.close()
+})
+
+test('rejects unnegotiated GCP2 commands before dispatch', async t => {
+  const { server, gateway } = gatewayHarness({
+    clientCommandRuntime: {
+      execute() {
+        throw new Error('must not dispatch')
+      },
+    },
+  })
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  t.after(async () => {
+    await gateway.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+  const modern = await connect(server, createGatewaySessionHello({
+    eventId: 'evt-client-hello',
+    clientInstanceId: 'web-runtime-test',
+    capabilities: [GatewayClientCapability.INPUT_TEXT],
+  }))
+  await waitFor(modern.received, event => event.type === 'session.ready')
+  modern.socket.send(JSON.stringify({
+    type: GatewayClientProtocolEvent.PERMISSION_RESPOND,
+    event_id: 'evt-client-permission',
+    permission_id: 'permission-1',
+    decision: 'always',
+  }))
+  const error = await waitFor(
+    modern.received,
+    event => event.request_event_id === 'evt-client-permission',
+  )
+  assert.equal(error.type, 'error')
+  assert.equal(error.error.code, 'capability_not_negotiated')
   modern.socket.close()
 })

--- a/shared/gateway-client-protocol.mjs
+++ b/shared/gateway-client-protocol.mjs
@@ -3,7 +3,11 @@ import {
   GatewayClientEvent,
   GATEWAY_CLIENT_EVENT_TYPES,
 } from './realtime-events.mjs'
-import { parseGatewayClientMessage } from './protocol/gateway-events.mjs'
+import {
+  GatewayInputPartSchema,
+  GatewayTaskSchema,
+  parseGatewayClientMessage,
+} from './protocol/gateway-events.mjs'
 
 export const GATEWAY_CLIENT_PROTOCOL_VERSION = '6.0.0'
 
@@ -13,6 +17,20 @@ export const GatewayClientProtocolEvent = Object.freeze({
   INPUT_AUDIO_APPEND: 'input_audio_buffer.append',
   CONVERSATION_ITEM_CREATE: 'conversation.item.create',
   RESPONSE_CANCEL: 'response.cancel',
+  CLIENT_EVENT_PUBLISH: 'client.event.publish',
+  CLIENT_EVENT_PUBLISH_RESULT: 'client.event.publish.result',
+  TASK_CREATE: 'task.create',
+  TASK_CREATE_RESULT: 'task.create.result',
+  TASK_GET: 'task.get',
+  TASK_GET_RESULT: 'task.get.result',
+  TASK_LIST: 'task.list',
+  TASK_LIST_RESULT: 'task.list.result',
+  TASK_CANCEL: 'task.cancel',
+  TASK_CANCEL_RESULT: 'task.cancel.result',
+  PERMISSION_RESPOND: 'permission.respond',
+  PERMISSION_RESPOND_RESULT: 'permission.respond.result',
+  CONVERSATION_HISTORY: 'conversation.history',
+  CONVERSATION_HISTORY_RESULT: 'conversation.history.result',
 })
 
 export const GatewayClientCapability = Object.freeze({
@@ -29,9 +47,9 @@ export const GatewayClientCapability = Object.freeze({
   SESSION_REPLAY: 'session.replay',
 })
 
-// GCP1 publishes the complete vocabulary so clients and extensions do not
-// invent competing names. Only capabilities whose runtime exists today are
-// negotiated; later stages append their implementations without changing the
+// The complete roadmap vocabulary is published so clients and extensions do
+// not invent competing names. Only capabilities whose runtime exists today
+// are negotiated; later stages append implementations without changing the
 // handshake shape.
 export const GATEWAY_CLIENT_KNOWN_CAPABILITIES = Object.freeze(
   Object.values(GatewayClientCapability),
@@ -43,6 +61,10 @@ export const GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES = Object.freeze([
   GatewayClientCapability.INPUT_IMAGE,
   GatewayClientCapability.INPUT_FILE,
   GatewayClientCapability.PLAYBACK_RECEIPTS,
+  GatewayClientCapability.TASK_COMMANDS,
+  GatewayClientCapability.PERMISSION_RESPOND,
+  GatewayClientCapability.CONVERSATION_HISTORY,
+  GatewayClientCapability.CLIENT_EVENTS,
 ])
 
 const IdentifierSchema = z.string().min(1).max(128)
@@ -105,6 +127,121 @@ export const GatewayProtocolErrorSchema = GatewayServerEnvelopeSchema.extend({
   }),
 })
 
+const EventNameSchema = z.string()
+  .min(3)
+  .max(120)
+  .regex(/^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$/)
+
+export const GatewayClientEventPublishSchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH),
+  name: EventNameSchema,
+  data: z.unknown().optional(),
+  delivery_hint: z.enum(['handle', 'context', 'respond', 'interrupt']).optional(),
+})
+
+export const GatewayClientEventPublishResultSchema = GatewayServerEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH_RESULT),
+  request_event_id: IdentifierSchema,
+  accepted: z.boolean(),
+  name: EventNameSchema,
+  duplicate: z.boolean().optional(),
+})
+
+export const GatewayTaskCreateSchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.TASK_CREATE),
+  message: z.object({
+    parts: z.array(GatewayInputPartSchema).min(1).max(16),
+  }),
+})
+
+export const GatewayTaskGetSchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.TASK_GET),
+  task_id: IdentifierSchema,
+})
+
+export const GatewayTaskListSchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.TASK_LIST),
+  active: z.boolean().optional(),
+  session_id: IdentifierSchema.optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+})
+
+export const GatewayTaskCancelSchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.TASK_CANCEL),
+  task_id: IdentifierSchema,
+})
+
+export const GatewayPermissionRespondSchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.PERMISSION_RESPOND),
+  permission_id: IdentifierSchema,
+  decision: z.enum(['always', 'reject']),
+})
+
+export const GatewayConversationHistorySchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.CONVERSATION_HISTORY),
+  session_id: IdentifierSchema.optional(),
+})
+
+const TaskResultBaseSchema = GatewayServerEnvelopeSchema.extend({
+  request_event_id: IdentifierSchema,
+  task: GatewayTaskSchema,
+})
+
+export const GatewayTaskCreateResultSchema = TaskResultBaseSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.TASK_CREATE_RESULT),
+})
+export const GatewayTaskGetResultSchema = TaskResultBaseSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.TASK_GET_RESULT),
+})
+export const GatewayTaskCancelResultSchema = TaskResultBaseSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.TASK_CANCEL_RESULT),
+})
+export const GatewayTaskListResultSchema = GatewayServerEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.TASK_LIST_RESULT),
+  request_event_id: IdentifierSchema,
+  tasks: z.array(GatewayTaskSchema).max(100),
+})
+export const GatewayPermissionRespondResultSchema = GatewayServerEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.PERMISSION_RESPOND_RESULT),
+  request_event_id: IdentifierSchema,
+  permission: z.unknown(),
+})
+export const GatewayConversationHistoryResultSchema = GatewayServerEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT),
+  request_event_id: IdentifierSchema,
+  messages: z.array(z.unknown()).max(100),
+})
+
+const GCP2_CLIENT_MESSAGE_SCHEMAS = Object.freeze({
+  [GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH]: GatewayClientEventPublishSchema,
+  [GatewayClientProtocolEvent.TASK_CREATE]: GatewayTaskCreateSchema,
+  [GatewayClientProtocolEvent.TASK_GET]: GatewayTaskGetSchema,
+  [GatewayClientProtocolEvent.TASK_LIST]: GatewayTaskListSchema,
+  [GatewayClientProtocolEvent.TASK_CANCEL]: GatewayTaskCancelSchema,
+  [GatewayClientProtocolEvent.PERMISSION_RESPOND]: GatewayPermissionRespondSchema,
+  [GatewayClientProtocolEvent.CONVERSATION_HISTORY]: GatewayConversationHistorySchema,
+})
+
+const GCP2_SERVER_MESSAGE_SCHEMAS = Object.freeze({
+  [GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH_RESULT]: GatewayClientEventPublishResultSchema,
+  [GatewayClientProtocolEvent.TASK_CREATE_RESULT]: GatewayTaskCreateResultSchema,
+  [GatewayClientProtocolEvent.TASK_GET_RESULT]: GatewayTaskGetResultSchema,
+  [GatewayClientProtocolEvent.TASK_LIST_RESULT]: GatewayTaskListResultSchema,
+  [GatewayClientProtocolEvent.TASK_CANCEL_RESULT]: GatewayTaskCancelResultSchema,
+  [GatewayClientProtocolEvent.PERMISSION_RESPOND_RESULT]: GatewayPermissionRespondResultSchema,
+  [GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT]: GatewayConversationHistoryResultSchema,
+})
+
+const GCP2_REQUIRED_CAPABILITIES = Object.freeze({
+  [GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH]: GatewayClientCapability.CLIENT_EVENTS,
+  [GatewayClientProtocolEvent.TASK_CREATE]: GatewayClientCapability.TASK_COMMANDS,
+  [GatewayClientProtocolEvent.TASK_GET]: GatewayClientCapability.TASK_COMMANDS,
+  [GatewayClientProtocolEvent.TASK_LIST]: GatewayClientCapability.TASK_COMMANDS,
+  [GatewayClientProtocolEvent.TASK_CANCEL]: GatewayClientCapability.TASK_COMMANDS,
+  [GatewayClientProtocolEvent.PERMISSION_RESPOND]: GatewayClientCapability.PERMISSION_RESPOND,
+  [GatewayClientProtocolEvent.CONVERSATION_HISTORY]: GatewayClientCapability.CONVERSATION_HISTORY,
+})
+
 const V6_CLIENT_EVENT_ALIASES = Object.freeze({
   [GatewayClientProtocolEvent.INPUT_AUDIO_APPEND]: GatewayClientEvent.AUDIO_APPEND,
   [GatewayClientProtocolEvent.CONVERSATION_ITEM_CREATE]: GatewayClientEvent.INPUT_MESSAGE,
@@ -151,6 +288,14 @@ export function normalizeGatewayClientProtocolMessage(value) {
     throw error
   }
   return parseGatewayClientMessage(normalized)
+}
+
+export function gatewayClientProtocolCapabilityFor(type) {
+  return GCP2_REQUIRED_CAPABILITIES[type] || null
+}
+
+export function isGatewayClientRuntimeMessage(type) {
+  return Boolean(GCP2_CLIENT_MESSAGE_SCHEMAS[type])
 }
 
 export function gatewayHelloAsLegacyConnect(hello) {
@@ -219,7 +364,7 @@ export function createGatewayClientProtocolMessage(type, payload = {}, {
   eventId = createGatewayProtocolEventId('client'),
   occurredAt,
 } = {}) {
-  return GatewayClientEnvelopeSchema.parse({
+  return parseGatewayClientProtocolMessage({
     type,
     event_id: eventId,
     ...(occurredAt == null ? {} : { occurred_at: occurredAt }),
@@ -231,6 +376,9 @@ export function parseGatewayClientProtocolMessage(value) {
   if (value?.type === GatewayClientProtocolEvent.SESSION_HELLO) {
     return GatewaySessionHelloSchema.parse(value)
   }
+  if (GCP2_CLIENT_MESSAGE_SCHEMAS[value?.type]) {
+    return GCP2_CLIENT_MESSAGE_SCHEMAS[value.type].parse(value)
+  }
   return GatewayClientEnvelopeSchema.parse(value)
 }
 
@@ -240,6 +388,9 @@ export function parseGatewayServerProtocolMessage(value) {
   }
   if (value?.type === 'error' && value?.error) {
     return GatewayProtocolErrorSchema.parse(value)
+  }
+  if (GCP2_SERVER_MESSAGE_SCHEMAS[value?.type]) {
+    return GCP2_SERVER_MESSAGE_SCHEMAS[value.type].parse(value)
   }
   return GatewayServerEnvelopeSchema.parse(value)
 }

--- a/test/gateway-client-protocol.test.mjs
+++ b/test/gateway-client-protocol.test.mjs
@@ -10,8 +10,10 @@ import {
   GatewaySessionHelloSchema,
   createGatewayClientProtocolMessage,
   createGatewaySessionHello,
+  gatewayClientProtocolCapabilityFor,
   negotiateGatewayClientCapabilities,
   normalizeGatewayClientProtocolMessage,
+  parseGatewayClientProtocolMessage,
   parseGatewayServerProtocolMessage,
   supportsGatewayClientProtocol,
 } from '../shared/gateway-client-protocol.mjs'
@@ -22,7 +24,7 @@ function ids() {
   return () => `evt_gateway_${++value}`
 }
 
-test('publishes a frozen capability vocabulary without advertising future stages', () => {
+test('publishes a frozen capability vocabulary and only advertises implemented stages', () => {
   assert.equal(GATEWAY_CLIENT_PROTOCOL_VERSION, '6.0.0')
   assert.equal(Object.isFrozen(GATEWAY_CLIENT_KNOWN_CAPABILITIES), true)
   assert.equal(Object.isFrozen(GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES), true)
@@ -33,7 +35,7 @@ test('publishes a frozen capability vocabulary without advertising future stages
   assert.ok(GATEWAY_CLIENT_KNOWN_CAPABILITIES.includes(GatewayClientCapability.SESSION_REPLAY))
   assert.equal(
     GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES.includes(GatewayClientCapability.CLIENT_EVENTS),
-    false,
+    true,
   )
   assert.equal(
     GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES.includes(
@@ -80,7 +82,41 @@ test('negotiates one supported 6.0 version and the capability intersection', () 
     GatewayClientCapability.CLIENT_EVENTS,
     GatewayClientCapability.INPUT_TEXT,
     GatewayClientCapability.INPUT_TEXT,
-  ]), [GatewayClientCapability.INPUT_TEXT])
+  ]), [
+    GatewayClientCapability.CLIENT_EVENTS,
+    GatewayClientCapability.INPUT_TEXT,
+  ])
+})
+
+test('validates GCP2 runtime commands and their correlated results', () => {
+  const create = parseGatewayClientProtocolMessage({
+    type: GatewayClientProtocolEvent.TASK_CREATE,
+    event_id: 'evt_create_1',
+    message: { parts: [{ type: 'text', text: '查询本机内存' }] },
+  })
+  assert.equal(create.message.parts[0].text, '查询本机内存')
+  assert.equal(
+    gatewayClientProtocolCapabilityFor(create.type),
+    GatewayClientCapability.TASK_COMMANDS,
+  )
+
+  const published = parseGatewayClientProtocolMessage({
+    type: GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH,
+    event_id: 'evt_presence_1',
+    name: 'desktop.presence.sleep_requested',
+    data: { reason: 'idle' },
+    delivery_hint: 'context',
+  })
+  assert.equal(published.name, 'desktop.presence.sleep_requested')
+
+  const result = parseGatewayServerProtocolMessage({
+    type: GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH_RESULT,
+    event_id: 'evt_gateway_1',
+    request_event_id: 'evt_presence_1',
+    accepted: true,
+    name: 'desktop.presence.sleep_requested',
+  })
+  assert.equal(result.request_event_id, 'evt_presence_1')
 })
 
 test('normalizes 6.0 event names into the existing business event vocabulary', () => {
@@ -138,6 +174,7 @@ test('6.0 hello and 5.x connect enter the same legacy business path', () => {
   assert.deepEqual(accepted.reply.capabilities, [
     GatewayClientCapability.INPUT_AUDIO,
     GatewayClientCapability.INPUT_TEXT,
+    GatewayClientCapability.CLIENT_EVENTS,
   ])
   assert.equal(accepted.reply.request_event_id, 'evt_client_hello')
   assert.deepEqual(accepted.pending, [pendingEvent])
@@ -196,6 +233,25 @@ test('preserves the legacy silent-ignore behavior for malformed messages', () =>
   const session = new GatewayClientProtocolSession({ sessionId: 'legacy' })
   assert.equal(session.receive({ type: 'not-a-real-event' }).event, null)
   assert.equal(session.mode, 'pending')
+})
+
+test('requires runtime capabilities to be negotiated before accepting commands', () => {
+  const session = new GatewayClientProtocolSession({
+    sessionId: 'runtime-capabilities',
+    createEventId: ids(),
+  })
+  session.receive(createGatewaySessionHello({
+    eventId: 'evt-client-hello',
+    clientInstanceId: 'client-1',
+    capabilities: [GatewayClientCapability.INPUT_TEXT],
+  }))
+  const rejected = session.receive({
+    type: GatewayClientProtocolEvent.TASK_LIST,
+    event_id: 'evt-client-list',
+  })
+  assert.equal(rejected.runtimeMessage, undefined)
+  assert.equal(rejected.reply.request_event_id, 'evt-client-list')
+  assert.equal(rejected.reply.error.code, 'capability_not_negotiated')
 })
 
 test('bounds server events held while the client has not selected a protocol', () => {


### PR DESCRIPTION
Part of #251

## Summary
- add the GCP2 Client Event definition registry and policy-driven GatewayEventRouter
- add correlated WebSocket commands for Task create/get/list/cancel, permission responses, and conversation history
- share one runtime command service with the existing REST compatibility aliases
- stamp trusted Client source identity at the authenticated connection boundary
- publish the extension entry point and update the bilingual specification, contract, and roadmap

## Boundaries
- does not add Agent Delivery (GCP3), Client Actions (GCP4), or replay (GCP5)
- keeps 5.x clients and REST compatibility paths unchanged

## Validation
- `npm run lint -- --quiet`
- `npm run build`
- Root, WebUI, TUI, Desktop, and CLI test suites
- GCP2 protocol/router/runtime/handshake tests
- dependency audit and npm package dry-run
- Server assertions pass locally; GitHub CI remains authoritative for clean process exit