### PR TITLE
feat: complete GCP5 Gateway Client protocol

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -22,13 +22,16 @@ The proposed 6.0 northbound boundary is documented in the draft
 [Gateway Client Protocol](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/gateway-protocol.md) and its
 [roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/gateway-client-protocol.md), tracked by
 [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251).
-Those documents remain the design target. GCP1–GCP4 are now available as an
-opt-in 6.0 handshake, Client Event ingress, runtime-command plane, Agent
-Delivery, and Client Action boundary over the existing WebSocket; capabilities
-for later stages remain vocabulary only until their runtimes ship.
+GCP1–GCP5 are complete: the 6.0 handshake, Client Event ingress,
+runtime-command plane, Agent Delivery, Client Actions, reference Client SDK,
+and bounded replay all share the same WebSocket.
 This contract index remains authoritative for implemented behavior.
 
-The current health-contract version is `5.4.0`. The additive `5.4` line adds
+The current health-contract version is `5.5.0`. The additive `5.5` line ships
+the shared reference Client SDK, bounded Task-event replay, and reconnect state
+recovery. First-party WebUI, Desktop, and TUI clients now pass the same
+conformance suite and no longer use internal REST routes for Task control,
+permission decisions, or conversation history. The additive `5.4` line adds
 correlated Client Actions and the shared Presence state machine. The additive
 `5.3` line adds provider-neutral Agent Delivery. The additive `5.2` line exposes
 registered Client Event ingress and Task, permission, and conversation-history
@@ -78,6 +81,7 @@ below instead of assuming the old list.
 | `realtime.gateway-client-protocol-v6-runtime-commands` | Negotiated 6.0 Clients can publish registered semantic Client Events and use correlated Task, permission, and conversation-history commands over the same WebSocket; existing REST routes call the same command service as compatibility aliases | `test/gateway-client-protocol.test.mjs`, `server/test/client-event-router.test.mjs`, `server/test/client-command-runtime.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-agent-delivery` | Client Events, Task results and progress, and permission prompts cross one provider-neutral `AgentDelivery` boundary with `handle`, `context`, `respond`, and `interrupt` modes | `server/test/agent-delivery.test.mjs`, `server/test/client-event-router.test.mjs`, `server/test/realtime-provider.test.mjs`, `server/test/announcement-manager.test.mjs` |
 | `realtime.gateway-client-protocol-v6-client-actions` | Correlated `client.action.request/result` messages execute Client-owned environment operations; `enter_sleep` is capability-gated and sleeping commits only after Client success | `test/gateway-client-protocol.test.mjs`, `server/test/client-action-port.test.mjs`, `server/test/gateway-client-handshake.test.mjs`, `desktop/test/enter-sleep-flow.test.mjs` |
+| `realtime.gateway-client-protocol-v6-reference-client-replay` | The shared reference Client SDK owns handshake, command correlation, Client Actions, reconnect, and recovery; Task pushes use bounded `sequence` replay and WebUI, Desktop, and TUI share one conformance suite | `test/gateway-client-sdk.test.mjs`, `test/gateway-client-conformance.test.mjs`, `server/test/gateway-client-protocol-session.test.mjs`, `server/test/gateway-client-replay-buffer.test.mjs` |
 | `desktop.orb-shell` | The orb form's main-process contract ships: `bindOrbShell` answers the channels the shipped preload sends | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` owns the orb window recipe; its `destroy()` is the host's synchronous teardown path (renderer exit is what releases the microphone) | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` covers the default anchor, display clamping and drop persistence | `desktop/test/orb-placement.test.mjs` |
@@ -98,6 +102,8 @@ is unsupported and breaks without notice.
 | `qwen-audio-agent/electron` | **CJS**: `load()` (every contract in one namespace), `PRELOAD_PATH` |
 | `qwen-audio-agent/gateway-protocol` | `GATEWAY_PROTOCOL_VERSION`, `GATEWAY_CAPABILITIES` |
 | `qwen-audio-agent/gateway-client-protocol` | GCP 6.0 envelope and handshake schemas, parsers, capability constants, and reference Client helpers |
+| `qwen-audio-agent/gateway-client-sdk` | `GatewayClient`: WebSocket lifecycle, 6.0 handshake, request correlation, Client Actions, bounded replay, and reconnect recovery |
+| `qwen-audio-agent/gateway-client-profiles` | Reference capability profiles for WebUI, Desktop, and TUI |
 | `qwen-audio-agent/client-events` | Client Event definition registry, built-in definitions, routing policies, and `GatewayEventRouter` for Gateway extensions |
 | `qwen-audio-agent/client-actions` | `ClientActionPort`, built-in action names, capability mapping, request/result correlation, deadlines, and in-flight deduplication |
 | `qwen-audio-agent/agent-delivery` | Provider-neutral `AgentDelivery` values and routing modes |
@@ -184,9 +190,11 @@ endpoint. Each Task keeps one stable `messageId`; every lifecycle update
 replaces its `qwen.audio.task` activity content. The native Task stream remains
 the default and existing clients receive no additional events.
 
-Endpoints not listed here (`/api/tasks`, `/api/backend/ui`, and
-`/api/permissions/:id`) are used by our own front ends and carry no stability
-promise.
+`/api/tasks`, `/api/permissions/:id`, `/api/conversations/:id/messages`, and
+`/api/sessions/:id/replay` are compatibility aliases as of health contract
+`5.5.0`: first-party clients use the 6.0 WebSocket commands and
+`session.replay`. The aliases will not be removed before health contract
+`6.0.0`. Other unlisted endpoints such as `/api/backend/ui` remain internal.
 
 ## Realtime events
 
@@ -197,11 +205,11 @@ those package entries rather than internal module paths.
 `gateway.connected` and `gateway.disconnected` are client-side lifecycle
 helpers used by the shared state reducer; they are not WebSocket wire events.
 
-Legacy 5.x clients send `connect` first. An opt-in 6.0 client instead sends
-`session.hello`, waits for the correlated `session.ready`, and then uses the
-negotiated capabilities. The Gateway normalizes both handshakes and the current
-6.0 input aliases into the same business path; later GCP capabilities are not
-advertised before their implementations exist. The handshake declares input/output mode,
+Legacy 5.x clients send `connect` first. That alias is deprecated as of health
+contract `5.5.0` and will not be removed before `6.0.0`. A 6.0 client sends
+`session.hello`, includes its connection configuration in that envelope, waits
+for the correlated `session.ready`, and then uses the negotiated capabilities.
+The handshake declares input/output mode,
 client identity, locale/time zone, and supported input kinds. Audio input is
 base64 PCM16 mono at the `inputSampleRate` reported by `voice.ready`; audio
 output uses the `sampleRate` carried by each `audio.delta`. A text or multimodal

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -18,12 +18,13 @@
 [Gateway Client Protocol](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/gateway-protocol.zh.md) 与
 [Roadmap](https://github.com/QwenAudio/qwen-audio-agent/blob/main/docs/roadmap/gateway-client-protocol.zh.md) 中，并由
 [GitHub issue #251](https://github.com/QwenAudio/qwen-audio-agent/issues/251)
-跟踪。它们仍是完整设计目标；GCP1–GCP4 已以可选的 6.0 握手、Client Event Ingress、
-运行时命令面、Agent Delivery 与 Client Action 边界落在现有 WebSocket 上。后续阶段的
-capability 仍是已冻结词汇，在对应运行时实现前不会参与协商。
+跟踪。GCP1–GCP5 已完成：6.0 握手、Client Event Ingress、运行时命令面、Agent
+Delivery、Client Action、参考 Client SDK 与有限回放均落在同一条 WebSocket 上。
 已实现行为仍以本契约索引为准。
 
-当前健康契约版本为 `5.4.0`。新增的 `5.4` 能力提供有关联关系的 Client Action 与共享
+当前健康契约版本为 `5.5.0`。新增的 `5.5` 能力提供共享参考 Client SDK、有限 Task
+事件回放与断线状态恢复。第一方 WebUI、Desktop 和 TUI 已通过同一套一致性测试，
+Task 控制、权限决策和对话历史不再依赖内部 REST 路由。`5.4` 能力提供有关联关系的 Client Action 与共享
 Presence 状态机；`5.3` 增加 Provider 无关 Agent Delivery；`5.2` 在协商后的 6.0
 WebSocket 上提供已注册
 Client Event Ingress 与 Task、权限、对话历史命令，同时保留 REST 兼容别名。`5.1`
@@ -66,6 +67,7 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `realtime.gateway-client-protocol-v6-runtime-commands` | 协商后的 6.0 Client 可以通过同一 WebSocket 发布已注册的语义 Client Event，并使用有关联结果的 Task、权限和对话历史命令；现有 REST 路由调用同一命令服务作为兼容别名 | `test/gateway-client-protocol.test.mjs`、`server/test/client-event-router.test.mjs`、`server/test/client-command-runtime.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-agent-delivery` | Client Event、Task 结果与低频进展、权限请求统一跨越 Provider 无关 `AgentDelivery` 边界，并支持 `handle`、`context`、`respond`、`interrupt` 四种模式 | `server/test/agent-delivery.test.mjs`、`server/test/client-event-router.test.mjs`、`server/test/realtime-provider.test.mjs`、`server/test/announcement-manager.test.mjs` |
 | `realtime.gateway-client-protocol-v6-client-actions` | 有关联关系的 `client.action.request/result` 执行 Client 自有环境操作；`enter_sleep` 按 capability 暴露，只有 Client 成功后才提交 sleeping | `test/gateway-client-protocol.test.mjs`、`server/test/client-action-port.test.mjs`、`server/test/gateway-client-handshake.test.mjs`、`desktop/test/enter-sleep-flow.test.mjs` |
+| `realtime.gateway-client-protocol-v6-reference-client-replay` | 共享参考 Client SDK 统一处理握手、命令关联、Client Action、重连与状态恢复；Task 推送以 `sequence` 有限回放，WebUI、Desktop、TUI 共用一致性测试 | `test/gateway-client-sdk.test.mjs`、`test/gateway-client-conformance.test.mjs`、`server/test/gateway-client-protocol-session.test.mjs`、`server/test/gateway-client-replay-buffer.test.mjs` |
 | `desktop.orb-shell` | 悬浮球形态的主进程契约随包发布：`bindOrbShell` 应答随包 preload 发出的全部通道 | `desktop/test/orb-shell.test.mjs` |
 | `desktop.orb-window-factory` | `createOrbWindow` 持有悬浮球窗口配方；其 `destroy()` 是宿主的同步销毁路径（渲染进程退出才能确定性释放麦克风） | `desktop/test/orb-window.test.mjs` |
 | `desktop.orb-placement` | `createOrbPlacement` 覆盖默认锚点、显示器夹取与拖放持久化 | `desktop/test/orb-placement.test.mjs` |
@@ -85,6 +87,8 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `qwen-audio-agent/electron` | **CJS**：`load()`（一个命名空间拿到全部契约）、`PRELOAD_PATH` |
 | `qwen-audio-agent/gateway-protocol` | `GATEWAY_PROTOCOL_VERSION`、`GATEWAY_CAPABILITIES` |
 | `qwen-audio-agent/gateway-client-protocol` | GCP 6.0 信封与握手 Schema、解析器、能力常量和参考 Client Helper |
+| `qwen-audio-agent/gateway-client-sdk` | `GatewayClient`：WebSocket 生命周期、6.0 握手、请求关联、Client Action、有限回放和重连恢复 |
+| `qwen-audio-agent/gateway-client-profiles` | WebUI、Desktop、TUI 的参考 capability profile |
 | `qwen-audio-agent/client-events` | 供 Gateway 扩展使用的 Client Event Definition Registry、内置定义、路由 Policy 与 `GatewayEventRouter` |
 | `qwen-audio-agent/client-actions` | `ClientActionPort`、内置 Action 名称、capability 映射、请求/结果关联、deadline 与进行中请求去重 |
 | `qwen-audio-agent/agent-delivery` | Provider 无关的 `AgentDelivery` 值与路由模式 |
@@ -167,8 +171,10 @@ await orb.load()
 稳定的 `messageId`，每次生命周期更新都会替换对应的 `qwen.audio.task` activity
 内容。原生 Task 事件流仍是默认格式，现有客户端不会收到任何新增事件。
 
-未在此列出的接口（`/api/tasks`、`/api/backend/ui` 与
-`/api/permissions/:id`）是我们自己前端在用的，不承诺稳定。
+`/api/tasks`、`/api/permissions/:id`、`/api/conversations/:id/messages` 与
+`/api/sessions/:id/replay` 从健康契约 `5.5.0` 起成为兼容别名：第一方 Client 已迁移到
+6.0 WebSocket 命令与 `session.replay`。这些别名不会早于健康契约 `6.0.0` 删除。
+`/api/backend/ui` 等未列出接口仍属内部实现，不承诺稳定。
 
 ## Realtime 事件
 
@@ -178,10 +184,9 @@ await orb.load()
 `gateway.connected` 与 `gateway.disconnected` 是共享状态 reducer 使用的客户端本地
 生命周期辅助事件，不会通过 WebSocket 下发。
 
-旧版 5.x 客户端在 WebSocket 打开后先发送 `connect`。选择 6.0 的客户端则发送
-`session.hello`，等待有关联关系的 `session.ready`，再按协商结果使用能力。Gateway
-把两种握手和当前 6.0 输入别名归一化到同一条业务路径；后续 GCP 能力在实现前不会被
-声明。握手用于声明输入/输出模式、客户端身份、语言/时区与
+旧版 5.x 客户端在 WebSocket 打开后先发送 `connect`；该别名从健康契约 `5.5.0`
+起废弃且不会早于 `6.0.0` 删除。6.0 客户端发送 `session.hello`，在同一信封中声明
+连接配置，等待有关联关系的 `session.ready`，再按协商结果使用能力。握手用于声明输入/输出模式、客户端身份、语言/时区与
 支持的输入类型。音频输入为 base64 PCM16 单声道，采样率取 `voice.ready` 返回的
 `inputSampleRate`；音频输出按每个 `audio.delta` 携带的 `sampleRate` 播放。文本或
 多模态轮次使用 `input.message`，按顺序提交 `text` / `file` 类型的 `parts`。Task
@@ -189,7 +194,7 @@ await orb.load()
 
 | 方向 | 事件组 | 含义 |
 | --- | --- | --- |
-| 客户端 → 服务端 | `connect` | 在提交输入前声明客户端及其语音/输入能力 |
+| 客户端 → 服务端 | `session.hello` | 协议协商并声明客户端、连接配置及输入能力；`connect` 仅为废弃兼容别名 |
 | 客户端 → 服务端 | `input.message`、`text.message` | 提交一轮文本或多模态对话输入 |
 | 客户端 → 服务端 | `audio.append` | 追加一段 base64 PCM16 单声道音频 |
 | 客户端 → 服务端 | `unmute`、`mute`、`input.unmute`、`input.mute` | 控制语音参与，或只控制麦克风采集 |

--- a/docs/gateway-protocol.md
+++ b/docs/gateway-protocol.md
@@ -65,7 +65,13 @@ The Client connects to `ws://<gateway>/api/realtime`. The first message is `sess
     "session.replay"
   ],
   "locale": "zh-CN",
-  "time_zone": "Asia/Shanghai"
+  "time_zone": "Asia/Shanghai",
+  "connection": {
+    "voice_enabled": true,
+    "input_enabled": true,
+    "output_enabled": true,
+    "text_only": false
+  }
 }
 ```
 
@@ -110,9 +116,8 @@ logic. A 6.0 Client starts with `session.hello`; Gateway returns
 6.0 input aliases into the existing internal event model. A 5.x Client may
 continue to start with `connect` and receives the unchanged legacy event shape.
 Only capabilities with working runtimes are negotiated. GCP2 Client Event and
-runtime-command capabilities, GCP3 Agent Delivery, and GCP4 Client Actions are
-now implemented; names reserved for GCP5 remain vocabulary-only until its
-runtime ships.
+runtime-command capabilities, GCP3 Agent Delivery, GCP4 Client Actions, and
+the GCP5 reference Client and bounded replay are implemented.
 
 ### 3.2 GCP2 runtime rollout
 
@@ -147,10 +152,23 @@ protocol-neutral `ClientActionPort`. The active Client capability-gates
 action-derived Realtime tools. `enter_sleep`, the desktop idle-event fallback,
 and the legacy Gateway timeout converge on one idempotent
 `PresenceController`; an action-capable Client is marked sleeping only after it
-reports that the environment transition completed. The current first-party
-desktop may publish the built-in idle event and return an Action result after
-the 5.x `connect` alias during migration;
-GCP5 moves them to `session.hello` without changing the Action semantics.
+reports that the environment transition completed. The first-party desktop now
+negotiates and returns Action results through `session.hello`; the 5.x
+`connect` path remains only as a deprecated compatibility alias.
+
+### 3.5 GCP5 reference Client and replay rollout
+
+GCP5 ships the shared `GatewayClient` SDK for handshake, command correlation,
+Client Actions, reconnect, and recovery. WebUI, Desktop, and TUI share one
+capability profile and conformance suite. Task lifecycle pushes carry a
+session-monotonic `sequence`; `session.replay` recovers bounded events missed
+at disconnect, then `task.list` and `conversation.history` on the same
+WebSocket reconcile final state that may have changed while offline. Media
+deltas, provisional transcripts, and immediate command results are not replayed.
+
+As of health contract `5.5.0`, `connect` and the REST Task, permission,
+conversation-history, and Session-replay paths are deprecated compatibility
+aliases. They will not be removed before health contract `6.0.0`.
 
 ## 4. Common event envelope
 
@@ -285,7 +303,7 @@ Client Action is not a replacement for MCP, OpenAPI, ACP, or A2A. It covers capa
 
 ### 5.4 Runtime commands and queries
 
-The active Client uses the same WebSocket for runtime commands and queries. Each command carries an `event_id`; its immediate `<command>.result` carries `request_event_id`. Later lifecycle changes remain ordinary server pushes rather than being hidden inside the command result; bounded replay is added in GCP5.
+The active Client uses the same WebSocket for runtime commands and queries. Each command carries an `event_id`; its immediate `<command>.result` carries `request_event_id`. Later lifecycle changes remain ordinary server pushes rather than being hidden inside the command result; `session.replay` provides bounded Task lifecycle replay.
 
 | Command | Direction | Meaning |
 |---|---|---|
@@ -510,7 +528,7 @@ Health checks, static assets, installation, and settings remain host/operations 
 
 ## 12. Conformance requirements
 
-Before 6.0 becomes stable, tests must cover:
+The stable 6.0 behavior is locked by tests covering:
 
 - global single-Client ownership, release, and heartbeat expiry;
 - version and capability negotiation;

--- a/docs/gateway-protocol.zh.md
+++ b/docs/gateway-protocol.zh.md
@@ -65,7 +65,13 @@ Client 连接 `ws://<gateway>/api/realtime`，第一条消息必须是 `session.
     "session.replay"
   ],
   "locale": "zh-CN",
-  "time_zone": "Asia/Shanghai"
+  "time_zone": "Asia/Shanghai",
+  "connection": {
+    "voice_enabled": true,
+    "input_enabled": true,
+    "output_enabled": true,
+    "text_only": false
+  }
 }
 ```
 
@@ -109,8 +115,7 @@ GCP1 在不分叉 Gateway 业务逻辑的前提下实现信封与握手。6.0 Cl
 `event_id`，并把 6.0 输入别名归一化到现有内部事件模型。5.x Client 仍可使用
 `connect`，收到的旧事件形状保持不变。握手只协商已有运行时实现的能力。GCP2 的
 Client Event 与运行时命令 capability、GCP3 Agent Delivery、GCP4 Client Action
-已经实现；GCP5 预留名称仍只用于统一扩展词汇，在对应 Runtime 完成前不会被声明为
-已实现。
+以及 GCP5 参考 Client 与有限回放均已实现。
 
 ### 3.2 GCP2 运行时落地
 
@@ -139,9 +144,19 @@ GCP4 实现有关联关系的 `client.action.request/result` 与协议无关的
 `ClientActionPort`。只有当前 Client 声明对应 capability，Realtime 才能看到由
 Action 派生的工具。`enter_sleep`、桌面空闲事件兜底与旧 Gateway 超时入口统一进入
 幂等 `PresenceController`；支持 Action 的 Client 只有在环境切换成功回执后才会被
-标记为 sleeping。迁移期间，现有第一方桌面 Client 可以在 5.x `connect` 别名后发布
-内置空闲事件并回传 Action Result；GCP5 再把它们迁移到 `session.hello`，Action
-语义不变。
+标记为 sleeping。第一方桌面 Client 已通过 `session.hello` 协商并回传 Action
+Result；5.x `connect` 只保留为废弃兼容别名。
+
+### 3.5 GCP5 参考 Client 与回放落地
+
+GCP5 发布共享 `GatewayClient` SDK，统一处理握手、命令关联、Client Action、断线重连
+和状态恢复。WebUI、Desktop 与 TUI 使用同一 capability profile 和一致性测试。Task
+生命周期推送携带 Session 内递增的 `sequence`，`session.replay` 有界回放断线前未消费
+的事件；随后通过同一 WebSocket 的 `task.list` 与 `conversation.history` 恢复断线期间
+可能变化的最终快照。媒体增量、临时转写和即时命令结果不回放。
+
+健康契约 `5.5.0` 起，`connect` 以及 Task、权限、对话历史和 Session 回放的 REST
+路径成为废弃兼容别名，且不会早于健康契约 `6.0.0` 删除。
 
 ## 4. 通用事件信封
 
@@ -274,7 +289,7 @@ Client Action 不替代 MCP、OpenAPI、ACP 或 A2A。它只用于当前 Client 
 
 ### 5.4 运行时命令与查询
 
-活动 Client 通过同一个 WebSocket 发起运行时命令与查询。每个命令携带 `event_id`；即时 `<command>.result` 通过 `request_event_id` 关联请求。后续生命周期变化仍作为普通服务端推送发布，不能隐藏在命令结果中；有界回放由 GCP5 补充。
+活动 Client 通过同一个 WebSocket 发起运行时命令与查询。每个命令携带 `event_id`；即时 `<command>.result` 通过 `request_event_id` 关联请求。后续生命周期变化仍作为普通服务端推送发布，不能隐藏在命令结果中；Task 生命周期推送由 `session.replay` 有界回放。
 
 | 命令 | 方向 | 语义 |
 |---|---|---|
@@ -498,7 +513,7 @@ Gateway 协议定义自己的类型。下表是刻意且非规范性的语义对
 
 ## 12. Conformance 要求
 
-6.0 稳定前至少覆盖：
+6.0 的稳定行为由以下测试范围锁定：
 
 - 全局单 Client 占用、释放和心跳超时；
 - 版本与 capability 协商；

--- a/docs/roadmap/gateway-client-protocol.md
+++ b/docs/roadmap/gateway-client-protocol.md
@@ -111,13 +111,13 @@ Exit criteria: Realtime Tool Calls and Gateway fallbacks use one action/state ma
 
 ## GCP5 — Reference clients, replay, and stabilization
 
-- [ ] Migrate WebUI, TUI, and Desktop to the shared reference Client SDK.
-- [ ] Add bounded replay and reconnect recovery.
-- [ ] Migrate Task control, permission decisions, conversation history, and Task event recovery away from internal REST/SSE aliases.
-- [ ] Run one conformance suite against all first-party clients.
-- [ ] Update `docs/contract.md` and its Chinese counterpart with locked capabilities and tests.
-- [ ] Deprecate old aliases for at least one announced release before removal.
-- [ ] Mark the 6.0 specification stable only after the replacement path is proven.
+- [x] Migrate WebUI, TUI, and Desktop to the shared reference Client SDK.
+- [x] Add bounded replay and reconnect recovery.
+- [x] Migrate Task control, permission decisions, conversation history, and Task event recovery away from internal REST/SSE aliases.
+- [x] Run one conformance suite against all first-party clients.
+- [x] Update `docs/contract.md` and its Chinese counterpart with locked capabilities and tests.
+- [x] Deprecate old aliases for at least one announced release before removal.
+- [x] Mark the 6.0 specification stable only after the replacement path is proven.
 
 Exit criteria: first-party clients contain presentation and environment behavior but no reconstructed Gateway state machine; Gateway contains no first-party Client implementation branch.
 

--- a/docs/roadmap/gateway-client-protocol.zh.md
+++ b/docs/roadmap/gateway-client-protocol.zh.md
@@ -111,13 +111,13 @@ Backend Agent
 
 ## GCP5 — 参考 Client、回放与稳定
 
-- [ ] WebUI、TUI、Desktop 迁移到共享参考 Client SDK。
-- [ ] 增加有界回放与重连恢复。
-- [ ] 将 Task 控制、权限决策、对话历史和 Task 事件恢复从内部 REST/SSE 别名迁走。
-- [ ] 对所有第一方 Client 运行同一套 conformance suite。
-- [ ] 在 `docs/contract.md` 及中文版记录有测试锁定的 capability。
-- [ ] 旧别名至少经过一个明确废弃版本后再删除。
-- [ ] 替代链路验证完成后，才将 6.0 Spec 标记为稳定。
+- [x] WebUI、TUI、Desktop 迁移到共享参考 Client SDK。
+- [x] 增加有界回放与重连恢复。
+- [x] 将 Task 控制、权限决策、对话历史和 Task 事件恢复从内部 REST/SSE 别名迁走。
+- [x] 对所有第一方 Client 运行同一套 conformance suite。
+- [x] 在 `docs/contract.md` 及中文版记录有测试锁定的 capability。
+- [x] 旧别名至少经过一个明确废弃版本后再删除。
+- [x] 替代链路验证完成后，才将 6.0 Spec 标记为稳定。
 
 完成条件：第一方 Client 只包含 Presentation 与环境行为，不自行重建 Gateway 状态机；Gateway 不包含第一方 Client 实现分支。
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "./realtime-events": "./shared/realtime-events.mjs",
     "./gateway-events": "./shared/protocol/gateway-events.mjs",
     "./gateway-client-protocol": "./shared/gateway-client-protocol.mjs",
+    "./gateway-client-sdk": "./shared/gateway-client-sdk.mjs",
+    "./gateway-client-profiles": "./shared/gateway-client-profiles.mjs",
     "./client-events": "./server/src/client/client-event-router.mjs",
     "./client-actions": "./server/src/client/client-action-port.mjs",
     "./agent-delivery": "./server/src/delivery/agent-delivery.mjs",

--- a/server/src/core/gateway-protocol.mjs
+++ b/server/src/core/gateway-protocol.mjs
@@ -10,6 +10,8 @@
 // Every capability listed here is locked by a test (see docs/contract.md);
 // anything not listed is internal and may change in any release.
 //
+// 5.5.0 adds the GCP5 reference Client SDK, bounded Task-event replay, and
+// migrates first-party task/history/permission recovery to the WebSocket.
 // 5.4.0 adds GCP4 ClientActionPort request/result correlation and the shared
 // presence state machine used by Realtime tools and Gateway sleep triggers.
 // 5.3.0 adds GCP3 provider-neutral AgentDelivery routing for Client Events,
@@ -39,7 +41,7 @@
 // desktop.settings-window, …) are not part of this contract, and a removed
 // capability is a breaking change. Hosts migrating from the fork must branch
 // on the capability list below, never on the version number.
-export const GATEWAY_PROTOCOL_VERSION = '5.4.0'
+export const GATEWAY_PROTOCOL_VERSION = '5.5.0'
 
 export const GATEWAY_CAPABILITIES = Object.freeze([
   // The Gateway statically hosts web/dist at its own origin, so a client may
@@ -111,6 +113,10 @@ export const GATEWAY_CAPABILITIES = Object.freeze([
   // request/results. enter_sleep is capability-gated and commits Gateway
   // sleeping only after the active Client reports a successful transition.
   'realtime.gateway-client-protocol-v6-client-actions',
+  // The shipped reference Client owns handshake, correlation, Actions and
+  // reconnection recovery. Replayable Task pushes carry monotonic sequence
+  // numbers and session.replay provides a bounded page after a cursor.
+  'realtime.gateway-client-protocol-v6-reference-client-replay',
   // The orb shell contract ships: qwen-audio-agent/orb/preload plus
   // orb/main's bindOrbShell, so a host may run the floating orb form.
   'desktop.orb-shell',

--- a/server/src/transport/gateway-client-protocol-session.mjs
+++ b/server/src/transport/gateway-client-protocol-session.mjs
@@ -13,6 +13,7 @@ import {
   supportsGatewayClientProtocol,
 } from '../../../shared/gateway-client-protocol.mjs'
 import { parseGatewayClientMessage } from '../../../shared/protocol/gateway-events.mjs'
+import { isReplayableGatewayEvent } from './gateway-client-replay-buffer.mjs'
 
 function eventId() {
   return `evt_gateway_${randomUUID().replaceAll('-', '')}`
@@ -24,6 +25,7 @@ export class GatewayClientProtocolSession {
     supportedCapabilities = GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES,
     createEventId = eventId,
     maxPendingServerEvents = 128,
+    replayBuffer = null,
   } = {}) {
     this.sessionId = String(sessionId || 'main')
     this.supportedCapabilities = [...supportedCapabilities]
@@ -33,6 +35,7 @@ export class GatewayClientProtocolSession {
     this.protocolVersion = null
     this.capabilities = []
     this.pendingServerEvents = []
+    this.replayBuffer = replayBuffer
   }
 
   receive(value) {
@@ -81,9 +84,12 @@ export class GatewayClientProtocolSession {
         )
       }
       try {
+        if (value.type === GatewayClientProtocolEvent.SESSION_REPLAY) {
+          return { event: null, reply: this.#replay(value) }
+        }
         return { event: null, runtimeMessage: parseGatewayClientProtocolMessage(value) }
       } catch (error) {
-        return this.#error('bad_event', error.message, {
+        return this.#error(error.code || 'bad_event', error.message, {
           requestEventId: value?.event_id,
         })
       }
@@ -107,11 +113,14 @@ export class GatewayClientProtocolSession {
       return null
     }
     if (this.mode === 'legacy') return event
-    if (event?.event_id) return event
-    return {
+    const encoded = event?.event_id ? event : {
       ...event,
       event_id: this.createEventId(),
     }
+    if (this.replayBuffer && isReplayableGatewayEvent(encoded)) {
+      return this.replayBuffer.append(encoded)
+    }
+    return encoded
   }
 
   #acceptHello(value) {
@@ -147,6 +156,28 @@ export class GatewayClientProtocolSession {
         capabilities: this.capabilities,
       },
       pending: this.#drainPending(),
+    }
+  }
+
+  #replay(message) {
+    const parsed = parseGatewayClientProtocolMessage(message)
+    if (!this.replayBuffer) {
+      const error = new Error('session replay is unavailable')
+      error.code = 'replay_unavailable'
+      throw error
+    }
+    const page = this.replayBuffer.replay(parsed.after_sequence, {
+      limit: parsed.limit,
+    })
+    return {
+      type: GatewayClientProtocolEvent.SESSION_REPLAY_RESULT,
+      event_id: this.createEventId(),
+      request_event_id: parsed.event_id,
+      events: page.events,
+      earliest_sequence: page.earliestSequence,
+      latest_sequence: page.latestSequence,
+      next_sequence: page.nextSequence,
+      has_more: page.hasMore,
     }
   }
 

--- a/server/src/transport/gateway-client-replay-buffer.mjs
+++ b/server/src/transport/gateway-client-replay-buffer.mjs
@@ -1,0 +1,57 @@
+import { GatewayTaskEvent } from '../../../shared/realtime-events.mjs'
+
+const REPLAYABLE_TYPES = new Set(Object.values(GatewayTaskEvent))
+
+export function isReplayableGatewayEvent(event) {
+  return Boolean(event && REPLAYABLE_TYPES.has(event.type))
+}
+
+export class GatewayClientReplayBuffer {
+  constructor({ limit = 512 } = {}) {
+    this.limit = Math.max(1, Number(limit) || 512)
+    this.sequence = 0
+    this.events = []
+  }
+
+  append(event) {
+    const recorded = Object.freeze({
+      ...event,
+      sequence: ++this.sequence,
+    })
+    this.events.push(recorded)
+    if (this.events.length > this.limit) this.events.shift()
+    return recorded
+  }
+
+  cursor() {
+    return {
+      earliestSequence: this.events[0]?.sequence || this.sequence,
+      latestSequence: this.sequence,
+    }
+  }
+
+  replay(afterSequence = 0, { limit = 50 } = {}) {
+    const after = Math.max(0, Number(afterSequence) || 0)
+    const pageSize = Math.min(200, Math.max(1, Number(limit) || 50))
+    const { earliestSequence, latestSequence } = this.cursor()
+    if (after > latestSequence) {
+      const error = new Error('replay cursor is ahead of the current session')
+      error.code = 'session_expired'
+      throw error
+    }
+    if (this.events.length && after < earliestSequence - 1) {
+      const error = new Error('replay cursor is older than the retained event window')
+      error.code = 'sequence_expired'
+      throw error
+    }
+    const available = this.events.filter(event => event.sequence > after)
+    const events = available.slice(0, pageSize)
+    return {
+      events: events.map(event => ({ ...event })),
+      earliestSequence,
+      latestSequence,
+      nextSequence: events.at(-1)?.sequence || after,
+      hasMore: available.length > events.length,
+    }
+  }
+}

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -63,12 +63,14 @@ import {
   ClientActionPort,
 } from '../client/client-action-port.mjs'
 import { PresenceController } from '../client/presence-controller.mjs'
+import { GatewayClientReplayBuffer } from '../transport/gateway-client-replay-buffer.mjs'
 
 const MAX_PENDING_AUDIO_CHUNKS = 30
 const RESPONSE_START_WATCHDOG_MS = 12000
 const PERMISSION_RESPONSE_GRACE_MS = 800
 const RESPONSE_CONTEXT_CLEANUP_MS = 30000
 const REALTIME_STABLE_CONNECTION_MS = 10000
+const MAX_CLIENT_REPLAY_SESSIONS = 32
 const clientProtocolSessions = new WeakMap()
 
 function gatewayTurnId() {
@@ -158,6 +160,8 @@ export function attachRealtimeGateway(server, {
     })
   const activeVoiceClients = new ActiveVoiceClients()
   const voiceConnections = new Map()
+  const activeClientSockets = new Set()
+  const replayBuffers = new Map()
   const frontendToolSourcesReady = Promise.all(
     frontendToolSources.map(source => source.initialize()),
   ).catch(error => {
@@ -209,11 +213,38 @@ export function attachRealtimeGateway(server, {
   })
 
   wss.on('connection', (ws, url, identity) => {
+    if (activeClientSockets.size > 0) {
+      ws.send(JSON.stringify({
+        type: 'error',
+        event_id: `evt_gateway_${randomUUID().replaceAll('-', '')}`,
+        message: 'Gateway 已由另一个 Client 使用',
+        error: {
+          code: 'client_occupied',
+          message: 'Gateway already has an active Client connection',
+        },
+      }))
+      ws.close(1008, 'client_occupied')
+      return
+    }
+    activeClientSockets.add(ws)
     const ownerId = identity.ownerId
     const sessionId = url.searchParams.get('sessionId') || 'main'
+    const replayKey = `${ownerId}\u0000${sessionId}`
+    let replayBuffer = replayBuffers.get(replayKey)
+    if (!replayBuffer) {
+      while (replayBuffers.size >= MAX_CLIENT_REPLAY_SESSIONS) {
+        replayBuffers.delete(replayBuffers.keys().next().value)
+      }
+      replayBuffer = new GatewayClientReplayBuffer()
+      replayBuffers.set(replayKey, replayBuffer)
+    } else {
+      replayBuffers.delete(replayKey)
+      replayBuffers.set(replayKey, replayBuffer)
+    }
     const clientProtocol = new GatewayClientProtocolSession({
       sessionId,
       supportedCapabilities: supportedClientCapabilities,
+      replayBuffer,
     })
     clientProtocolSessions.set(ws, clientProtocol)
     const connectionLogger = logger.child({
@@ -1415,6 +1446,7 @@ export function attachRealtimeGateway(server, {
     })
 
     ws.on('close', () => {
+      activeClientSockets.delete(ws)
       clientProtocolSessions.delete(ws)
       connectionLogger.info('voice_client.disconnected', {
         clientType: descriptor.type,

--- a/server/test/gateway-client-handshake.test.mjs
+++ b/server/test/gateway-client-handshake.test.mjs
@@ -249,3 +249,32 @@ test('rejects unnegotiated GCP2 commands before dispatch', async t => {
   assert.equal(error.error.code, 'capability_not_negotiated')
   modern.socket.close()
 })
+
+test('allows only one active Gateway Client connection', async t => {
+  const { server, gateway } = gatewayHarness()
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  t.after(async () => {
+    await gateway.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+  const first = await connect(server, createGatewaySessionHello({
+    eventId: 'evt-first-hello',
+    clientInstanceId: 'first-client',
+    capabilities: [GatewayClientCapability.INPUT_TEXT],
+  }))
+  await waitFor(first.received, event => event.type === 'session.ready')
+
+  const second = await connect(server, createGatewaySessionHello({
+    eventId: 'evt-second-hello',
+    clientInstanceId: 'second-client',
+    capabilities: [GatewayClientCapability.INPUT_TEXT],
+  }))
+  const occupied = await waitFor(
+    second.received,
+    event => event.error?.code === 'client_occupied',
+  )
+  assert.equal(occupied.type, 'error')
+  await new Promise(resolve => second.socket.once('close', resolve))
+  assert.equal(first.socket.readyState, WebSocket.OPEN)
+  first.socket.close()
+})

--- a/server/test/gateway-client-protocol-session.test.mjs
+++ b/server/test/gateway-client-protocol-session.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  GatewayClientCapability,
+  GatewayClientProtocolEvent,
+  createGatewaySessionHello,
+} from '../../shared/gateway-client-protocol.mjs'
+import { GatewayClientProtocolSession } from '../src/transport/gateway-client-protocol-session.mjs'
+import { GatewayClientReplayBuffer } from '../src/transport/gateway-client-replay-buffer.mjs'
+
+test('shares a bounded Task replay cursor across protocol connections', () => {
+  const replayBuffer = new GatewayClientReplayBuffer()
+  const first = new GatewayClientProtocolSession({
+    sessionId: 'replay-test',
+    replayBuffer,
+    createEventId: (() => {
+      let index = 0
+      return () => `evt_gateway_${++index}`
+    })(),
+  })
+  first.receive(createGatewaySessionHello({
+    eventId: 'evt_hello_1',
+    clientInstanceId: 'client-1',
+    capabilities: [GatewayClientCapability.SESSION_REPLAY],
+  }))
+  const running = first.encode({ type: 'task.running', task: { id: 'task-1' } })
+  const progress = first.encode({ type: 'task.progress', task: { id: 'task-1' } })
+  assert.equal(running.sequence, 1)
+  assert.equal(progress.sequence, 2)
+  assert.equal(first.encode({ type: 'audio.delta', audio: 'AA==', sampleRate: 24000 }).sequence, undefined)
+
+  const second = new GatewayClientProtocolSession({
+    sessionId: 'replay-test',
+    replayBuffer,
+    createEventId: () => 'evt_gateway_replay',
+  })
+  second.receive(createGatewaySessionHello({
+    eventId: 'evt_hello_2',
+    clientInstanceId: 'client-2',
+    capabilities: [GatewayClientCapability.SESSION_REPLAY],
+  }))
+  const outcome = second.receive({
+    type: GatewayClientProtocolEvent.SESSION_REPLAY,
+    event_id: 'evt_client_replay',
+    after_sequence: 1,
+    limit: 50,
+  })
+  assert.equal(outcome.reply.type, GatewayClientProtocolEvent.SESSION_REPLAY_RESULT)
+  assert.equal(outcome.reply.request_event_id, 'evt_client_replay')
+  assert.deepEqual(outcome.reply.events.map(event => event.sequence), [2])
+  assert.equal(outcome.reply.has_more, false)
+})
+

--- a/server/test/gateway-client-replay-buffer.test.mjs
+++ b/server/test/gateway-client-replay-buffer.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  GatewayClientReplayBuffer,
+  isReplayableGatewayEvent,
+} from '../src/transport/gateway-client-replay-buffer.mjs'
+
+test('retains only bounded Task lifecycle events with monotonic sequence', () => {
+  const buffer = new GatewayClientReplayBuffer({ limit: 2 })
+  assert.equal(isReplayableGatewayEvent({ type: 'audio.delta' }), false)
+  assert.equal(isReplayableGatewayEvent({ type: 'task.running' }), true)
+  assert.equal(buffer.append({ type: 'task.running', task: { id: '1' } }).sequence, 1)
+  assert.equal(buffer.append({ type: 'task.progress', task: { id: '1' } }).sequence, 2)
+  assert.equal(buffer.append({ type: 'task.completed', task: { id: '1' } }).sequence, 3)
+  assert.deepEqual(
+    buffer.replay(1).events.map(event => event.sequence),
+    [2, 3],
+  )
+  assert.throws(
+    () => buffer.replay(0),
+    error => error.code === 'sequence_expired',
+  )
+})
+
+test('paginates a replay window without advancing the underlying cursor', () => {
+  const buffer = new GatewayClientReplayBuffer()
+  for (let index = 0; index < 3; index += 1) {
+    buffer.append({ type: 'task.updated', task: { id: String(index) } })
+  }
+  const first = buffer.replay(0, { limit: 2 })
+  assert.equal(first.hasMore, true)
+  assert.equal(first.nextSequence, 2)
+  const second = buffer.replay(first.nextSequence, { limit: 2 })
+  assert.equal(second.hasMore, false)
+  assert.deepEqual(second.events.map(event => event.sequence), [3])
+})

--- a/shared/gateway-client-profiles.mjs
+++ b/shared/gateway-client-profiles.mjs
@@ -1,0 +1,28 @@
+import { clientInputCapabilities } from './client-input-capabilities.mjs'
+import { GatewayClientCapability } from './gateway-client-protocol.mjs'
+
+export const GatewayReferenceClientType = Object.freeze({
+  WEB: 'web',
+  DESKTOP: 'desktop',
+  TUI: 'cli',
+})
+
+export function gatewayReferenceClientCapabilities(clientType = 'web') {
+  const input = clientInputCapabilities(clientType)
+  return [
+    GatewayClientCapability.INPUT_TEXT,
+    ...(input.audio ? [GatewayClientCapability.INPUT_AUDIO] : []),
+    ...(input.image ? [GatewayClientCapability.INPUT_IMAGE] : []),
+    ...(input.resource ? [GatewayClientCapability.INPUT_FILE] : []),
+    GatewayClientCapability.PLAYBACK_RECEIPTS,
+    GatewayClientCapability.TASK_COMMANDS,
+    GatewayClientCapability.PERMISSION_RESPOND,
+    GatewayClientCapability.CONVERSATION_HISTORY,
+    GatewayClientCapability.CLIENT_EVENTS,
+    GatewayClientCapability.SESSION_REPLAY,
+    ...(clientType === GatewayReferenceClientType.DESKTOP
+      ? [GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP]
+      : []),
+  ]
+}
+

--- a/shared/gateway-client-protocol.mjs
+++ b/shared/gateway-client-protocol.mjs
@@ -33,6 +33,8 @@ export const GatewayClientProtocolEvent = Object.freeze({
   PERMISSION_RESPOND_RESULT: 'permission.respond.result',
   CONVERSATION_HISTORY: 'conversation.history',
   CONVERSATION_HISTORY_RESULT: 'conversation.history.result',
+  SESSION_REPLAY: 'session.replay',
+  SESSION_REPLAY_RESULT: 'session.replay.result',
 })
 
 export const GatewayClientCapability = Object.freeze({
@@ -72,6 +74,7 @@ export const GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES = Object.freeze([
   GatewayClientCapability.CONVERSATION_HISTORY,
   GatewayClientCapability.CLIENT_EVENTS,
   GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP,
+  GatewayClientCapability.SESSION_REPLAY,
 ])
 
 const IdentifierSchema = z.string().min(1).max(128)
@@ -107,6 +110,17 @@ export const GatewaySessionHelloSchema = GatewayClientEnvelopeSchema.extend({
   capabilities: z.array(CapabilitySchema).max(64),
   locale: z.string().min(2).max(40).optional(),
   time_zone: z.string().min(1).max(80).optional(),
+  connection: z.object({
+    voice_enabled: z.boolean().optional(),
+    input_enabled: z.boolean().optional(),
+    output_enabled: z.boolean().optional(),
+    text_only: z.boolean().optional(),
+    wake_word_only: z.boolean().optional(),
+    provider: z.string().min(1).max(80).optional(),
+    working_directory: z.string().min(1).max(4096).optional(),
+    client_states: z.array(z.string().min(1).max(80)).max(16).optional(),
+    takeover: z.boolean().optional(),
+  }).optional(),
 }).superRefine((value, context) => {
   if (new Set(value.capabilities).size !== value.capabilities.length) {
     context.addIssue({
@@ -214,6 +228,12 @@ export const GatewayConversationHistorySchema = GatewayClientEnvelopeSchema.exte
   session_id: IdentifierSchema.optional(),
 })
 
+export const GatewaySessionReplaySchema = GatewayClientEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.SESSION_REPLAY),
+  after_sequence: z.number().int().nonnegative().default(0),
+  limit: z.number().int().min(1).max(200).default(50),
+})
+
 const TaskResultBaseSchema = GatewayServerEnvelopeSchema.extend({
   request_event_id: IdentifierSchema,
   task: GatewayTaskSchema,
@@ -243,6 +263,15 @@ export const GatewayConversationHistoryResultSchema = GatewayServerEnvelopeSchem
   request_event_id: IdentifierSchema,
   messages: z.array(z.unknown()).max(100),
 })
+export const GatewaySessionReplayResultSchema = GatewayServerEnvelopeSchema.extend({
+  type: z.literal(GatewayClientProtocolEvent.SESSION_REPLAY_RESULT),
+  request_event_id: IdentifierSchema,
+  events: z.array(GatewayServerEnvelopeSchema).max(200),
+  earliest_sequence: z.number().int().nonnegative(),
+  latest_sequence: z.number().int().nonnegative(),
+  next_sequence: z.number().int().nonnegative(),
+  has_more: z.boolean(),
+})
 
 const GATEWAY_RUNTIME_CLIENT_MESSAGE_SCHEMAS = Object.freeze({
   [GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH]: GatewayClientEventPublishSchema,
@@ -253,6 +282,7 @@ const GATEWAY_RUNTIME_CLIENT_MESSAGE_SCHEMAS = Object.freeze({
   [GatewayClientProtocolEvent.TASK_CANCEL]: GatewayTaskCancelSchema,
   [GatewayClientProtocolEvent.PERMISSION_RESPOND]: GatewayPermissionRespondSchema,
   [GatewayClientProtocolEvent.CONVERSATION_HISTORY]: GatewayConversationHistorySchema,
+  [GatewayClientProtocolEvent.SESSION_REPLAY]: GatewaySessionReplaySchema,
 })
 
 const GATEWAY_RUNTIME_SERVER_MESSAGE_SCHEMAS = Object.freeze({
@@ -264,6 +294,7 @@ const GATEWAY_RUNTIME_SERVER_MESSAGE_SCHEMAS = Object.freeze({
   [GatewayClientProtocolEvent.TASK_CANCEL_RESULT]: GatewayTaskCancelResultSchema,
   [GatewayClientProtocolEvent.PERMISSION_RESPOND_RESULT]: GatewayPermissionRespondResultSchema,
   [GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT]: GatewayConversationHistoryResultSchema,
+  [GatewayClientProtocolEvent.SESSION_REPLAY_RESULT]: GatewaySessionReplayResultSchema,
 })
 
 const GATEWAY_RUNTIME_REQUIRED_CAPABILITIES = Object.freeze({
@@ -275,6 +306,7 @@ const GATEWAY_RUNTIME_REQUIRED_CAPABILITIES = Object.freeze({
   [GatewayClientProtocolEvent.TASK_CANCEL]: GatewayClientCapability.TASK_COMMANDS,
   [GatewayClientProtocolEvent.PERMISSION_RESPOND]: GatewayClientCapability.PERMISSION_RESPOND,
   [GatewayClientProtocolEvent.CONVERSATION_HISTORY]: GatewayClientCapability.CONVERSATION_HISTORY,
+  [GatewayClientProtocolEvent.SESSION_REPLAY]: GatewayClientCapability.SESSION_REPLAY,
 })
 
 const V6_CLIENT_EVENT_ALIASES = Object.freeze({
@@ -355,6 +387,21 @@ export function gatewayHelloAsLegacyConnect(hello) {
       image: capabilities.has(GatewayClientCapability.INPUT_IMAGE),
       resource: capabilities.has(GatewayClientCapability.INPUT_FILE),
     },
+    ...(parsed.connection ? {
+      voiceEnabled: parsed.connection.voice_enabled ?? audioInput,
+      inputEnabled: parsed.connection.input_enabled ?? audioInput,
+      outputEnabled: parsed.connection.output_enabled ?? true,
+      textOnly: parsed.connection.text_only ?? !audioInput,
+      wakeWordOnly: parsed.connection.wake_word_only === true,
+      takeover: parsed.connection.takeover === true,
+      ...(parsed.connection.provider ? { provider: parsed.connection.provider } : {}),
+      ...(parsed.connection.working_directory
+        ? { workingDirectory: parsed.connection.working_directory }
+        : {}),
+      ...(parsed.connection.client_states
+        ? { clientStates: parsed.connection.client_states }
+        : {}),
+    } : {}),
   })
 }
 
@@ -378,6 +425,7 @@ export function createGatewaySessionHello({
   capabilities = GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES,
   locale,
   timeZone,
+  connection,
 } = {}) {
   return GatewaySessionHelloSchema.parse({
     type: GatewayClientProtocolEvent.SESSION_HELLO,
@@ -392,6 +440,7 @@ export function createGatewaySessionHello({
     capabilities,
     locale,
     time_zone: timeZone,
+    connection,
   })
 }
 

--- a/shared/gateway-client-sdk.mjs
+++ b/shared/gateway-client-sdk.mjs
@@ -1,0 +1,340 @@
+import {
+  GATEWAY_CLIENT_PROTOCOL_VERSION,
+  GatewayClientCapability,
+  GatewayClientProtocolEvent,
+  createGatewayClientProtocolMessage,
+  createGatewaySessionHello,
+  parseGatewayServerProtocolMessage,
+} from './gateway-client-protocol.mjs'
+
+const RESULT_TYPES = new Set([
+  GatewayClientProtocolEvent.CLIENT_EVENT_PUBLISH_RESULT,
+  GatewayClientProtocolEvent.TASK_CREATE_RESULT,
+  GatewayClientProtocolEvent.TASK_GET_RESULT,
+  GatewayClientProtocolEvent.TASK_LIST_RESULT,
+  GatewayClientProtocolEvent.TASK_CANCEL_RESULT,
+  GatewayClientProtocolEvent.PERMISSION_RESPOND_RESULT,
+  GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT,
+  GatewayClientProtocolEvent.SESSION_REPLAY_RESULT,
+  'error',
+])
+
+function addSocketListener(socket, type, listener) {
+  if (typeof socket.addEventListener === 'function') {
+    socket.addEventListener(type, listener)
+    return
+  }
+  socket.on(type, listener)
+}
+
+function socketPayload(value) {
+  return value?.data === undefined ? value : value.data
+}
+
+function socketOpen(socket) {
+  return socket?.readyState === 1
+}
+
+function decodeMessage(raw) {
+  const value = socketPayload(raw)
+  return JSON.parse(typeof value === 'string' ? value : value.toString())
+}
+
+function connectionConfiguration(value = {}) {
+  if (!value || typeof value !== 'object') return undefined
+  return {
+    ...(value.voiceEnabled === undefined ? {} : { voice_enabled: value.voiceEnabled === true }),
+    ...(value.inputEnabled === undefined ? {} : { input_enabled: value.inputEnabled === true }),
+    ...(value.outputEnabled === undefined ? {} : { output_enabled: value.outputEnabled === true }),
+    ...(value.textOnly === undefined ? {} : { text_only: value.textOnly === true }),
+    ...(value.wakeWordOnly === undefined ? {} : { wake_word_only: value.wakeWordOnly === true }),
+    ...(value.provider ? { provider: String(value.provider) } : {}),
+    ...(value.workingDirectory ? { working_directory: String(value.workingDirectory) } : {}),
+    ...(Array.isArray(value.clientStates) ? { client_states: value.clientStates } : {}),
+    ...(value.takeover === undefined ? {} : { takeover: value.takeover === true }),
+  }
+}
+
+export class GatewayClient {
+  constructor({
+    url,
+    createSocket,
+    clientType = 'web',
+    clientVersion,
+    clientInstanceId,
+    clientLabel,
+    capabilities = [],
+    locale,
+    timeZone,
+    configure,
+    reconnect = true,
+    reconnectMinMs = 500,
+    reconnectMaxMs = 5_000,
+    requestTimeoutMs = 10_000,
+    onEvent,
+    onStatus,
+    onAction,
+    onRecovery,
+  } = {}) {
+    if (!url) throw new TypeError('url is required')
+    if (typeof createSocket !== 'function') throw new TypeError('createSocket is required')
+    this.url = String(url)
+    this.createSocket = createSocket
+    this.client = {
+      type: clientType,
+      version: clientVersion,
+      instanceId: clientInstanceId,
+      label: clientLabel,
+    }
+    this.requestedCapabilities = [...new Set(capabilities)]
+    this.locale = locale
+    this.timeZone = timeZone
+    this.configure = configure
+    this.reconnect = reconnect !== false
+    this.reconnectMinMs = Math.max(50, Number(reconnectMinMs) || 500)
+    this.reconnectMaxMs = Math.max(this.reconnectMinMs, Number(reconnectMaxMs) || 5_000)
+    this.requestTimeoutMs = Math.max(100, Number(requestTimeoutMs) || 10_000)
+    this.onEvent = onEvent
+    this.onStatus = onStatus
+    this.onAction = onAction
+    this.onRecovery = onRecovery
+    this.socket = null
+    this.stopped = true
+    this.ready = false
+    this.negotiatedCapabilities = []
+    this.reconnectDelay = this.reconnectMinMs
+    this.reconnectTimer = null
+    this.pending = new Map()
+    this.lastSequence = 0
+  }
+
+  start() {
+    if (!this.stopped) return this
+    this.stopped = false
+    this.#connect()
+    return this
+  }
+
+  stop() {
+    this.stopped = true
+    this.ready = false
+    clearTimeout(this.reconnectTimer)
+    this.reconnectTimer = null
+    this.#rejectPending('client_stopped', 'Gateway Client stopped')
+    const socket = this.socket
+    this.socket = null
+    socket?.close?.()
+  }
+
+  supports(capability) {
+    return this.negotiatedCapabilities.includes(capability)
+  }
+
+  get readyState() {
+    return this.socket?.readyState ?? 3
+  }
+
+  close() {
+    this.stop()
+  }
+
+  send(event) {
+    if (!socketOpen(this.socket)) return false
+    try {
+      this.socket.send(typeof event === 'string' ? event : JSON.stringify(event))
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  request(type, payload = {}, { timeoutMs = this.requestTimeoutMs } = {}) {
+    if (!this.ready) {
+      return Promise.reject(Object.assign(new Error('Gateway Client is not ready'), {
+        code: 'client_not_ready',
+      }))
+    }
+    const message = createGatewayClientProtocolMessage(type, payload)
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(message.event_id)
+        reject(Object.assign(new Error(`${type} timed out`), {
+          code: 'request_timeout',
+        }))
+      }, Math.max(100, Number(timeoutMs) || this.requestTimeoutMs))
+      timer.unref?.()
+      this.pending.set(message.event_id, { resolve, reject, timer, type })
+      if (!this.send(message)) {
+        clearTimeout(timer)
+        this.pending.delete(message.event_id)
+        reject(Object.assign(new Error('Gateway connection is unavailable'), {
+          code: 'connection_unavailable',
+        }))
+      }
+    })
+  }
+
+  async recover() {
+    const recovered = { events: [], tasks: [], messages: [] }
+    if (this.supports(GatewayClientCapability.SESSION_REPLAY) && this.lastSequence > 0) {
+      try {
+        let cursor = this.lastSequence
+        let hasMore = true
+        while (hasMore) {
+          const page = await this.request(GatewayClientProtocolEvent.SESSION_REPLAY, {
+            after_sequence: cursor,
+            limit: 200,
+          })
+          for (const event of page.events || []) this.#dispatch(event, { replayed: true })
+          recovered.events.push(...(page.events || []))
+          cursor = page.next_sequence
+          hasMore = page.has_more === true
+        }
+      } catch (error) {
+        if (!['sequence_expired', 'session_expired'].includes(error.code)) {
+          throw error
+        }
+        this.lastSequence = 0
+      }
+    }
+    if (this.supports(GatewayClientCapability.TASK_COMMANDS)) {
+      const result = await this.request(GatewayClientProtocolEvent.TASK_LIST, { limit: 100 })
+      recovered.tasks = result.tasks || []
+    }
+    if (this.supports(GatewayClientCapability.CONVERSATION_HISTORY)) {
+      const result = await this.request(GatewayClientProtocolEvent.CONVERSATION_HISTORY)
+      recovered.messages = result.messages || []
+    }
+    this.onRecovery?.(recovered)
+    return recovered
+  }
+
+  #connect() {
+    if (this.stopped) return
+    this.onStatus?.({ state: 'connecting' })
+    const socket = this.createSocket(this.url)
+    this.socket = socket
+    addSocketListener(socket, 'open', () => {
+      if (this.socket !== socket || this.stopped) return
+      this.reconnectDelay = this.reconnectMinMs
+      this.onStatus?.({ state: 'connected' })
+      const configured = typeof this.configure === 'function'
+        ? this.configure()
+        : this.configure
+      this.send(createGatewaySessionHello({
+        protocolMin: GATEWAY_CLIENT_PROTOCOL_VERSION,
+        protocolMax: GATEWAY_CLIENT_PROTOCOL_VERSION,
+        clientType: this.client.type,
+        clientVersion: this.client.version,
+        clientInstanceId: this.client.instanceId,
+        clientLabel: this.client.label,
+        capabilities: this.requestedCapabilities,
+        locale: this.locale,
+        timeZone: this.timeZone,
+        connection: connectionConfiguration(configured),
+      }))
+    })
+    addSocketListener(socket, 'message', raw => {
+      if (this.socket !== socket || this.stopped) return
+      let event
+      try {
+        event = parseGatewayServerProtocolMessage(decodeMessage(raw))
+      } catch {
+        return
+      }
+      this.#receive(event)
+    })
+    addSocketListener(socket, 'error', error => {
+      if (this.socket !== socket || this.stopped) return
+      this.onStatus?.({ state: 'unavailable', error })
+    })
+    addSocketListener(socket, 'close', () => {
+      if (this.socket !== socket) return
+      this.socket = null
+      this.ready = false
+      this.negotiatedCapabilities = []
+      this.#rejectPending('connection_closed', 'Gateway connection closed')
+      if (this.stopped) return
+      this.onStatus?.({ state: 'disconnected' })
+      if (!this.reconnect) return
+      this.reconnectTimer = setTimeout(() => this.#connect(), this.reconnectDelay)
+      this.reconnectDelay = Math.min(this.reconnectMaxMs, this.reconnectDelay * 2)
+    })
+  }
+
+  #receive(event) {
+    if (event.type === GatewayClientProtocolEvent.SESSION_READY) {
+      this.ready = true
+      this.negotiatedCapabilities = [...event.capabilities]
+      this.onStatus?.({ state: 'ready', event })
+      this.recover().catch(error => this.onStatus?.({ state: 'recovery_failed', error }))
+      return
+    }
+    if (event.type === GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST) {
+      this.#handleAction(event)
+      return
+    }
+    const pending = event.request_event_id
+      ? this.pending.get(event.request_event_id)
+      : null
+    if (pending && RESULT_TYPES.has(event.type)) {
+      clearTimeout(pending.timer)
+      this.pending.delete(event.request_event_id)
+      if (event.type === 'error') {
+        pending.reject(Object.assign(new Error(event.error.message), {
+          code: event.error.code,
+        }))
+      } else pending.resolve(event)
+      return
+    }
+    this.#dispatch(
+      event.type === 'error' && event.error && !event.message
+        ? { ...event, message: event.error.message }
+        : event,
+    )
+  }
+
+  #dispatch(event, metadata = {}) {
+    if (Number.isInteger(event.sequence)) {
+      if (event.sequence <= this.lastSequence) return
+      this.lastSequence = Math.max(this.lastSequence, event.sequence)
+    }
+    this.onEvent?.(event, metadata)
+  }
+
+  async #handleAction(event) {
+    let result
+    try {
+      result = await this.onAction?.(event)
+    } catch (error) {
+      result = {
+        status: 'failed',
+        error: { code: 'client_action_failed', message: String(error?.message || error) },
+      }
+    }
+    const normalized = result?.status ? result : {
+      status: 'unsupported',
+      error: {
+        code: 'client_action_unsupported',
+        message: `Unsupported Client Action: ${String(event.name || '')}`,
+      },
+    }
+    this.send(createGatewayClientProtocolMessage(
+      GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
+      {
+        request_event_id: event.event_id,
+        status: normalized.status,
+        ...(normalized.output === undefined ? {} : { output: normalized.output }),
+        ...(normalized.error ? { error: normalized.error } : {}),
+      },
+    ))
+  }
+
+  #rejectPending(code, message) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(Object.assign(new Error(message), { code }))
+    }
+    this.pending.clear()
+  }
+}

--- a/test/gateway-client-conformance.test.mjs
+++ b/test/gateway-client-conformance.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { GatewayClient } from '../shared/gateway-client-sdk.mjs'
+import {
+  GatewayReferenceClientType,
+  gatewayReferenceClientCapabilities,
+} from '../shared/gateway-client-profiles.mjs'
+import {
+  GatewayClientCapability,
+  GatewayClientProtocolEvent,
+} from '../shared/gateway-client-protocol.mjs'
+
+class ConformanceSocket {
+  constructor() {
+    this.readyState = 0
+    this.listeners = new Map()
+    this.sent = []
+  }
+
+  addEventListener(type, listener) {
+    const current = this.listeners.get(type) || []
+    current.push(listener)
+    this.listeners.set(type, current)
+  }
+
+  emit(type, value = {}) {
+    for (const listener of this.listeners.get(type) || []) listener(value)
+  }
+
+  open() { this.readyState = 1; this.emit('open') }
+  send(raw) { this.sent.push(JSON.parse(raw)) }
+  close() { this.readyState = 3 }
+  receive(value) { this.emit('message', { data: JSON.stringify(value) }) }
+}
+
+for (const clientType of Object.values(GatewayReferenceClientType)) {
+  test(`${clientType} satisfies the reference Gateway Client conformance flow`, async () => {
+    const socket = new ConformanceSocket()
+    let recovery
+    const client = new GatewayClient({
+      url: 'ws://gateway.test/api/realtime',
+      createSocket: () => socket,
+      clientType,
+      clientInstanceId: `${clientType}-conformance`,
+      capabilities: gatewayReferenceClientCapabilities(clientType),
+      reconnect: false,
+      onRecovery: value => { recovery = value },
+      onAction: async () => ({ status: 'completed' }),
+    }).start()
+    socket.open()
+    const hello = socket.sent[0]
+    assert.equal(hello.type, GatewayClientProtocolEvent.SESSION_HELLO)
+    assert.equal(hello.client.type, clientType)
+    socket.receive({
+      type: GatewayClientProtocolEvent.SESSION_READY,
+      event_id: `evt_${clientType}_ready`,
+      request_event_id: hello.event_id,
+      protocol_version: '6.0.0',
+      session_id: 'main',
+      capabilities: hello.capabilities,
+    })
+    await new Promise(resolve => setImmediate(resolve))
+    const tasks = socket.sent.find(event => event.type === GatewayClientProtocolEvent.TASK_LIST)
+    socket.receive({
+      type: GatewayClientProtocolEvent.TASK_LIST_RESULT,
+      event_id: `evt_${clientType}_tasks`,
+      request_event_id: tasks.event_id,
+      tasks: [],
+    })
+    await new Promise(resolve => setImmediate(resolve))
+    const history = socket.sent.find(event => (
+      event.type === GatewayClientProtocolEvent.CONVERSATION_HISTORY
+    ))
+    socket.receive({
+      type: GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT,
+      event_id: `evt_${clientType}_history`,
+      request_event_id: history.event_id,
+      messages: [],
+    })
+    await new Promise(resolve => setImmediate(resolve))
+    assert.deepEqual(recovery, { events: [], tasks: [], messages: [] })
+    assert.equal(
+      client.supports(GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP),
+      clientType === GatewayReferenceClientType.DESKTOP,
+    )
+    client.stop()
+  })
+}
+

--- a/test/gateway-client-protocol.test.mjs
+++ b/test/gateway-client-protocol.test.mjs
@@ -43,6 +43,12 @@ test('publishes a frozen capability vocabulary and only advertises implemented s
     ),
     true,
   )
+  assert.equal(
+    GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES.includes(
+      GatewayClientCapability.SESSION_REPLAY,
+    ),
+    true,
+  )
 })
 
 test('validates the 6.0 envelope and rejects duplicate capabilities', () => {
@@ -143,6 +149,24 @@ test('validates runtime commands, Client Actions and correlated results', () => 
     request_event_id: action.event_id,
     status: 'failed',
   }))
+
+  const replay = parseGatewayClientProtocolMessage({
+    type: GatewayClientProtocolEvent.SESSION_REPLAY,
+    event_id: 'evt_client_replay',
+    after_sequence: 12,
+    limit: 200,
+  })
+  assert.equal(replay.after_sequence, 12)
+  assert.equal(
+    gatewayClientProtocolCapabilityFor(replay.type),
+    GatewayClientCapability.SESSION_REPLAY,
+  )
+  assert.throws(() => parseGatewayClientProtocolMessage({
+    type: GatewayClientProtocolEvent.SESSION_REPLAY,
+    event_id: 'evt_client_replay_unbounded',
+    after_sequence: 0,
+    limit: 201,
+  }))
 })
 
 test('normalizes 6.0 event names into the existing business event vocabulary', () => {
@@ -190,13 +214,25 @@ test('6.0 hello and 5.x connect enter the same legacy business path', () => {
       GatewayClientCapability.INPUT_TEXT,
       GatewayClientCapability.CLIENT_EVENTS,
     ],
+    connection: {
+      voice_enabled: true,
+      input_enabled: false,
+      output_enabled: true,
+      text_only: false,
+      provider: 'dashscope',
+      working_directory: '/tmp/client-project',
+      client_states: ['active'],
+    },
   })
   const accepted = modern.receive(hello)
   assert.equal(accepted.event.type, 'connect')
   assert.equal(accepted.event.clientType, 'desktop')
-  assert.equal(accepted.event.inputEnabled, true)
+  assert.equal(accepted.event.inputEnabled, false)
   assert.equal(accepted.event.outputEnabled, true)
   assert.equal(accepted.event.textOnly, false)
+  assert.equal(accepted.event.provider, 'dashscope')
+  assert.equal(accepted.event.workingDirectory, '/tmp/client-project')
+  assert.deepEqual(accepted.event.clientStates, ['active'])
   assert.deepEqual(accepted.reply.capabilities, [
     GatewayClientCapability.INPUT_AUDIO,
     GatewayClientCapability.INPUT_TEXT,

--- a/test/gateway-client-sdk.test.mjs
+++ b/test/gateway-client-sdk.test.mjs
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { GatewayClient } from '../shared/gateway-client-sdk.mjs'
+import {
+  GatewayClientCapability,
+  GatewayClientProtocolEvent,
+} from '../shared/gateway-client-protocol.mjs'
+
+class FakeSocket {
+  constructor() {
+    this.readyState = 0
+    this.listeners = new Map()
+    this.sent = []
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || []
+    listeners.push(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  emit(type, value = {}) {
+    for (const listener of this.listeners.get(type) || []) listener(value)
+  }
+
+  open() {
+    this.readyState = 1
+    this.emit('open')
+  }
+
+  receive(value) {
+    this.emit('message', { data: JSON.stringify(value) })
+  }
+
+  send(value) { this.sent.push(JSON.parse(value)) }
+  close() { this.readyState = 3 }
+}
+
+test('reference Client negotiates once and correlates runtime commands', async () => {
+  const socket = new FakeSocket()
+  const client = new GatewayClient({
+    url: 'ws://gateway.test/api/realtime',
+    createSocket: () => socket,
+    clientInstanceId: 'sdk-test',
+    capabilities: [GatewayClientCapability.TASK_COMMANDS],
+    reconnect: false,
+  }).start()
+  socket.open()
+  assert.equal(socket.sent[0].type, GatewayClientProtocolEvent.SESSION_HELLO)
+  socket.receive({
+    type: GatewayClientProtocolEvent.SESSION_READY,
+    event_id: 'evt_gateway_ready',
+    request_event_id: socket.sent[0].event_id,
+    protocol_version: '6.0.0',
+    session_id: 'main',
+    capabilities: [GatewayClientCapability.TASK_COMMANDS],
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  const recoveryRequest = socket.sent.find(event => event.type === 'task.list')
+  socket.receive({
+    type: GatewayClientProtocolEvent.TASK_LIST_RESULT,
+    event_id: 'evt_gateway_tasks',
+    request_event_id: recoveryRequest.event_id,
+    tasks: [],
+  })
+  await new Promise(resolve => setImmediate(resolve))
+
+  const pending = client.request(GatewayClientProtocolEvent.TASK_GET, {
+    task_id: 'task-1',
+  })
+  const request = socket.sent.at(-1)
+  socket.receive({
+    type: GatewayClientProtocolEvent.TASK_GET_RESULT,
+    event_id: 'evt_gateway_task',
+    request_event_id: request.event_id,
+    task: {
+      id: 'task-1', workState: 'working', status: 'running', kind: 'work',
+      objective: 'test', createdAt: 1, elapsedMs: 1,
+    },
+  })
+  assert.equal((await pending).task.id, 'task-1')
+  client.stop()
+})
+
+test('reference Client executes negotiated Actions and deduplicates replayed events', async () => {
+  const socket = new FakeSocket()
+  const received = []
+  const client = new GatewayClient({
+    url: 'ws://gateway.test/api/realtime',
+    createSocket: () => socket,
+    clientInstanceId: 'sdk-action-test',
+    capabilities: [GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP],
+    reconnect: false,
+    onEvent: event => received.push(event),
+    onAction: async () => ({ status: 'completed' }),
+  }).start()
+  socket.open()
+  socket.receive({
+    type: GatewayClientProtocolEvent.SESSION_READY,
+    event_id: 'evt_gateway_ready',
+    request_event_id: socket.sent[0].event_id,
+    protocol_version: '6.0.0',
+    session_id: 'main',
+    capabilities: [GatewayClientCapability.CLIENT_ACTION_ENTER_SLEEP],
+  })
+  socket.receive({
+    type: GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST,
+    event_id: 'evt_gateway_action',
+    name: 'desktop.presence.enter_sleep',
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  const result = socket.sent.at(-1)
+  assert.equal(result.type, GatewayClientProtocolEvent.CLIENT_ACTION_RESULT)
+  assert.equal(result.request_event_id, 'evt_gateway_action')
+
+  socket.receive({ type: 'task.running', event_id: 'evt_task_1', sequence: 1 })
+  socket.receive({ type: 'task.running', event_id: 'evt_task_1', sequence: 1 })
+  assert.equal(received.length, 1)
+  client.stop()
+})
+
+test('reference Client reconnects, replays from its cursor, then reconciles snapshots', async () => {
+  const sockets = []
+  const received = []
+  let recovered
+  const client = new GatewayClient({
+    url: 'ws://gateway.test/api/realtime',
+    createSocket: () => {
+      const socket = new FakeSocket()
+      sockets.push(socket)
+      return socket
+    },
+    clientInstanceId: 'sdk-reconnect-test',
+    capabilities: [
+      GatewayClientCapability.SESSION_REPLAY,
+      GatewayClientCapability.TASK_COMMANDS,
+      GatewayClientCapability.CONVERSATION_HISTORY,
+    ],
+    reconnectMinMs: 50,
+    reconnectMaxMs: 50,
+    onEvent: event => received.push(event),
+    onRecovery: value => { recovered = value },
+  }).start()
+  const first = sockets[0]
+  first.open()
+  first.receive({
+    type: GatewayClientProtocolEvent.SESSION_READY,
+    event_id: 'evt_ready_1',
+    request_event_id: first.sent[0].event_id,
+    protocol_version: '6.0.0',
+    session_id: 'main',
+    capabilities: [],
+  })
+  first.receive({ type: 'task.running', event_id: 'evt_task_1', sequence: 1 })
+  first.readyState = 3
+  first.emit('close')
+  await new Promise(resolve => setTimeout(resolve, 60))
+
+  const second = sockets[1]
+  second.open()
+  second.receive({
+    type: GatewayClientProtocolEvent.SESSION_READY,
+    event_id: 'evt_ready_2',
+    request_event_id: second.sent[0].event_id,
+    protocol_version: '6.0.0',
+    session_id: 'main',
+    capabilities: [
+      GatewayClientCapability.SESSION_REPLAY,
+      GatewayClientCapability.TASK_COMMANDS,
+      GatewayClientCapability.CONVERSATION_HISTORY,
+    ],
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  const replay = second.sent.find(event => event.type === GatewayClientProtocolEvent.SESSION_REPLAY)
+  assert.equal(replay.after_sequence, 1)
+  second.receive({
+    type: GatewayClientProtocolEvent.SESSION_REPLAY_RESULT,
+    event_id: 'evt_replay_result',
+    request_event_id: replay.event_id,
+    events: [{ type: 'task.completed', event_id: 'evt_task_2', sequence: 2 }],
+    earliest_sequence: 1,
+    latest_sequence: 2,
+    next_sequence: 2,
+    has_more: false,
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  const tasks = second.sent.find(event => event.type === GatewayClientProtocolEvent.TASK_LIST)
+  second.receive({
+    type: GatewayClientProtocolEvent.TASK_LIST_RESULT,
+    event_id: 'evt_tasks_result',
+    request_event_id: tasks.event_id,
+    tasks: [],
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  const history = second.sent.find(event => event.type === GatewayClientProtocolEvent.CONVERSATION_HISTORY)
+  second.receive({
+    type: GatewayClientProtocolEvent.CONVERSATION_HISTORY_RESULT,
+    event_id: 'evt_history_result',
+    request_event_id: history.event_id,
+    messages: [],
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(received.map(event => event.sequence), [1, 2])
+  assert.deepEqual(recovered.events.map(event => event.sequence), [2])
+  client.stop()
+})

--- a/tui/src/index.mjs
+++ b/tui/src/index.mjs
@@ -16,6 +16,8 @@ import {
 } from '../../shared/input-parts.mjs'
 import { createLogger } from '../../shared/logger.mjs'
 import { clientInputCapabilities } from '../../shared/client-input-capabilities.mjs'
+import { GatewayClient } from '../../shared/gateway-client-sdk.mjs'
+import { gatewayReferenceClientCapabilities } from '../../shared/gateway-client-profiles.mjs'
 import { formatCitationLines } from '../../shared/citation-display.mjs'
 import { startMacVoiceIO } from './macos-voice-io.mjs'
 import { resamplePcm16 } from './pcm-audio.mjs'
@@ -1492,16 +1494,10 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
     }
   }
 
-  const syncActiveTasks = async () => {
-    const url = new URL('/api/tasks', options.url)
-    url.searchParams.set('sessionId', options.sessionId)
-    url.searchParams.set('active', 'true')
-    const response = await fetch(url, { headers })
-    if (!response.ok) {
-      throw new Error(`任务状态恢复失败（${response.status}）`)
-    }
-    const payload = await response.json()
-    for (const task of payload.tasks || []) {
+  const restoreTasks = tasks => {
+    for (const task of tasks || []) {
+      if (!['queued', 'running', 'delegated', 'finalizing', 'cancelling'].includes(task.status)
+        && task.authorization?.status !== 'pending') continue
       const type = task.authorization?.status === 'pending'
         ? 'task.permission.requested'
         : `task.${task.status}`
@@ -1511,65 +1507,69 @@ export async function runTui(options = parseArguments(process.argv.slice(2))) {
 
   const connectGateway = () => {
     if (closed || bridgeExited) return
-    const nextSocket = new WebSocket(
-      websocketUrl(options.url, options.sessionId),
-      { headers },
-    )
-    socket = nextSocket
-    nextSocket.on('open', () => {
-      if (socket !== nextSocket || closed) return
-      reconnectDelay = 500
-      gatewayClientState = reduceGatewayClientState(gatewayClientState, {
-        type: GatewayServerEvent.GATEWAY_CONNECTED,
-      })
-      setStatus('Gateway 已连接 · 语音服务准备中')
-      nextSocket.send(JSON.stringify(connectMessage({
+    const nextClient = new GatewayClient({
+      url: websocketUrl(options.url, options.sessionId),
+      createSocket: url => new WebSocket(url, { headers }),
+      clientType: 'cli',
+      clientLabel: 'CLI',
+      clientInstanceId: `tui-${process.pid}`,
+      capabilities: gatewayReferenceClientCapabilities('cli'),
+      reconnect: false,
+      configure: () => connectMessage({
         voiceEnabled: true,
         inputEnabled: !muted,
         outputEnabled: true,
         takeover: options.takeover === true,
-      })))
-      syncActiveTasks().catch(error => {
-        print(style(`[任务状态] ${error.message}`, 'yellow'))
-      })
-      if (connectedOnce) {
-        print(style('[qwen-audio-agent 已重新连接]', 'green'))
-      } else {
-        connectedOnce = true
-        print(
-          `${style('qwen-audio-agent Voice TUI', 'bold')} · ${health.realtimeLabel || health.realtimeModelProfile?.label || health.realtimeModel || 'Realtime'} → ${health.backend?.label || health.backend?.kind || 'Gateway'}\n`
-          + `${realtimeModelStatusText(health)}\n`
-          + `会话：${options.sessionId}\n`
-          + `音频：${audioMode.label}\n`
-          + `${helpText(audioMode)}\n`,
-        )
-      }
+      }),
+      locale: Intl.DateTimeFormat().resolvedOptions().locale,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      onEvent: event => handleGatewayMessage(JSON.stringify(event)),
+      onRecovery: recovery => restoreTasks(recovery.tasks),
+      onStatus: status => {
+        if (socket !== nextClient || closed) return
+        if (status.state === 'connected') {
+          reconnectDelay = 500
+          gatewayClientState = reduceGatewayClientState(gatewayClientState, {
+            type: GatewayServerEvent.GATEWAY_CONNECTED,
+          })
+          setStatus('Gateway 已连接 · 语音服务准备中')
+          if (connectedOnce) {
+            print(style('[qwen-audio-agent 已重新连接]', 'green'))
+          } else {
+            connectedOnce = true
+            print(
+              `${style('qwen-audio-agent Voice TUI', 'bold')} · ${health.realtimeLabel || health.realtimeModelProfile?.label || health.realtimeModel || 'Realtime'} → ${health.backend?.label || health.backend?.kind || 'Gateway'}\n`
+              + `${realtimeModelStatusText(health)}\n`
+              + `会话：${options.sessionId}\n`
+              + `音频：${audioMode.label}\n`
+              + `${helpText(audioMode)}\n`,
+            )
+          }
+        } else if (status.state === 'unavailable') {
+          if (!closed) print(`${style('[连接错误]', 'red')} ${status.error?.message || '连接失败'}`)
+        } else if (status.state === 'recovery_failed') {
+          print(style(`[任务状态] ${status.error.message}`, 'yellow'))
+        } else if (status.state === 'disconnected') {
+          gatewayClientState = reduceGatewayClientState(gatewayClientState, {
+            type: GatewayServerEvent.GATEWAY_DISCONNECTED,
+          })
+          setCaptureEnabled(false)
+          playback.clear()
+          transcriptDisplay.reset()
+          if (closed) {
+            print('qwen-audio-agent 连接已关闭。')
+          } else if (bridgeExited) {
+            cleanup()
+          } else {
+            setStatus('Gateway 已断开 · 正在自动重连 · /exit 或 Ctrl-C 可退出')
+            print(style('[qwen-audio-agent 连接中断，正在重连]', 'yellow'))
+            scheduleReconnect()
+          }
+        }
+      },
     })
-    nextSocket.on('message', handleGatewayMessage)
-    nextSocket.on('error', error => {
-      if (!closed) print(`${style('[连接错误]', 'red')} ${error.message}`)
-    })
-    nextSocket.on('close', () => {
-      if (socket !== nextSocket) return
-      socket = null
-      gatewayClientState = reduceGatewayClientState(gatewayClientState, {
-        type: GatewayServerEvent.GATEWAY_DISCONNECTED,
-      })
-      setCaptureEnabled(false)
-      playback.clear()
-      transcriptDisplay.reset()
-      if (closed) {
-        print('qwen-audio-agent 连接已关闭。')
-        return
-      }
-      if (bridgeExited) {
-        cleanup()
-        return
-      }
-      setStatus('Gateway 已断开 · 正在自动重连 · /exit 或 Ctrl-C 可退出')
-      print(style('[qwen-audio-agent 连接中断，正在重连]', 'yellow'))
-      scheduleReconnect()
-    })
+    socket = nextClient
+    nextClient.start()
   }
 
   const scheduleReconnect = () => {

--- a/tui/src/text-cli.mjs
+++ b/tui/src/text-cli.mjs
@@ -4,6 +4,11 @@ import { createInterface } from 'node:readline'
 import { pathToFileURL } from 'node:url'
 import WebSocket from 'ws'
 import { formatCitationLines } from '../../shared/citation-display.mjs'
+import { GatewayClient } from '../../shared/gateway-client-sdk.mjs'
+import {
+  GatewayClientProtocolEvent,
+} from '../../shared/gateway-client-protocol.mjs'
+import { gatewayReferenceClientCapabilities } from '../../shared/gateway-client-profiles.mjs'
 import { inputPartsFromText } from './input-parts.mjs'
 import { isExitCommand } from './terminal-commands.mjs'
 
@@ -83,64 +88,59 @@ export async function runCli(options = parseArguments(process.argv.slice(2))) {
   }
   const headers = cookie ? { Cookie: cookie } : {}
 
-  const api = async (path, init = {}) => {
-    const response = await fetch(`${options.url}${path}`, {
-      ...init,
-      headers: { ...headers, ...init.headers },
-    })
-    const payload = await response.json()
-    if (!response.ok) throw new Error(payload.error || `请求失败 (${response.status})`)
-    return payload
-  }
-
-  const socket = new WebSocket(websocketUrl(options.url, options.sessionId), { headers })
   const print = text => process.stdout.write(`${text}\n`)
   let streaming = false
   const startedResponses = new Set()
-
-  const opened = new Promise((resolvePromise, rejectPromise) => {
-    socket.once('open', resolvePromise)
-    socket.once('error', rejectPromise)
+  let resolveOpened
+  let rejectOpened
+  const opened = new Promise((resolve, reject) => {
+    resolveOpened = resolve
+    rejectOpened = reject
   })
-  socket.on('open', () => {
-    socket.send(JSON.stringify({
+  const client = new GatewayClient({
+    url: websocketUrl(options.url, options.sessionId),
+    createSocket: url => new WebSocket(url, { headers }),
+    clientType: 'cli',
+    clientLabel: 'Text CLI',
+    clientInstanceId: `text-cli-${process.pid}`,
+    capabilities: gatewayReferenceClientCapabilities('cli'),
+    reconnect: false,
+    configure: () => ({
       type: 'connect',
       voiceEnabled: true,  // 启用输出通道以接收任务播报;CLI 不发音频、忽略音频帧
       textOnly: true,
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       locale: 'zh-CN',
-    }))
-    print(`${DIM}已连接(文本模式,会话 ${options.sessionId});/help 查看命令${RST}`)
-  })
-
-  socket.on('message', raw => {
-    let event
-    try {
-      event = JSON.parse(raw.toString())
-    } catch {
-      return
-    }
-    if (event.type === 'audio.delta') {
+    }),
+    onStatus: status => {
+      if (status.state === 'ready') {
+        print(`${DIM}已连接(文本模式,会话 ${options.sessionId});/help 查看命令${RST}`)
+        resolveOpened()
+      } else if (status.state === 'unavailable') rejectOpened(status.error)
+      else if (status.state === 'disconnected') print(`${RED}连接已断开${RST}`)
+    },
+    onEvent: event => {
+      if (event.type === 'audio.delta') {
       // 文本客户端不放音频,但需要回执播放状态:
       // 网关把 assistant 转写押到 playback.started 之后才下发(与播放同步的设计)。
       const responseId = String(event.responseId || '')
       if (responseId && !startedResponses.has(responseId)) {
         startedResponses.add(responseId)
-        socket.send(JSON.stringify({ type: 'playback.started', responseId }))
+        client.send({ type: 'playback.started', responseId })
       }
-    } else if (event.type === 'audio.done') {
+      } else if (event.type === 'audio.done') {
       const responseId = String(event.responseId || '')
       if (responseId && startedResponses.has(responseId)) {
         startedResponses.delete(responseId)
-        socket.send(JSON.stringify({ type: 'playback.ended', responseId }))
+        client.send({ type: 'playback.ended', responseId })
       }
-    } else if (event.type === 'transcript.delta' && event.role === 'assistant') {
+      } else if (event.type === 'transcript.delta' && event.role === 'assistant') {
       if (!streaming) {
         process.stdout.write(`${BOLD}\u{1F916} ${RST}`)
         streaming = true
       }
       process.stdout.write(event.content || '')
-    } else if (event.type === 'transcript.final') {
+      } else if (event.type === 'transcript.final') {
       if (event.role === 'assistant') {
         if (streaming) {
           process.stdout.write('\n')
@@ -151,15 +151,16 @@ export async function runCli(options = parseArguments(process.argv.slice(2))) {
         const citations = formatCitationLines(event.citations)
         if (citations) print(`${DIM}${citations}${RST}`)
       }
-    } else if (event.type === 'error') {
+      } else if (event.type === 'error') {
       if (streaming) {
         process.stdout.write('\n')
         streaming = false
       }
       print(`${RED}[错误] ${event.message}${RST}`)
-    }
+      }
+    },
   })
-  socket.on('close', () => print(`${RED}连接已断开${RST}`))
+  client.start()
 
   await opened
   const readline = createInterface({ input: process.stdin })
@@ -175,23 +176,21 @@ export async function runCli(options = parseArguments(process.argv.slice(2))) {
       }
       try {
         if (command === '/tasks') {
-          const payload = await api(
-            `/api/tasks?sessionId=${encodeURIComponent(options.sessionId)}`,
-          )
+          const payload = await client.request(GatewayClientProtocolEvent.TASK_LIST)
           const tasks = payload.tasks || []
           if (!tasks.length) print(`${DIM}(无任务)${RST}`)
           tasks.forEach(task => print(`  ${YELLOW}${taskLine(task)}${RST}`))
         } else if (command === '/cancel') {
-          const payload = await api(
-            `/api/tasks?sessionId=${encodeURIComponent(options.sessionId)}`,
-          )
+          const payload = await client.request(GatewayClientProtocolEvent.TASK_LIST)
           const tasks = payload.tasks || []
           const target = selectCancellableTask(tasks, argument)
           if (!target) {
             print(`${RED}没有可取消的任务${RST}`)
             continue
           }
-          await api(`/api/tasks/${encodeURIComponent(target.id)}`, { method: 'DELETE' })
+          await client.request(GatewayClientProtocolEvent.TASK_CANCEL, {
+            task_id: target.id,
+          })
           print(`${DIM}· 已取消 ${target.id}${RST}`)
         } else {
           print(`${RED}未知命令 ${command}${RST}`)
@@ -202,13 +201,13 @@ export async function runCli(options = parseArguments(process.argv.slice(2))) {
       continue
     }
     const parts = await inputPartsFromText(text)
-    socket.send(JSON.stringify({
+    client.send({
       type: 'input.message',
       parts,
       textOnly: true,
-    }))
+    })
   }
-  socket.close()
+  client.stop()
   readline.close()
 }
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -220,6 +220,7 @@ export default function App() {
   const workSettledAtRef = useRef(workSettledAt)
   const lastWakeAtRef = useRef(0)
   const previousDesktopLifecycle = useRef('active')
+  const gatewayCommandsRef = useRef(null)
   const sessionIdRef = useRef(sessionId)
   sessionIdRef.current = sessionId
   const spriteAnimationCue = spriteAnimationCues[0] || null
@@ -278,15 +279,9 @@ export default function App() {
       }),
     ))
     try {
-      const response = await fetch(
-        `api/permissions/${encodeURIComponent(permission.id)}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ decision }),
-        },
-      )
-      if (response.status === 404 || response.status === 409) {
+      await gatewayCommandsRef.current?.respondPermission(permission.id, decision)
+    } catch (error) {
+      if (['permission_not_found', 'task_not_found'].includes(error.code)) {
         setAgentTasks(items => upsertTask(
           items,
           taskId,
@@ -294,11 +289,6 @@ export default function App() {
         ))
         return
       }
-      if (!response.ok) {
-        const payload = await response.json().catch(() => ({}))
-        throw new Error(payload.error || t('请求失败（{status}）', { status: response.status }))
-      }
-    } catch (error) {
       setAgentTasks(items => upsertTask(
         items,
         taskId,
@@ -464,43 +454,30 @@ export default function App() {
     ) {
       window.qwenAudioAgentDesktop?.wake()
     }
-    if (event.type === 'gateway.connected') {
-      fetch(`api/conversations/${encodeURIComponent(sessionId)}/messages`)
-        .then(response => response.ok ? response.json() : Promise.reject())
-        .then(payload => {
-          if (sessionIdRef.current !== sessionId) return
-          setMessages(items => mergeConversationHistory(items, payload.messages))
+    if (event.type === 'session.recovered') {
+      if (sessionIdRef.current !== sessionId) return
+      setMessages(items => mergeConversationHistory(items, event.messages || []))
+      const serverTasks = event.tasks || []
+      const byId = new Map(serverTasks.map(task => [task.id, task]))
+      setAgentTasks(items => {
+        const known = new Set(items.map(task => task.id))
+        const reconciled = items.flatMap(task => {
+          const current = byId.get(task.id)
+          if (current && taskDeliverySettled(current)) return []
+          if (current) return [taskView(current, task)]
+          if (task.phase !== 'disconnected') return [task]
+          return [{
+            ...task,
+            phase: 'failed',
+            error: t('网关重连后未找到这次后台执行，请重新提交。'),
+          }]
         })
-        .catch(() => {})
-      fetch(`api/tasks?sessionId=${encodeURIComponent(sessionId)}`)
-        .then(response => response.ok ? response.json() : Promise.reject())
-        .then(payload => {
-          const serverTasks = payload.tasks || []
-          const byId = new Map(serverTasks.map(task => [task.id, task]))
-          setAgentTasks(items => {
-            const known = new Set(items.map(task => task.id))
-            const reconciled = items.flatMap(task => {
-              const current = byId.get(task.id)
-              if (current && taskDeliverySettled(current)) return []
-              if (current) return [taskView(current, task)]
-              if (task.phase !== 'disconnected') return [task]
-              return [{
-                ...task,
-                phase: 'failed',
-                error: t('网关重连后未找到这次后台执行，请重新提交。'),
-              }]
-            })
-            serverTasks
-              .filter(task => (
-                taskNeedsPresentation(task)
-                && !known.has(task.id)
-              ))
-              .reverse()
-              .forEach(task => reconciled.push(taskView(task)))
-            return reconciled
-          })
-        })
-        .catch(() => {})
+        serverTasks
+          .filter(task => taskNeedsPresentation(task) && !known.has(task.id))
+          .reverse()
+          .forEach(task => reconciled.push(taskView(task)))
+        return reconciled
+      })
     }
     if (event.type === 'voice.deactivated') {
       setVoiceEnabled(false)
@@ -793,6 +770,7 @@ export default function App() {
       lastWakeAt: lastWakeAtRef.current,
     }),
   })
+  gatewayCommandsRef.current = voice
   const lifecycleTransition = (
     desktopOrbMode && desktopLifecycle !== 'active'
   )
@@ -1423,6 +1401,7 @@ export default function App() {
     <section className="workspace">
       {showDomainLibrary && <DomainLibraryPanel
         onClose={() => setShowDomainLibrary(false)}
+        getTask={voice.getTask}
       />}
       <div className="hero">
         <button

--- a/web/src/DomainLibraryPanel.jsx
+++ b/web/src/DomainLibraryPanel.jsx
@@ -20,7 +20,7 @@ function formatBytes(bytes) {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
-export default function DomainLibraryPanel({ onClose }) {
+export default function DomainLibraryPanel({ onClose, getTask }) {
   const [documents, setDocuments] = useState([])
   const [path, setPath] = useState('')
   const [busy, setBusy] = useState(false)
@@ -54,13 +54,7 @@ export default function DomainLibraryPanel({ onClose }) {
     if (!converting.length) return undefined
     const timer = setInterval(async () => {
       for (const item of converting) {
-        const response = await fetch(
-          `api/tasks/${encodeURIComponent(item.taskId)}`,
-          { cache: 'no-store' },
-        ).catch(() => null)
-        if (!response?.ok) continue
-        // /api/tasks/:id 直接返回 task 本身，不是 { task }
-        const task = await response.json().catch(() => null)
+        const task = await getTask?.(item.taskId).catch(() => null)
         const status = task?.status
         if (!status || ['queued', 'running', 'delegated', 'finalizing'].includes(status)) {
           continue
@@ -75,7 +69,7 @@ export default function DomainLibraryPanel({ onClose }) {
       }
     }, POLL_INTERVAL_MS)
     return () => clearInterval(timer)
-  }, [converting, refresh])
+  }, [converting, getTask, refresh])
 
   const submit = async event => {
     event.preventDefault()

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -10,9 +10,10 @@ import {
 } from '../../shared/gateway-client-state.mjs'
 import { clientInputCapabilities } from '../../shared/client-input-capabilities.mjs'
 import {
-  createGatewayProtocolEventId,
   GatewayClientProtocolEvent,
 } from '../../shared/gateway-client-protocol.mjs'
+import { GatewayClient } from '../../shared/gateway-client-sdk.mjs'
+import { gatewayReferenceClientCapabilities } from '../../shared/gateway-client-profiles.mjs'
 import { decodePcm, pcmBase64, resample } from './audio.js'
 import { confirmTrackedPlaybackStart } from './playback-lifecycle.js'
 import { t } from './i18n.js'
@@ -67,6 +68,10 @@ export function realtimeClientMode({
     // it must not claim voice ownership.
     outputEnabled: textOnly || inputOnlyMute === true || inputEnabled,
   }
+}
+
+export function gatewayClientCapabilities({ clientType = 'web' } = {}) {
+  return gatewayReferenceClientCapabilities(clientType)
 }
 
 // Keeps a persisted front end selection only while the server still offers it.
@@ -567,28 +572,83 @@ export default function useRealtimeVoice({
       setVisualError(false)
       return undefined
     }
-    let disposed = false
-    let reconnectTimer
-    let reconnectDelay = 500
     const mutedResponses = mutedPlaybackResponses.current
-    const connect = () => {
-      if (disposed) return
-      const socket = new WebSocket(socketUrl(sessionId))
-      socketRef.current = socket
-      socket.onopen = () => {
-        reconnectDelay = 500
+    const handleEvent = event => {
+      dispatchClientState(event)
+      if (event.type === GatewayServerEvent.VOICE_READY && event.inputSampleRate) {
+        inputSampleRate.current = event.inputSampleRate
+        hasConnectedRef.current = true
         setError('')
         setVisualError(false)
-        const connectedEvent = { type: GatewayServerEvent.GATEWAY_CONNECTED }
-        dispatchClientState(connectedEvent)
-        eventRef.current?.(connectedEvent)
+        flushPendingManualInputs()
+      }
+      if (event.type === GatewayServerEvent.VOICE_CONNECTION) {
+        if (event.state === 'connected') {
+          hasConnectedRef.current = true
+          setError('')
+          setVisualError(false)
+          flushPendingManualInputs()
+        } else if (event.state === 'unavailable') {
+          setError(event.message || t('语音前台连接异常，正在重试'))
+          setVisualError(true)
+        }
+      }
+      if (event.type === GatewayServerEvent.TURN_STARTED) {
+        currentTurnId.current = event.turnId || ''
+        if (
+          manualInputPendingRef.current
+          && String(event.turnId || '').startsWith('text_')
+        ) {
+          manualInputTurnRef.current = event.turnId
+        }
+      }
+      if (releasesManualInputGuard(event, manualInputTurnRef.current)) {
+        releaseManualInputGuard()
+      }
+      if (
+        event.type === GatewayServerEvent.VOICE_STATE
+        && acceptsVoiceState(event, currentTurnId.current)
+        && event.state === 'listening'
+      ) {
+        stopPlayback('user_interruption')
+      }
+      if (event.type === GatewayServerEvent.PLAYBACK_CLEAR) {
+        stopPlayback(event.reason || '')
+      }
+      if (event.type === GatewayServerEvent.AUDIO_DELTA) {
+        if (outputMutedRef.current || !audioRef.current) {
+          consumeMutedAudio(event.responseId)
+        } else {
+          play(event.audio, event.sampleRate, event.responseId)
+        }
+      }
+      if (event.type === GatewayServerEvent.AUDIO_DONE) {
+        if (mutedPlaybackResponses.current.has(event.responseId)) {
+          finishMutedAudio(event.responseId)
+        } else {
+          markAudioDone(event.responseId)
+        }
+      }
+      if (event.type === GatewayServerEvent.ERROR) setError(event.message)
+      eventRef.current?.(event)
+    }
+    const client = new GatewayClient({
+      url: socketUrl(sessionId),
+      createSocket: url => new WebSocket(url),
+      clientType,
+      clientLabel,
+      clientInstanceId: clientInstanceId.current,
+      capabilities: gatewayClientCapabilities({ clientType }),
+      locale: navigator.language,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      configure: () => {
         const mode = realtimeClientMode({
           enabled: enabledRef.current,
           inputReady: inputReadyRef.current,
           inputOnlyMute,
           wakeWordOnly: wakeWordOnlyRef.current,
         })
-        socket.send(JSON.stringify({
+        return {
           type: GatewayClientEvent.CONNECT,
           timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           locale: navigator.language,
@@ -607,145 +667,52 @@ export default function useRealtimeVoice({
           takeover,
           // Empty means "keep the server default front end".
           ...(realtimeProvider ? { provider: realtimeProvider } : {}),
-        }))
-      }
-      socket.onmessage = async message => {
-        let event
-        try {
-          event = JSON.parse(message.data)
-        } catch {
-          return
         }
-        if (event.type === GatewayClientProtocolEvent.CLIENT_ACTION_REQUEST) {
-          let result
-          try {
-            result = await clientActionRef.current?.(event)
-          } catch (error) {
-            result = {
-              status: 'failed',
-              error: {
-                code: 'client_action_failed',
-                message: String(error?.message || error).slice(0, 500),
-              },
-            }
-          }
-          const normalized = result?.status ? result : {
-            status: 'unsupported',
-            error: {
-              code: 'client_action_unsupported',
-              message: `Unsupported Client Action: ${String(event.name || '')}`,
-            },
-          }
-          if (socket.readyState === WebSocket.OPEN) {
-            socket.send(JSON.stringify({
-              type: GatewayClientProtocolEvent.CLIENT_ACTION_RESULT,
-              event_id: createGatewayProtocolEventId('client'),
-              request_event_id: event.event_id,
-              status: normalized.status,
-              ...(normalized.output === undefined
-                ? {}
-                : { output: normalized.output }),
-              ...(normalized.error ? { error: normalized.error } : {}),
-            }))
-          }
-          return
-        }
-        dispatchClientState(event)
-        if (event.type === GatewayServerEvent.VOICE_READY && event.inputSampleRate) {
-          inputSampleRate.current = event.inputSampleRate
-          hasConnectedRef.current = true
+      },
+      onEvent: handleEvent,
+      onAction: event => clientActionRef.current?.(event),
+      onRecovery: recovery => eventRef.current?.({
+        type: 'session.recovered',
+        ...recovery,
+      }),
+      onStatus: status => {
+        if (status.state === 'connected') {
           setError('')
           setVisualError(false)
-          flushPendingManualInputs()
-        }
-        if (event.type === GatewayServerEvent.VOICE_CONNECTION) {
-          if (event.state === 'connected') {
-            hasConnectedRef.current = true
-            setError('')
-            setVisualError(false)
-            flushPendingManualInputs()
-          } else if (event.state === 'unavailable') {
-            setError(event.message || t('语音前台连接异常，正在重试'))
-            setVisualError(true)
-          }
-        }
-        if (event.type === GatewayServerEvent.TURN_STARTED) {
-          currentTurnId.current = event.turnId || ''
-          if (
-            manualInputPendingRef.current
-            && String(event.turnId || '').startsWith('text_')
-          ) {
-            manualInputTurnRef.current = event.turnId
-          }
-        }
-        if (releasesManualInputGuard(event, manualInputTurnRef.current)) {
-          releaseManualInputGuard()
-        }
-        if (event.type === GatewayServerEvent.VOICE_STATE) {
-          if (acceptsVoiceState(event, currentTurnId.current)) {
-            if (event.state === 'listening') {
-              stopPlayback('user_interruption')
-            }
-          }
-        }
-        if (event.type === GatewayServerEvent.PLAYBACK_CLEAR) {
-          stopPlayback(event.reason || '')
-        }
-        if (event.type === GatewayServerEvent.AUDIO_DELTA) {
-          if (outputMutedRef.current || !audioRef.current) {
-            consumeMutedAudio(event.responseId)
-          } else {
-            play(event.audio, event.sampleRate, event.responseId)
-          }
-        }
-        if (event.type === GatewayServerEvent.AUDIO_DONE) {
-          if (mutedPlaybackResponses.current.has(event.responseId)) {
-            finishMutedAudio(event.responseId)
-          } else {
-            markAudioDone(event.responseId)
-          }
-        }
-        if (event.type === GatewayServerEvent.ERROR) setError(event.message)
-        eventRef.current?.(event)
-      }
-      socket.onerror = () => {
-        if (!disposed) {
+          const connectedEvent = { type: GatewayServerEvent.GATEWAY_CONNECTED }
+          dispatchClientState(connectedEvent)
+          eventRef.current?.(connectedEvent)
+        } else if (status.state === 'unavailable') {
           dispatchClientState({
             type: GatewayServerEvent.VOICE_CONNECTION,
             state: 'unavailable',
           })
           setError(t('实时语音连接中断，正在重连'))
           setVisualError(true)
-        }
-      }
-      socket.onclose = () => {
-        if (socketRef.current === socket) socketRef.current = null
-        if (disposed) return
-        releaseManualInputGuard()
-        stopPlayback()
-        const disconnectedEvent = {
+        } else if (status.state === 'disconnected') {
+          releaseManualInputGuard()
+          stopPlayback()
+          const disconnectedEvent = {
           type: GatewayServerEvent.GATEWAY_DISCONNECTED,
         }
         dispatchClientState(disconnectedEvent)
-        setError(t('实时语音连接中断，正在重连'))
-        setVisualError(true)
-        eventRef.current?.(disconnectedEvent)
-        reconnectTimer = setTimeout(connect, reconnectDelay)
-        reconnectDelay = Math.min(5000, reconnectDelay * 2)
+          setError(t('实时语音连接中断，正在重连'))
+          setVisualError(true)
+          eventRef.current?.(disconnectedEvent)
+        }
       }
-    }
+    })
+    socketRef.current = client
     setError('')
     dispatchClientState({
       type: GatewayServerEvent.VOICE_CONNECTION,
       state: 'connecting',
     })
-    connect()
+    client.start()
 
     return () => {
-      disposed = true
-      clearTimeout(reconnectTimer)
       stopPlayback(suspended ? 'desktop_hidden' : 'connection_closed')
-      socketRef.current?.close()
+      client.stop()
       socketRef.current = null
       mutedResponses.clear()
       releaseManualInputGuard()
@@ -913,6 +880,35 @@ export default function useRealtimeVoice({
     })
   ), [sendSocketEvent])
 
+  const requestGateway = useCallback((type, payload = {}) => {
+    const client = socketRef.current
+    if (!client?.request) {
+      return Promise.reject(Object.assign(new Error('Gateway 尚未连接'), {
+        code: 'client_not_ready',
+      }))
+    }
+    return client.request(type, payload)
+  }, [])
+  const listTasks = useCallback(options => requestGateway(
+    GatewayClientProtocolEvent.TASK_LIST,
+    options,
+  ).then(result => result.tasks), [requestGateway])
+  const getTask = useCallback(taskId => requestGateway(
+    GatewayClientProtocolEvent.TASK_GET,
+    { task_id: taskId },
+  ).then(result => result.task), [requestGateway])
+  const cancelTask = useCallback(taskId => requestGateway(
+    GatewayClientProtocolEvent.TASK_CANCEL,
+    { task_id: taskId },
+  ).then(result => result.task), [requestGateway])
+  const respondPermission = useCallback((permissionId, decision) => requestGateway(
+    GatewayClientProtocolEvent.PERMISSION_RESPOND,
+    { permission_id: permissionId, decision },
+  ).then(result => result.permission), [requestGateway])
+  const conversationHistory = useCallback(() => requestGateway(
+    GatewayClientProtocolEvent.CONVERSATION_HISTORY,
+  ).then(result => result.messages), [requestGateway])
+
   const sendInput = useCallback(parts => {
     holdManualInputGuard()
     const event = {
@@ -946,5 +942,10 @@ export default function useRealtimeVoice({
     wake,
     publishClientEvent,
     sendInput,
+    listTasks,
+    getTask,
+    cancelTask,
+    respondPermission,
+    conversationHistory,
   }
 }


### PR DESCRIPTION
## Summary\n\n- add the shared Gateway Client SDK and first-party capability profiles\n- migrate WebUI, Desktop, and TUI task/history/permission flows to the v6 WebSocket protocol\n- add bounded Task-event replay with snapshot reconciliation after reconnect\n- enforce the documented single active Gateway Client connection\n- lock the GCP5 contract, conformance tests, and compatibility-alias deprecation window\n\n## Validation\n\n- root tests: 96 passed, 1 skipped\n- server suite: 413 passed; the existing Node test-runner open handle still requires manual termination\n- WebUI: 97 passed; production build passed\n- Desktop: passed\n- TUI: 56 passed\n- CLI: 143 passed\n- lint, build, release dependency audit, npm dry-run pack, and diff checks passed\n\nCompletes the GCP5 implementation tracked in #251.