### PR TITLE
refactor(car): migrate cockpit client to GCP 6.0

### DIFF
--- a/examples/car/react-app/README.md
+++ b/examples/car/react-app/README.md
@@ -1,6 +1,8 @@
 # Qwen Audio Agent Car 前端
 
-这是 Qwen Audio Agent Car 的 React + Vite 前端。它负责车机 UI、VoiceDock、浏览器麦克风采集、音频播放、调试面板和 Agent actions 的前端状态同步。
+这是 Qwen Audio Agent Car 的 React + Vite 场景客户端。它负责车机 UI、VoiceDock、浏览器麦克风采集、音频播放和调试面板，不依赖框架 WebUI。
+
+对话通过公开的 Gateway Client Protocol 6.0 接入 qwen-audio-agent Gateway；车辆、导航、音乐、天气和闪购状态通过座舱领域服务的 HTTP/SSE 通道获取。Gateway 不解析这些座舱业务对象。
 
 ## 技术栈
 
@@ -34,12 +36,13 @@ npm run lint
 
 | 文件 | 说明 |
 |---|---|
-| `src/App.jsx` | 前端根状态、屏幕切换、Agent actions 分发 |
+| `src/App.jsx` | 前端根状态、屏幕切换和场景状态投影 |
 | `src/App.css` | 全局样式、Dock、VoiceDock、调试面板、应用页样式 |
 | `src/components/VehiclePanel.jsx` | 车辆主界面和 VoiceDock 容器 |
 | `src/components/VoiceDock.jsx` | 语音 Dock 布局、麦克风、灵魂选择、设置入口 |
 | `src/components/VoiceWave.jsx` | Canvas 光场动效，响应 listening / thinking / speaking / progress |
 | `src/hooks/useVoiceSession.js` | 麦克风采集、WebSocket、PCM 播放、语音事件归一 |
+| `src/hooks/useCockpitState.js` | 座舱领域状态快照、SSE 更新和直接操作 |
 | `src/components/ChatPanel.jsx` | 文本和语音统一调试面板 |
 | `src/components/MapPanel.jsx` | 地图和导航状态 |
 | `src/components/MusicPanel.jsx` | 音乐应用 |
@@ -50,10 +53,10 @@ npm run lint
 
 ## 语音链路
 
-`useVoiceSession` 连接后端：
+`useVoiceSession` 只连接对话中控：
 
 ```text
-WS /api/voice/realtime?clientId=...
+WS /api/realtime?sessionId=...
 ```
 
 职责：
@@ -61,9 +64,19 @@ WS /api/voice/realtime?clientId=...
 - 请求麦克风权限。
 - 将输入音频转换为 16 kHz mono PCM16。
 - 接收 24 kHz PCM 音频并排队播放。
+- 发送 GCP `playback.started` / `playback.ended` / `playback.cancelled` 回执。
 - 输出 `voiceState`、`inputLevel`、`outputLevel` 给 `VoiceDock`。
-- 接收 `agent_actions`、`agent_map_action` 并交给 `App.jsx` 更新 UI。
-- 把 `agent_thinking`、`agent_progress`、`agent_tool_call`、`agent_debug`、`transcript_delta` 归一为 ChatPanel 消息。
+- 将标准 transcript 和 Task 事件归一为 ChatPanel 消息，并通过 GCP 恢复最近对话。
+
+`useCockpitState` 独立连接 `cockpit-domain`：
+
+```text
+GET  /api/cockpit/state
+GET  /api/cockpit/events
+POST /api/cockpit/commands
+```
+
+语音任务和面板直接操作共享同一个领域状态源，不通过对话事件传递 `actions[]`。
 
 ## UI 状态约定
 
@@ -79,4 +92,6 @@ VoiceDock 的主提示文案是“说吧，想做什么？”。有任务进度�
 
 - `localhost` 可以直接使用浏览器麦克风。
 - 局域网 IP 访问通常需要 HTTPS 或浏览器允许不安全源，否则麦克风权限会被拦截。
-- 前端只感知通用 Realtime WebSocket，不感知具体语音 provider。
+- `VITE_GATEWAY_ORIGIN` 可指定 Gateway 地址；开发代理默认指向 `http://127.0.0.1:18888`。
+- `VITE_COCKPIT_DOMAIN_ORIGIN` 可指定领域服务地址，默认 `http://127.0.0.1:3010`。
+- 前端只感知 GCP，不感知具体 Realtime provider 或后台 Agent。

--- a/examples/car/react-app/package-lock.json
+++ b/examples/car/react-app/package-lock.json
@@ -11,6 +11,7 @@
         "@amap/amap-jsapi-loader": "^1.0.1",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.1",
+        "qwen-audio-agent": "file:../../..",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "three": "^0.184.0"
@@ -25,6 +26,46 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
         "vite": "^8.0.12"
+      }
+    },
+    "../../..": {
+      "version": "1.11.0",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "server",
+        "web",
+        "tui",
+        "desktop",
+        "cli"
+      ],
+      "dependencies": {
+        "@a2a-js/sdk": "1.0.1",
+        "@agentclientprotocol/sdk": "1.3.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "@qwen-code/open-computer-use": "^0.2.3",
+        "electron-updater": "6.8.9",
+        "express": "^4.22.2",
+        "sherpa-onnx": "1.13.4",
+        "tar-stream": "3.1.7",
+        "unbzip2-stream": "1.4.3",
+        "ws": "^8.21.1",
+        "yaml": "2.9.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "qwenaudio": "cli/bin/qwenaudio.mjs"
+      },
+      "devDependencies": {
+        "concurrently": "^9.2.0",
+        "electron-builder": "26.15.7",
+        "eslint": "10.8.0",
+        "eslint-plugin-react-hooks": "7.1.1",
+        "globals": "17.9.0",
+        "vitepress": "^1.6.4"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@amap/amap-jsapi-loader": {
@@ -794,9 +835,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -814,9 +852,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -834,9 +869,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,9 +886,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -874,9 +903,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,9 +920,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2134,9 +2157,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2158,9 +2178,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2182,9 +2199,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2206,9 +2220,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2527,6 +2538,10 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qwen-audio-agent": {
+      "resolved": "../../..",
+      "link": true
     },
     "node_modules/react": {
       "version": "19.2.6",

--- a/examples/car/react-app/package.json
+++ b/examples/car/react-app/package.json
@@ -13,6 +13,7 @@
     "@amap/amap-jsapi-loader": "^1.0.1",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
+    "qwen-audio-agent": "file:../../..",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "three": "^0.184.0"

--- a/examples/car/react-app/src/App.jsx
+++ b/examples/car/react-app/src/App.jsx
@@ -7,6 +7,7 @@ import SettingsPanel from './components/SettingsPanel'
 import ChatPanel from './components/ChatPanel'
 import MusicPanel, { PLAYLIST } from './components/MusicPanel'
 import FlashBuyPanel from './components/FlashBuyPanel'
+import useCockpitState from './hooks/useCockpitState'
 import useVoiceSession from './hooks/useVoiceSession'
 
 const INITIAL_CAR_STATE = {
@@ -74,33 +75,40 @@ function parseHash() {
 
 export default function App() {
   const clientId = useMemo(() => getClientId(), [])
+  const { state: cockpitState, execute: executeCockpitCommand } = useCockpitState(clientId)
   const [screen, setScreen] = useState('main')
   const [settingsTab, setSettingsTab] = useState('persona')
   const [selectedPersona, setSelectedPersona] = useState(() => getStoredChoice(PERSONA_STORAGE_KEY, DEFAULT_PERSONA, VALID_PERSONAS))
   const [selectedVoice, setSelectedVoice] = useState(() => getStoredChoice(VOICE_STORAGE_KEY, DEFAULT_VOICE, VALID_VOICES))
   const [selectedWake, setSelectedWake] = useState('主驾')
   const [memories, setMemories] = useState([])
-  const [carState, setCarState] = useState(INITIAL_CAR_STATE)
+  const carState = cockpitState?.vehicle || INITIAL_CAR_STATE
   const [showChat, setShowChat] = useState(false)
   const [chatMessages, setChatMessages] = useState([])
   const [customSkills, setCustomSkills] = useState([])
-  const [navState, setNavState] = useState({ status: 'idle' })
-  const navStateRef = useRef(navState)
-  useEffect(() => { navStateRef.current = navState }, [navState])
-  const [mapActions, setMapActions] = useState([])
+  const navState = cockpitState?.navigation || { status: 'idle' }
+  const mapActions = useMemo(() => [], [])
   const [routeStrategy, setRouteStrategy] = useState(0)
-  const [musicState, setMusicState] = useState({ playing: false, currentIndex: 0 })
-  const [flashBuyState, setFlashBuyState] = useState(INITIAL_FLASH_BUY_STATE)
-  const [weatherState, setWeatherState] = useState(INITIAL_WEATHER_STATE)
+  const musicState = cockpitState?.music || { playing: false, currentIndex: 0 }
+  const flashBuyState = cockpitState?.flashbuy || INITIAL_FLASH_BUY_STATE
+  const weatherState = cockpitState?.weather || INITIAL_WEATHER_STATE
   const [voiceMuted, setVoiceMuted] = useState(true)
   const [thinking, setThinking] = useState(false)
   const voiceAssistantMessageIdRef = useRef(null)
 
-  const musicPlay = useCallback(() => setMusicState(prev => ({ ...prev, playing: true })), [])
-  const musicPause = useCallback(() => setMusicState(prev => ({ ...prev, playing: false })), [])
-  const musicNext = useCallback(() => setMusicState(prev => ({ ...prev, currentIndex: (prev.currentIndex + 1) % PLAYLIST.length, playing: true })), [])
-  const musicPrev = useCallback(() => setMusicState(prev => ({ ...prev, currentIndex: (prev.currentIndex - 1 + PLAYLIST.length) % PLAYLIST.length, playing: true })), [])
-  const musicSelectTrack = useCallback((i) => setMusicState({ playing: true, currentIndex: i }), [])
+  const runCockpitCommand = useCallback((name, args = {}) => {
+    executeCockpitCommand(name, args).catch(error => {
+      console.warn(`Cockpit command ${name} failed`, error)
+    })
+  }, [executeCockpitCommand])
+
+  const musicPlay = useCallback(() => runCockpitCommand('music_play'), [runCockpitCommand])
+  const musicPause = useCallback(() => runCockpitCommand('music_pause'), [runCockpitCommand])
+  const musicNext = useCallback(() => runCockpitCommand('music_next'), [runCockpitCommand])
+  const musicPrev = useCallback(() => runCockpitCommand('music_previous'), [runCockpitCommand])
+  const musicSelectTrack = useCallback((index) => {
+    runCockpitCommand('music_play', { query: PLAYLIST[index]?.title })
+  }, [runCockpitCommand])
 
   useEffect(() => {
     localStorage.setItem(PERSONA_STORAGE_KEY, selectedPersona)
@@ -122,45 +130,16 @@ export default function App() {
 
   const handleFlashBuyAction = useCallback((event) => {
     if (event.type === 'set_category') {
-      setFlashBuyState(prev => ({ ...prev, category: event.category, items: [] }))
+      runCockpitCommand('flashbuy', { action: 'search', category: event.category })
     } else if (event.type === 'toggle_item') {
-      setFlashBuyState(prev => {
-        const item = (prev.items || []).find(row => row.id === event.itemId) || event.item
-        if (!item) return prev
-        const exists = prev.cartItems.some(row => (row.itemId || row.id) === event.itemId)
-        const cartItems = exists
-          ? prev.cartItems.filter(row => (row.itemId || row.id) !== event.itemId)
-          : [...prev.cartItems, { ...item, itemId: item.id, quantity: 1 }]
-        return {
-          ...prev,
-          status: cartItems.length ? 'cart_updated' : 'selecting',
-          message: cartItems.length ? '已更新购物车' : '请选择商品',
-          cartItems,
-          total: cartItems.reduce((sum, row) => sum + row.price * (row.quantity || 1), 0),
-          preview: null,
-          order: null,
-        }
-      })
+      const exists = flashBuyState.cartItems.some(row => row.id === event.itemId)
+      runCockpitCommand('flashbuy', exists
+        ? { action: 'update_cart', itemId: event.itemId, quantity: 0 }
+        : { action: 'add_to_cart', itemId: event.itemId })
     } else if (event.type === 'confirm_order') {
-      setFlashBuyState(prev => {
-        if (!prev.cartItems.length && !prev.preview) return prev
-        const order = {
-          id: `SG${Math.floor(1000 + Math.random() * 9000)}`,
-          status: '骑手取货中',
-          eta: prev.preview?.eta || prev.cartItems[0]?.eta || '25分钟',
-          total: prev.preview?.total || prev.total,
-        }
-        return {
-          ...prev,
-          status: 'completed',
-          message: '已完成下单',
-          order,
-          cartItems: [],
-          preview: null,
-        }
-      })
+      runCockpitCommand('flashbuy', { action: 'confirm_order', confirmed: true })
     }
-  }, [])
+  }, [flashBuyState.cartItems, runCockpitCommand])
 
   const fetchMemories = useCallback(async () => {
     try {
@@ -182,17 +161,6 @@ export default function App() {
     }
   }, [clientId])
 
-  const fetchChatHistory = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/history?clientId=${clientId}`)
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const items = await res.json()
-      if (Array.isArray(items)) setChatMessages(items)
-    } catch (error) {
-      console.warn('Failed to fetch chat history', error)
-    }
-  }, [clientId])
-
   const deleteSkill = useCallback(async (name) => {
     try {
       const res = await fetch(`/api/skills/${encodeURIComponent(name)}?clientId=${clientId}`, { method: 'DELETE' })
@@ -204,8 +172,15 @@ export default function App() {
   }, [clientId])
 
   const toggleCarPart = useCallback((part) => {
-    setCarState(prev => ({ ...prev, [part]: prev[part] === 0 ? 1 : 0 }))
-  }, [])
+    const action = carState[part] === 0 ? 'open' : 'close'
+    if (part.startsWith('window')) {
+      runCockpitCommand('vehicle_window_control', { action, window: part })
+    } else if (part === 'sunroof') {
+      runCockpitCommand('vehicle_sunroof_control', { action })
+    } else if (part === 'headlights') {
+      runCockpitCommand('vehicle_headlights_control', { action })
+    }
+  }, [carState, runCockpitCommand])
 
   const navigateHome = useCallback(() => {
     setScreen('main')
@@ -239,113 +214,6 @@ export default function App() {
 
   const toggleVoiceMute = useCallback(() => {
     setVoiceMuted(prev => !prev)
-  }, [])
-
-  const handleAgentActions = useCallback((actions) => {
-    for (const action of actions) {
-      if (action.type === 'car_control') {
-        if (action.part === 'ac') {
-          setCarState(prev => ({
-            ...prev,
-            ac: action.state,
-            ...(action.temperature != null ? { acTemp: action.temperature } : {}),
-            ...(action.mode ? { acMode: action.mode } : {}),
-            ...(action.fan != null ? { acFan: action.fan } : {}),
-          }))
-        } else if (action.part in INITIAL_CAR_STATE) {
-          setCarState(prev => ({ ...prev, [action.part]: action.state }))
-        }
-      } else if (action.type === 'music') {
-        if (action.action === 'play') {
-          if (action.query) {
-            const q = action.query.toLowerCase()
-            const idx = PLAYLIST.findIndex(t => t.title.toLowerCase().includes(q) || t.artist.toLowerCase().includes(q))
-            if (idx >= 0) setMusicState({ playing: true, currentIndex: idx })
-            else setMusicState(prev => ({ ...prev, playing: true }))
-          } else {
-            setMusicState(prev => ({ ...prev, playing: true }))
-          }
-          if (navStateRef.current.status !== 'navigating') {
-            setScreen('music')
-            window.location.hash = '#music'
-          }
-        } else if (action.action === 'pause') {
-          setMusicState(prev => ({ ...prev, playing: false }))
-        } else if (action.action === 'next') {
-          setMusicState(prev => ({ ...prev, currentIndex: (prev.currentIndex + 1) % PLAYLIST.length, playing: true }))
-        } else if (action.action === 'prev') {
-          setMusicState(prev => ({ ...prev, currentIndex: (prev.currentIndex - 1 + PLAYLIST.length) % PLAYLIST.length, playing: true }))
-        }
-      } else if (action.type === 'navigation') {
-        if (action.action === 'start') {
-          setMapActions([])
-          if (action.strategy != null) setRouteStrategy(action.strategy)
-          setNavState({ status: 'navigating', destination: action.destination, via: action.via, route: action.route })
-          setScreen('main')
-          window.location.hash = '#main'
-        } else if (action.action === 'stop') {
-          setMapActions([])
-          setNavState({ status: 'idle' })
-        }
-      } else if (action.type === 'flashbuy') {
-        if (action.action === 'open') {
-          setScreen('flashbuy')
-          window.location.hash = '#flashbuy'
-        } else if (action.action === 'status') {
-          setFlashBuyState(prev => ({
-            ...prev,
-            status: action.status || prev.status,
-            message: action.message || prev.message,
-            order: action.status === 'ordering' ? null : prev.order,
-          }))
-        } else if (action.action === 'results') {
-          setFlashBuyState(prev => ({
-            ...prev,
-            status: action.status || 'selecting',
-            message: action.message || '已找到附近可送商品',
-            category: action.category || prev.category,
-            items: action.items || [],
-            preview: null,
-            order: null,
-          }))
-        } else if (action.action === 'cart') {
-          setFlashBuyState(prev => ({
-            ...prev,
-            status: action.status || 'cart_updated',
-            message: action.message || '已更新购物车',
-            category: action.category || prev.category,
-            cartItems: action.items || [],
-            total: action.total || 0,
-            preview: null,
-            order: null,
-          }))
-        } else if (action.action === 'preview') {
-          setFlashBuyState(prev => ({
-            ...prev,
-            status: action.status || 'awaiting_confirm',
-            message: action.message || '请确认订单后下单',
-            category: action.category || prev.category,
-            preview: action.preview || null,
-            cartItems: action.preview?.items || prev.cartItems,
-            total: action.preview?.total ?? prev.total,
-            order: null,
-          }))
-        } else if (action.action === 'completed') {
-          setFlashBuyState(prev => ({
-            ...prev,
-            status: 'completed',
-            message: action.message || '已完成下单',
-            order: action.order || null,
-            cartItems: [],
-            preview: null,
-          }))
-        } else if (action.action === 'cancelled') {
-          setFlashBuyState({ ...INITIAL_FLASH_BUY_STATE, message: action.message || '已取消当前闪购流程' })
-        }
-      } else if (action.type === 'weather') {
-        if (action.weather) setWeatherState(action.weather)
-      }
-    }
   }, [])
 
   const handleVoiceMessage = useCallback((event) => {
@@ -423,10 +291,14 @@ export default function App() {
     if (event.role === 'user') {
       voiceAssistantMessageIdRef.current = null
       if (!event.content) return
-      setChatMessages(prev => [
-        ...prev,
-        { id: crypto.randomUUID(), role: 'user', content: event.content },
-      ].slice(-80))
+      setChatMessages(prev => {
+        const last = prev.at(-1)
+        if (last?.role === 'user' && last.content === event.content) return prev
+        return [
+          ...prev,
+          { id: crypto.randomUUID(), role: 'user', content: event.content },
+        ].slice(-80)
+      })
       return
     }
 
@@ -444,37 +316,35 @@ export default function App() {
     }
   }, [fetchMemories, fetchSkills])
 
-  const handleMapAction = useCallback((event) => {
-    if (event.action === 'clear') {
-      setMapActions([])
-    } else {
-      setMapActions(prev => [...prev, event])
-      setScreen('main')
-      window.location.hash = '#main'
-    }
+  const handleConversationRecovery = useCallback((messages) => {
+    voiceAssistantMessageIdRef.current = null
+    setChatMessages((Array.isArray(messages) ? messages : []).map(message => ({
+      ...message,
+      id: message.id || crypto.randomUUID(),
+    })).slice(-10))
   }, [])
 
-  const { voiceState, inputLevel, outputLevel, progress: voiceProgress } = useVoiceSession({
+  const {
+    voiceState,
+    inputLevel,
+    outputLevel,
+    progress: voiceProgress,
+    sendInput,
+  } = useVoiceSession({
     muted: voiceMuted,
     clientId,
-    persona: selectedPersona,
-    routeStrategy,
-    thinking,
-    onAgentActions: handleAgentActions,
-    onMapAction: handleMapAction,
     onVoiceMessage: handleVoiceMessage,
+    onConversationRecovery: handleConversationRecovery,
   })
 
-  const handleClearHistory = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/history?clientId=${clientId}`, { method: 'DELETE' })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      voiceAssistantMessageIdRef.current = null
-      setChatMessages([])
-    } catch (error) {
-      console.warn('Failed to clear chat history', error)
-    }
-  }, [clientId])
+  const handleClearHistory = useCallback(() => {
+    voiceAssistantMessageIdRef.current = null
+    setChatMessages([])
+  }, [])
+
+  const handleTextMessage = useCallback((text) => (
+    sendInput([{ type: 'text', text }])
+  ), [sendInput])
 
   useEffect(() => {
     if (!['navigation', 'flashbuy'].includes(voiceProgress?.domain)) return undefined
@@ -494,7 +364,6 @@ export default function App() {
     Promise.resolve().then(() => {
       fetchMemories()
       fetchSkills()
-      fetchChatHistory()
     })
     const onHashChange = () => {
       const { screen: s, tab } = parseHash()
@@ -504,7 +373,7 @@ export default function App() {
     window.addEventListener('hashchange', onHashChange)
     onHashChange()
     return () => window.removeEventListener('hashchange', onHashChange)
-  }, [fetchMemories, fetchSkills, fetchChatHistory])
+  }, [fetchMemories, fetchSkills])
 
   return (
     <main className="device" aria-label="车机语音交互原型">
@@ -547,7 +416,7 @@ export default function App() {
               />
             )}
           </div>
-          {showChat && <ChatPanel onClose={toggleChat} messages={chatMessages} onMessagesChange={setChatMessages} onActions={handleAgentActions} onClearHistory={handleClearHistory} onMemoryChange={fetchMemories} onSkillChange={fetchSkills} onMapAction={handleMapAction} onNavigate={navigateHome} routeStrategy={routeStrategy} soul={selectedPersona} clientId={clientId} voiceActive={!voiceMuted} thinking={thinking} onThinkingChange={setThinking} />}
+          {showChat && <ChatPanel onClose={toggleChat} messages={chatMessages} onMessagesChange={setChatMessages} onClearHistory={handleClearHistory} onSendMessage={handleTextMessage} voiceActive={!voiceMuted} thinking={thinking} onThinkingChange={setThinking} />}
         </div>
 
         <Dock screen={screen} onNavigateHome={navigateHome} onOpenSettings={() => openSettings('persona')} onToggleChat={toggleChat} carState={carState} musicState={musicState} onTogglePlay={musicState.playing ? musicPause : musicPlay} onOpenMusic={openMusic} onOpenFlashBuy={openFlashBuy} />

--- a/examples/car/react-app/src/components/ChatPanel.jsx
+++ b/examples/car/react-app/src/components/ChatPanel.jsx
@@ -37,9 +37,6 @@ const TOOL_TAGS = {
   web_search: { label: '联网查询', cls: 'tag-skill' },
 }
 
-const MEMORY_MUTATION_TOOLS = new Set(['memory_write', 'memory_delete'])
-const SKILL_MUTATION_TOOLS = new Set(['skill_create', 'skill_delete'])
-
 function progressTag(progress) {
   if (progress.domain === 'flashbuy') return { label: '闪购', cls: 'tag-skill' }
   if (progress.domain === 'weather') return { label: '天气', cls: 'tag-nav' }
@@ -59,9 +56,17 @@ function getDefaultPosition(panel) {
   }
 }
 
-export default function ChatPanel({ onClose, messages, onMessagesChange, onActions, onClearHistory, onMemoryChange, onSkillChange, onMapAction, onNavigate, routeStrategy, soul, clientId, voiceActive = false, thinking = false, onThinkingChange }) {
+export default function ChatPanel({
+  onClose,
+  messages,
+  onMessagesChange,
+  onClearHistory,
+  onSendMessage,
+  voiceActive = false,
+  thinking = false,
+  onThinkingChange,
+}) {
   const [input, setInput] = useState('')
-  const [loading, setLoading] = useState(false)
   const [position, setPosition] = useState({ x: 0, y: 0 })
   const panelRef = useRef(null)
   const listRef = useRef(null)
@@ -85,7 +90,7 @@ export default function ChatPanel({ onClose, messages, onMessagesChange, onActio
 
   useEffect(() => {
     listRef.current?.scrollTo(0, listRef.current.scrollHeight)
-  }, [messages, loading])
+  }, [messages])
 
   const handleDragStart = useCallback((e) => {
     const panel = panelRef.current
@@ -112,98 +117,22 @@ export default function ChatPanel({ onClose, messages, onMessagesChange, onActio
     document.addEventListener('mouseup', onUp)
   }, [])
 
-  const sendMessage = async () => {
+  const sendMessage = () => {
     const text = input.trim()
-    if (!text || loading) return
+    if (!text) return
 
-    const userMsg = { role: 'user', content: text }
-    const newMessages = [...messages, userMsg]
-    onMessagesChange(newMessages)
+    const userMsg = { id: crypto.randomUUID(), role: 'user', content: text }
+    const accepted = onSendMessage?.(text) === true
+    onMessagesChange([
+      ...messages,
+      userMsg,
+      ...(accepted ? [] : [{
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: '对话中控尚未连接，请稍后再试。',
+      }]),
+    ])
     setInput('')
-    setLoading(true)
-
-    const assistantMsg = { role: 'assistant', content: '', thinking: '', thinkingMs: 0, debug: { tool_calls: [] } }
-    const streamMessages = [...newMessages, assistantMsg]
-    let thinkingStart = null
-
-    try {
-      const res = await fetch('/api/chat/stream', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: newMessages, soul, strategy: routeStrategy, thinking, clientId }),
-      })
-
-      const reader = res.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ''
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split('\n')
-        buffer = lines.pop()
-
-        for (const line of lines) {
-          if (!line.startsWith('data: ')) continue
-          const event = JSON.parse(line.slice(6))
-
-          if (event.type === 'map_action') {
-            if (onMapAction) onMapAction(event)
-          } else if (event.type === 'thinking') {
-            if (!thinkingStart) thinkingStart = Date.now()
-            assistantMsg.thinking += event.content
-            onMessagesChange([...streamMessages])
-          } else if (event.type === 'progress') {
-            assistantMsg.debug.progress = [...(assistantMsg.debug.progress || []), event]
-            if (event.domain === 'navigation' && onNavigate) onNavigate()
-            if (event.domain === 'flashbuy' && onActions) {
-              onActions([
-                { type: 'flashbuy', action: 'open' },
-                { type: 'flashbuy', action: 'status', status: event.stage, message: event.message },
-              ])
-            }
-            onMessagesChange([...streamMessages])
-          } else if (event.type === 'tool_call') {
-            if (thinkingStart) {
-              assistantMsg.thinkingMs = Date.now() - thinkingStart
-              thinkingStart = null
-            }
-            if (event.name === 'navigation' && onNavigate) onNavigate()
-            if (MEMORY_MUTATION_TOOLS.has(event.name) && onMemoryChange) onMemoryChange()
-            if (SKILL_MUTATION_TOOLS.has(event.name) && onSkillChange) onSkillChange()
-            assistantMsg.debug.tool_calls = [...assistantMsg.debug.tool_calls, event]
-            onMessagesChange([...streamMessages])
-          } else if (event.type === 'action') {
-            if (onActions) onActions([event.action])
-          } else if (event.type === 'text') {
-            if (thinkingStart) {
-              assistantMsg.thinkingMs = Date.now() - thinkingStart
-              thinkingStart = null
-            }
-            assistantMsg.content += event.content
-            onMessagesChange([...streamMessages])
-          } else if (event.type === 'done') {
-            assistantMsg.content = event.content
-            assistantMsg.debug.rounds = event.debug?.rounds
-            assistantMsg.debug.usage = event.debug?.usage
-            assistantMsg.debug.duration_ms = event.debug?.duration_ms
-            onMessagesChange([...streamMessages])
-            if (onMemoryChange) onMemoryChange()
-            if (onSkillChange) onSkillChange()
-          } else if (event.type === 'error') {
-            assistantMsg.content = event.message || '抱歉，执行失败，请稍后再试。'
-            onMessagesChange([...streamMessages])
-          }
-        }
-      }
-    } catch {
-      assistantMsg.content = '抱歉，连接失败，请稍后再试。'
-      onMessagesChange([...streamMessages])
-    } finally {
-      setLoading(false)
-    }
   }
 
   const handleKeyDown = (e) => {
@@ -278,11 +207,6 @@ export default function ChatPanel({ onClose, messages, onMessagesChange, onActio
             </div>
           </div>
         ))}
-        {loading && (
-          <div className="chat-bubble assistant loading">
-            <span className="dot-pulse"></span>
-          </div>
-        )}
       </div>
       {voiceActive ? (
         <div className="chat-input-area chat-input-voice-hint">
@@ -313,9 +237,8 @@ export default function ChatPanel({ onClose, messages, onMessagesChange, onActio
               onChange={e => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="输入消息..."
-              disabled={loading}
             />
-            <button className="chat-send" onClick={sendMessage} disabled={loading || !input.trim()}>
+            <button className="chat-send" onClick={sendMessage} disabled={!input.trim()}>
               <svg className="icon icon-sm" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M2 21 23 12 2 3v7l15 2-15 2v7Z" fill="currentColor" />
               </svg>

--- a/examples/car/react-app/src/hooks/useCockpitState.js
+++ b/examples/car/react-app/src/hooks/useCockpitState.js
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'react'
+
+function domainOrigin() {
+  return import.meta.env.VITE_COCKPIT_DOMAIN_ORIGIN || 'http://127.0.0.1:3010'
+}
+
+export default function useCockpitState(cockpitId) {
+  const [state, setState] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let disposed = false
+    const query = new URLSearchParams({ cockpitId })
+    const stateUrl = `${domainOrigin()}/api/cockpit/state?${query}`
+    const eventsUrl = `${domainOrigin()}/api/cockpit/events?${query}`
+
+    fetch(stateUrl)
+      .then(response => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        return response.json()
+      })
+      .then(value => {
+        if (!disposed) {
+          setState(value)
+          setError(null)
+        }
+      })
+      .catch(reason => {
+        if (!disposed) setError(reason?.message || '座舱状态服务不可用')
+      })
+
+    const events = new EventSource(eventsUrl)
+    events.addEventListener('snapshot', event => {
+      if (!disposed) setState(JSON.parse(event.data))
+    })
+    events.addEventListener('state', event => {
+      if (!disposed) setState(JSON.parse(event.data).state)
+    })
+    events.addEventListener('open', () => {
+      if (!disposed) setError(null)
+    })
+    events.addEventListener('error', () => {
+      if (!disposed) setError('座舱状态连接中断，正在重连')
+    })
+    return () => {
+      disposed = true
+      events.close()
+    }
+  }, [cockpitId])
+
+  const execute = useCallback(async (name, args = {}) => {
+    const response = await fetch(`${domainOrigin()}/api/cockpit/commands`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cockpitId, name, arguments: args }),
+    })
+    const result = await response.json()
+    if (!response.ok) throw new Error(result.error || `HTTP ${response.status}`)
+    return result
+  }, [cockpitId])
+
+  return { state, error, execute }
+}

--- a/examples/car/react-app/src/hooks/useVoiceSession.js
+++ b/examples/car/react-app/src/hooks/useVoiceSession.js
@@ -1,39 +1,49 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { GatewayClient } from 'qwen-audio-agent/gateway-client-sdk'
+import { GatewayClientCapability } from 'qwen-audio-agent/gateway-client-protocol'
+import {
+  GatewayClientEvent,
+  GatewayServerEvent,
+} from 'qwen-audio-agent/realtime-events'
 
 const INPUT_SAMPLE_RATE = 16000
 const OUTPUT_SAMPLE_RATE = 24000
 const SPEECH_THRESHOLD = 0.035
-const THINKING_TIMEOUT_MS = 35000
+const TASK_TERMINAL_EVENTS = new Set([
+  'task.completed',
+  'task.failed',
+  'task.cancelled',
+])
 
-function voiceWsUrl(clientId) {
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${protocol}//${window.location.host}/api/voice/realtime?clientId=${encodeURIComponent(clientId)}`
+function gatewayWsUrl(sessionId) {
+  const origin = import.meta.env.VITE_GATEWAY_ORIGIN || window.location.origin
+  const url = new URL('/api/realtime', origin)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  url.searchParams.set('sessionId', sessionId)
+  return url.toString()
 }
 
 function floatToPcm16Base64(samples) {
   const bytes = new Uint8Array(samples.length * 2)
   const view = new DataView(bytes.buffer)
-  for (let i = 0; i < samples.length; i += 1) {
-    const sample = Math.max(-1, Math.min(1, samples[i]))
-    view.setInt16(i * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true)
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, samples[index]))
+    view.setInt16(index * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true)
   }
-
   let binary = ''
-  const chunkSize = 0x8000
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + 0x8000))
   }
   return btoa(binary)
 }
 
 function base64Pcm16ToFloat32(base64) {
   const binary = atob(base64)
-  const samples = new Float32Array(binary.length / 2)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i)
+  const bytes = Uint8Array.from(binary, character => character.charCodeAt(0))
   const view = new DataView(bytes.buffer)
-  for (let i = 0; i < samples.length; i += 1) {
-    samples[i] = view.getInt16(i * 2, true) / 0x8000
+  const samples = new Float32Array(bytes.length / 2)
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] = view.getInt16(index * 2, true) / 0x8000
   }
   return samples
 }
@@ -43,378 +53,385 @@ function resampleLinear(input, fromRate, toRate) {
   const ratio = fromRate / toRate
   const length = Math.max(1, Math.round(input.length / ratio))
   const output = new Float32Array(length)
-  for (let i = 0; i < length; i += 1) {
-    const index = i * ratio
-    const before = Math.floor(index)
+  for (let index = 0; index < length; index += 1) {
+    const position = index * ratio
+    const before = Math.floor(position)
     const after = Math.min(input.length - 1, before + 1)
-    const weight = index - before
-    output[i] = input[before] * (1 - weight) + input[after] * weight
+    const weight = position - before
+    output[index] = input[before] * (1 - weight) + input[after] * weight
   }
   return output
 }
 
 function rmsLevel(samples) {
+  if (!samples.length) return 0
   let sum = 0
-  for (let i = 0; i < samples.length; i += 1) sum += samples[i] * samples[i]
+  for (let index = 0; index < samples.length; index += 1) {
+    sum += samples[index] * samples[index]
+  }
   return Math.sqrt(sum / samples.length)
 }
 
-export default function useVoiceSession({ muted, clientId, persona, routeStrategy, thinking = false, onAgentActions, onMapAction, onVoiceMessage }) {
+function taskProgress(event) {
+  if (!String(event?.type || '').startsWith('task.')) return null
+  const task = event.task || {}
+  const activity = Array.isArray(task.activity) ? task.activity.at(-1) : null
+  const category = activity?.category || task.kind || 'task'
+  return {
+    domain: category,
+    stage: activity?.status || task.status || event.type.slice(5),
+    message: event.message || activity?.message || task.message || '',
+    taskId: task.id,
+  }
+}
+
+function gatewayVoiceState(event) {
+  if (event?.type === GatewayServerEvent.VOICE_STATE) {
+    return event.state === 'processing' ? 'thinking' : event.state
+  }
+  if (event?.type === GatewayServerEvent.AGENT_ACTIVITY) return 'thinking'
+  if (String(event?.type || '').startsWith('task.') && !TASK_TERMINAL_EVENTS.has(event.type)) {
+    return 'thinking'
+  }
+  return null
+}
+
+export default function useVoiceSession({
+  muted,
+  clientId,
+  onVoiceMessage,
+  onConversationRecovery,
+}) {
   const [voiceState, setVoiceState] = useState('idle')
   const [inputLevel, setInputLevel] = useState(0)
   const [outputLevel, setOutputLevel] = useState(0)
   const [progress, setProgress] = useState(null)
   const [error, setError] = useState(null)
-  const cleanupRef = useRef(() => {})
-  const onAgentActionsRef = useRef(onAgentActions)
-  const onMapActionRef = useRef(onMapAction)
+  const clientRef = useRef(null)
+  const audioContextRef = useRef(null)
+  const inputSampleRateRef = useRef(INPUT_SAMPLE_RATE)
+  const mutedRef = useRef(muted)
   const onVoiceMessageRef = useRef(onVoiceMessage)
+  const onConversationRecoveryRef = useRef(onConversationRecovery)
+  const playbackRef = useRef({
+    cursor: 0,
+    sources: new Set(),
+    counts: new Map(),
+    started: new Set(),
+    done: new Set(),
+    startTimers: new Map(),
+  })
 
+  useEffect(() => { mutedRef.current = muted }, [muted])
+  useEffect(() => { onVoiceMessageRef.current = onVoiceMessage }, [onVoiceMessage])
   useEffect(() => {
-    onAgentActionsRef.current = onAgentActions
-  }, [onAgentActions])
+    onConversationRecoveryRef.current = onConversationRecovery
+  }, [onConversationRecovery])
 
-  useEffect(() => {
-    onMapActionRef.current = onMapAction
-  }, [onMapAction])
+  const sendPlaybackReceipt = useCallback((type, responseId, reason = '') => {
+    if (!responseId) return
+    clientRef.current?.send({
+      type,
+      responseId,
+      ...(reason ? { reason } : {}),
+    })
+  }, [])
 
-  useEffect(() => {
-    onVoiceMessageRef.current = onVoiceMessage
-  }, [onVoiceMessage])
+  const finishResponsePlayback = useCallback((responseId) => {
+    const playback = playbackRef.current
+    if (
+      !playback.done.has(responseId)
+      || !playback.started.has(responseId)
+      || (playback.counts.get(responseId) || 0) > 0
+    ) return
+    sendPlaybackReceipt(GatewayClientEvent.PLAYBACK_ENDED, responseId)
+    playback.done.delete(responseId)
+    playback.started.delete(responseId)
+    playback.counts.delete(responseId)
+    if (!playback.counts.size) {
+      setOutputLevel(0)
+      setVoiceState('idle')
+    }
+  }, [sendPlaybackReceipt])
 
-  useEffect(() => {
-    cleanupRef.current()
+  const clearPlayback = useCallback((reason = '') => {
+    const playback = playbackRef.current
+    const responseIds = new Set([
+      ...playback.counts.keys(),
+      ...playback.started,
+      ...playback.done,
+    ])
+    for (const timer of playback.startTimers.values()) clearTimeout(timer)
+    for (const source of playback.sources) {
+      try { source.stop() } catch { /* source already ended */ }
+      try { source.disconnect() } catch { /* source already disconnected */ }
+    }
+    for (const responseId of responseIds) {
+      sendPlaybackReceipt(GatewayClientEvent.PLAYBACK_CANCELLED, responseId, reason)
+    }
+    playbackRef.current = {
+      cursor: audioContextRef.current?.currentTime || 0,
+      sources: new Set(),
+      counts: new Map(),
+      started: new Set(),
+      done: new Set(),
+      startTimers: new Map(),
+    }
+    setOutputLevel(0)
+  }, [sendPlaybackReceipt])
 
-    if (muted) {
-      const resetFrame = requestAnimationFrame(() => {
-        setVoiceState('idle')
-        setInputLevel(0)
-        setOutputLevel(0)
-        setProgress(null)
-        setError(null)
+  const playPcmAudio = useCallback((audioBase64, sampleRate, responseId) => {
+    const context = audioContextRef.current
+    if (!context || mutedRef.current) {
+      if (!playbackRef.current.started.has(responseId)) {
+        playbackRef.current.started.add(responseId)
+        sendPlaybackReceipt(GatewayClientEvent.PLAYBACK_STARTED, responseId)
+      }
+      return
+    }
+    try {
+      const samples = base64Pcm16ToFloat32(audioBase64)
+      const buffer = context.createBuffer(1, samples.length, sampleRate || OUTPUT_SAMPLE_RATE)
+      buffer.copyToChannel(samples, 0)
+      const source = context.createBufferSource()
+      source.buffer = buffer
+      source.connect(context.destination)
+      const playback = playbackRef.current
+      const startAt = Math.max(context.currentTime + 0.02, playback.cursor)
+      playback.cursor = startAt + buffer.duration
+      playback.sources.add(source)
+      playback.counts.set(responseId, (playback.counts.get(responseId) || 0) + 1)
+      if (!playback.started.has(responseId) && !playback.startTimers.has(responseId)) {
+        const timer = setTimeout(() => {
+          const current = playbackRef.current
+          current.startTimers.delete(responseId)
+          if (!current.counts.has(responseId) || current.started.has(responseId)) return
+          current.started.add(responseId)
+          sendPlaybackReceipt(GatewayClientEvent.PLAYBACK_STARTED, responseId)
+        }, Math.max(0, (startAt - context.currentTime) * 1000))
+        playback.startTimers.set(responseId, timer)
+      }
+      source.addEventListener('ended', () => {
+        const current = playbackRef.current
+        current.sources.delete(source)
+        current.counts.set(responseId, Math.max(0, (current.counts.get(responseId) || 0) - 1))
+        try { source.disconnect() } catch { /* source already disconnected */ }
+        finishResponsePlayback(responseId)
       })
-      cleanupRef.current = () => {}
-      return () => cancelAnimationFrame(resetFrame)
+      source.start(startAt)
+      setOutputLevel(Math.min(1, rmsLevel(samples) / 0.18))
+      setVoiceState('speaking')
+    } catch (reason) {
+      sendPlaybackReceipt(GatewayClientEvent.PLAYBACK_CANCELLED, responseId, 'playback_error')
+      setError(reason?.message || '语音播放失败')
+      setVoiceState('error')
+    }
+  }, [finishResponsePlayback, sendPlaybackReceipt])
+
+  useEffect(() => {
+    const handleEvent = (event) => {
+      const state = gatewayVoiceState(event)
+      if (state) setVoiceState(state)
+      if (event.type === GatewayServerEvent.VOICE_READY && event.inputSampleRate) {
+        inputSampleRateRef.current = event.inputSampleRate
+        setError(null)
+      } else if (event.type === GatewayServerEvent.AUDIO_DELTA) {
+        playPcmAudio(event.audio, event.sampleRate, event.responseId)
+      } else if (event.type === GatewayServerEvent.AUDIO_DONE) {
+        const playback = playbackRef.current
+        if (!playback.started.has(event.responseId)) {
+          playback.started.add(event.responseId)
+          sendPlaybackReceipt(GatewayClientEvent.PLAYBACK_STARTED, event.responseId)
+        }
+        playback.done.add(event.responseId)
+        finishResponsePlayback(event.responseId)
+      } else if (event.type === GatewayServerEvent.PLAYBACK_CLEAR) {
+        clearPlayback(event.reason || 'gateway_clear')
+      } else if (
+        event.type === GatewayServerEvent.TRANSCRIPT_DELTA
+        || event.type === GatewayServerEvent.TRANSCRIPT_FINAL
+      ) {
+        onVoiceMessageRef.current?.({
+          role: event.role,
+          content: event.content,
+          delta: event.type === GatewayServerEvent.TRANSCRIPT_DELTA,
+          final: event.type === GatewayServerEvent.TRANSCRIPT_FINAL,
+        })
+      } else if (event.type === GatewayServerEvent.ERROR) {
+        setError(event.message || '语音服务错误')
+        setVoiceState('error')
+      }
+      const nextProgress = taskProgress(event)
+      if (nextProgress) {
+        setProgress(nextProgress)
+        onVoiceMessageRef.current?.({ role: 'assistant', progress: nextProgress })
+        if (TASK_TERMINAL_EVENTS.has(event.type)) {
+          setTimeout(() => setProgress(null), 1800)
+        }
+      }
     }
 
-    let cancelled = false
+    const client = new GatewayClient({
+      url: gatewayWsUrl(clientId),
+      createSocket: url => new WebSocket(url),
+      clientType: 'web',
+      clientVersion: '2.0.0',
+      clientInstanceId: clientId,
+      clientLabel: 'Cockpit Conversation Client',
+      capabilities: [
+        GatewayClientCapability.INPUT_AUDIO,
+        GatewayClientCapability.INPUT_TEXT,
+        GatewayClientCapability.PLAYBACK_RECEIPTS,
+        GatewayClientCapability.TASK_COMMANDS,
+        GatewayClientCapability.PERMISSION_RESPOND,
+        GatewayClientCapability.CONVERSATION_HISTORY,
+        GatewayClientCapability.SESSION_REPLAY,
+      ],
+      locale: navigator.language,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      configure: () => ({
+        voiceEnabled: !mutedRef.current,
+        inputEnabled: !mutedRef.current,
+        outputEnabled: !mutedRef.current,
+        textOnly: mutedRef.current,
+      }),
+      onEvent: handleEvent,
+      onRecovery: recovery => {
+        onConversationRecoveryRef.current?.(recovery.messages || [])
+      },
+      onStatus: status => {
+        if (status.state === 'ready') {
+          setError(null)
+        } else if (status.state === 'unavailable' || status.state === 'disconnected') {
+          setError('对话中控连接中断，正在重连')
+          setVoiceState('error')
+        }
+      },
+    })
+    clientRef.current = client
+    client.start()
+    return () => {
+      clearPlayback('connection_closed')
+      client.stop()
+      if (clientRef.current === client) clientRef.current = null
+    }
+  }, [clearPlayback, clientId, finishResponsePlayback, playPcmAudio, sendPlaybackReceipt])
+
+  useEffect(() => {
+    if (muted) {
+      clientRef.current?.send({ type: GatewayClientEvent.MUTE })
+      const frame = requestAnimationFrame(() => {
+        setInputLevel(0)
+        setOutputLevel(0)
+        setVoiceState('idle')
+        clearPlayback('client_muted')
+      })
+      return () => cancelAnimationFrame(frame)
+    }
+
+    let disposed = false
     let frame = 0
-    let stream = null
-    let audioContext = null
+    let media = null
     let source = null
     let analyser = null
     let processor = null
     let lastVoiceAt = 0
-    let remoteBusy = false
-    let displayState = 'idle'
-    let ws = null
-    let playbackCursor = 0
-    let playbackTimers = []
-    let playbackSources = []
-    let playbackActive = false
-    let postPlaybackState = null
-    let progressClearTimer = 0
-    let thinkingTimer = 0
-
-    const clearProgressTimer = () => {
-      if (progressClearTimer) {
-        clearTimeout(progressClearTimer)
-        progressClearTimer = 0
-      }
-    }
-
-    const clearThinkingTimer = () => {
-      if (thinkingTimer) {
-        clearTimeout(thinkingTimer)
-        thinkingTimer = 0
-      }
-    }
-
-    const clearProgressLater = (delay = 2200) => {
-      clearProgressTimer()
-      progressClearTimer = setTimeout(() => {
-        setProgress(null)
-        progressClearTimer = 0
-      }, delay)
-    }
-
-    const setDisplayState = (next) => {
-      if (displayState === next) return
-      displayState = next
-      clearThinkingTimer()
-      if (next === 'thinking') {
-        thinkingTimer = setTimeout(() => {
-          thinkingTimer = 0
-          if (displayState !== 'thinking') return
-          remoteBusy = false
-          postPlaybackState = null
-          setOutputLevel(0)
-          setError('语音处理超时，请再试一次')
-          setDisplayState('idle')
-          clearProgressLater(800)
-        }, THINKING_TIMEOUT_MS)
-      }
-      setVoiceState(next)
-    }
-
-    const sendWs = (payload) => {
-      if (ws?.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify(payload))
-      }
-    }
-
-    const clearPlaybackTimers = () => {
-      playbackTimers.forEach(timer => clearTimeout(timer))
-      playbackTimers = []
-    }
-
-    const clearPlayback = () => {
-      clearPlaybackTimers()
-      playbackSources.forEach((sourceNode) => {
-        try {
-          sourceNode.stop()
-        } catch {
-          // The source may already have ended.
-        }
-        try {
-          sourceNode.disconnect()
-        } catch {
-          // Already disconnected.
-        }
-      })
-      playbackSources = []
-      playbackCursor = audioContext?.currentTime || 0
-      playbackActive = false
-      postPlaybackState = null
-      setOutputLevel(0)
-    }
-
-    const hasPendingPlayback = () => (
-      playbackActive
-      && audioContext
-      && audioContext.currentTime < playbackCursor - 0.02
-    )
-
-    const finishPlaybackIfDone = () => {
-      if (!playbackActive || hasPendingPlayback()) return
-      playbackActive = false
-      setOutputLevel(0)
-      if (postPlaybackState) {
-        const nextState = postPlaybackState
-        postPlaybackState = null
-        setDisplayState(nextState)
-      } else if (!remoteBusy) {
-        setDisplayState('idle')
-      }
-    }
-
-    const playPcmAudio = (audioBase64, sampleRate = OUTPUT_SAMPLE_RATE) => {
-      if (!audioContext) return
-      const samples = base64Pcm16ToFloat32(audioBase64)
-      const buffer = audioContext.createBuffer(1, samples.length, sampleRate)
-      buffer.copyToChannel(samples, 0)
-      const output = audioContext.createBufferSource()
-      output.buffer = buffer
-      output.connect(audioContext.destination)
-      playbackSources.push(output)
-      output.addEventListener('ended', () => {
-        playbackSources = playbackSources.filter(item => item !== output)
-        try {
-          output.disconnect()
-        } catch {
-          // Already disconnected.
-        }
-      })
-
-      const startAt = Math.max(audioContext.currentTime + 0.02, playbackCursor)
-      playbackCursor = startAt + buffer.duration
-      output.start(startAt)
-
-      const level = Math.min(1, rmsLevel(samples) / 0.18)
-      playbackActive = true
-      setOutputLevel(level)
-      setDisplayState('speaking')
-
-      const timer = setTimeout(() => {
-        finishPlaybackIfDone()
-      }, Math.max(0, (playbackCursor - audioContext.currentTime) * 1000 + 50))
-      playbackTimers.push(timer)
-    }
-
-    const cleanup = () => {
-      cancelled = true
-      cancelAnimationFrame(frame)
-      playbackActive = false
-      clearThinkingTimer()
-      clearProgressTimer()
-      clearPlayback()
-      processor?.disconnect()
-      source?.disconnect()
-      stream?.getTracks().forEach(track => track.stop())
-      audioContext?.close()
-      if (ws?.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'mute' }))
-      }
-      ws?.close()
-    }
-
-    cleanupRef.current = cleanup
 
     const start = async () => {
       try {
         if (!navigator.mediaDevices?.getUserMedia) {
           throw new Error('当前浏览器不支持麦克风采集')
         }
-
-        ws = new WebSocket(voiceWsUrl(clientId))
-        ws.addEventListener('open', () => {
-          sendWs({ type: 'config', soul: persona, routeStrategy, thinking })
-          sendWs({ type: 'unmute' })
-        })
-        ws.addEventListener('message', (event) => {
-          let payload
-          try {
-            payload = JSON.parse(event.data)
-          } catch {
-            return
-          }
-
-          if (payload.type === 'voice_state') {
-            remoteBusy = ['thinking', 'speaking'].includes(payload.state)
-            if (payload.state === 'idle' && !hasPendingPlayback()) clearProgressLater(900)
-            if (hasPendingPlayback() && payload.state !== 'speaking') {
-              postPlaybackState = payload.state
-              setDisplayState('speaking')
-            } else {
-              postPlaybackState = null
-              setDisplayState(payload.state)
-            }
-          } else if (payload.type === 'transcript') {
-            if (payload.content) {
-              onVoiceMessageRef.current?.({ role: payload.role, content: payload.content, final: true })
-            }
-          } else if (payload.type === 'transcript_delta') {
-            if (payload.content) {
-              onVoiceMessageRef.current?.({ role: payload.role, content: payload.content, delta: true })
-            }
-          } else if (payload.type === 'audio') {
-            remoteBusy = true
-            playPcmAudio(payload.audio, payload.sampleRate || OUTPUT_SAMPLE_RATE)
-          } else if (payload.type === 'audio_done') {
-            remoteBusy = false
-            clearProgressLater()
-            if (hasPendingPlayback()) {
-              setDisplayState('speaking')
-            } else if (playbackActive) {
-              finishPlaybackIfDone()
-            } else {
-              setOutputLevel(0)
-              setDisplayState('idle')
-            }
-          } else if (payload.type === 'agent_actions') {
-            onAgentActionsRef.current?.(payload.actions || [])
-          } else if (payload.type === 'playback.clear') {
-            remoteBusy = false
-            clearPlayback()
-            setDisplayState(payload.reason === 'user_interruption' ? 'listening' : 'idle')
-          } else if (payload.type === 'agent_map_action') {
-            if (payload.mapAction) onMapActionRef.current?.(payload.mapAction)
-          } else if (payload.type === 'agent_thinking') {
-            onVoiceMessageRef.current?.({ role: 'assistant', thinkingDelta: payload.content })
-          } else if (payload.type === 'agent_tool_call') {
-            onVoiceMessageRef.current?.({ role: 'assistant', toolCall: payload.toolCall })
-          } else if (payload.type === 'agent_progress') {
-            if (payload.progress) {
-              setProgress(payload.progress)
-              if (payload.progress.stage === 'navigation_started' || payload.progress.stage === 'route_ready') {
-                clearProgressLater(1800)
-              }
-            }
-            onVoiceMessageRef.current?.({ role: 'assistant', progress: payload.progress })
-          } else if (payload.type === 'agent_debug') {
-            clearProgressLater(800)
-            onVoiceMessageRef.current?.({ role: 'assistant', debug: payload.debug })
-          } else if (payload.type === 'error') {
-            remoteBusy = false
-            setDisplayState('error')
-            setError(payload.message || '语音服务错误')
-          }
-        })
-        ws.addEventListener('error', () => {
-          remoteBusy = false
-          setDisplayState('error')
-          setError('语音服务连接失败')
-        })
-
-        stream = await navigator.mediaDevices.getUserMedia({
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext
+        if (!AudioContextClass) throw new Error('当前浏览器不支持实时语音播放')
+        const context = audioContextRef.current?.state === 'closed'
+          ? new AudioContextClass()
+          : audioContextRef.current || new AudioContextClass()
+        audioContextRef.current = context
+        await context.resume()
+        media = await navigator.mediaDevices.getUserMedia({
           audio: {
             echoCancellation: true,
             noiseSuppression: true,
             autoGainControl: true,
           },
         })
-        if (cancelled) {
-          stream.getTracks().forEach(track => track.stop())
+        if (disposed) {
+          media.getTracks().forEach(track => track.stop())
           return
         }
-
-        const AudioContextClass = window.AudioContext || window.webkitAudioContext
-        audioContext = new AudioContextClass()
-        analyser = audioContext.createAnalyser()
+        analyser = context.createAnalyser()
         analyser.fftSize = 512
-        source = audioContext.createMediaStreamSource(stream)
+        source = context.createMediaStreamSource(media)
         source.connect(analyser)
-        processor = audioContext.createScriptProcessor(2048, 1, 1)
-        processor.onaudioprocess = (event) => {
-          if (cancelled || !ws || ws.readyState !== WebSocket.OPEN) return
-          const input = event.inputBuffer.getChannelData(0)
-          const pcm = floatToPcm16Base64(resampleLinear(input, audioContext.sampleRate, INPUT_SAMPLE_RATE))
-          sendWs({ type: 'audio', audio: pcm })
+        processor = context.createScriptProcessor(2048, 1, 1)
+        processor.onaudioprocess = event => {
+          const activeClient = clientRef.current
+          if (!activeClient?.ready || mutedRef.current) return
+          const samples = resampleLinear(
+            event.inputBuffer.getChannelData(0),
+            context.sampleRate,
+            inputSampleRateRef.current,
+          )
+          activeClient.send({
+            type: GatewayClientEvent.AUDIO_APPEND,
+            audio: floatToPcm16Base64(samples),
+          })
         }
         source.connect(processor)
-        processor.connect(audioContext.destination)
+        processor.connect(context.destination)
+        clientRef.current?.send({ type: GatewayClientEvent.UNMUTE })
+        setError(null)
 
         const data = new Float32Array(analyser.fftSize)
-        setError(null)
-        setDisplayState('idle')
-
         const tick = () => {
           analyser.getFloatTimeDomainData(data)
-          let sum = 0
-          for (let i = 0; i < data.length; i += 1) {
-            sum += data[i] * data[i]
-          }
-
-          const rms = Math.sqrt(sum / data.length)
-          const level = Math.min(1, rms / 0.18)
+          const level = rmsLevel(data)
           const now = performance.now()
-          setInputLevel(level)
-
-          if (rms > SPEECH_THRESHOLD && !remoteBusy) {
+          setInputLevel(Math.min(1, level / 0.18))
+          if (level > SPEECH_THRESHOLD) {
             lastVoiceAt = now
-            if (displayState === 'idle') setDisplayState('listening')
+            setVoiceState(current => current === 'idle' ? 'listening' : current)
           } else if (now - lastVoiceAt > 900) {
-            if (!remoteBusy && !playbackActive) setDisplayState('idle')
+            setVoiceState(current => current === 'listening' ? 'idle' : current)
           }
-
           frame = requestAnimationFrame(tick)
         }
-
         frame = requestAnimationFrame(tick)
-      } catch (err) {
-        if (!cancelled) {
+      } catch (reason) {
+        if (!disposed) {
           setInputLevel(0)
           setVoiceState('error')
-          setProgress(null)
-          setError(err.message || '麦克风不可用')
+          setError(reason?.message || '麦克风不可用')
         }
       }
     }
-
     start()
 
-    return cleanup
-  }, [clientId, muted, persona, routeStrategy, thinking])
+    return () => {
+      disposed = true
+      cancelAnimationFrame(frame)
+      processor?.disconnect()
+      source?.disconnect()
+      media?.getTracks().forEach(track => track.stop())
+    }
+  }, [clearPlayback, muted])
 
-  return { voiceState, inputLevel, outputLevel, progress, error }
+  useEffect(() => () => {
+    audioContextRef.current?.close()
+    audioContextRef.current = null
+  }, [])
+
+  const sendInput = useCallback((parts) => (
+    clientRef.current?.send({ type: GatewayClientEvent.INPUT_MESSAGE, parts }) === true
+  ), [])
+
+  return {
+    voiceState,
+    inputLevel,
+    outputLevel,
+    progress,
+    error,
+    sendInput,
+  }
 }

--- a/examples/car/react-app/vite.config.js
+++ b/examples/car/react-app/vite.config.js
@@ -6,6 +6,10 @@ export default defineConfig({
   envDir: '../',
   server: {
     proxy: {
+      '/api/realtime': {
+        target: 'http://127.0.0.1:18888',
+        ws: true,
+      },
       '/api': {
         target: 'http://localhost:3001',
         ws: true,


### PR DESCRIPTION
## Summary

- migrate the cockpit voice client from the private `/api/voice/realtime` protocol to Gateway Client Protocol 6.0
- use the published `GatewayClient` SDK for capability negotiation, recovery, transcripts, Task events, audio and playback receipts
- keep browser audio I/O and all cockpit UI components local to the scenario client
- subscribe to the cockpit domain service over HTTP/SSE and route direct panel operations through the same authoritative state
- remove the legacy `actions[]` and streaming chat dependency from the client path

## Boundary

The cockpit client does not inherit or import framework WebUI components. It reuses only the public protocol/package entries. Cockpit business state remains outside Gateway.

## Tests

- `npm run lint`
- `npm run example:car:lint`
- `npm run example:car:build`
- `npm test --prefix examples/car/domain`
- `npm test --prefix examples/car/server`
- GCP handshake, protocol session and replay buffer tests

Closes #273