### PR TITLE
feat(gateway): add GCP4 client actions

### DIFF
--- a/desktop/test/enter-sleep-flow.test.mjs
+++ b/desktop/test/enter-sleep-flow.test.mjs
@@ -1,8 +1,14 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { ClientActionPort } from '../../server/src/client/client-action-port.mjs'
+import { PresenceController } from '../../server/src/client/presence-controller.mjs'
 import { ToolCallHandler } from '../../server/src/voice/tools/tool-call-handler.mjs'
-import { applyDesktopClientState } from '../../web/src/desktop-hide.js'
+import { performDesktopClientAction } from '../../web/src/desktop-hide.js'
 import { DesktopPresence } from '../src/desktop-presence.mjs'
+import {
+  GatewayClientCapability,
+  GatewayClientProtocolEvent,
+} from '../../shared/gateway-client-protocol.mjs'
 
 test('an enter_sleep tool call hides the desktop orb end to end', async () => {
   const window = {
@@ -20,7 +26,30 @@ test('an enter_sleep tool call hides the desktop orb end to end', async () => {
     },
   })
   const outputs = []
-  let stateTransition
+  let sleeping = false
+  let clientActions
+  clientActions = new ClientActionPort({
+    getCapabilities: () => [GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP],
+    createEventId: () => 'evt_gateway_sleep',
+    send: async event => {
+      const result = await performDesktopClientAction(event, {
+        desktop: true,
+        bridge: {
+          enterHide: async () => ({ state: presence.hide('requested') }),
+        },
+      })
+      clientActions.receive({
+        type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+        event_id: 'evt_client_sleep',
+        request_event_id: event.event_id,
+        ...result,
+      })
+    },
+  })
+  const presenceController = new PresenceController({
+    clientActions,
+    onSleeping: () => { sleeping = true },
+  })
   const handler = new ToolCallHandler({
     ownerId: 'owner',
     sessionId: 'voice',
@@ -29,20 +58,8 @@ test('an enter_sleep tool call hides the desktop orb end to end', async () => {
     }),
     getTurnId: () => 'turn-one',
     getTurnGeneration: () => 1,
-    getClientContext: () => ({ states: ['sleeping'] }),
-    requestClientState: state => {
-      stateTransition = applyDesktopClientState({
-        type: 'client.state',
-        state,
-      }, {
-        desktop: true,
-        bridge: {
-          enterHide: async () => ({
-            state: presence.hide('requested'),
-          }),
-        },
-      })
-    },
+    getClientContext: () => ({ actions: ['desktop.presence.enter_sleep'] }),
+    presenceController,
   })
 
   await handler.handle({
@@ -53,10 +70,11 @@ test('an enter_sleep tool call hides the desktop orb end to end', async () => {
     turnId: 'turn-one',
     turnGeneration: 1,
   })
-  await stateTransition
+  await new Promise(resolve => setTimeout(resolve, 0))
 
   assert.equal(window.hidden, true)
   assert.equal(presence.state, 'hidden')
+  assert.equal(sleeping, true)
   assert.equal(outputs.length, 1)
   assert.equal(outputs[0][1].status, 'sleeping')
   assert.equal(outputs[0][3].createResponse, false)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -347,9 +347,12 @@ conversation events. Package-level `shared` modules are foundational runtime
 utilities; server `core` and `process` may depend on them, but they must not
 depend on server layers.
 
-`server/src/client` owns the northbound Client Event registry and runtime
-command application service. It may depend only on public `shared` protocol
-values, provider-neutral `delivery` values, and the protocol-neutral Task layer.
+`server/src/client` owns the northbound Client Event registry, runtime-command
+application service, `ClientActionPort`, and idempotent presence state machine.
+Client Actions describe an environment operation and wait for the active Client
+to report its result; they never import Electron or another UI implementation.
+This layer may depend only on public `shared` protocol values, provider-neutral
+`delivery` values, and the protocol-neutral Task layer.
 `server/src/delivery` owns the `AgentDelivery` value and has no dependency on
 Client, Realtime, or Backend implementations. The composition root in
 `server/src/app` injects those services into the Realtime transport; neither

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -277,8 +277,10 @@ Qwen Code ACP, Kimi Code ACP, or another ACP Agent
 UI 仅消费公共 Task 与对话事件。包级别的 `shared` 模块是基础运行时
 工具；server `core` 和 `process` 可以依赖它们，但它们不得依赖 server 层。
 
-`server/src/client` 管理北向 Client Event Registry 与运行时命令应用服务，只能依赖
-公开 `shared` 协议值、与供应商无关的 `delivery` 值和协议无关的 Task 层。
+`server/src/client` 管理北向 Client Event Registry、运行时命令应用服务、
+`ClientActionPort` 与幂等 Presence 状态机。Client Action 描述一次环境操作并等待
+当前 Client 回传结果，不导入 Electron 或任何 UI 实现。该层只能依赖公开 `shared`
+协议值、与供应商无关的 `delivery` 值和协议无关的 Task 层。
 `server/src/delivery` 只管理 `AgentDelivery` 值，不依赖 Client、Realtime 或 Backend
 具体实现。`server/src/app` 组合根把这些服务注入
 Realtime Transport；语音链路与 Client 代码都不能导入其具体实现。

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -22,13 +22,15 @@ The proposed 6.0 northbound boundary is documented in the draft
 [Gateway Client Protocol](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/gateway-protocol.md) and its
 [roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/gateway-client-protocol.md), tracked by
 [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251).
-Those documents remain the design target. GCP1 and GCP2 are now available as
-an opt-in 6.0 handshake, Client Event ingress, and runtime-command plane over
-the existing WebSocket; capabilities for later stages remain vocabulary only
-until their runtimes ship.
+Those documents remain the design target. GCP1–GCP4 are now available as an
+opt-in 6.0 handshake, Client Event ingress, runtime-command plane, Agent
+Delivery, and Client Action boundary over the existing WebSocket; capabilities
+for later stages remain vocabulary only until their runtimes ship.
 This contract index remains authoritative for implemented behavior.
 
-The current health-contract version is `5.2.0`. The additive `5.2` line exposes
+The current health-contract version is `5.4.0`. The additive `5.4` line adds
+correlated Client Actions and the shared Presence state machine. The additive
+`5.3` line adds provider-neutral Agent Delivery. The additive `5.2` line exposes
 registered Client Event ingress and Task, permission, and conversation-history
 commands on the negotiated 6.0 WebSocket while retaining REST compatibility
 aliases. The additive `5.1` line exposes
@@ -75,6 +77,7 @@ below instead of assuming the old list.
 | `realtime.gateway-client-protocol-v6-handshake` | The same WebSocket accepts an opt-in 6.0 `session.hello`, returns correlated `session.ready`, negotiates implemented capabilities, and normalizes 6.0 input aliases into the existing business path | `test/gateway-client-protocol.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-runtime-commands` | Negotiated 6.0 Clients can publish registered semantic Client Events and use correlated Task, permission, and conversation-history commands over the same WebSocket; existing REST routes call the same command service as compatibility aliases | `test/gateway-client-protocol.test.mjs`, `server/test/client-event-router.test.mjs`, `server/test/client-command-runtime.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-agent-delivery` | Client Events, Task results and progress, and permission prompts cross one provider-neutral `AgentDelivery` boundary with `handle`, `context`, `respond`, and `interrupt` modes | `server/test/agent-delivery.test.mjs`, `server/test/client-event-router.test.mjs`, `server/test/realtime-provider.test.mjs`, `server/test/announcement-manager.test.mjs` |
+| `realtime.gateway-client-protocol-v6-client-actions` | Correlated `client.action.request/result` messages execute Client-owned environment operations; `enter_sleep` is capability-gated and sleeping commits only after Client success | `test/gateway-client-protocol.test.mjs`, `server/test/client-action-port.test.mjs`, `server/test/gateway-client-handshake.test.mjs`, `desktop/test/enter-sleep-flow.test.mjs` |
 | `desktop.orb-shell` | The orb form's main-process contract ships: `bindOrbShell` answers the channels the shipped preload sends | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` owns the orb window recipe; its `destroy()` is the host's synchronous teardown path (renderer exit is what releases the microphone) | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` covers the default anchor, display clamping and drop persistence | `desktop/test/orb-placement.test.mjs` |
@@ -96,6 +99,7 @@ is unsupported and breaks without notice.
 | `qwen-audio-agent/gateway-protocol` | `GATEWAY_PROTOCOL_VERSION`, `GATEWAY_CAPABILITIES` |
 | `qwen-audio-agent/gateway-client-protocol` | GCP 6.0 envelope and handshake schemas, parsers, capability constants, and reference Client helpers |
 | `qwen-audio-agent/client-events` | Client Event definition registry, built-in definitions, routing policies, and `GatewayEventRouter` for Gateway extensions |
+| `qwen-audio-agent/client-actions` | `ClientActionPort`, built-in action names, capability mapping, request/result correlation, deadlines, and in-flight deduplication |
 | `qwen-audio-agent/agent-delivery` | Provider-neutral `AgentDelivery` values and routing modes |
 | `qwen-audio-agent/gateway-setup` | `gatewaySetupStatus`, `assertGatewaySetup` |
 | `qwen-audio-agent/gateway-process` | `GatewayProcess`, `createGatewayProcess`, `GATEWAY_READY_MESSAGE`, `DEFAULT_GATEWAY_ENTRY`, `validateGatewayOrigin`, `portInUse` |
@@ -213,13 +217,14 @@ conversation surface.
 | client → server | `unmute`, `mute`, `input.unmute`, `input.mute` | Control voice participation or only microphone capture |
 | client → server | `interrupt`, `sleep`, `wake` | Interrupt the foreground response or control explicit sleep |
 | client → server | `playback.started`, `playback.ended`, `playback.cancelled` | Report client-side playback lifecycle by `responseId` |
+| server → client → server | `client.action.request`, `client.action.result` | Execute a capability-gated Client Environment operation and return its correlated outcome |
 | server → client | `voice.ready`, `voice.connection`, `voice.ownership`, `voice.deactivated`, `voice.sleep` | Voice connection, ownership, and sleep lifecycle |
 | server → client | `turn.started`, `voice.state` | Foreground conversation-turn identity and state |
 | server → client | `audio.delta`, `audio.done`, `playback.clear` | Audio playback stream and cancellation |
 | server → client | `response.started`, `response.interrupted` | Response lifecycle keyed by `responseId` |
 | server → client | `transcript.delta`, `transcript.final`, `transcript.discard` | User and assistant transcript lifecycle |
 | server → client | `task.*` | Optional background Task snapshots, progress, authorization, and completion |
-| server → client | `agent.activity`, `client.state`, `error` | Foreground activity hints, supported client-state requests, and errors |
+| server → client | `agent.activity`, `client.state`, `error` | Foreground activity hints, the temporary 5.x client-state migration alias, and errors |
 
 | Direction | Event | Meaning |
 | --- | --- | --- |

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -18,12 +18,14 @@
 [Gateway Client Protocol](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/gateway-protocol.zh.md) 与
 [Roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/gateway-client-protocol.zh.md) 中，并由
 [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)
-跟踪。它们仍是完整设计目标；GCP1 与 GCP2 已以可选的 6.0 握手、Client Event Ingress
-与运行时命令面落在现有 WebSocket 上。后续阶段的 capability 仍是已冻结词汇，在对应
-运行时实现前不会参与协商。
+跟踪。它们仍是完整设计目标；GCP1–GCP4 已以可选的 6.0 握手、Client Event Ingress、
+运行时命令面、Agent Delivery 与 Client Action 边界落在现有 WebSocket 上。后续阶段的
+capability 仍是已冻结词汇，在对应运行时实现前不会参与协商。
 已实现行为仍以本契约索引为准。
 
-当前健康契约版本为 `5.2.0`。新增的 `5.2` 能力在协商后的 6.0 WebSocket 上提供已注册
+当前健康契约版本为 `5.4.0`。新增的 `5.4` 能力提供有关联关系的 Client Action 与共享
+Presence 状态机；`5.3` 增加 Provider 无关 Agent Delivery；`5.2` 在协商后的 6.0
+WebSocket 上提供已注册
 Client Event Ingress 与 Task、权限、对话历史命令，同时保留 REST 兼容别名。`5.1`
 能力提供可选 GCP 6.0
 `session.hello` / `session.ready` 握手，同时保留 5.x `connect` 路径与业务事件别名。
@@ -63,6 +65,7 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `realtime.gateway-client-protocol-v6-handshake` | 同一 WebSocket 可选择以 6.0 `session.hello` 接入，返回有关联关系的 `session.ready`，协商已实现能力，并把 6.0 输入别名归一化到现有业务路径 | `test/gateway-client-protocol.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-runtime-commands` | 协商后的 6.0 Client 可以通过同一 WebSocket 发布已注册的语义 Client Event，并使用有关联结果的 Task、权限和对话历史命令；现有 REST 路由调用同一命令服务作为兼容别名 | `test/gateway-client-protocol.test.mjs`、`server/test/client-event-router.test.mjs`、`server/test/client-command-runtime.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-agent-delivery` | Client Event、Task 结果与低频进展、权限请求统一跨越 Provider 无关 `AgentDelivery` 边界，并支持 `handle`、`context`、`respond`、`interrupt` 四种模式 | `server/test/agent-delivery.test.mjs`、`server/test/client-event-router.test.mjs`、`server/test/realtime-provider.test.mjs`、`server/test/announcement-manager.test.mjs` |
+| `realtime.gateway-client-protocol-v6-client-actions` | 有关联关系的 `client.action.request/result` 执行 Client 自有环境操作；`enter_sleep` 按 capability 暴露，只有 Client 成功后才提交 sleeping | `test/gateway-client-protocol.test.mjs`、`server/test/client-action-port.test.mjs`、`server/test/gateway-client-handshake.test.mjs`、`desktop/test/enter-sleep-flow.test.mjs` |
 | `desktop.orb-shell` | 悬浮球形态的主进程契约随包发布：`bindOrbShell` 应答随包 preload 发出的全部通道 | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` 持有悬浮球窗口配方；其 `destroy()` 是宿主的同步销毁路径（渲染进程退出才能确定性释放麦克风） | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` 覆盖默认锚点、显示器夹取与拖放持久化 | `desktop/test/orb-placement.test.mjs` |
@@ -83,6 +86,7 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `qwen-audio-agent/gateway-protocol` | `GATEWAY_PROTOCOL_VERSION`、`GATEWAY_CAPABILITIES` |
 | `qwen-audio-agent/gateway-client-protocol` | GCP 6.0 信封与握手 Schema、解析器、能力常量和参考 Client Helper |
 | `qwen-audio-agent/client-events` | 供 Gateway 扩展使用的 Client Event Definition Registry、内置定义、路由 Policy 与 `GatewayEventRouter` |
+| `qwen-audio-agent/client-actions` | `ClientActionPort`、内置 Action 名称、capability 映射、请求/结果关联、deadline 与进行中请求去重 |
 | `qwen-audio-agent/agent-delivery` | Provider 无关的 `AgentDelivery` 值与路由模式 |
 | `qwen-audio-agent/gateway-setup` | `gatewaySetupStatus`、`assertGatewaySetup` |
 | `qwen-audio-agent/gateway-process` | `GatewayProcess`、`createGatewayProcess`、`GATEWAY_READY_MESSAGE`、`DEFAULT_GATEWAY_ENTRY`、`validateGatewayOrigin`、`portInUse` |
@@ -191,13 +195,14 @@ await orb.load()
 | 客户端 → 服务端 | `unmute`、`mute`、`input.unmute`、`input.mute` | 控制语音参与，或只控制麦克风采集 |
 | 客户端 → 服务端 | `interrupt`、`sleep`、`wake` | 打断前台回复，或控制显式休眠 |
 | 客户端 → 服务端 | `playback.started`、`playback.ended`、`playback.cancelled` | 按 `responseId` 回报客户端播放生命周期 |
+| 服务端 → 客户端 → 服务端 | `client.action.request`、`client.action.result` | 执行 capability 约束的 Client Environment 操作并返回有关联结果 |
 | 服务端 → 客户端 | `voice.ready`、`voice.connection`、`voice.ownership`、`voice.deactivated`、`voice.sleep` | 语音连接、占用权与休眠生命周期 |
 | 服务端 → 客户端 | `turn.started`、`voice.state` | 前台对话轮次标识与状态 |
 | 服务端 → 客户端 | `audio.delta`、`audio.done`、`playback.clear` | 播放音频流及清除指令 |
 | 服务端 → 客户端 | `response.started`、`response.interrupted` | 以 `responseId` 标识的回复生命周期 |
 | 服务端 → 客户端 | `transcript.delta`、`transcript.final`、`transcript.discard` | 用户与助手转写生命周期 |
 | 服务端 → 客户端 | `task.*` | 可选的后台 Task 快照、进度、授权与完成事件 |
-| 服务端 → 客户端 | `agent.activity`、`client.state`、`error` | 前台活动提示、客户端状态请求与错误 |
+| 服务端 → 客户端 | `agent.activity`、`client.state`、`error` | 前台活动提示、临时保留的 5.x Client State 迁移别名与错误 |
 
 | 方向 | 事件 | 含义 |
 | --- | --- | --- |

--- a/docs/gateway-protocol.md
+++ b/docs/gateway-protocol.md
@@ -110,8 +110,9 @@ logic. A 6.0 Client starts with `session.hello`; Gateway returns
 6.0 input aliases into the existing internal event model. A 5.x Client may
 continue to start with `connect` and receives the unchanged legacy event shape.
 Only capabilities with working runtimes are negotiated. GCP2 Client Event and
-runtime-command capabilities and GCP3 Agent Delivery are now implemented;
-names reserved for GCP4–GCP5 remain vocabulary-only until their runtimes ship.
+runtime-command capabilities, GCP3 Agent Delivery, and GCP4 Client Actions are
+now implemented; names reserved for GCP5 remain vocabulary-only until its
+runtime ships.
 
 ### 3.2 GCP2 runtime rollout
 
@@ -138,6 +139,18 @@ Realtime providers encode only the resulting context item and optional response;
 raw Client or backend protocol objects never enter the model. Existing Task
 announcement batching, safe-window retry, notification claims, and playback
 acknowledgement remain the reliable lifecycle around that shared projection.
+
+### 3.4 GCP4 Client Action rollout
+
+GCP4 implements correlated `client.action.request/result` messages and a
+protocol-neutral `ClientActionPort`. The active Client capability-gates
+action-derived Realtime tools. `enter_sleep`, the desktop idle-event fallback,
+and the legacy Gateway timeout converge on one idempotent
+`PresenceController`; an action-capable Client is marked sleeping only after it
+reports that the environment transition completed. The current first-party
+desktop may publish the built-in idle event and return an Action result after
+the 5.x `connect` alias during migration;
+GCP5 moves them to `session.hello` without changing the Action semantics.
 
 ## 4. Common event envelope
 
@@ -261,6 +274,12 @@ client.action.result
 ```
 
 `status` is `completed`, `failed`, or `unsupported`. Failure includes a bounded `{code, message}` object. Gateway exposes an action-derived Realtime tool only when the active Client negotiated the corresponding capability.
+
+The first implemented action is `desktop.presence.enter_sleep`. Its tool,
+automatic Client Event fallback, timeout handling, and duplicate requests share
+one Presence state machine. The legacy `client.state` sleeping message remains
+accepted by current clients as a migration alias, but is no longer the execution
+boundary.
 
 Client Action is not a replacement for MCP, OpenAPI, ACP, or A2A. It covers capabilities owned by the connected Client Environment. Other external systems continue to use the appropriate tool or backend adapter.
 

--- a/docs/gateway-protocol.zh.md
+++ b/docs/gateway-protocol.zh.md
@@ -108,8 +108,9 @@ GCP1 在不分叉 Gateway 业务逻辑的前提下实现信封与握手。6.0 Cl
 `session.hello` 开始；Gateway 返回 `session.ready`，为后续下行事件补充
 `event_id`，并把 6.0 输入别名归一化到现有内部事件模型。5.x Client 仍可使用
 `connect`，收到的旧事件形状保持不变。握手只协商已有运行时实现的能力。GCP2 的
-Client Event 与运行时命令 capability、GCP3 Agent Delivery 已经实现；GCP4–GCP5
-预留的名称仍只用于统一扩展词汇，在对应 Runtime 完成前不会被声明为已实现。
+Client Event 与运行时命令 capability、GCP3 Agent Delivery、GCP4 Client Action
+已经实现；GCP5 预留名称仍只用于统一扩展词汇，在对应 Runtime 完成前不会被声明为
+已实现。
 
 ### 3.2 GCP2 运行时落地
 
@@ -131,6 +132,16 @@ GCP3 实现第 6 节定义的 Provider 无关值与四种路由模式。Task 最
 Realtime Provider 只编码最终的上下文项与可选回复；Client 或后台协议原始对象不会
 进入模型。现有 Task 播报的批处理、安全窗口重试、通知认领和播放确认继续作为这条共享
 投影外围的可靠生命周期。
+
+### 3.4 GCP4 Client Action 落地
+
+GCP4 实现有关联关系的 `client.action.request/result` 与协议无关的
+`ClientActionPort`。只有当前 Client 声明对应 capability，Realtime 才能看到由
+Action 派生的工具。`enter_sleep`、桌面空闲事件兜底与旧 Gateway 超时入口统一进入
+幂等 `PresenceController`；支持 Action 的 Client 只有在环境切换成功回执后才会被
+标记为 sleeping。迁移期间，现有第一方桌面 Client 可以在 5.x `connect` 别名后发布
+内置空闲事件并回传 Action Result；GCP5 再把它们迁移到 `session.hello`，Action
+语义不变。
 
 ## 4. 通用事件信封
 
@@ -254,6 +265,10 @@ client.action.result
 ```
 
 `status` 为 `completed`、`failed` 或 `unsupported`。失败包含有界的 `{code, message}`。只有活动 Client 协商了相应 capability，Gateway 才向 Realtime 暴露由该 Action 派生的工具。
+
+首个实现的 Action 是 `desktop.presence.enter_sleep`。它的工具调用、自动 Client
+Event 兜底、超时和重复请求共用一个 Presence 状态机。旧 `client.state` sleeping
+消息仍作为当前 Client 的迁移兼容入口，但不再承担实际执行边界。
 
 Client Action 不替代 MCP、OpenAPI、ACP 或 A2A。它只用于当前 Client Environment 自己拥有的能力；其他外部系统继续使用适合的工具或 Backend Adapter。
 

--- a/docs/roadmap/gateway-client-protocol.md
+++ b/docs/roadmap/gateway-client-protocol.md
@@ -100,12 +100,12 @@ Exit criteria: one event can update Gateway/UI only, update model context silent
 
 ## GCP4 — Client Action port
 
-- [ ] Add `ClientActionPort` and `client.action.request/result`.
-- [ ] Advertise Client Action capabilities during handshake.
-- [ ] Expose action-derived Realtime tools only when supported.
-- [ ] Migrate `enter_sleep` from `requestClientState()` to the shared action path.
-- [ ] Add one idempotent `PresenceController` for user-requested, automatic, timeout, and duplicate sleep requests.
-- [ ] Mark sleeping only after a successful Client Action result.
+- [x] Add `ClientActionPort` and `client.action.request/result`.
+- [x] Advertise Client Action capabilities during handshake.
+- [x] Expose action-derived Realtime tools only when supported.
+- [x] Migrate `enter_sleep` from `requestClientState()` to the shared action path.
+- [x] Add one idempotent `PresenceController` for user-requested, automatic, timeout, and duplicate sleep requests.
+- [x] Mark sleeping only after a successful Client Action result.
 
 Exit criteria: Realtime Tool Calls and Gateway fallbacks use one action/state machine, and Gateway Core no longer knows how Desktop hides its window.
 

--- a/docs/roadmap/gateway-client-protocol.zh.md
+++ b/docs/roadmap/gateway-client-protocol.zh.md
@@ -100,12 +100,12 @@ Backend Agent
 
 ## GCP4 — Client Action Port
 
-- [ ] 增加 `ClientActionPort` 与 `client.action.request/result`。
-- [ ] 在握手中声明 Client Action capability。
-- [ ] 只有 Client 支持时才暴露 Action 派生的 Realtime 工具。
-- [ ] 将 `enter_sleep` 从 `requestClientState()` 迁移到共享 Action 链路。
-- [ ] 以一个幂等 `PresenceController` 处理用户主动、自动、超时与重复休眠请求。
-- [ ] Client Action 成功后才标记 sleeping。
+- [x] 增加 `ClientActionPort` 与 `client.action.request/result`。
+- [x] 在握手中声明 Client Action capability。
+- [x] 只有 Client 支持时才暴露 Action 派生的 Realtime 工具。
+- [x] 将 `enter_sleep` 从 `requestClientState()` 迁移到共享 Action 链路。
+- [x] 以一个幂等 `PresenceController` 处理用户主动、自动、超时与重复休眠请求。
+- [x] Client Action 成功后才标记 sleeping。
 
 完成条件：Realtime Tool Call 与 Gateway 兜底共用一个 Action/状态机，Gateway Core 不再知道 Desktop 如何隐藏窗口。
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "./gateway-events": "./shared/protocol/gateway-events.mjs",
     "./gateway-client-protocol": "./shared/gateway-client-protocol.mjs",
     "./client-events": "./server/src/client/client-event-router.mjs",
+    "./client-actions": "./server/src/client/client-action-port.mjs",
     "./agent-delivery": "./server/src/delivery/agent-delivery.mjs",
     "./ag-ui-events": "./shared/protocol/agui-events.mjs",
     "./session-events": "./shared/session-events.mjs",

--- a/server/eval/frontend-runtime-evaluations.mjs
+++ b/server/eval/frontend-runtime-evaluations.mjs
@@ -33,7 +33,7 @@ async function evaluateRoutingContract() {
   const prompt = loadFrontendPrompt()
   const names = toolNames({
     frontend: { capabilities: ['web-search', 'url-fetch', 'knowledge'] },
-    client: { states: ['sleeping'] },
+    client: { actions: ['desktop.presence.enter_sleep'] },
   })
   const required = [
     'spawn_thinking',

--- a/server/src/client/client-action-port.mjs
+++ b/server/src/client/client-action-port.mjs
@@ -1,0 +1,144 @@
+import {
+  createGatewayProtocolEventId,
+  GatewayClientActionName,
+  GatewayClientCapability,
+  GatewayClientProtocolEvent,
+  GatewayClientActionResultSchema,
+} from '../../../shared/gateway-client-protocol.mjs'
+
+export const ClientActionName = GatewayClientActionName
+
+const ACTION_CAPABILITIES = Object.freeze({
+  [ClientActionName.ENTER_SLEEP]: GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
+})
+
+export function clientActionCapability(name) {
+  return ACTION_CAPABILITIES[String(name || '')] || null
+}
+
+function actionError(code, message, details = {}) {
+  const error = new Error(message)
+  error.code = code
+  Object.assign(error, details)
+  return error
+}
+
+/**
+ * Protocol-neutral Gateway-to-Client action boundary.
+ *
+ * The port owns correlation, deadlines, capability checks and duplicate
+ * in-flight requests. Client implementations own the environment operation.
+ */
+export class ClientActionPort {
+  constructor({
+    send,
+    getCapabilities = () => [],
+    capabilityForAction = clientActionCapability,
+    timeoutMs = 5_000,
+    createEventId = () => createGatewayProtocolEventId('gateway'),
+  } = {}) {
+    this.send = send
+    this.getCapabilities = getCapabilities
+    this.capabilityForAction = capabilityForAction
+    this.timeoutMs = Math.max(100, Number(timeoutMs) || 5_000)
+    this.createEventId = createEventId
+    this.pendingById = new Map()
+    this.pendingByKey = new Map()
+  }
+
+  supports(name) {
+    const capability = this.capabilityForAction(String(name || ''))
+    return Boolean(
+      capability
+      && new Set(this.getCapabilities?.() || []).has(capability),
+    )
+  }
+
+  request(name, argumentsValue = {}, {
+    idempotencyKey = '',
+    timeoutMs = this.timeoutMs,
+  } = {}) {
+    const actionName = String(name || '').trim()
+    const capability = this.capabilityForAction(actionName)
+    if (!capability || !this.supports(actionName)) {
+      return Promise.reject(actionError(
+        'client_action_unsupported',
+        `Client does not support ${actionName || 'this action'}`,
+      ))
+    }
+    if (typeof this.send !== 'function') {
+      return Promise.reject(actionError(
+        'client_action_unavailable',
+        'No active Client Action transport is available',
+      ))
+    }
+    const key = String(idempotencyKey || '').trim()
+    if (key && this.pendingByKey.has(key)) return this.pendingByKey.get(key).promise
+
+    const requestId = this.createEventId()
+    const deferred = Promise.withResolvers()
+    const pending = {
+      requestId,
+      name: actionName,
+      key,
+      resolve: deferred.resolve,
+      reject: deferred.reject,
+      timer: null,
+      promise: deferred.promise,
+    }
+    pending.timer = setTimeout(() => {
+      this.#settle(pending, null, actionError(
+        'client_action_timeout',
+        `Client Action timed out: ${actionName}`,
+      ))
+    }, Math.max(100, Number(timeoutMs) || this.timeoutMs))
+    pending.timer.unref?.()
+    this.pendingById.set(requestId, pending)
+    if (key) this.pendingByKey.set(key, pending)
+    try {
+      this.send({
+        type: GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST,
+        event_id: requestId,
+        name: actionName,
+        arguments: argumentsValue,
+      })
+    } catch (error) {
+      this.#settle(pending, null, error)
+    }
+    return pending.promise
+  }
+
+  receive(value) {
+    const result = GatewayClientActionResultSchema.parse(value)
+    const pending = this.pendingById.get(result.request_event_id)
+    if (!pending) return false
+    if (result.status === 'completed') {
+      this.#settle(pending, result)
+      return true
+    }
+    this.#settle(pending, null, actionError(
+      result.error?.code || `client_action_${result.status}`,
+      result.error?.message || `Client Action ${result.status}: ${pending.name}`,
+      { result },
+    ))
+    return true
+  }
+
+  close(reason = 'Client disconnected') {
+    const error = actionError('client_action_disconnected', reason)
+    for (const pending of [...this.pendingById.values()]) {
+      this.#settle(pending, null, error)
+    }
+  }
+
+  #settle(pending, result, error = null) {
+    if (this.pendingById.get(pending.requestId) !== pending) return
+    clearTimeout(pending.timer)
+    this.pendingById.delete(pending.requestId)
+    if (pending.key && this.pendingByKey.get(pending.key) === pending) {
+      this.pendingByKey.delete(pending.key)
+    }
+    if (error) pending.reject(error)
+    else pending.resolve(result)
+  }
+}

--- a/server/src/client/presence-controller.mjs
+++ b/server/src/client/presence-controller.mjs
@@ -1,0 +1,88 @@
+import { ClientActionName } from './client-action-port.mjs'
+
+export const PresenceState = Object.freeze({
+  ACTIVE: 'active',
+  SLEEP_REQUESTED: 'sleep_requested',
+  SLEEPING: 'sleeping',
+})
+
+/**
+ * Idempotent state machine shared by model tools and Gateway sleep triggers.
+ * The environment transition is authoritative: sleeping is committed only
+ * after the active Client reports that its action completed.
+ */
+export class PresenceController {
+  constructor({
+    clientActions,
+    beforeSleep = async () => {},
+    onSleeping = () => {},
+    onFailure = () => {},
+  } = {}) {
+    this.clientActions = clientActions
+    this.beforeSleep = beforeSleep
+    this.onSleeping = onSleeping
+    this.onFailure = onFailure
+    this.state = PresenceState.ACTIVE
+    this.pending = null
+  }
+
+  supportsSleep() {
+    return this.clientActions?.supports(ClientActionName.ENTER_SLEEP) === true
+  }
+
+  requestSleep({ source = 'gateway', requireClientAction = true } = {}) {
+    if (this.state === PresenceState.SLEEPING) {
+      return Promise.resolve({ status: 'completed', state: this.state, duplicate: true })
+    }
+    if (this.pending) return this.pending
+    if (requireClientAction && !this.supportsSleep()) {
+      const error = new Error('当前入口不支持休眠。')
+      error.code = 'client_action_unsupported'
+      return Promise.reject(error)
+    }
+
+    this.state = PresenceState.SLEEP_REQUESTED
+    const pending = Promise.resolve()
+      .then(() => this.beforeSleep({ source }))
+      .then(() => requireClientAction
+        ? this.clientActions.request(
+            ClientActionName.ENTER_SLEEP,
+            { source },
+            { idempotencyKey: 'presence.sleep' },
+          )
+        : { status: 'completed', handledBy: 'gateway' })
+      .then(result => {
+        this.state = PresenceState.SLEEPING
+        // Resolve action waiters before closing the Realtime frontend. A model
+        // tool can then receive its function result, while the state itself is
+        // already authoritative because the Client Action has completed.
+        const transition = setTimeout(() => {
+          if (this.state === PresenceState.SLEEPING) {
+            this.onSleeping({ source, result })
+          }
+        }, 0)
+        transition.unref?.()
+        return { status: 'completed', state: this.state, result }
+      })
+      .catch(error => {
+        this.state = PresenceState.ACTIVE
+        this.onFailure({ source, error })
+        throw error
+      })
+      .finally(() => {
+        if (this.pending === pending) this.pending = null
+      })
+    this.pending = pending
+    return pending
+  }
+
+  wake() {
+    this.state = PresenceState.ACTIVE
+  }
+
+  close() {
+    this.clientActions?.close()
+    this.pending = null
+    this.state = PresenceState.ACTIVE
+  }
+}

--- a/server/src/core/gateway-protocol.mjs
+++ b/server/src/core/gateway-protocol.mjs
@@ -10,6 +10,8 @@
 // Every capability listed here is locked by a test (see docs/contract.md);
 // anything not listed is internal and may change in any release.
 //
+// 5.4.0 adds GCP4 ClientActionPort request/result correlation and the shared
+// presence state machine used by Realtime tools and Gateway sleep triggers.
 // 5.3.0 adds GCP3 provider-neutral AgentDelivery routing for Client Events,
 // Task results and progress, and permission prompts.
 // 5.2.0 adds GCP2 Client Event ingress and WebSocket runtime commands for
@@ -37,7 +39,7 @@
 // desktop.settings-window, …) are not part of this contract, and a removed
 // capability is a breaking change. Hosts migrating from the fork must branch
 // on the capability list below, never on the version number.
-export const GATEWAY_PROTOCOL_VERSION = '5.3.0'
+export const GATEWAY_PROTOCOL_VERSION = '5.4.0'
 
 export const GATEWAY_CAPABILITIES = Object.freeze([
   // The Gateway statically hosts web/dist at its own origin, so a client may
@@ -105,6 +107,10 @@ export const GATEWAY_CAPABILITIES = Object.freeze([
   // provider-neutral AgentDelivery runtime with handle/context/respond/
   // interrupt modes before any Realtime-provider encoding occurs.
   'realtime.gateway-client-protocol-v6-agent-delivery',
+  // Gateway-to-Client environment operations use correlated action
+  // request/results. enter_sleep is capability-gated and commits Gateway
+  // sleeping only after the active Client reports a successful transition.
+  'realtime.gateway-client-protocol-v6-client-actions',
   // The orb shell contract ships: qwen-audio-agent/orb/preload plus
   // orb/main's bindOrbShell, so a host may run the floating orb form.
   'desktop.orb-shell',

--- a/server/src/transport/gateway-client-protocol-session.mjs
+++ b/server/src/transport/gateway-client-protocol-session.mjs
@@ -48,6 +48,20 @@ export class GatewayClientProtocolSession {
     }
 
     if (this.mode === 'legacy') {
+      // Client Actions are introduced by 6.0, but current first-party clients
+      // still open with the 5.x connect alias during staged migration. Accept
+      // only the typed result message here; every other legacy behavior stays
+      // unchanged and GCP5 will move these clients to session.hello.
+      if ([
+        GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+        GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH,
+      ].includes(value?.type)) {
+        try {
+          return { event: null, runtimeMessage: parseGatewayClientProtocolMessage(value) }
+        } catch {
+          return { event: null }
+        }
+      }
       return { event: this.#parseLegacy(value) }
     }
 

--- a/server/src/voice/frontend-tools.mjs
+++ b/server/src/voice/frontend-tools.mjs
@@ -15,6 +15,7 @@ import {
   FRONTEND_TOOL_APPROVAL_CAPABILITY,
 } from '../frontend/tools/frontend-tool-source.mjs'
 import { spawnThinkingTool } from './tools/spawn-thinking-tool.mjs'
+import { ClientActionName } from '../client/client-action-port.mjs'
 
 export { SPAWN_THINKING_TOOL_NAME } from './tools/spawn-thinking-tool.mjs'
 export const SCHEDULE_REMINDER_TOOL_NAME = 'schedule_reminder'
@@ -404,7 +405,10 @@ export const frontendToolRegistry = new FrontendToolRegistry([
   },
   {
     definition: enterSleepTool,
-    policy: { mode: 'control', requiredClientStates: ['sleeping'] },
+    policy: {
+      mode: 'control',
+      requiredClientActions: [ClientActionName.ENTER_SLEEP],
+    },
   },
 ])
 

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -58,6 +58,11 @@ import {
 import { createAgentDelivery } from '../delivery/agent-delivery.mjs'
 import { permissionResponseInstructions } from './frontend-tools.mjs'
 import { RealtimeAgentDeliveryRuntime } from './realtime-agent-delivery-runtime.mjs'
+import {
+  ClientActionName,
+  ClientActionPort,
+} from '../client/client-action-port.mjs'
+import { PresenceController } from '../client/presence-controller.mjs'
 
 const MAX_PENDING_AUDIO_CHUNKS = 30
 const RESPONSE_START_WATCHDOG_MS = 12000
@@ -230,10 +235,29 @@ export function attachRealtimeGateway(server, {
     let permissionResponseTimer = null
     let sleeping = false
     let waking = false
-    let explicitSleepRequested = false
     let wakeDetector = null
     let wakeDetectorPromise = null
     let sleepController
+    const sleepFallbackTimers = new Set()
+    const clientActionCapabilities = new Set()
+    const clientActions = new ClientActionPort({
+      send: event => send(ws, event),
+      getCapabilities: () => [...clientActionCapabilities],
+    })
+    const presenceController = new PresenceController({
+      clientActions,
+      beforeSleep: async () => {
+        inputEnabled = false
+        realtimeSession.clearPendingAudio()
+        prepareSleepMode()
+        await wakeDetectorPromise
+      },
+      onSleeping: () => enterSleep(),
+      onFailure: ({ error }) => connectionLogger.warn('presence.sleep_failed', {
+        code: String(error?.code || 'client_action_failed'),
+        error: String(error?.message || error),
+      }),
+    })
     const announcementWindow = new AnnouncementWindow()
     const notificationClaimantId = `voice_${randomUUID()}`
     let clientContext = normalizeClientContext()
@@ -504,6 +528,7 @@ export function attachRealtimeGateway(server, {
       deactivate: replacement => {
         sleeping = false
         waking = false
+        presenceController.wake()
         sleepController?.disable()
         inputEnabled = false
         outputEnabled = false
@@ -580,14 +605,7 @@ export function attachRealtimeGateway(server, {
         announcedPermissions.delete(authorizationId)
         announcePendingPermissions()
       },
-      requestClientState: state => {
-        if (!clientContext.states?.includes(state)) return
-        send(ws, {
-          type: GatewayServerEvent.CLIENT_STATE,
-          state,
-        })
-        if (state === 'sleeping') enterSleep()
-      },
+      presenceController,
       onAgentActivity: activity => send(ws, {
         type: GatewayServerEvent.AGENT_ACTIVITY,
         ...activity,
@@ -877,18 +895,14 @@ export function attachRealtimeGateway(server, {
 
     const enterSleep = () => {
       if (sleeping) return
+      for (const timer of sleepFallbackTimers) clearTimeout(timer)
+      sleepFallbackTimers.clear()
       sleeping = true
       waking = false
       announcementWindow.reset()
       progressAnnouncements.clear()
       wakeDetector?.reset()
       realtimeSession.close()
-      if (clientContext.states?.includes('sleeping')) {
-        send(ws, {
-          type: GatewayServerEvent.CLIENT_STATE,
-          state: 'sleeping',
-        })
-      }
       send(ws, {
         type: GatewayServerEvent.VOICE_CONNECTION,
         state: 'sleeping',
@@ -948,19 +962,13 @@ export function attachRealtimeGateway(server, {
     // The desktop window and the realtime provider enter sleep as one explicit
     // state transition. Desktop decides when it is safe to hide because only
     // the client knows about visible work, permission prompts and playback.
-    const requestExplicitSleep = () => {
-      if (!config.wakeWordEnabled || nonVoiceClient) return false
-      explicitSleepRequested = true
-      inputEnabled = false
-      realtimeSession.clearPendingAudio()
-      prepareSleepMode()
-      const finish = () => {
-        if (!explicitSleepRequested || !wakeDetector) return false
-        enterSleep()
-        return sleeping
-      }
-      if (wakeDetector) return finish()
-      wakeDetectorPromise?.then(finish).catch(() => {})
+    const requestExplicitSleep = (source = 'client') => {
+      presenceController.requestSleep({ source }).catch(error => {
+        send(ws, {
+          type: GatewayServerEvent.ERROR,
+          message: `休眠没有完成：${error.message}`,
+        })
+      })
       return true
     }
 
@@ -1003,9 +1011,9 @@ export function attachRealtimeGateway(server, {
 
     const wakeFromSleep = () => {
       if (!sleeping || waking) return
-      explicitSleepRequested = false
       sleeping = false
       waking = true
+      presenceController.wake()
       sleepController.wake()
       send(ws, {
         type: GatewayServerEvent.VOICE_SLEEP,
@@ -1022,6 +1030,7 @@ export function attachRealtimeGateway(server, {
       } catch (error) {
         sleeping = false
         waking = false
+        presenceController.wake()
         sleepController.disable()
         send(ws, {
           type: GatewayServerEvent.VOICE_SLEEP,
@@ -1046,7 +1055,12 @@ export function attachRealtimeGateway(server, {
         && !realtimeSession.connecting
         && !waking
       ),
-      onSleep: enterSleep,
+      onSleep: () => presenceController.requestSleep({
+        source: 'timeout',
+        requireClientAction: false,
+      }).catch(error => connectionLogger.warn('presence.timeout_failed', {
+        error: error.message,
+      })),
     })
 
     send(ws, { type: GatewayServerEvent.VOICE_STATE, state: 'idle' })
@@ -1086,6 +1100,14 @@ export function attachRealtimeGateway(server, {
       })
     }
     const handleRuntimeMessage = async message => {
+      if (message.type === GatewayClientProtocolEvent.CLIENT_ACTION_RESULT) {
+        if (!clientActions.receive(message)) {
+          connectionLogger.debug('client_action.result_stale', {
+            requestEventId: message.request_event_id,
+          })
+        }
+        return
+      }
       if (message.type === GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH) {
         if (!clientEventRouter) {
           const error = new Error('Client Event runtime unavailable')
@@ -1102,6 +1124,17 @@ export function attachRealtimeGateway(server, {
           name: result.name,
           ...(result.duplicate ? { duplicate: true } : {}),
         })
+        if (
+          !result.duplicate
+          && result.name === 'desktop.presence.sleep_requested'
+        ) {
+          const timer = setTimeout(() => {
+            sleepFallbackTimers.delete(timer)
+            if (!sleeping) requestExplicitSleep('client_event_timeout')
+          }, 5_000)
+          timer.unref?.()
+          sleepFallbackTimers.add(timer)
+        }
         if (!result.duplicate && result.delivery) {
           agentDeliveries.deliver(result.delivery).then(outcome => {
             if (outcome?.completed || outcome?.handled) return
@@ -1207,6 +1240,22 @@ export function attachRealtimeGateway(server, {
           && Array.isArray(event.clientStates)
           && event.clientStates.includes('sleeping')
         ) ? ['sleeping'] : []
+        clientActionCapabilities.clear()
+        if (
+          clientProtocol.capabilities.includes(
+            GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
+          )
+          || clientContext.states.includes('sleeping')
+        ) {
+          clientActionCapabilities.add(
+            GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
+          )
+        }
+        clientContext.actions = [
+          ...(clientActions.supports(ClientActionName.ENTER_SLEEP)
+            ? [ClientActionName.ENTER_SLEEP]
+            : []),
+        ]
         clientContext.inputCapabilities = (
           event.inputCapabilities
           && typeof event.inputCapabilities === 'object'
@@ -1217,11 +1266,11 @@ export function attachRealtimeGateway(server, {
             resource: event.inputCapabilities.resource === true,
           }
           : null
-        // A desktop that advertises the sleeping state owns its inactivity
-        // policy. Keep Gateway's legacy automatic timer only for clients that
-        // cannot request an explicit synchronized sleep transition.
+        // An action-capable desktop owns its inactivity policy and publishes a
+        // semantic request. Keep Gateway's legacy timer only for clients that
+        // cannot request a synchronized Client Action transition.
         sleepController.setTimeoutMs(
-          clientContext.states.includes('sleeping')
+          clientActions.supports(ClientActionName.ENTER_SLEEP)
             ? 0
             : config.sleepTimeoutMs,
         )
@@ -1231,6 +1280,7 @@ export function attachRealtimeGateway(server, {
           if (sleeping) {
             sleeping = false
             waking = true
+            presenceController.wake()
             sleepController.wake()
           }
           prepareSleepMode()
@@ -1241,7 +1291,6 @@ export function attachRealtimeGateway(server, {
           }
         }).catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.UNMUTE) {
-        explicitSleepRequested = false
         if (nonVoiceClient) {
           inputEnabled = false
           outputEnabled = true
@@ -1258,7 +1307,6 @@ export function attachRealtimeGateway(server, {
           })
           .catch(reportFrontendError)
       } else if (event.type === GatewayClientEvent.INPUT_UNMUTE) {
-        explicitSleepRequested = false
         if (nonVoiceClient) return
         if (activeVoiceClients.isActive(ownerId, voiceClient)) {
           inputEnabled = true
@@ -1339,10 +1387,10 @@ export function attachRealtimeGateway(server, {
           })
         }
       } else if (event.type === GatewayClientEvent.MUTE) {
-        explicitSleepRequested = false
         releaseVoiceClient()
         sleeping = false
         waking = false
+        presenceController.wake()
         sleepController?.disable()
         turns.advanceBoundary()
         announcementWindow.reset()
@@ -1352,11 +1400,10 @@ export function attachRealtimeGateway(server, {
         inputEnabled = false
         realtimeSession.clearPendingAudio()
       } else if (event.type === GatewayClientEvent.SLEEP) {
-        requestExplicitSleep()
+        requestExplicitSleep('client')
       } else if (event.type === GatewayClientEvent.WAKE) {
         // 桌面快捷键/托盘唤起只恢复窗口可见性，休眠中的前台连接靠这个事件
         // 恢复，复用唤醒词检测之后同一套重连与退避路径。
-        explicitSleepRequested = false
         if (sleeping) wakeFromSleep()
         else sleepController.recordActivity()
       } else if (event.type === GatewayClientEvent.INPUT_SUSPEND_ACK) {
@@ -1388,6 +1435,9 @@ export function attachRealtimeGateway(server, {
       clearTimeout(permissionRetryTimer)
       permissionRetryTimer = null
       sleepController?.close()
+      for (const timer of sleepFallbackTimers) clearTimeout(timer)
+      sleepFallbackTimers.clear()
+      presenceController.close()
       realtimeSession.close()
       // Invisible memory: distil durable personal facts from this session in
       // the background. All gating (debounce, minimum turns, disabled state)

--- a/server/src/voice/tools/frontend-tool-registry.mjs
+++ b/server/src/voice/tools/frontend-tool-registry.mjs
@@ -20,6 +20,14 @@ function clientStates(context) {
   )
 }
 
+function clientActions(context) {
+  return new Set(
+    Array.isArray(context?.client?.actions)
+      ? context.client.actions.map(String)
+      : [],
+  )
+}
+
 function frontendCapabilities(context) {
   return new Set(
     Array.isArray(context?.frontend?.capabilities)
@@ -33,11 +41,16 @@ function policyAllows(policy = {}, context = {}) {
   const requiredStates = Array.isArray(policy.requiredClientStates)
     ? policy.requiredClientStates
     : []
+  const availableActions = clientActions(context)
+  const requiredActions = Array.isArray(policy.requiredClientActions)
+    ? policy.requiredClientActions
+    : []
   const availableCapabilities = frontendCapabilities(context)
   const requiredCapabilities = Array.isArray(policy.requiredCapabilities)
     ? policy.requiredCapabilities
     : []
   return requiredStates.every(state => availableStates.has(state))
+    && requiredActions.every(action => availableActions.has(action))
     && requiredCapabilities.every(capability => (
       availableCapabilities.has(capability)
     ))
@@ -76,6 +89,11 @@ function normalizedPolicy(policy = {}) {
   if (Array.isArray(policy.requiredClientStates)) {
     normalized.requiredClientStates = Object.freeze([
       ...policy.requiredClientStates.map(String),
+    ])
+  }
+  if (Array.isArray(policy.requiredClientActions)) {
+    normalized.requiredClientActions = Object.freeze([
+      ...policy.requiredClientActions.map(String),
     ])
   }
   if (Array.isArray(policy.requiredCapabilities)) {

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -120,7 +120,7 @@ export class ToolCallHandler {
     respondAuthorization,
     permissionPolicy,
     onPermissionDeliveryFailed = () => {},
-    requestClientState = () => {},
+    presenceController = null,
     onAgentActivity = () => {},
     inputAssets = null,
     frontendRetrieval = null,
@@ -145,7 +145,7 @@ export class ToolCallHandler {
     this.respondAuthorization = respondAuthorization
     this.permissionPolicy = permissionPolicy
     this.onPermissionDeliveryFailed = onPermissionDeliveryFailed
-    this.requestClientState = requestClientState
+    this.presenceController = presenceController
     this.onAgentActivity = onAgentActivity
     this.inputAssets = inputAssets
     this.frontendRetrieval = frontendRetrieval
@@ -1097,23 +1097,34 @@ export class ToolCallHandler {
   }
 
   async enterSleep(callId, turnId) {
-    const supported = this.getClientContext()?.states?.includes('sleeping')
-    if (!supported) {
+    if (!this.presenceController?.supportsSleep()) {
       await this.sendOutput(
         callId,
-        failure('unsupported_client_state', '当前入口不支持休眠。'),
+        failure('client_action_unsupported', '当前入口不支持休眠。'),
         turnId,
       )
       return
     }
-    await this.sendOutput(
-      callId,
-      { status: 'sleeping' },
-      turnId,
-      null,
-      { createResponse: false },
-    )
-    this.requestClientState('sleeping')
+    try {
+      await this.presenceController.requestSleep({ source: 'realtime_tool' })
+      await this.sendOutput(
+        callId,
+        { status: 'sleeping' },
+        turnId,
+        null,
+        { createResponse: false },
+      )
+    } catch (error) {
+      await this.sendOutput(
+        callId,
+        failure(
+          error.code || 'client_action_failed',
+          `休眠没有完成：${error.message}`,
+          { retryable: true },
+        ),
+        turnId,
+      )
+    }
   }
 
   async webSearch({ callId, turnId, args }) {

--- a/server/test/client-action-port.test.mjs
+++ b/server/test/client-action-port.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  ClientActionName,
+  ClientActionPort,
+} from '../src/client/client-action-port.mjs'
+import {
+  PresenceController,
+  PresenceState,
+} from '../src/client/presence-controller.mjs'
+import {
+  GatewayClientCapability,
+  GatewayClientProtocolEvent,
+} from '../../shared/gateway-client-protocol.mjs'
+
+test('correlates a supported Client Action request and result', async () => {
+  const sent = []
+  let port
+  port = new ClientActionPort({
+    getCapabilities: () => [GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP],
+    createEventId: () => 'evt_gateway_action',
+    send: event => {
+      sent.push(event)
+      queueMicrotask(() => port.receive({
+        type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+        event_id: 'evt_client_result',
+        request_event_id: event.event_id,
+        status: 'completed',
+        output: { state: 'hidden' },
+      }))
+    },
+  })
+
+  const result = await port.request(ClientActionName.ENTER_SLEEP)
+  assert.equal(sent.length, 1)
+  assert.equal(sent[0].type, GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST)
+  assert.equal(sent[0].name, ClientActionName.ENTER_SLEEP)
+  assert.equal(result.output.state, 'hidden')
+})
+
+test('deduplicates a pending action and fails closed without capability', async () => {
+  let resolveAction
+  let calls = 0
+  const port = new ClientActionPort({
+    getCapabilities: () => [GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP],
+    send: () => { calls += 1 },
+  })
+  const first = port.request(ClientActionName.ENTER_SLEEP, {}, {
+    idempotencyKey: 'presence.sleep',
+  })
+  const pending = [...port.pendingById.values()][0]
+  resolveAction = () => port.receive({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+    event_id: 'evt_client_result',
+    request_event_id: pending.requestId,
+    status: 'completed',
+  })
+  const duplicate = port.request(ClientActionName.ENTER_SLEEP, {}, {
+    idempotencyKey: 'presence.sleep',
+  })
+  assert.equal(first, duplicate)
+  assert.equal(calls, 1)
+  resolveAction()
+  await first
+
+  const unsupported = new ClientActionPort({ getCapabilities: () => [] })
+  await assert.rejects(
+    unsupported.request(ClientActionName.ENTER_SLEEP),
+    error => error.code === 'client_action_unsupported',
+  )
+})
+
+test('propagates Client Action failure and never treats it as completion', async () => {
+  let port
+  port = new ClientActionPort({
+    getCapabilities: () => [GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP],
+    send: event => queueMicrotask(() => port.receive({
+      type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+      event_id: 'evt_client_failure',
+      request_event_id: event.event_id,
+      status: 'failed',
+      error: { code: 'desktop_hide_failed', message: 'window refused to hide' },
+    })),
+  })
+  await assert.rejects(
+    port.request(ClientActionName.ENTER_SLEEP),
+    error => error.code === 'desktop_hide_failed',
+  )
+})
+
+test('PresenceController commits sleeping after one completed Client Action', async () => {
+  let finish
+  let actionCalls = 0
+  let committed = 0
+  const controller = new PresenceController({
+    clientActions: {
+      supports: () => true,
+      request: () => {
+        actionCalls += 1
+        return new Promise(resolve => { finish = resolve })
+      },
+      close() {},
+    },
+    onSleeping: () => { committed += 1 },
+  })
+
+  const first = controller.requestSleep({ source: 'tool' })
+  const duplicate = controller.requestSleep({ source: 'timeout' })
+  assert.equal(first, duplicate)
+  assert.equal(controller.state, PresenceState.SLEEP_REQUESTED)
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(actionCalls, 1)
+  finish({ status: 'completed' })
+  await first
+  assert.equal(controller.state, PresenceState.SLEEPING)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  assert.equal(committed, 1)
+  assert.equal((await controller.requestSleep()).duplicate, true)
+  controller.wake()
+  assert.equal(controller.state, PresenceState.ACTIVE)
+})

--- a/server/test/dependency-boundaries.test.mjs
+++ b/server/test/dependency-boundaries.test.mjs
@@ -40,6 +40,7 @@ const allowedDependencies = {
   task: new Set(['agent', 'core', 'session', 'task']),
   transport: new Set(['shared', 'task', 'transport']),
   voice: new Set([
+    'client',
     'conversation',
     'core',
     'delivery',

--- a/server/test/frontend-agent-context.test.mjs
+++ b/server/test/frontend-agent-context.test.mjs
@@ -85,7 +85,7 @@ test('describes prior input references without embedding their file data', () =>
 
 test('keeps client capabilities out of the runtime prose context', () => {
   const desktop = buildFrontendContext({
-    client: { states: ['sleeping'] },
+    client: { actions: ['desktop.presence.enter_sleep'] },
   })
   assert.doesNotMatch(desktop, /enter_sleep|does not cancel background work/)
 })

--- a/server/test/frontend-tool-registry.test.mjs
+++ b/server/test/frontend-tool-registry.test.mjs
@@ -59,20 +59,22 @@ test('appends namespaced dynamic tools without changing the static registry', ()
   )
 })
 
-test('exposes client-state tools only when the client advertises support', () => {
+test('exposes Client Action tools only when the client advertises support', () => {
   assert.equal(frontendToolRegistry.isEnabled(ENTER_SLEEP_TOOL_NAME), false)
   assert.equal(
     frontendToolRegistry.isEnabled(ENTER_SLEEP_TOOL_NAME, {
-      client: { states: ['sleeping'] },
+      client: { actions: ['desktop.presence.enter_sleep'] },
     }),
     true,
   )
   assert.deepEqual(
-    names(frontendTools({ client: { states: ['sleeping'] } })),
+    names(frontendTools({
+      client: { actions: ['desktop.presence.enter_sleep'] },
+    })),
     [...DEFAULT_TOOL_NAMES, ENTER_SLEEP_TOOL_NAME],
   )
   assert.deepEqual(
-    names(frontendTools({ client: { states: ['unknown'] } })),
+    names(frontendTools({ client: { actions: ['unknown'] } })),
     DEFAULT_TOOL_NAMES,
   )
 })
@@ -137,10 +139,10 @@ test('keeps visibility policy separate from runtime execution checks', () => {
   const entry = frontendToolRegistry.get(ENTER_SLEEP_TOOL_NAME)
   assert.deepEqual(entry.policy, {
     mode: 'control',
-    requiredClientStates: ['sleeping'],
+    requiredClientActions: ['desktop.presence.enter_sleep'],
   })
   assert.equal(Object.isFrozen(entry.policy), true)
-  assert.equal(Object.isFrozen(entry.policy.requiredClientStates), true)
+  assert.equal(Object.isFrozen(entry.policy.requiredClientActions), true)
 })
 
 test('declares one background tool and classifies every other tool', () => {

--- a/server/test/gateway-client-handshake.test.mjs
+++ b/server/test/gateway-client-handshake.test.mjs
@@ -171,6 +171,51 @@ test('routes negotiated GCP2 commands and Client Events with correlated results'
   modern.socket.close()
 })
 
+test('commits sleep only after the negotiated Client Action completes', async t => {
+  const { server, gateway } = gatewayHarness()
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  t.after(async () => {
+    await gateway.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const modern = await connect(server, createGatewaySessionHello({
+    eventId: 'evt-client-action-hello',
+    clientType: 'desktop',
+    clientInstanceId: 'desktop-action-test',
+    capabilities: [GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP],
+  }))
+  const ready = await waitFor(modern.received, event => event.type === 'session.ready')
+  assert.deepEqual(ready.capabilities, [
+    GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
+  ])
+
+  modern.socket.send(JSON.stringify({
+    type: 'sleep',
+    event_id: 'evt-client-sleep-command',
+  }))
+  const action = await waitFor(
+    modern.received,
+    event => event.type === GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST,
+  )
+  assert.equal(action.name, 'desktop.presence.enter_sleep')
+  assert.equal(modern.received.some(event => (
+    event.type === 'voice.sleep' && event.state === 'sleeping'
+  )), false)
+
+  modern.socket.send(JSON.stringify({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+    event_id: 'evt-client-action-result',
+    request_event_id: action.event_id,
+    status: 'completed',
+    output: { state: 'hidden' },
+  }))
+  await waitFor(modern.received, event => (
+    event.type === 'voice.sleep' && event.state === 'sleeping'
+  ))
+  modern.socket.close()
+})
+
 test('rejects unnegotiated GCP2 commands before dispatch', async t => {
   const { server, gateway } = gatewayHarness({
     clientCommandRuntime: {

--- a/server/test/realtime-provider.test.mjs
+++ b/server/test/realtime-provider.test.mjs
@@ -623,17 +623,17 @@ test('client text-only hints do not change the Qwen Realtime session', () => {
   )
 })
 
-test('offers the sleep tool only to a client that advertises the state', () => {
+test('offers the sleep tool only to a client that advertises the action', () => {
   const ordinary = REALTIME_PROVIDERS.qwen.buildSession({
     configured: false,
-    agentContext: { client: { states: [] } },
+    agentContext: { client: { actions: [] } },
   })
   const desktop = REALTIME_PROVIDERS.qwen.buildSession({
     configured: false,
-    agentContext: { client: { states: ['sleeping'] } },
+    agentContext: { client: { actions: ['desktop.presence.enter_sleep'] } },
   })
   const s2sDesktop = REALTIME_PROVIDERS['speech-to-speech'].buildSession({
-    agentContext: { client: { states: ['sleeping'] } },
+    agentContext: { client: { actions: ['desktop.presence.enter_sleep'] } },
   })
 
   assert.equal(

--- a/server/test/recall.test.mjs
+++ b/server/test/recall.test.mjs
@@ -181,7 +181,7 @@ test('the tool is only exposed when session digests are enabled', () => {
   // 与既有的条件工具互不干扰
   const both = names({
     frontend: { capabilities: [FRONTEND_RECALL_CAPABILITY] },
-    client: { states: ['sleeping'] },
+    client: { actions: ['desktop.presence.enter_sleep'] },
   })
   assert.ok(both.includes(RECALL_TOOL_NAME))
   assert.ok(both.includes('enter_sleep'))

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -17,7 +17,7 @@ function harness({
   permissionPolicy,
   onPermissionDeliveryFailed,
   clientContext = {},
-  requestClientState,
+  presenceController,
   inputAssets,
   onAgentActivity,
   frontendRetrieval,
@@ -56,7 +56,7 @@ function harness({
     permissionPolicy,
     onPermissionDeliveryFailed,
     getClientContext: () => clientContext,
-    requestClientState,
+    presenceController,
     onAgentActivity,
     inputAssets,
     frontendRetrieval,
@@ -265,10 +265,12 @@ function waitForTask(manager, taskId) {
 }
 
 test('asks a capable client to enter sleep without creating another response', async () => {
-  const states = []
+  const sources = []
   const kit = harness({
-    clientContext: { states: ['sleeping'] },
-    requestClientState: state => states.push(state),
+    presenceController: {
+      supportsSleep: () => true,
+      requestSleep: async ({ source }) => sources.push(source),
+    },
   })
 
   await kit.handler.handle({
@@ -277,7 +279,7 @@ test('asks a capable client to enter sleep without creating another response', a
     arguments: '{}',
   }, { turnId: 'turn-one', turnGeneration: 1 })
 
-  assert.deepEqual(states, ['sleeping'])
+  assert.deepEqual(sources, ['realtime_tool'])
   assert.equal(kit.outputs[0][1].status, 'sleeping')
   assert.equal(kit.outputs[0][3].createResponse, false)
 })
@@ -371,7 +373,7 @@ test('fails closed when a stale model calls the unavailable knowledge tool', asy
   assert.equal(kit.outputs[0][1].error_code, 'tool_unavailable')
 })
 
-test('rejects sleep when the client did not advertise that state', async () => {
+test('rejects sleep when the client does not advertise the action', async () => {
   const kit = harness()
 
   await kit.handler.handle({
@@ -380,7 +382,7 @@ test('rejects sleep when the client did not advertise that state', async () => {
     arguments: '{}',
   }, { turnId: 'turn-one', turnGeneration: 1 })
 
-  assert.equal(kit.outputs[0][1].error_code, 'unsupported_client_state')
+  assert.equal(kit.outputs[0][1].error_code, 'client_action_unsupported')
 })
 
 test('fails closed for tools absent from the frontend registry', async () => {

--- a/shared/gateway-client-protocol.mjs
+++ b/shared/gateway-client-protocol.mjs
@@ -19,6 +19,8 @@ export const GatewayClientProtocolEvent = Object.freeze({
   RESPONSE_CANCEL: 'response.cancel',
   CLIENT_EVENT_PUBLISH: 'client.event.publish',
   CLIENT_EVENT_PUBLISH_RESULT: 'client.event.publish.result',
+  CLIENT_ACTION_REQUEST: 'client.action.request',
+  CLIENT_ACTION_RESULT: 'client.action.result',
   TASK_CREATE: 'task.create',
   TASK_CREATE_RESULT: 'task.create.result',
   TASK_GET: 'task.get',
@@ -47,6 +49,10 @@ export const GatewayClientCapability = Object.freeze({
   SESSION_REPLAY: 'session.replay',
 })
 
+export const GatewayClientActionName = Object.freeze({
+  ENTER_SLEEP: 'desktop.presence.enter_sleep',
+})
+
 // The complete roadmap vocabulary is published so clients and extensions do
 // not invent competing names. Only capabilities whose runtime exists today
 // are negotiated; later stages append implementations without changing the
@@ -65,6 +71,7 @@ export const GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES = Object.freeze([
   GatewayClientCapability.PERMISSION_RESPOND,
   GatewayClientCapability.CONVERSATION_HISTORY,
   GatewayClientCapability.CLIENT_EVENTS,
+  GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
 ])
 
 const IdentifierSchema = z.string().min(1).max(128)
@@ -147,6 +154,31 @@ export const GatewayClientEventPublishResultSchema = GatewayServerEnvelopeSchema
   duplicate: z.boolean().optional(),
 })
 
+export const GatewayClientActionRequestSchema = GatewayServerEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST),
+  name: EventNameSchema,
+  arguments: z.unknown().optional(),
+})
+
+export const GatewayClientActionResultSchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.CLIENT_ACTION_RESULT),
+  request_event_id: IdentifierSchema,
+  status: z.enum(['completed', 'failed', 'unsupported']),
+  output: z.unknown().optional(),
+  error: z.object({
+    code: z.string().min(1).max(80),
+    message: z.string().min(1).max(500),
+  }).optional(),
+}).superRefine((value, context) => {
+  if (value.status !== 'completed' && !value.error) {
+    context.addIssue({
+      code: 'custom',
+      path: ['error'],
+      message: 'failed and unsupported Client Actions require an error',
+    })
+  }
+})
+
 export const GatewayTaskCreateSchema = GatewayClientEnvelopeSchema.extend({
   type: z.literal(GatewayClientProtocolEvent.TASK_CREATE),
   message: z.object({
@@ -212,8 +244,9 @@ export const GatewayConversationHistoryResultSchema = GatewayServerEnvelopeSchem
   messages: z.array(z.unknown()).max(100),
 })
 
-const GCP2_CLIENT_MESSAGE_SCHEMAS = Object.freeze({
+const GATEWAY_RUNTIME_CLIENT_MESSAGE_SCHEMAS = Object.freeze({
   [GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH]: GatewayClientEventPublishSchema,
+  [GatewayClientProtocolEvent.CLIENT_ACTION_RESULT]: GatewayClientActionResultSchema,
   [GatewayClientProtocolEvent.TASK_CREATE]: GatewayTaskCreateSchema,
   [GatewayClientProtocolEvent.TASK_GET]: GatewayTaskGetSchema,
   [GatewayClientProtocolEvent.TASK_LIST]: GatewayTaskListSchema,
@@ -222,8 +255,9 @@ const GCP2_CLIENT_MESSAGE_SCHEMAS = Object.freeze({
   [GatewayClientProtocolEvent.CONVERSATION_HISTORY]: GatewayConversationHistorySchema,
 })
 
-const GCP2_SERVER_MESSAGE_SCHEMAS = Object.freeze({
+const GATEWAY_RUNTIME_SERVER_MESSAGE_SCHEMAS = Object.freeze({
   [GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH_RESULT]: GatewayClientEventPublishResultSchema,
+  [GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST]: GatewayClientActionRequestSchema,
   [GatewayClientProtocolEvent.TASK_CREATE_RESULT]: GatewayTaskCreateResultSchema,
   [GatewayClientProtocolEvent.TASK_GET_RESULT]: GatewayTaskGetResultSchema,
   [GatewayClientProtocolEvent.TASK_LIST_RESULT]: GatewayTaskListResultSchema,
@@ -232,8 +266,9 @@ const GCP2_SERVER_MESSAGE_SCHEMAS = Object.freeze({
   [GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT]: GatewayConversationHistoryResultSchema,
 })
 
-const GCP2_REQUIRED_CAPABILITIES = Object.freeze({
+const GATEWAY_RUNTIME_REQUIRED_CAPABILITIES = Object.freeze({
   [GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH]: GatewayClientCapability.CLIENT_EVENTS,
+  [GatewayClientProtocolEvent.CLIENT_ACTION_RESULT]: GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
   [GatewayClientProtocolEvent.TASK_CREATE]: GatewayClientCapability.TASK_COMMANDS,
   [GatewayClientProtocolEvent.TASK_GET]: GatewayClientCapability.TASK_COMMANDS,
   [GatewayClientProtocolEvent.TASK_LIST]: GatewayClientCapability.TASK_COMMANDS,
@@ -291,11 +326,11 @@ export function normalizeGatewayClientProtocolMessage(value) {
 }
 
 export function gatewayClientProtocolCapabilityFor(type) {
-  return GCP2_REQUIRED_CAPABILITIES[type] || null
+  return GATEWAY_RUNTIME_REQUIRED_CAPABILITIES[type] || null
 }
 
 export function isGatewayClientRuntimeMessage(type) {
-  return Boolean(GCP2_CLIENT_MESSAGE_SCHEMAS[type])
+  return Boolean(GATEWAY_RUNTIME_CLIENT_MESSAGE_SCHEMAS[type])
 }
 
 export function gatewayHelloAsLegacyConnect(hello) {
@@ -376,8 +411,8 @@ export function parseGatewayClientProtocolMessage(value) {
   if (value?.type === GatewayClientProtocolEvent.SESSION_HELLO) {
     return GatewaySessionHelloSchema.parse(value)
   }
-  if (GCP2_CLIENT_MESSAGE_SCHEMAS[value?.type]) {
-    return GCP2_CLIENT_MESSAGE_SCHEMAS[value.type].parse(value)
+  if (GATEWAY_RUNTIME_CLIENT_MESSAGE_SCHEMAS[value?.type]) {
+    return GATEWAY_RUNTIME_CLIENT_MESSAGE_SCHEMAS[value.type].parse(value)
   }
   return GatewayClientEnvelopeSchema.parse(value)
 }
@@ -389,8 +424,8 @@ export function parseGatewayServerProtocolMessage(value) {
   if (value?.type === 'error' && value?.error) {
     return GatewayProtocolErrorSchema.parse(value)
   }
-  if (GCP2_SERVER_MESSAGE_SCHEMAS[value?.type]) {
-    return GCP2_SERVER_MESSAGE_SCHEMAS[value.type].parse(value)
+  if (GATEWAY_RUNTIME_SERVER_MESSAGE_SCHEMAS[value?.type]) {
+    return GATEWAY_RUNTIME_SERVER_MESSAGE_SCHEMAS[value.type].parse(value)
   }
   return GatewayServerEnvelopeSchema.parse(value)
 }

--- a/test/gateway-client-protocol.test.mjs
+++ b/test/gateway-client-protocol.test.mjs
@@ -41,7 +41,7 @@ test('publishes a frozen capability vocabulary and only advertises implemented s
     GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES.includes(
       GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
     ),
-    false,
+    true,
   )
 })
 
@@ -88,7 +88,7 @@ test('negotiates one supported 6.0 version and the capability intersection', () 
   ])
 })
 
-test('validates GCP2 runtime commands and their correlated results', () => {
+test('validates runtime commands, Client Actions and correlated results', () => {
   const create = parseGatewayClientProtocolMessage({
     type: GatewayClientProtocolEvent.TASK_CREATE,
     event_id: 'evt_create_1',
@@ -117,6 +117,32 @@ test('validates GCP2 runtime commands and their correlated results', () => {
     name: 'desktop.presence.sleep_requested',
   })
   assert.equal(result.request_event_id, 'evt_presence_1')
+
+  const action = parseGatewayServerProtocolMessage({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST,
+    event_id: 'evt_gateway_action_1',
+    name: 'desktop.presence.enter_sleep',
+    arguments: {},
+  })
+  assert.equal(action.name, 'desktop.presence.enter_sleep')
+  const actionResult = parseGatewayClientProtocolMessage({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+    event_id: 'evt_client_action_1',
+    request_event_id: action.event_id,
+    status: 'completed',
+    output: { state: 'hidden' },
+  })
+  assert.equal(actionResult.request_event_id, action.event_id)
+  assert.equal(
+    gatewayClientProtocolCapabilityFor(actionResult.type),
+    GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
+  )
+  assert.throws(() => parseGatewayClientProtocolMessage({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+    event_id: 'evt_client_action_failed',
+    request_event_id: action.event_id,
+    status: 'failed',
+  }))
 })
 
 test('normalizes 6.0 event names into the existing business event vocabulary', () => {
@@ -193,6 +219,16 @@ test('6.0 hello and 5.x connect enter the same legacy business path', () => {
   })
   assert.equal(connected.event.type, accepted.event.type)
   assert.equal(connected.reply, undefined)
+  const legacyActionResult = legacy.receive({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+    event_id: 'evt_client_legacy_action',
+    request_event_id: 'evt_gateway_legacy_action',
+    status: 'completed',
+  })
+  assert.equal(
+    legacyActionResult.runtimeMessage.type,
+    GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+  )
   assert.deepEqual(connected.pending, [pendingEvent])
   assert.equal(legacy.encode(pendingEvent), pendingEvent)
 })

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -51,6 +51,7 @@ import {
   desktopWakeWordEnabled,
   desktopWorkSettled,
   desktopTasksWorking,
+  performDesktopClientAction,
 } from './desktop-hide.js'
 import {
   desktopTaskCards,
@@ -785,6 +786,12 @@ export default function App() {
       setWaitingForVoice(false)
       setActivity(message)
     },
+    onClientAction: event => performDesktopClientAction(event, {
+      desktop: desktopOrbMode,
+      bridge: window.qwenAudioAgentDesktop,
+      onLifecycle: setDesktopLifecycle,
+      lastWakeAt: lastWakeAtRef.current,
+    }),
   })
   const lifecycleTransition = (
     desktopOrbMode && desktopLifecycle !== 'active'
@@ -940,6 +947,7 @@ export default function App() {
   // 快捷键/托盘唤起只恢复窗口；Gateway 若在休眠，前台连接会停在 sleeping，
   // 需要显式唤醒才能走到 connected，否则悬浮球永远无法就绪。
   const wakeGateway = voice.wake
+  const publishClientEvent = voice.publishClientEvent
   useEffect(() => {
     if (!desktopOrbMode || desktopLifecycle !== 'waking') return
     wakeGateway()
@@ -963,15 +971,16 @@ export default function App() {
       timeoutSeconds: autoHideSeconds,
     })
     const timer = setTimeout(() => {
-      window.qwenAudioAgentDesktop?.enterHide()
-        .then(lifecycle => setDesktopLifecycle(lifecycle.state))
-        .catch(() => {})
+      publishClientEvent('desktop.presence.sleep_requested', {
+        idle_ms: autoHideSeconds * 1000,
+      })
     }, Math.max(0, deadline - Date.now()))
     return () => clearTimeout(timer)
   }, [
     desktopLifecycle,
     desktopSurfaceMode,
     lastInteractionAt,
+    publishClientEvent,
     voice.connectionState,
     voice.visualError,
     workSettled,

--- a/web/src/desktop-hide.js
+++ b/web/src/desktop-hide.js
@@ -1,4 +1,8 @@
 import { GatewayServerEvent } from '../../shared/realtime-events.mjs'
+import {
+  GatewayClientActionName,
+  GatewayClientProtocolEvent,
+} from '../../shared/gateway-client-protocol.mjs'
 
 const ACTIVE_TASK_PHASES = new Set([
   'queued',
@@ -89,6 +93,60 @@ export function desktopHideDeadline({
 // 可能恰好在唤醒瞬间到期，迟到的过期指令不应把悬浮球藏回去
 // （随后的 voice.wake 会重新唤醒 Gateway）。
 export const DESKTOP_WAKE_GRACE_MS = 5000
+
+export async function performDesktopClientAction(event, {
+  desktop = false,
+  bridge,
+  onLifecycle = () => {},
+  lastWakeAt = 0,
+  now = Date.now(),
+} = {}) {
+  if (event?.type !== GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST) return null
+  if (
+    !desktop
+    || event.name !== GatewayClientActionName.ENTER_SLEEP
+    || typeof bridge?.enterHide !== 'function'
+  ) {
+    return {
+      status: 'unsupported',
+      error: {
+        code: 'client_action_unsupported',
+        message: `Unsupported Client Action: ${String(event?.name || '')}`,
+      },
+    }
+  }
+  if (now - lastWakeAt < DESKTOP_WAKE_GRACE_MS) {
+    return {
+      status: 'failed',
+      error: {
+        code: 'desktop_wake_grace',
+        message: 'Desktop is still inside its wake grace period',
+      },
+    }
+  }
+  try {
+    const lifecycle = await bridge.enterHide()
+    if (lifecycle?.state) onLifecycle(lifecycle.state)
+    if (lifecycle?.state !== 'hidden') {
+      return {
+        status: 'failed',
+        error: {
+          code: 'desktop_hide_incomplete',
+          message: 'Desktop did not enter the hidden state',
+        },
+      }
+    }
+    return { status: 'completed', output: { state: 'hidden' } }
+  } catch (error) {
+    return {
+      status: 'failed',
+      error: {
+        code: 'desktop_hide_failed',
+        message: String(error?.message || error).slice(0, 500),
+      },
+    }
+  }
+}
 
 export async function applyDesktopClientState(event, {
   desktop = false,

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -9,6 +9,10 @@ import {
   reduceGatewayClientState,
 } from '../../shared/gateway-client-state.mjs'
 import { clientInputCapabilities } from '../../shared/client-input-capabilities.mjs'
+import {
+  createGatewayProtocolEventId,
+  GatewayClientProtocolEvent,
+} from '../../shared/gateway-client-protocol.mjs'
 import { decodePcm, pcmBase64, resample } from './audio.js'
 import { confirmTrackedPlaybackStart } from './playback-lifecycle.js'
 import { t } from './i18n.js'
@@ -212,6 +216,7 @@ export default function useRealtimeVoice({
   realtimeProvider = '',
   onEvent,
   onInputError,
+  onClientAction,
 }) {
   const [clientState, dispatchClientState] = useReducer(
     reduceGatewayClientState,
@@ -229,6 +234,7 @@ export default function useRealtimeVoice({
   } = clientState
   const eventRef = useRef(onEvent)
   const inputErrorRef = useRef(onInputError)
+  const clientActionRef = useRef(onClientAction)
   const wakeWordOnlyRef = useRef(wakeWordOnly)
   const socketRef = useRef(null)
   const hasConnectedRef = useRef(false)
@@ -261,6 +267,7 @@ export default function useRealtimeVoice({
   })
   eventRef.current = onEvent
   inputErrorRef.current = onInputError
+  clientActionRef.current = onClientAction
   wakeWordOnlyRef.current = wakeWordOnly
   enabledRef.current = enabled
   outputMutedRef.current = outputMuted
@@ -602,11 +609,45 @@ export default function useRealtimeVoice({
           ...(realtimeProvider ? { provider: realtimeProvider } : {}),
         }))
       }
-      socket.onmessage = message => {
+      socket.onmessage = async message => {
         let event
         try {
           event = JSON.parse(message.data)
         } catch {
+          return
+        }
+        if (event.type === GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST) {
+          let result
+          try {
+            result = await clientActionRef.current?.(event)
+          } catch (error) {
+            result = {
+              status: 'failed',
+              error: {
+                code: 'client_action_failed',
+                message: String(error?.message || error).slice(0, 500),
+              },
+            }
+          }
+          const normalized = result?.status ? result : {
+            status: 'unsupported',
+            error: {
+              code: 'client_action_unsupported',
+              message: `Unsupported Client Action: ${String(event.name || '')}`,
+            },
+          }
+          if (socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({
+              type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+              event_id: createGatewayProtocolEventId('client'),
+              request_event_id: event.event_id,
+              status: normalized.status,
+              ...(normalized.output === undefined
+                ? {}
+                : { output: normalized.output }),
+              ...(normalized.error ? { error: normalized.error } : {}),
+            }))
+          }
           return
         }
         dispatchClientState(event)
@@ -862,6 +903,16 @@ export default function useRealtimeVoice({
     sendSocketEvent({ type: GatewayClientEvent.WAKE })
   ), [sendSocketEvent])
 
+  const publishClientEvent = useCallback((name, data = {}, deliveryHint) => (
+    sendSocketEvent({
+      type: GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH,
+      event_id: createGatewayProtocolEventId('client'),
+      name,
+      data,
+      ...(deliveryHint ? { delivery_hint: deliveryHint } : {}),
+    })
+  ), [sendSocketEvent])
+
   const sendInput = useCallback(parts => {
     holdManualInputGuard()
     const event = {
@@ -893,6 +944,7 @@ export default function useRealtimeVoice({
     activateAudio,
     interrupt,
     wake,
+    publishClientEvent,
     sendInput,
   }
 }

--- a/web/test/desktop-hide.test.mjs
+++ b/web/test/desktop-hide.test.mjs
@@ -10,7 +10,11 @@ import {
   desktopTasksWorking,
   desktopWakeWordEnabled,
   desktopWorkSettled,
+  performDesktopClientAction,
 } from '../src/desktop-hide.js'
+import {
+  GatewayClientProtocolEvent,
+} from '../../shared/gateway-client-protocol.mjs'
 
 test('distinguishes active tasks from tasks waiting for authorization', () => {
   assert.equal(desktopTasksActive([]), false)
@@ -81,6 +85,29 @@ test('maps a supported sleeping client state to the desktop bridge', async () =>
     type: 'client.state',
     state: 'sleeping',
   }), false)
+})
+
+test('reports Client Action completion only after the desktop is hidden', async () => {
+  const lifecycle = []
+  const result = await performDesktopClientAction({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST,
+    name: 'desktop.presence.enter_sleep',
+  }, {
+    desktop: true,
+    bridge: { enterHide: async () => ({ state: 'hidden' }) },
+    onLifecycle: state => lifecycle.push(state),
+  })
+  assert.deepEqual(result, {
+    status: 'completed',
+    output: { state: 'hidden' },
+  })
+  assert.deepEqual(lifecycle, ['hidden'])
+
+  const unsupported = await performDesktopClientAction({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST,
+    name: 'hardware.light.turn_on',
+  }, { desktop: true })
+  assert.equal(unsupported.status, 'unsupported')
 })
 
 test('uses a 60 second desktop hide default and supports never', () => {


### PR DESCRIPTION
## Summary

- add correlated `client.action.request/result` messages and a protocol-neutral `ClientActionPort`
- capability-gate action-derived Realtime tools and migrate `enter_sleep` off the legacy `client.state` execution path
- unify model-requested, desktop idle, Gateway timeout, and duplicate sleep requests in one idempotent `PresenceController`
- make Desktop report successful hiding before Gateway commits `sleeping`, with a bounded automatic fallback when the model does not call the tool
- update the bilingual protocol, architecture, contract, roadmap, package exports, and conformance coverage

## Validation

- Root: 90 passed, 1 skipped
- Server: 413 assertions passed (the local Node runner retains the pre-existing open handle after completion)
- WebUI: 97 passed
- TUI: 56 passed
- Desktop: 211 passed
- CLI: 143 passed
- `npm run lint`
- `npm run build`
- `npm run audit:release`
- `npm pack --dry-run --json` (Client Action and Presence modules included)

Part of #251