### PR TITLE
feat(gateway): add GCP3 agent delivery

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -349,7 +349,9 @@ depend on server layers.
 
 `server/src/client` owns the northbound Client Event registry and runtime
 command application service. It may depend only on public `shared` protocol
-values and the protocol-neutral Task layer. The composition root in
+values, provider-neutral `delivery` values, and the protocol-neutral Task layer.
+`server/src/delivery` owns the `AgentDelivery` value and has no dependency on
+Client, Realtime, or Backend implementations. The composition root in
 `server/src/app` injects those services into the Realtime transport; neither
 the voice path nor Client code imports their concrete implementation.
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -278,7 +278,9 @@ UI 仅消费公共 Task 与对话事件。包级别的 `shared` 模块是基础�
 工具；server `core` 和 `process` 可以依赖它们，但它们不得依赖 server 层。
 
 `server/src/client` 管理北向 Client Event Registry 与运行时命令应用服务，只能依赖
-公开 `shared` 协议值和协议无关的 Task 层。`server/src/app` 组合根把这些服务注入
+公开 `shared` 协议值、与供应商无关的 `delivery` 值和协议无关的 Task 层。
+`server/src/delivery` 只管理 `AgentDelivery` 值，不依赖 Client、Realtime 或 Backend
+具体实现。`server/src/app` 组合根把这些服务注入
 Realtime Transport；语音链路与 Client 代码都不能导入其具体实现。
 
 Gateway 可以将不可变的 `web/dist` 产物作为部署便利来提供，但这仅是静态托管。

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -74,6 +74,7 @@ below instead of assuming the old list.
 | `realtime.conversation-client-v1` | `WS /api/realtime`, published event constants, and message schemas form the replaceable text/audio/multimodal Conversation Client boundary | `test/gateway-event-schema.test.mjs`, `test/custom-conversation-client.test.mjs` |
 | `realtime.gateway-client-protocol-v6-handshake` | The same WebSocket accepts an opt-in 6.0 `session.hello`, returns correlated `session.ready`, negotiates implemented capabilities, and normalizes 6.0 input aliases into the existing business path | `test/gateway-client-protocol.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-runtime-commands` | Negotiated 6.0 Clients can publish registered semantic Client Events and use correlated Task, permission, and conversation-history commands over the same WebSocket; existing REST routes call the same command service as compatibility aliases | `test/gateway-client-protocol.test.mjs`, `server/test/client-event-router.test.mjs`, `server/test/client-command-runtime.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
+| `realtime.gateway-client-protocol-v6-agent-delivery` | Client Events, Task results and progress, and permission prompts cross one provider-neutral `AgentDelivery` boundary with `handle`, `context`, `respond`, and `interrupt` modes | `server/test/agent-delivery.test.mjs`, `server/test/client-event-router.test.mjs`, `server/test/realtime-provider.test.mjs`, `server/test/announcement-manager.test.mjs` |
 | `desktop.orb-shell` | The orb form's main-process contract ships: `bindOrbShell` answers the channels the shipped preload sends | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` owns the orb window recipe; its `destroy()` is the host's synchronous teardown path (renderer exit is what releases the microphone) | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` covers the default anchor, display clamping and drop persistence | `desktop/test/orb-placement.test.mjs` |
@@ -95,6 +96,7 @@ is unsupported and breaks without notice.
 | `qwen-audio-agent/gateway-protocol` | `GATEWAY_PROTOCOL_VERSION`, `GATEWAY_CAPABILITIES` |
 | `qwen-audio-agent/gateway-client-protocol` | GCP 6.0 envelope and handshake schemas, parsers, capability constants, and reference Client helpers |
 | `qwen-audio-agent/client-events` | Client Event definition registry, built-in definitions, routing policies, and `GatewayEventRouter` for Gateway extensions |
+| `qwen-audio-agent/agent-delivery` | Provider-neutral `AgentDelivery` values and routing modes |
 | `qwen-audio-agent/gateway-setup` | `gatewaySetupStatus`, `assertGatewaySetup` |
 | `qwen-audio-agent/gateway-process` | `GatewayProcess`, `createGatewayProcess`, `GATEWAY_READY_MESSAGE`, `DEFAULT_GATEWAY_ENTRY`, `validateGatewayOrigin`, `portInUse` |
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`, `findRunningGateway`, `acquireGatewayLease` |

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -62,6 +62,7 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `realtime.conversation-client-v1` | `WS /api/realtime`、公开事件常量与消息 Schema 共同构成可替换的文本/音频/多模态对话客户端边界 | `test/gateway-event-schema.test.mjs`、`test/custom-conversation-client.test.mjs` |
 | `realtime.gateway-client-protocol-v6-handshake` | 同一 WebSocket 可选择以 6.0 `session.hello` 接入，返回有关联关系的 `session.ready`，协商已实现能力，并把 6.0 输入别名归一化到现有业务路径 | `test/gateway-client-protocol.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-runtime-commands` | 协商后的 6.0 Client 可以通过同一 WebSocket 发布已注册的语义 Client Event，并使用有关联结果的 Task、权限和对话历史命令；现有 REST 路由调用同一命令服务作为兼容别名 | `test/gateway-client-protocol.test.mjs`、`server/test/client-event-router.test.mjs`、`server/test/client-command-runtime.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
+| `realtime.gateway-client-protocol-v6-agent-delivery` | Client Event、Task 结果与低频进展、权限请求统一跨越 Provider 无关 `AgentDelivery` 边界，并支持 `handle`、`context`、`respond`、`interrupt` 四种模式 | `server/test/agent-delivery.test.mjs`、`server/test/client-event-router.test.mjs`、`server/test/realtime-provider.test.mjs`、`server/test/announcement-manager.test.mjs` |
 | `desktop.orb-shell` | 悬浮球形态的主进程契约随包发布：`bindOrbShell` 应答随包 preload 发出的全部通道 | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` 持有悬浮球窗口配方；其 `destroy()` 是宿主的同步销毁路径（渲染进程退出才能确定性释放麦克风） | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` 覆盖默认锚点、显示器夹取与拖放持久化 | `desktop/test/orb-placement.test.mjs` |
@@ -82,6 +83,7 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `qwen-audio-agent/gateway-protocol` | `GATEWAY_PROTOCOL_VERSION`、`GATEWAY_CAPABILITIES` |
 | `qwen-audio-agent/gateway-client-protocol` | GCP 6.0 信封与握手 Schema、解析器、能力常量和参考 Client Helper |
 | `qwen-audio-agent/client-events` | 供 Gateway 扩展使用的 Client Event Definition Registry、内置定义、路由 Policy 与 `GatewayEventRouter` |
+| `qwen-audio-agent/agent-delivery` | Provider 无关的 `AgentDelivery` 值与路由模式 |
 | `qwen-audio-agent/gateway-setup` | `gatewaySetupStatus`、`assertGatewaySetup` |
 | `qwen-audio-agent/gateway-process` | `GatewayProcess`、`createGatewayProcess`、`GATEWAY_READY_MESSAGE`、`DEFAULT_GATEWAY_ENTRY`、`validateGatewayOrigin`、`portInUse` |
 | `qwen-audio-agent/gateway-lease` | `readGatewayLease`、`findRunningGateway`、`acquireGatewayLease` |

--- a/docs/gateway-protocol.md
+++ b/docs/gateway-protocol.md
@@ -110,8 +110,8 @@ logic. A 6.0 Client starts with `session.hello`; Gateway returns
 6.0 input aliases into the existing internal event model. A 5.x Client may
 continue to start with `connect` and receives the unchanged legacy event shape.
 Only capabilities with working runtimes are negotiated. GCP2 Client Event and
-runtime-command capabilities are now implemented; names reserved for GCP3–GCP5
-remain vocabulary-only until their runtimes ship.
+runtime-command capabilities and GCP3 Agent Delivery are now implemented;
+names reserved for GCP4–GCP5 remain vocabulary-only until their runtimes ship.
 
 ### 3.2 GCP2 runtime rollout
 
@@ -125,9 +125,19 @@ registry owns payload Schema, size, rate, retention, coalescing, maximum route,
 and an optional deterministic handler. Gateway stamps owner, Session, Client
 type, and Client instance from the authenticated connection; none of those
 trusted fields are accepted from event data. The first built-in definition is
-`desktop.presence.sleep_requested`. Its model delivery is intentionally deferred
-to GCP3, so GCP2 accepts, validates, retains, and handles the event without
-pretending it is user input.
+`desktop.presence.sleep_requested`. GCP2 accepts, validates, retains, and
+handles the event without pretending it is user input; GCP3 now projects it
+through the shared Agent Delivery boundary.
+
+### 3.3 GCP3 delivery rollout
+
+GCP3 implements the provider-neutral value and all four routing modes from
+section 6. Task results, low-frequency meaningful progress, permission prompts,
+and registered Client Event projections use one `RealtimeAgentDeliveryRuntime`.
+Realtime providers encode only the resulting context item and optional response;
+raw Client or backend protocol objects never enter the model. Existing Task
+announcement batching, safe-window retry, notification claims, and playback
+acknowledgement remain the reliable lifecycle around that shared projection.
 
 ## 4. Common event envelope
 
@@ -358,9 +368,15 @@ An optional provider-neutral `AgentDelivery` records how the Realtime frontend a
   origin: 'client',
   text: '用户触摸了桌面上的水杯。',
   mode: 'context',
-  correlation: { eventName: 'user.object.touched' }
+  correlation: { eventName: 'user.object.touched' },
+  presentation: { instructions: '', allowTools: false, contextTiming: 'response' }
 }
 ```
+
+`presentation` is optional provider-neutral response policy. It may constrain
+how a response is expressed, whether the frontend Agent may call its own tools,
+and whether context must be visible before a queued response; it is never a
+Realtime-provider response object.
 
 Routing modes are:
 

--- a/docs/gateway-protocol.zh.md
+++ b/docs/gateway-protocol.zh.md
@@ -108,8 +108,8 @@ GCP1 在不分叉 Gateway 业务逻辑的前提下实现信封与握手。6.0 Cl
 `session.hello` 开始；Gateway 返回 `session.ready`，为后续下行事件补充
 `event_id`，并把 6.0 输入别名归一化到现有内部事件模型。5.x Client 仍可使用
 `connect`，收到的旧事件形状保持不变。握手只协商已有运行时实现的能力。GCP2 的
-Client Event 与运行时命令 capability 已经实现；GCP3–GCP5 预留的名称仍只用于统一
-扩展词汇，在对应 Runtime 完成前不会被声明为已实现。
+Client Event 与运行时命令 capability、GCP3 Agent Delivery 已经实现；GCP4–GCP5
+预留的名称仍只用于统一扩展词汇，在对应 Runtime 完成前不会被声明为已实现。
 
 ### 3.2 GCP2 运行时落地
 
@@ -120,9 +120,17 @@ Task、权限和对话历史命令。即时结果与错误通过 `request_event_
 Client Event Definition 在 Gateway 组合阶段注册。Registry 统一定义 payload
 Schema、大小、频率、保存、合并、最大路由等级与可选确定性 Handler。Gateway 根据
 已认证连接填写 owner、Session、Client 类型与 Client 实例；这些可信字段不能由
-Event data 提供。首个内置定义是 `desktop.presence.sleep_requested`。它进入模型的
-Delivery 留到 GCP3，因此 GCP2 只负责接收、校验、保存和确定性处理，不会把它伪装成
-用户输入。
+Event data 提供。首个内置定义是 `desktop.presence.sleep_requested`。GCP2 负责接收、
+校验、保存和确定性处理，不会把它伪装成用户输入；GCP3 已经把它投影到统一的 Agent
+Delivery 边界。
+
+### 3.3 GCP3 Delivery 落地
+
+GCP3 实现第 6 节定义的 Provider 无关值与四种路由模式。Task 最终结果、有意义的低频
+进展、权限请求和已注册 Client Event 投影统一进入 `RealtimeAgentDeliveryRuntime`。
+Realtime Provider 只编码最终的上下文项与可选回复；Client 或后台协议原始对象不会
+进入模型。现有 Task 播报的批处理、安全窗口重试、通知认领和播放确认继续作为这条共享
+投影外围的可靠生命周期。
 
 ## 4. 通用事件信封
 
@@ -353,9 +361,14 @@ Gateway Trigger ─┘        ├─ 确定性 Handler
   origin: 'client',
   text: '用户触摸了桌面上的水杯。',
   mode: 'context',
-  correlation: { eventName: 'user.object.touched' }
+  correlation: { eventName: 'user.object.touched' },
+  presentation: { instructions: '', allowTools: false, contextTiming: 'response' }
 }
 ```
+
+`presentation` 是可选的 Provider 无关回复策略，可以约束回复表达方式、前台 Agent
+能否调用自身工具，以及上下文是否必须先于排队中的回复生效；它绝不是某个 Realtime
+Provider 的 response 对象。
 
 路由模式：
 

--- a/docs/roadmap/gateway-client-protocol.md
+++ b/docs/roadmap/gateway-client-protocol.md
@@ -90,11 +90,11 @@ Exit criteria: a Client can publish a registered environment or user-behavior ev
 
 ## GCP3 — Agent Delivery
 
-- [ ] Define provider-neutral `AgentDelivery` and the `handle`, `context`, `respond`, and `interrupt` routing modes.
-- [ ] Add context-only injection to each Realtime Provider.
-- [ ] Extract reusable delivery serialization, blocking, retry, and playback acknowledgement from the current Task announcement path.
-- [ ] Route meaningful Task, permission, Gateway, and Client events through the shared delivery runtime.
-- [ ] Keep high-frequency progress and media off the model path.
+- [x] Define provider-neutral `AgentDelivery` and the `handle`, `context`, `respond`, and `interrupt` routing modes.
+- [x] Add context-only injection to each Realtime Provider.
+- [x] Extract shared delivery serialization and provider projection while retaining the Task path's blocking, retry, and playback acknowledgement lifecycle.
+- [x] Route meaningful Task, permission, Gateway, and Client event projections through the shared delivery runtime.
+- [x] Keep high-frequency progress and media off the model path.
 
 Exit criteria: one event can update Gateway/UI only, update model context silently, or produce exactly one safe Realtime response without provider-specific Gateway code.
 

--- a/docs/roadmap/gateway-client-protocol.zh.md
+++ b/docs/roadmap/gateway-client-protocol.zh.md
@@ -90,11 +90,11 @@ Backend Agent
 
 ## GCP3 — Agent Delivery
 
-- [ ] 定义 Provider 无关 `AgentDelivery` 以及 `handle`、`context`、`respond`、`interrupt`。
-- [ ] 为全部 Realtime Provider 增加 context-only 注入。
-- [ ] 从当前 Task 播报链路抽取可复用的串行化、阻塞、重试和播放确认。
-- [ ] 让有意义的 Task、权限、Gateway 与 Client Event 使用共享 Delivery Runtime。
-- [ ] 高频进展和媒体不进入模型路径。
+- [x] 定义 Provider 无关 `AgentDelivery` 以及 `handle`、`context`、`respond`、`interrupt`。
+- [x] 为全部 Realtime Provider 增加 context-only 注入。
+- [x] 抽取共享 Delivery 串行化与 Provider 投影，同时保留 Task 链路的阻塞、重试和播放确认生命周期。
+- [x] 让有意义的 Task、权限、Gateway 与 Client Event 投影使用共享 Delivery Runtime。
+- [x] 高频进展和媒体不进入模型路径。
 
 完成条件：同一个事件可以只更新 Gateway/UI、静默更新模型上下文，或只产生一次安全的 Realtime 回复，并且 Gateway 不包含 Provider 专属逻辑。
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "./gateway-events": "./shared/protocol/gateway-events.mjs",
     "./gateway-client-protocol": "./shared/gateway-client-protocol.mjs",
     "./client-events": "./server/src/client/client-event-router.mjs",
+    "./agent-delivery": "./server/src/delivery/agent-delivery.mjs",
     "./ag-ui-events": "./shared/protocol/agui-events.mjs",
     "./session-events": "./shared/session-events.mjs",
     "./session-journal": "./server/src/session/session-journal.mjs",

--- a/server/src/client/client-event-router.mjs
+++ b/server/src/client/client-event-router.mjs
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { createAgentDelivery } from '../delivery/agent-delivery.mjs'
 
 const ROUTE_PRIORITY = Object.freeze({
   handle: 0,
@@ -54,6 +55,26 @@ export const BUILTIN_CLIENT_EVENT_DEFINITIONS = Object.freeze([
     rateLimit: Object.freeze({ max: 4, windowMs: 10_000 }),
     retention: 'latest',
     route: 'respond',
+    project: event => createAgentDelivery({
+      id: `client_event_${event.id}`,
+      causeEventId: event.id,
+      mode: event.route,
+      origin: 'client-event',
+      text: [
+        '<client_environment_event>',
+        '客户端准备因一段时间无交互而进入休眠。',
+        Number.isFinite(event.data.idle_ms)
+          ? `空闲时长：${event.data.idle_ms} 毫秒`
+          : '',
+        '这不是用户的新话语。请自然回应当前情境，并调用可用的休眠工具完成状态切换。',
+        '</client_environment_event>',
+      ].filter(Boolean).join('\n'),
+      correlation: { clientEventId: event.id },
+      presentation: {
+        instructions: '把这个客户端环境事件作为当前情境自然处理；不要把它说成用户刚刚说的话。',
+        allowTools: true,
+      },
+    }),
   }),
 ])
 
@@ -99,6 +120,7 @@ export class ClientEventDefinitionRegistry {
         ? definition.coalesceKey
         : null,
       handle: typeof definition.handle === 'function' ? definition.handle : null,
+      project: typeof definition.project === 'function' ? definition.project : null,
     })
     this.definitions.set(name, normalized)
     return normalized
@@ -184,6 +206,7 @@ export class GatewayEventRouter {
       route: boundedRoute(message.delivery_hint, definition.route),
     })
     await definition.handle?.(event)
+    const delivery = definition.project?.(event) || null
     this.seen.set(duplicateKey, now)
     this.#boundSeen()
 
@@ -196,6 +219,7 @@ export class GatewayEventRouter {
       duplicate: false,
       name: definition.name,
       event,
+      delivery,
     }
   }
 

--- a/server/src/core/gateway-protocol.mjs
+++ b/server/src/core/gateway-protocol.mjs
@@ -10,6 +10,8 @@
 // Every capability listed here is locked by a test (see docs/contract.md);
 // anything not listed is internal and may change in any release.
 //
+// 5.3.0 adds GCP3 provider-neutral AgentDelivery routing for Client Events,
+// Task results and progress, and permission prompts.
 // 5.2.0 adds GCP2 Client Event ingress and WebSocket runtime commands for
 // Tasks, permissions, and conversation history while retaining the existing
 // REST paths as migration aliases.
@@ -35,7 +37,7 @@
 // desktop.settings-window, …) are not part of this contract, and a removed
 // capability is a breaking change. Hosts migrating from the fork must branch
 // on the capability list below, never on the version number.
-export const GATEWAY_PROTOCOL_VERSION = '5.2.0'
+export const GATEWAY_PROTOCOL_VERSION = '5.3.0'
 
 export const GATEWAY_CAPABILITIES = Object.freeze([
   // The Gateway statically hosts web/dist at its own origin, so a client may
@@ -99,6 +101,10 @@ export const GATEWAY_CAPABILITIES = Object.freeze([
   // Task, permission, and conversation-history runtime commands over the same
   // WebSocket. Immediate results and errors correlate through request_event_id.
   'realtime.gateway-client-protocol-v6-runtime-commands',
+  // Semantic Client, Task and permission events are projected into one
+  // provider-neutral AgentDelivery runtime with handle/context/respond/
+  // interrupt modes before any Realtime-provider encoding occurs.
+  'realtime.gateway-client-protocol-v6-agent-delivery',
   // The orb shell contract ships: qwen-audio-agent/orb/preload plus
   // orb/main's bindOrbShell, so a host may run the floating orb form.
   'desktop.orb-shell',

--- a/server/src/delivery/agent-delivery.mjs
+++ b/server/src/delivery/agent-delivery.mjs
@@ -1,0 +1,66 @@
+import { randomUUID } from 'node:crypto'
+
+export const AgentDeliveryMode = Object.freeze({
+  HANDLE: 'handle',
+  CONTEXT: 'context',
+  RESPOND: 'respond',
+  INTERRUPT: 'interrupt',
+})
+
+const MODES = new Set(Object.values(AgentDeliveryMode))
+
+function clean(value) {
+  return String(value || '').trim()
+}
+
+/**
+ * Provider-neutral input for the frontend Agent.
+ *
+ * Domain runtimes own event policy and serialization. Realtime adapters only
+ * receive this value after the Gateway has decided whether the event should be
+ * handled internally, added to context, answered, or allowed to interrupt.
+ */
+export function createAgentDelivery({
+  id = `delivery_${randomUUID()}`,
+  causeEventId = null,
+  mode = AgentDeliveryMode.HANDLE,
+  origin = 'gateway',
+  text,
+  correlation = {},
+  presentation = {},
+} = {}) {
+  const normalizedMode = clean(mode)
+  const normalizedText = clean(text)
+  if (!MODES.has(normalizedMode)) {
+    throw new TypeError(`invalid AgentDelivery mode: ${normalizedMode || '<empty>'}`)
+  }
+  if (normalizedMode !== AgentDeliveryMode.HANDLE && !normalizedText) {
+    throw new TypeError('model-visible AgentDelivery requires text')
+  }
+  const presentationInstructions = clean(presentation.instructions)
+  const presentationAllowsTools = presentation.allowTools === true
+  const contextTiming = presentation.contextTiming === 'immediate'
+    ? 'immediate'
+    : 'response'
+  return Object.freeze({
+    id: clean(id) || `delivery_${randomUUID()}`,
+    ...(clean(causeEventId) ? { causeEventId: clean(causeEventId) } : {}),
+    mode: normalizedMode,
+    origin: clean(origin) || 'gateway',
+    text: normalizedText,
+    correlation: Object.freeze({ ...correlation }),
+    ...(presentationInstructions || presentationAllowsTools || contextTiming === 'immediate'
+      ? {
+          presentation: Object.freeze({
+            instructions: presentationInstructions,
+            allowTools: presentationAllowsTools,
+            contextTiming,
+          }),
+        }
+      : {}),
+  })
+}
+
+export function isModelVisibleDelivery(delivery) {
+  return delivery?.mode !== AgentDeliveryMode.HANDLE
+}

--- a/server/src/voice/announcement/announcement-manager.mjs
+++ b/server/src/voice/announcement/announcement-manager.mjs
@@ -1,8 +1,11 @@
 import { randomUUID } from 'node:crypto'
+import { createAgentDelivery } from '../../delivery/agent-delivery.mjs'
+import { RealtimeAgentDeliveryRuntime } from '../realtime-agent-delivery-runtime.mjs'
 
 export class AnnouncementManager {
   constructor({
     getFrontend,
+    deliveryRuntime = null,
     isDeliveryBlocked,
     announceIntoContext = true,
     resultContextMaxChars = 6000,
@@ -21,6 +24,10 @@ export class AnnouncementManager {
   }) {
     this.getFrontend = getFrontend
     this.isDeliveryBlocked = isDeliveryBlocked || (() => false)
+    this.deliveryRuntime = deliveryRuntime || new RealtimeAgentDeliveryRuntime({
+      getFrontend,
+      isDeliveryBlocked: this.isDeliveryBlocked,
+    })
     this.announceIntoContext = announceIntoContext
     this.resultContextMaxChars = resultContextMaxChars
     this.maxBatchItems = maxBatchItems
@@ -303,13 +310,14 @@ export class AnnouncementManager {
         taskId: batch.taskIds.length === 1 ? batch.taskIds[0] : null,
         taskIds: batch.taskIds,
       }
-      const outcome = this.announceIntoContext && frontend.injectResult
-        ? await frontend.injectResult(
-            eventText,
-            'announcement',
-            context,
-            { injectContext: !batch.contextInjected },
-          )
+      const outcome = this.announceIntoContext
+        ? await this.deliveryRuntime.deliver(createAgentDelivery({
+            id: `task_result_${batch.deliveryTurnId}`,
+            mode: 'respond',
+            origin: 'announcement',
+            text: eventText,
+            correlation: context,
+          }), { injectContext: !batch.contextInjected })
         : await frontend.speak(eventText, 'announcement', context)
       if (
         this.deliveryGeneration !== deliveryGeneration

--- a/server/src/voice/announcement/progress-announcement-manager.mjs
+++ b/server/src/voice/announcement/progress-announcement-manager.mjs
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
+import { createAgentDelivery } from '../../delivery/agent-delivery.mjs'
 import { progressResponseInstructions } from '../frontend-tools.mjs'
+import { RealtimeAgentDeliveryRuntime } from '../realtime-agent-delivery-runtime.mjs'
 
 const DEFAULT_INTERVAL_MS = 60_000
 const DEFAULT_QUIET_MS = 800
@@ -38,6 +40,7 @@ function progressPayload(candidate) {
 export class ProgressAnnouncementManager {
   constructor({
     getFrontend,
+    deliveryRuntime = null,
     isDeliveryBlocked = () => false,
     isTaskActive = () => true,
     intervalMs = DEFAULT_INTERVAL_MS,
@@ -51,6 +54,10 @@ export class ProgressAnnouncementManager {
   } = {}) {
     this.getFrontend = getFrontend
     this.isDeliveryBlocked = isDeliveryBlocked
+    this.deliveryRuntime = deliveryRuntime || new RealtimeAgentDeliveryRuntime({
+      getFrontend,
+      isDeliveryBlocked,
+    })
     this.isTaskActive = isTaskActive
     this.intervalMs = Math.max(1, Number(intervalMs) || DEFAULT_INTERVAL_MS)
     this.quietMs = Math.max(0, Number(quietMs) || 0)
@@ -188,7 +195,14 @@ export class ProgressAnnouncementManager {
       blocked = true
     }
     const frontend = this.getFrontend?.()
-    if (blocked || typeof frontend?.injectResult !== 'function') {
+    if (
+      blocked
+      || frontend?.ready === false
+      || (
+        typeof frontend?.injectDelivery !== 'function'
+        && typeof frontend?.injectResult !== 'function'
+      )
+    ) {
       candidate.notBefore = timestamp + this.retryMs
       this.schedule()
       return
@@ -196,15 +210,18 @@ export class ProgressAnnouncementManager {
 
     this.delivering = true
     try {
-      await frontend.injectResult(
-        progressPayload(candidate),
-        'progress',
-        progressContext(candidate),
-        {
-          injectContext: true,
-          instructions: progressResponseInstructions,
-        },
-      )
+      const outcome = await this.deliveryRuntime.deliver(createAgentDelivery({
+        id: `task_progress_${candidate.deliveryTurnId}`,
+        mode: 'respond',
+        origin: 'progress',
+        text: progressPayload(candidate),
+        correlation: progressContext(candidate),
+        presentation: { instructions: progressResponseInstructions },
+      }))
+      if (!outcome?.completed) {
+        candidate.notBefore = this.now() + this.retryMs
+        return
+      }
       // A user interruption consumes this low-priority update too. Replaying
       // the same monologue would be more disruptive than omitting it.
       this.lastAnnouncedAt = this.now()

--- a/server/src/voice/providers/dashscope.mjs
+++ b/server/src/voice/providers/dashscope.mjs
@@ -97,7 +97,7 @@ export const dashscopeProvider = {
     instructions: speakResponseInstructions(content),
   }),
 
-  buildResultInjection: content => ({
+  buildResultInjection: (content, { allowTools = false } = {}) => ({
     item: {
       type: 'message',
       role: 'user',
@@ -105,7 +105,7 @@ export const dashscopeProvider = {
     },
     response: {
       modalities: responseModalities(activeModelProfile()),
-      tool_choice: 'none',
+      tool_choice: allowTools ? 'auto' : 'none',
       instructions: resultResponseInstructions,
     },
   }),

--- a/server/src/voice/providers/s2s.mjs
+++ b/server/src/voice/providers/s2s.mjs
@@ -102,7 +102,7 @@ export const s2sProvider = {
     tool_choice: 'none',
   }),
 
-  buildResultInjection: content => ({
+  buildResultInjection: (content, { allowTools = false } = {}) => ({
     item: {
       type: 'message',
       role: 'user',
@@ -110,7 +110,7 @@ export const s2sProvider = {
     },
     response: {
       modalities: ['audio'],
-      tool_choice: 'none',
+      tool_choice: allowTools ? 'auto' : 'none',
       instructions: resultResponseInstructions,
     },
   }),

--- a/server/src/voice/realtime-agent-delivery-runtime.mjs
+++ b/server/src/voice/realtime-agent-delivery-runtime.mjs
@@ -1,0 +1,61 @@
+import {
+  AgentDeliveryMode,
+  createAgentDelivery,
+} from '../delivery/agent-delivery.mjs'
+
+/**
+ * Projects provider-neutral AgentDelivery values into one Realtime frontend.
+ * Blocking remains Gateway policy; provider dialects never escape this class.
+ */
+export class RealtimeAgentDeliveryRuntime {
+  constructor({
+    getFrontend,
+    isDeliveryBlocked = () => false,
+  } = {}) {
+    this.getFrontend = getFrontend
+    this.isDeliveryBlocked = isDeliveryBlocked
+  }
+
+  async deliver(value, { shouldDeliver, injectContext = true } = {}) {
+    const delivery = createAgentDelivery(value)
+    if (delivery.mode === AgentDeliveryMode.HANDLE) {
+      return { completed: true, handled: true, mode: delivery.mode }
+    }
+    if (this.isDeliveryBlocked()) {
+      return { completed: false, blocked: true, mode: delivery.mode }
+    }
+    const frontend = this.getFrontend?.()
+    const inject = typeof frontend?.injectDelivery === 'function'
+      ? frontend.injectDelivery.bind(frontend)
+      : delivery.mode === AgentDeliveryMode.RESPOND
+        && typeof frontend?.injectResult === 'function'
+        ? (text, origin, context, options) => frontend.injectResult(
+            text,
+            origin,
+            context,
+            {
+              injectContext: options.injectContext,
+              instructions: options.instructions,
+            },
+          )
+        : null
+    // Older code-level embedders did not expose an explicit ready flag. Keep
+    // that interface working while requiring a concrete injection primitive.
+    if (frontend?.ready === false || !inject) {
+      return { completed: false, unavailable: true, mode: delivery.mode }
+    }
+    return inject(
+      delivery.text,
+      delivery.origin,
+      delivery.correlation,
+      {
+        route: delivery.mode,
+        injectContext,
+        instructions: delivery.presentation?.instructions || '',
+        allowTools: delivery.presentation?.allowTools === true,
+        contextTiming: delivery.presentation?.contextTiming || 'response',
+        shouldRespond: shouldDeliver,
+      },
+    )
+  }
+}

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -55,6 +55,9 @@ import {
   GatewayClientCapability,
   GatewayClientProtocolEvent,
 } from '../../../shared/gateway-client-protocol.mjs'
+import { createAgentDelivery } from '../delivery/agent-delivery.mjs'
+import { permissionResponseInstructions } from './frontend-tools.mjs'
+import { RealtimeAgentDeliveryRuntime } from './realtime-agent-delivery-runtime.mjs'
 
 const MAX_PENDING_AUDIO_CHUNKS = 30
 const RESPONSE_START_WATCHDOG_MS = 12000
@@ -240,6 +243,15 @@ export function attachRealtimeGateway(server, {
     const announcedPermissions = new Set()
     let permissionRetryTimer = null
     let realtimeSession
+    const agentDeliveries = new RealtimeAgentDeliveryRuntime({
+      getFrontend: () => realtimeSession?.frontend,
+      isDeliveryBlocked: () => (
+        sleeping
+        || waking
+        || !outputEnabled
+        || !realtimeSession?.ready
+      ),
+    })
     let runtimeMessageChain = Promise.resolve()
     const activeSessionTasks = () => taskManager.list({
       ownerId,
@@ -284,14 +296,30 @@ export function attachRealtimeGateway(server, {
         return
       }
       announcedPermissions.add(permission.id)
-      realtimeSession.frontend.injectPermission(permission, {
+      agentDeliveries.deliver(createAgentDelivery({
+        id: `permission_${permission.id}`,
+        causeEventId: permission.id,
+        mode: 'respond',
+        origin: 'permission',
+        text: [
+          '<backend_permission_request>',
+          `authorization_id=${permission.id}`,
+          `operation=${permission.summary}`,
+          '</backend_permission_request>',
+        ].join('\n'),
         // A permission prompt is a new model input and response. taskId keeps
         // it correlated with the work without reusing the user's old turn.
-        turnId: gatewayTurnId(),
-        taskId: task.id,
-        authorizationId: permission.id,
-      }, {
-        shouldSpeak: () => activeSessionTasks().some(activeTask => (
+        correlation: {
+          turnId: gatewayTurnId(),
+          taskId: task.id,
+          authorizationId: permission.id,
+        },
+        presentation: {
+          instructions: permissionResponseInstructions,
+          contextTiming: 'immediate',
+        },
+      }), {
+        shouldDeliver: () => activeSessionTasks().some(activeTask => (
           activeTask.authorization?.id === permission.id
           && activeTask.authorization.status === 'pending'
         )),
@@ -323,6 +351,7 @@ export function attachRealtimeGateway(server, {
       {
         resultOptions: {
           getFrontend: () => realtimeSession?.frontend,
+          deliveryRuntime: agentDeliveries,
           isDeliveryBlocked: () => (
             sleeping
             || waking
@@ -355,6 +384,7 @@ export function attachRealtimeGateway(server, {
         },
         progressOptions: {
           getFrontend: () => realtimeSession?.frontend,
+          deliveryRuntime: agentDeliveries,
           isDeliveryBlocked: () => (
             sleeping
             || waking
@@ -1072,6 +1102,20 @@ export function attachRealtimeGateway(server, {
           name: result.name,
           ...(result.duplicate ? { duplicate: true } : {}),
         })
+        if (!result.duplicate && result.delivery) {
+          agentDeliveries.deliver(result.delivery).then(outcome => {
+            if (outcome?.completed || outcome?.handled) return
+            connectionLogger.warn('client_event.delivery_skipped', {
+              name: result.name,
+              mode: result.delivery.mode,
+              blocked: outcome?.blocked === true,
+              unavailable: outcome?.unavailable === true,
+            })
+          }).catch(error => connectionLogger.warn('client_event.delivery_failed', {
+            name: result.name,
+            error: error.message,
+          }))
+        }
         return
       }
       if (!clientCommandRuntime) {

--- a/server/src/voice/realtime-provider.mjs
+++ b/server/src/voice/realtime-provider.mjs
@@ -408,15 +408,63 @@ export class RealtimeFrontend {
     context = {},
     { injectContext = true, instructions = '' } = {},
   ) {
+    const outcome = await this.injectDelivery(text, origin, context, {
+      route: 'respond',
+      injectContext,
+      instructions,
+    })
+    if (!outcome) return outcome
+    const { route: _route, ...legacyOutcome } = outcome
+    return legacyOutcome
+  }
+
+  async injectDelivery(
+    text,
+    origin = 'gateway',
+    context = {},
+    {
+      route = 'respond',
+      injectContext = true,
+      instructions = '',
+      allowTools = false,
+      contextTiming = 'response',
+      shouldRespond,
+    } = {},
+  ) {
     const content = String(text || '').trim()
     if (!content) return
-    const injection = this.provider.buildResultInjection(content)
+    if (route === 'handle') {
+      return { completed: true, handled: true, route }
+    }
+    if (!['context', 'respond', 'interrupt'].includes(route)) {
+      throw new TypeError(`unsupported AgentDelivery route: ${route}`)
+    }
+    if (route === 'interrupt') this.cancel()
+    const injection = this.provider.buildResultInjection(content, { allowTools })
     if (instructions && injection?.response) {
       injection.response.instructions = String(instructions)
     }
     let contextInjected = false
-    const outcome = await this.enqueueResponse(origin, context, async () => {
+    if (route === 'context') {
       if (injectContext) {
+        await this.enqueueAction(async () => {
+          await this.createConversationItem(injection.item)
+          contextInjected = true
+        })
+      }
+      return {
+        completed: true,
+        contextInjected,
+        route,
+      }
+    }
+    if (contextTiming === 'immediate' && injectContext) {
+      await this.createConversationItem(injection.item)
+      contextInjected = true
+    }
+    const outcome = await this.enqueueResponse(origin, context, async () => {
+      if (shouldRespond && !shouldRespond()) return false
+      if (injectContext && !contextInjected) {
         await this.createConversationItem(injection.item)
         contextInjected = true
       }
@@ -425,6 +473,7 @@ export class RealtimeFrontend {
     return {
       ...(outcome || {}),
       contextInjected,
+      route,
     }
   }
 

--- a/server/test/agent-delivery.test.mjs
+++ b/server/test/agent-delivery.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  AgentDeliveryMode,
+  createAgentDelivery,
+  isModelVisibleDelivery,
+} from '../src/delivery/agent-delivery.mjs'
+import {
+  RealtimeAgentDeliveryRuntime,
+} from '../src/voice/realtime-agent-delivery-runtime.mjs'
+
+test('normalizes all provider-neutral AgentDelivery routing modes', () => {
+  for (const mode of Object.values(AgentDeliveryMode)) {
+    const delivery = createAgentDelivery({
+      id: `delivery-${mode}`,
+      causeEventId: 'event-1',
+      mode,
+      origin: 'test',
+      text: mode === 'handle' ? '' : 'event text',
+      correlation: { taskId: 'task-1' },
+    })
+    assert.equal(delivery.mode, mode)
+    assert.equal(delivery.causeEventId, 'event-1')
+    assert.equal(isModelVisibleDelivery(delivery), mode !== 'handle')
+  }
+  assert.throws(
+    () => createAgentDelivery({ mode: 'urgent', text: 'x' }),
+    /invalid AgentDelivery mode/u,
+  )
+})
+
+test('projects handle, context, respond and interrupt without provider objects', async () => {
+  const calls = []
+  const frontend = {
+    ready: true,
+    injectDelivery: async (...args) => {
+      calls.push(args)
+      return { completed: true, route: args[3].route }
+    },
+  }
+  const runtime = new RealtimeAgentDeliveryRuntime({
+    getFrontend: () => frontend,
+  })
+
+  assert.deepEqual(await runtime.deliver({ mode: 'handle' }), {
+    completed: true,
+    handled: true,
+    mode: 'handle',
+  })
+  for (const mode of ['context', 'respond', 'interrupt']) {
+    const result = await runtime.deliver({
+      id: `delivery-${mode}`,
+      mode,
+      origin: 'task',
+      text: `${mode} text`,
+      correlation: { taskId: 'task-1' },
+    })
+    assert.equal(result.route, mode)
+  }
+  assert.deepEqual(calls.map(call => call[3].route), [
+    'context',
+    'respond',
+    'interrupt',
+  ])
+  assert.deepEqual(calls[0][2], { taskId: 'task-1' })
+})
+
+test('reports blocked delivery without touching the realtime frontend', async () => {
+  let called = false
+  const runtime = new RealtimeAgentDeliveryRuntime({
+    getFrontend: () => ({
+      ready: true,
+      injectDelivery: async () => {
+        called = true
+      },
+    }),
+    isDeliveryBlocked: () => true,
+  })
+  const outcome = await runtime.deliver({ mode: 'respond', text: 'later' })
+  assert.equal(outcome.blocked, true)
+  assert.equal(called, false)
+})

--- a/server/test/client-event-router.test.mjs
+++ b/server/test/client-event-router.test.mjs
@@ -82,6 +82,8 @@ test('deduplicates by trusted source and retains only the latest event', async (
     source: { ownerId: 'spoofed-owner', clientType: 'spoofed-client' },
   }), { source })
   assert.equal(first.event.route, 'context')
+  assert.equal(first.delivery.mode, 'context')
+  assert.equal(first.delivery.causeEventId, 'evt-sleep-1')
   assert.deepEqual(first.event.source, source)
   assert.equal(first.event.source.ownerId, 'owner-1')
 
@@ -100,6 +102,7 @@ test('deduplicates by trusted source and retains only the latest event', async (
     delivery_hint: 'interrupt',
   }), { source })
   assert.equal(next.event.route, 'respond')
+  assert.equal(next.delivery.mode, 'respond')
   assert.equal(router.latestEvents().length, 1)
   assert.equal(router.latestEvents()[0].data.reason, 'new')
 })

--- a/server/test/dependency-boundaries.test.mjs
+++ b/server/test/dependency-boundaries.test.mjs
@@ -15,6 +15,7 @@ const allowedDependencies = {
     'client',
     'conversation',
     'core',
+    'delivery',
     'domain',
     'frontend',
     'providers',
@@ -29,7 +30,8 @@ const allowedDependencies = {
   providers: new Set(['core', 'frontend', 'providers', 'shared']),
   agent: new Set(['agent', 'backend', 'core', 'shared']),
   backend: new Set(['backend', 'core', 'shared']),
-  client: new Set(['client', 'shared', 'task']),
+  client: new Set(['client', 'delivery', 'shared', 'task']),
+  delivery: new Set(['delivery']),
   conversation: new Set(['conversation', 'core', 'shared']),
   // 资料库刻意不依赖 conversation：它复用的落盘与敏感闸门都在 core，
   // 让「用户给的手册」去依赖「会话逻辑」是没有道理的耦合。
@@ -40,6 +42,7 @@ const allowedDependencies = {
   voice: new Set([
     'conversation',
     'core',
+    'delivery',
     'frontend',
     'shared',
     'task',

--- a/server/test/realtime-provider.test.mjs
+++ b/server/test/realtime-provider.test.mjs
@@ -1289,6 +1289,87 @@ test('injects a completed work result into Qwen conversation with tools disabled
   })
 })
 
+test('injects AgentDelivery context without creating a realtime response', async () => {
+  const frontend = createQwenFrontend({ responseStartTimeoutMs: 50 })
+  const sent = []
+  frontend.ready = true
+  frontend.send = payload => sent.push(payload)
+
+  const outcome = frontend.injectDelivery(
+    '客户端环境已变化。',
+    'client-event',
+    { clientEventId: 'event-1' },
+    { route: 'context' },
+  )
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(sent.map(event => event.type), ['conversation.item.create'])
+  frontend.handleLifecycle({
+    type: 'conversation.item.created',
+    item: { ...sent[0].item, status: 'completed' },
+  })
+  assert.deepEqual(await outcome, {
+    completed: true,
+    contextInjected: true,
+    route: 'context',
+  })
+  assert.deepEqual(sent.map(event => event.type), ['conversation.item.create'])
+})
+
+test('can expose permission context before its response queue becomes idle', async () => {
+  const frontend = createQwenFrontend({
+    responseStartTimeoutMs: 50,
+    responseCompletionTimeoutMs: 50,
+  })
+  const sent = []
+  frontend.ready = true
+  frontend.send = payload => sent.push(payload)
+  frontend.activeResponses.add('response-active')
+
+  const outcome = frontend.injectDelivery(
+    '<backend_permission_request>operation=test</backend_permission_request>',
+    'permission',
+    { authorizationId: 'permission-1' },
+    { route: 'respond', contextTiming: 'immediate' },
+  )
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(sent.map(event => event.type), ['conversation.item.create'])
+  frontend.handleLifecycle({
+    type: 'conversation.item.created',
+    item: { ...sent[0].item, status: 'completed' },
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(sent.map(event => event.type), ['conversation.item.create'])
+
+  frontend.handleLifecycle({
+    type: 'response.done',
+    response: { id: 'response-active', status: 'completed' },
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(sent[1].type, 'response.create')
+  frontend.handleLifecycle({
+    type: 'response.created',
+    response: { id: 'response-permission' },
+  })
+  frontend.handleLifecycle({
+    type: 'response.done',
+    response: { id: 'response-permission', status: 'completed' },
+  })
+  assert.equal((await outcome).contextInjected, true)
+})
+
+test('keeps tool policy provider-neutral for all result-injection providers', () => {
+  for (const provider of [REALTIME_PROVIDERS.qwen, REALTIME_PROVIDERS.s2s]) {
+    assert.equal(
+      provider.buildResultInjection('event', { allowTools: true }).response.tool_choice,
+      'auto',
+    )
+    assert.equal(
+      provider.buildResultInjection('event').response.tool_choice,
+      'none',
+    )
+  }
+})
+
 test('injects progress with response-scoped presentation instructions', async () => {
   const frontend = createQwenFrontend({
     responseStartTimeoutMs: 50,


### PR DESCRIPTION
## Summary

- add provider-neutral `AgentDelivery` with `handle`, `context`, `respond`, and `interrupt` modes
- route Task results/progress, permission prompts, and registered Client Events through one Realtime delivery runtime
- add context-only provider injection while preserving existing Task batching, retry, and playback acknowledgement
- publish the GCP3 capability and update the bilingual protocol, architecture, contract, and roadmap docs

## Validation

- targeted AgentDelivery, Client Event, Realtime Provider, and dependency-boundary tests: 82 passed
- Server suite: 409 assertions passed (local Node test runner retains a pre-existing open handle after completion)
- WebUI: 96 passed
- TUI: 56 passed
- Desktop and CLI suites passed
- `npm run lint`
- `npm run build`
- `npm run audit:release`
- `npm pack --dry-run --json`

Part of #251