### PR TITLE
fix(acp): declare builtin computer-use MCP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- 修复内置 `open-computer-use` MCP 缺少 `stdio` 传输类型，导致 Kimi Code 等严格
+  校验 ACP MCP 描述的后台无法创建 Session 的问题。
 - 新增 Pi 后台支持：通过社区 `pi-acp` 适配器接入，并支持一键安装。Pi 没有
   内置沙箱与权限审批机制，始终等效于 `full` 权限，请仅在可信环境中使用。
 

--- a/server/src/agent/builtin-mcp.mjs
+++ b/server/src/agent/builtin-mcp.mjs
@@ -59,6 +59,7 @@ export function computerUseMcpServer(env = process.env) {
   if (!binPath) return null
   const descriptor = {
     name: 'open-computer-use',
+    type: 'stdio',
     command: process.execPath,
     args: [binPath, 'mcp'],
     // The bin is a Node script; when the Gateway runs inside Electron the

--- a/server/test/acp-backend-adapter.test.mjs
+++ b/server/test/acp-backend-adapter.test.mjs
@@ -2485,6 +2485,7 @@ test('reports recent project Session updates with Gateway delegation status', as
 test('injects builtin MCP servers into coordinator and project sessions', async () => {
   const builtin = {
     name: 'open-computer-use',
+    type: 'stdio',
     command: process.execPath,
     args: ['/repo/node_modules/open-computer-use/bin', 'mcp'],
     env: [{ name: 'ELECTRON_RUN_AS_NODE', value: '1' }],
@@ -2542,9 +2543,11 @@ test('injects builtin MCP servers into coordinator and project sessions', async 
   assert.equal(coordinator.length, 2)
   assert.equal(coordinator[0].type, 'http')
   assert.equal(coordinator[1], builtin)
+  assert.equal(coordinator[1].type, 'stdio')
 
   const project = sessionMcp.get('project-session')
   assert.deepEqual(project, [builtin])
+  assert.equal(project[0].type, 'stdio')
   await adapter.close()
 })
 

--- a/server/test/builtin-mcp.test.mjs
+++ b/server/test/builtin-mcp.test.mjs
@@ -10,6 +10,7 @@ test('computer-use MCP server resolves as stdio descriptor by default', () => {
   const descriptor = computerUseMcpServer({})
   assert.ok(descriptor, 'expected descriptor when package is installed')
   assert.equal(descriptor.name, 'open-computer-use')
+  assert.equal(descriptor.type, 'stdio')
   assert.equal(descriptor.command, process.execPath)
   assert.equal(descriptor.args.length, 2)
   assert.match(descriptor.args[0], /open-computer-use/)


### PR DESCRIPTION
## Summary

- declare the built-in `open-computer-use` MCP server as `type: "stdio"`
- keep the standard descriptor unchanged for other ACP backends
- verify the descriptor survives coordinator and delegated Session injection
- document the Kimi Code strict-validation compatibility fix

Closes #176.
Supersedes #253 while preserving contributor attribution.

## Validation

- `node --test server/test/builtin-mcp.test.mjs server/test/acp-backend-adapter.test.mjs`
- `npm test --workspace @qwen-audio-agent/server`
- `npm run lint`
- `git diff --check`