### PR TITLE
docs: link the user guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qwen Audio Agent
 
-[中文](README_ZH.md) | [English](README.md)
+[中文](README_ZH.md) | [English](README.md) | [User Guide](https://qwenaudio.github.io/qwen-audio-agent/) | [Quickstart](https://qwenaudio.github.io/qwen-audio-agent/getting-started/quickstart)
 
 [![CI](https://github.com/QwenAudio/qwen-audio-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/QwenAudio/qwen-audio-agent/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/qwen-audio-agent)](https://www.npmjs.com/package/qwen-audio-agent)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,6 +1,6 @@
 # Qwen Audio Agent
 
-[中文](README_ZH.md) | [English](README.md)
+[中文](README_ZH.md) | [English](README.md) | [用户手册](https://qwenaudio.github.io/qwen-audio-agent/zh/) | [快速开始](https://qwenaudio.github.io/qwen-audio-agent/zh/getting-started/quickstart)
 
 [![CI](https://github.com/QwenAudio/qwen-audio-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/QwenAudio/qwen-audio-agent/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/qwen-audio-agent)](https://www.npmjs.com/package/qwen-audio-agent)


### PR DESCRIPTION
## Summary

- add the English User Guide and Quickstart links to the README language navigation
- add the matching Chinese user manual and quickstart links

## Validation

- `git diff --check`
- verified all four documentation URLs return successfully