### PR TITLE
feat: support OrcaRouter as a managed OpenClaw model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ AGENT_PROTOCOL=openclaw
 # Pi 没有权限审批机制，无论配置什么都始终生效 full。
 # QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
 # QWEN_AUDIO_AGENT_BACKEND_AGENT=
+# 可选：OpenCode/OpenClaw 自动配置支持两种云端模型服务。
+# 默认使用百炼（DASHSCOPE_API_KEY）；设置 OPENCLAW_ORCAROUTER_API_KEY（或
+# ORCAROUTER_API_KEY）后改用 OrcaRouter（https://api.orcarouter.ai/v1）。
+# OPENCLAW_ORCAROUTER_API_KEY=sk-orca-...
 # 可选：通过 ACP 标准覆盖 Session 模型；OpenCode/OpenClaw 托管初始化也会使用。
 # 后台未声明 ACP 模型选项时请留空，沿用 Agent 原有配置
 # QWEN_AUDIO_AGENT_BACKEND_MODEL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- OpenClaw 一键托管初始化支持使用 OrcaRouter 作为模型服务：设置
+  `OPENCLAW_ORCAROUTER_API_KEY`（或 `ORCAROUTER_API_KEY`）后，自动生成的 OpenClaw
+  配置将对接 `https://api.orcarouter.ai/v1`，与百炼配置互为替代。
 - 后台 Session 模型覆盖统一使用 ACP `configOptions` 与
   `session/set_config_option`，不再调用私有模型接口或生成后台配置文件；未声明标准
   模型选项的 Agent 将沿用自身配置。OpenCode/OpenClaw 一键托管初始化保持不变。

--- a/cli/test/backend-runtime-discovery.test.mjs
+++ b/cli/test/backend-runtime-discovery.test.mjs
@@ -292,9 +292,10 @@ test('automatic fallback requires explicit Bailian setup', {
 
     const openClawResult = execute('scripts/openclaw.mjs', openClaw, {
       OPENCLAW_RUNTIME: 'auto',
+      ORCAROUTER_API_KEY: '',
     }, ['acp'])
     assert.notEqual(openClawResult.status, 0)
-    assert.match(openClawResult.stderr, /requires DASHSCOPE_API_KEY/)
+    assert.match(openClawResult.stderr, /requires a DASHSCOPE_API_KEY or OPENCLAW_ORCAROUTER_API_KEY/)
   } finally {
     openCode.close()
     openClaw.close()
@@ -613,6 +614,43 @@ test('automatically configures explicit Bailian models for OpenCode and OpenClaw
     )), true)
   } finally {
     openCode.close()
+    openClaw.close()
+  }
+})
+
+test('provisions managed OpenClaw against OrcaRouter when its key is set', {
+  skip: process.platform === 'win32',
+}, () => {
+  const openClaw = fixture()
+  try {
+    command(resolve(openClaw.bin, 'openclaw'), {
+      version: 'OpenClaw 2026.6.33',
+      captureModels: true,
+    })
+    const openClawOutput = run('scripts/openclaw.mjs', openClaw, {
+      OPENCLAW_ORCAROUTER_API_KEY: 'sk-orca-test',
+      QWEN_AUDIO_AGENT_BACKEND_MODEL: 'openai/gpt-4o-mini',
+    }, ['gateway', 'run'])
+    assert.deepEqual(openClawOutput.slice(-5), [
+      'OPENCODE_MODEL=',
+      'OPENCLAW_MODEL=orcarouter/openai/gpt-4o-mini',
+      'OPENCLAW_MODEL_ID=openai/gpt-4o-mini',
+      `OPENCLAW_CONFIG_PATH=${resolve(
+        openClaw.directory,
+        'config/backends/openclaw/openclaw.json5',
+      )}`,
+      `OPENCLAW_STATE_DIR=${resolve(
+        openClaw.directory,
+        'config/backends/openclaw/state/gateway-18789',
+      )}`,
+    ])
+    const config = readFileSync(resolve(
+      openClaw.directory,
+      'config/backends/openclaw/openclaw.json5',
+    ), 'utf8')
+    assert.match(config, /api\.orcarouter\.ai/)
+    assert.match(config, /openai-completions/)
+  } finally {
     openClaw.close()
   }
 })

--- a/cli/test/backend-setup.test.mjs
+++ b/cli/test/backend-setup.test.mjs
@@ -165,6 +165,30 @@ test('does not report automatic fallback ready without Bailian setup', () => {
   }
 })
 
+test('reports automatic OpenClaw package setup with OrcaRouter', () => {
+  const openClaw = inspector({
+    backend: 'openclaw',
+    env: {
+      OPENCLAW_ORCAROUTER_API_KEY: 'sk-orca-test',
+      QWEN_AUDIO_AGENT_BACKEND_MODEL: 'openai/gpt-4o-mini',
+    },
+    commands: { npx: '/bin/npx' },
+  }).backends[0]
+  assert.equal(openClaw.ready, true)
+  assert.equal(openClaw.backend.source, 'managed')
+  assert.equal(openClaw.configuration, 'automatic-orcarouter')
+
+  const aliased = inspector({
+    backend: 'openclaw',
+    env: {
+      ORCAROUTER_API_KEY: 'sk-orca-test',
+      QWEN_AUDIO_AGENT_BACKEND_MODEL: 'openai/gpt-4o-mini',
+    },
+    commands: { npx: '/bin/npx' },
+  }).backends[0]
+  assert.equal(aliased.configuration, 'automatic-orcarouter')
+})
+
 test('checks explicit generic ACP commands and adapter binaries', () => {
   const generic = inspector({
     backend: 'acp',

--- a/config/openclaw/openclaw.json5
+++ b/config/openclaw/openclaw.json5
@@ -19,6 +19,23 @@
           },
         ],
       },
+      orcarouter: {
+        baseUrl: "https://api.orcarouter.ai/v1",
+        apiKey: { source: "env", provider: "default", id: "OPENCLAW_ORCAROUTER_API_KEY" },
+        api: "openai-completions",
+        models: [
+          {
+            id: "${QWEN_AUDIO_AGENT_OPENCLAW_MODEL_ID}",
+            name: "${QWEN_AUDIO_AGENT_OPENCLAW_MODEL_ID}",
+            reasoning: false,
+            input: ["text"],
+            contextWindow: 200000,
+            maxTokens: 8192,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            compat: { thinkingFormat: "openai" },
+          },
+        ],
+      },
     },
   },
   agents: {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,11 @@ QWEN_AUDIO_AGENT_BACKEND_MODEL=qwen3.7-max
 ```
 
 With the above configuration, OpenCode and OpenClaw can automatically download compatible
-versions and configure the Bailian model, enabling one-click startup. If no backend model is
+versions and configure the Bailian model, enabling one-click startup. For the OpenClaw backend,
+setting `OPENCLAW_ORCAROUTER_API_KEY` (or `ORCAROUTER_API_KEY`) instead of `DASHSCOPE_API_KEY`
+provisions the managed instance against [OrcaRouter](https://www.orcarouter.ai)
+(`https://api.orcarouter.ai/v1`), an OpenAI-compatible AI gateway for models and agents.
+If no backend model is
 specified, the user's already installed and configured Agent is used preferentially, without
 overwriting its models, providers, tools, MCPs, Skills, and authentication. Other backends
 currently require users to install and configure them manually.

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -88,7 +88,10 @@ QWEN_AUDIO_AGENT_BACKEND_MODEL=qwen3.7-max
 ```
 
 OpenCode 和 OpenClaw 在以上配置下可以自动下载兼容版本并配置百炼模型，实现
-一键启动。若未指定后台模型，则优先使用用户已经安装和配置的 Agent，不覆盖其
+一键启动。OpenClaw 后台也可以改设 `OPENCLAW_ORCAROUTER_API_KEY`（或
+`ORCAROUTER_API_KEY`）代替 `DASHSCOPE_API_KEY`，让托管实例对接
+[OrcaRouter](https://www.orcarouter.ai)（`https://api.orcarouter.ai/v1`），
+一个面向模型与 Agent 的 OpenAI 兼容 AI 网关。若未指定后台模型，则优先使用用户已经安装和配置的 Agent，不覆盖其
 模型、Provider、工具、MCP、Skill 和认证。其他后台暂时需要用户自行安装配置。
 
 这是 qwen-audio-agent 唯一的后台 Session 模型覆盖入口。模型 ID 是后台通过 ACP

--- a/docs/configuration/backend.md
+++ b/docs/configuration/backend.md
@@ -198,7 +198,12 @@ When `OPENCLAW_BASE_URL` is not set, it preferentially launches the `openclaw`
 in the user environment. When both
 `DASHSCOPE_API_KEY` and `QWEN_AUDIO_AGENT_BACKEND_MODEL` are provided, an independent Bailian
 configuration and state directory is generated for the qwen-audio-agent process, without
-modifying the user's native configuration. When no backend model is specified, it inherits the
+modifying the user's native configuration. Alternatively, setting
+`OPENCLAW_ORCAROUTER_API_KEY` (or `ORCAROUTER_API_KEY`) instead of `DASHSCOPE_API_KEY`
+provisions the managed instance against [OrcaRouter](https://www.orcarouter.ai)
+(`https://api.orcarouter.ai/v1`) — an OpenAI-compatible AI gateway that provides
+adaptive routing, failover, zero-markup inference, observability, and guardrails for
+models and agents. When no backend model is specified, it inherits the
 user's native configuration, models, and authentication, but does not enable external messaging
 channels such as DingTalk in the independent instance. In managed mode, if the original configuration
 has enabled a Gateway Token, it will be automatically read and used for local ACP connections; it can

--- a/docs/configuration/backend.zh.md
+++ b/docs/configuration/backend.zh.md
@@ -166,7 +166,11 @@ qwen-audio-agent Gateway 关闭。
 未设置 `OPENCLAW_BASE_URL` 时，默认优先启动用户环境中的 `openclaw`。同时提供
 `DASHSCOPE_API_KEY` 和
 `QWEN_AUDIO_AGENT_BACKEND_MODEL` 时，会为 qwen-audio-agent 进程生成独立的
-百炼配置和状态目录，不修改用户原生配置。未指定后台模型时则继承用户的原生
+百炼配置和状态目录，不修改用户原生配置。也可以改设
+`OPENCLAW_ORCAROUTER_API_KEY`（或 `ORCAROUTER_API_KEY`）代替 `DASHSCOPE_API_KEY`，
+让托管实例对接 [OrcaRouter](https://www.orcarouter.ai)
+（`https://api.orcarouter.ai/v1`）——一个 OpenAI 兼容的 AI 网关，提供自适应路由、
+故障转移、零加价推理、可观测性和护栏，同时服务模型与 Agent。未指定后台模型时则继承用户的原生
 配置、模型和认证，但不会在独立实例中启用钉钉等外部消息渠道。自管模式下若原配置
 启用了 Gateway Token，会自动读取并用于本地 ACP 连接；也可以通过
 `OPENCLAW_GATEWAY_TOKEN` 覆盖，或设置 `OPENCLAW_CONFIG_PATH` 明确指定另一份

--- a/scripts/openclaw.mjs
+++ b/scripts/openclaw.mjs
@@ -54,17 +54,26 @@ process.env.QWEN_AUDIO_AGENT_OPENCLAW_STATE_DIR = STATE_DIR
 process.env.QWEN_AUDIO_AGENT_OPENCLAW_WORKSPACE = WORKSPACE
 mkdirSync(STATE_DIR, { recursive: true })
 mkdirSync(WORKSPACE, { recursive: true })
-// ── managed (DashScope) OpenClaw ─────────────────────────────────────────────
+// ── managed (DashScope/OrcaRouter) OpenClaw ──────────────────────────────────
 
 let managed = false
 const MODEL = (process.env.QWEN_AUDIO_AGENT_BACKEND_MODEL || '').toLowerCase()
 const EXTERNAL_SERVICE = (
   process.env.QWEN_AUDIO_AGENT_BACKEND_OWNERSHIP === 'external'
 )
+const OPENCLAW_ORCAROUTER_API_KEY = (
+  process.env.OPENCLAW_ORCAROUTER_API_KEY || ''
+).trim()
+const ORCAROUTER_API_KEY = OPENCLAW_ORCAROUTER_API_KEY
+  || (process.env.DASHSCOPE_API_KEY ? '' : (process.env.ORCAROUTER_API_KEY || '').trim())
+const MANAGED_PROVIDER = ORCAROUTER_API_KEY ? 'orcarouter' : 'bailian'
+const managedCredential = ORCAROUTER_API_KEY
+  || process.env.DASHSCOPE_API_KEY
+  || ''
 if (
   !EXTERNAL_SERVICE
   && !process.env.OPENCLAW_CONFIG_PATH
-  && process.env.DASHSCOPE_API_KEY
+  && managedCredential
   && MODEL
   && MODEL !== 'auto'
 ) {
@@ -73,10 +82,18 @@ if (
   mkdirSync(cfgDir, { recursive: true })
   copyFileSync(join(ROOT, 'config', 'openclaw', 'openclaw.json5'), join(cfgDir, 'openclaw.json5'))
   process.env.OPENCLAW_CONFIG_PATH = join(cfgDir, 'openclaw.json5')
-  const modelId = process.env.QWEN_AUDIO_AGENT_BACKEND_MODEL.includes('/')
-    ? process.env.QWEN_AUDIO_AGENT_BACKEND_MODEL.split('/')[1] : process.env.QWEN_AUDIO_AGENT_BACKEND_MODEL
-  process.env.QWEN_AUDIO_AGENT_OPENCLAW_MODEL = `bailian/${modelId}`
+  const rawModel = process.env.QWEN_AUDIO_AGENT_BACKEND_MODEL.trim()
+  // OrcaRouter model names are provider-scoped (e.g. openai/gpt-4o-mini); the
+  // provider prefix above must be stripped by OpenClaw before the request, so
+  // the full path stays in the model id. Bailian models are bare names.
+  const modelId = MANAGED_PROVIDER === 'orcarouter'
+    ? rawModel
+    : (rawModel.includes('/')
+        ? rawModel.split('/')[1]
+        : rawModel)
+  process.env.QWEN_AUDIO_AGENT_OPENCLAW_MODEL = `${MANAGED_PROVIDER}/${modelId}`
   process.env.QWEN_AUDIO_AGENT_OPENCLAW_MODEL_ID = modelId
+  process.env.OPENCLAW_ORCAROUTER_API_KEY = ORCAROUTER_API_KEY
 }
 
 // ── gateway-specific setup ───────────────────────────────────────────────────
@@ -164,7 +181,9 @@ async function runPackage() {
   await spawnAndProxy(binary, CLI_ARGS)
 }
 async function runManaged() {
-  if (!process.env.DASHSCOPE_API_KEY) fatal('Automatic OpenClaw setup requires DASHSCOPE_API_KEY.')
+  if (!managedCredential) {
+    fatal('Automatic OpenClaw setup requires a DASHSCOPE_API_KEY or OPENCLAW_ORCAROUTER_API_KEY.')
+  }
   if (!process.env.QWEN_AUDIO_AGENT_BACKEND_MODEL || MODEL === 'auto') {
     fatal('Automatic OpenClaw setup requires QWEN_AUDIO_AGENT_BACKEND_MODEL.')
   }

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -81,10 +81,17 @@ export function resolveBackendModels(env = process.env) {
   ).trim()
   const common = configured.toLowerCase() === 'auto' ? '' : configured
   const name = backendModelName(common)
+  const orcarouter = Boolean(
+    String(env.OPENCLAW_ORCAROUTER_API_KEY || '').trim()
+    || (
+      !String(env.DASHSCOPE_API_KEY || '').trim()
+      && String(env.ORCAROUTER_API_KEY || '').trim()
+    ),
+  )
   return {
     common,
     openCode: common ? `alibaba-cn/${name}` : '',
-    openClaw: common ? `bailian/${name}` : '',
+    openClaw: common ? `${orcarouter ? 'orcarouter' : 'bailian'}/${name}` : '',
     qoder: common,
     qwen: common,
     kimi: common,
@@ -156,6 +163,19 @@ const managedOpenClawBailian = (
   && Boolean(process.env.DASHSCOPE_API_KEY)
   && !process.env.OPENCLAW_CONFIG_PATH
 )
+const managedOpenClawOrcaRouter = (
+  configuredAgentProtocol === 'openclaw'
+  && Boolean(backendModels.common)
+  && Boolean(
+    String(process.env.OPENCLAW_ORCAROUTER_API_KEY || '').trim()
+    || (
+      !String(process.env.DASHSCOPE_API_KEY || '').trim()
+      && String(process.env.ORCAROUTER_API_KEY || '').trim()
+    ),
+  )
+  && !process.env.OPENCLAW_CONFIG_PATH
+)
+const managedOpenClaw = managedOpenClawBailian || managedOpenClawOrcaRouter
 const requestedBackendPermissionMode = String(
   process.env.QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE || 'native',
 ).toLowerCase()
@@ -292,7 +312,7 @@ export const config = {
           process.env.OPENCLAW_COORDINATOR_AGENT,
           'voice-coordinator',
         )
-        || (managedOpenClawBailian ? 'qwen-audio-agent-backend' : '')
+        || (managedOpenClaw ? 'qwen-audio-agent-backend' : '')
       ),
     },
     qoder: {

--- a/server/src/process/backend-drivers/openclaw.mjs
+++ b/server/src/process/backend-drivers/openclaw.mjs
@@ -38,12 +38,18 @@ export const openClawRuntimeDriver = {
   },
 
   prepareEnvironment(env, backend) {
-    const managedBailian = backend.ownership === 'owned'
+    const managedCredential = (
+      env.OPENCLAW_ORCAROUTER_API_KEY
+      || (!env.DASHSCOPE_API_KEY && env.ORCAROUTER_API_KEY)
+      || env.DASHSCOPE_API_KEY
+      || ''
+    )
+    const managed = backend.ownership === 'owned'
       && !String(env.OPENCLAW_CONFIG_PATH || '').trim()
-      && Boolean(String(env.DASHSCOPE_API_KEY || '').trim())
+      && Boolean(String(managedCredential).trim())
       && Boolean(String(env.QWEN_AUDIO_AGENT_BACKEND_MODEL || '').trim())
       && String(env.QWEN_AUDIO_AGENT_BACKEND_MODEL).trim().toLowerCase() !== 'auto'
-    if (managedBailian && !String(env.OPENCLAW_GATEWAY_TOKEN || '').trim()) {
+    if (managed && !String(env.OPENCLAW_GATEWAY_TOKEN || '').trim()) {
       // Gateway transport authentication is independent from the local user
       // identity signing secret and remains private to this backend plugin.
       env.OPENCLAW_GATEWAY_TOKEN = randomBytes(32).toString('hex')

--- a/server/test/config.test.mjs
+++ b/server/test/config.test.mjs
@@ -232,6 +232,32 @@ test('uses a DeepSeek-specific model without leaking unrelated overrides', () =>
   }).deepSeekHarness, '')
 })
 
+test('maps managed OpenClaw models to OrcaRouter when its key is present', () => {
+  for (const key of ['OPENCLAW_ORCAROUTER_API_KEY', 'ORCAROUTER_API_KEY']) {
+    assert.deepEqual(resolveBackendModels({
+      QWEN_AUDIO_AGENT_BACKEND_MODEL: 'qwen3.7-plus',
+      [key]: 'sk-orca-test',
+    }), {
+      common: 'qwen3.7-plus',
+      openCode: 'alibaba-cn/qwen3.7-plus',
+      openClaw: 'orcarouter/qwen3.7-plus',
+      qoder: 'qwen3.7-plus',
+      qwen: 'qwen3.7-plus',
+      kimi: 'qwen3.7-plus',
+      hermes: 'qwen3.7-plus',
+      codeBuddy: 'qwen3.7-plus',
+      codex: 'qwen3.7-plus',
+      claude: 'qwen3.7-plus',
+      pi: 'qwen3.7-plus',
+      deepSeekHarness: '',
+      acp: 'qwen3.7-plus',
+    })
+  }
+  assert.equal(resolveBackendModels({
+    QWEN_AUDIO_AGENT_BACKEND_MODEL: 'qwen3.7-max',
+  }).openClaw, 'bailian/qwen3.7-max')
+})
+
 test('changes the realtime configuration signature when only the model changes', () => {
   const shared = {
     DASHSCOPE_API_KEY: 'same-key',

--- a/server/test/managed-backend.test.mjs
+++ b/server/test/managed-backend.test.mjs
@@ -143,6 +143,28 @@ test('Gateway-owned backend moves away from occupied ports', async () => {
   assert.deepEqual(signals, [[-4242, 'SIGTERM']])
 })
 
+test('provisions an OrcaRouter-managed OpenClaw Gateway token', async () => {
+  const env = {
+    AGENT_PROTOCOL: 'openclaw',
+    QWEN_AUDIO_AGENT_BACKEND_OWNERSHIP: 'owned',
+    OPENCLAW_BASE_URL: 'http://127.0.0.1:18789',
+    OPENCLAW_ORCAROUTER_API_KEY: 'sk-orca-test',
+    QWEN_AUDIO_AGENT_BACKEND_MODEL: 'openai/gpt-4o-mini',
+  }
+  const child = childProcess()
+  const runtime = await startManagedBackend({
+    root: '/repo',
+    env,
+    platform: 'darwin',
+    isAddressInUse: async () => false,
+    findFreeAddress: async () => 'http://127.0.0.1:45679',
+    spawnImpl: () => child,
+  })
+  runtime.killImpl = () => {}
+  assert.equal(env.OPENCLAW_GATEWAY_TOKEN.length, 64)
+  runtime.close()
+})
+
 test('force-stops a managed backend that ignores graceful shutdown', async () => {
   const env = {
     AGENT_PROTOCOL: 'openclaw',

--- a/shared/backend-setup.mjs
+++ b/shared/backend-setup.mjs
@@ -367,6 +367,16 @@ function inspectBackend(id, {
     && Boolean(clean(env.QWEN_AUDIO_AGENT_BACKEND_MODEL))
     && clean(env.QWEN_AUDIO_AGENT_BACKEND_MODEL).toLowerCase() !== 'auto'
   )
+  const automaticOrcaRouter = (
+    id === 'openclaw'
+    && Boolean(
+      clean(env.OPENCLAW_ORCAROUTER_API_KEY)
+      || (!clean(env.DASHSCOPE_API_KEY) && clean(env.ORCAROUTER_API_KEY)),
+    )
+    && Boolean(clean(env.QWEN_AUDIO_AGENT_BACKEND_MODEL))
+    && clean(env.QWEN_AUDIO_AGENT_BACKEND_MODEL).toLowerCase() !== 'auto'
+  )
+  const automaticManaged = automaticBailian || automaticOrcaRouter
   // 桌面版运行时不做 npx 自动部署，检测同样关闭 managed 回退分支。
   const installedOnly = clean(env.QWEN_AUDIO_AGENT_DESKTOP_INSTALLED_ONLY) === '1'
   let backend = explicitRuntime(id, env, find)
@@ -393,7 +403,7 @@ function inspectBackend(id, {
       && runtime === 'auto'
     ) {
       const npx = find('npx')
-      if (npx && automaticBailian) {
+      if (npx && automaticManaged) {
         backend = {
           ready: true,
           source: 'managed',
@@ -401,7 +411,7 @@ function inspectBackend(id, {
         }
       } else if (npx) {
         backend.issue = `未找到 ${definition.label}；自动部署需要 `
-          + 'DASHSCOPE_API_KEY 和 QWEN_AUDIO_AGENT_BACKEND_MODEL'
+          + 'DASHSCOPE_API_KEY（或 OPENCLAW_ORCAROUTER_API_KEY）和 QWEN_AUDIO_AGENT_BACKEND_MODEL'
       }
     }
   }
@@ -415,7 +425,7 @@ function inspectBackend(id, {
     backend.version = version
     if (!versionAtLeast(version, spec.minimumVersion)) {
       const npx = !installedOnly && runtime === 'auto' ? find('npx') : ''
-      if (npx && automaticBailian) {
+      if (npx && automaticManaged) {
         backend = {
           ready: true,
           source: 'managed',
@@ -426,7 +436,7 @@ function inspectBackend(id, {
         backend.ready = false
         backend.issue = npx
           ? `OpenCode ${version || '版本未知'} 不兼容；自动部署需要 `
-            + 'DASHSCOPE_API_KEY 和 QWEN_AUDIO_AGENT_BACKEND_MODEL'
+            + 'DASHSCOPE_API_KEY（或 OPENCLAW_ORCAROUTER_API_KEY）和 QWEN_AUDIO_AGENT_BACKEND_MODEL'
           : version
             ? `OpenCode ${version} 低于最低版本 ${spec.minimumVersion}`
             : '无法确认 OpenCode 版本'
@@ -493,7 +503,9 @@ function inspectBackend(id, {
     integration: spec.integration,
     configuration: id === 'acp'
       ? 'command-managed'
-      : automaticBailian ? 'automatic-bailian' : 'preserved',
+      : automaticOrcaRouter
+        ? 'automatic-orcarouter'
+        : automaticBailian ? 'automatic-bailian' : 'preserved',
     authentication: 'backend-managed',
     issues,
     platform,
@@ -612,11 +624,13 @@ export function formatBackendSetup(report) {
       ? [
           backendText(item),
           integrationText(item),
-          item.configuration === 'automatic-bailian'
-            ? '自动配置百炼 API Key 与后台模型'
-            : item.configuration === 'preserved'
-              ? '复用用户级配置'
-              : '配置由 ACP Agent 管理',
+          item.configuration === 'automatic-orcarouter'
+            ? '自动配置 OrcaRouter API Key 与后台模型'
+            : item.configuration === 'automatic-bailian'
+              ? '自动配置百炼 API Key 与后台模型'
+              : item.configuration === 'preserved'
+                ? '复用用户级配置'
+                : '配置由 ACP Agent 管理',
         ]
       : item.issues
     lines.push(


### PR DESCRIPTION
## Summary

qwen-audio-agent's managed OpenClaw backend is provisioned exclusively against DashScope today. This PR adds [OrcaRouter](https://www.orcarouter.ai) as a first-class named provider in `config/openclaw/openclaw.json5`, mirroring the existing `bailian` entry. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents — like OpenRouter it exposes a provider/model namespace across many models, but also adds adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance on the same endpoint. It also runs gateway-level, zero-trust security for AI agents on that endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Setting `OPENCLAW_ORCAROUTER_API_KEY` (or `ORCAROUTER_API_KEY`) provisions the managed OpenClaw instance against `https://api.orcarouter.ai/v1` instead of Bailian.

## Verification

- New/updated tests pass: `config.test.mjs`, `managed-backend.test.mjs`, `backend-setup.test.mjs`, `backend-runtime-discovery.test.mjs`; `eslint` clean.
- L3 live test: `POST /v1/chat/completions` with a real key returned `200` (`openai/gpt-4o-mini`).

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
