### PR TITLE
fix(car): restore voice after cockpit unmute

### DIFF
--- a/examples/car/react-app/src/App.jsx
+++ b/examples/car/react-app/src/App.jsx
@@ -280,6 +280,7 @@ export default function App() {
     inputLevel,
     outputLevel,
     progress: voiceProgress,
+    error: voiceError,
     sendInput,
   } = useVoiceSession({
     muted: voiceMuted,
@@ -331,6 +332,7 @@ export default function App() {
               voiceMuted={voiceMuted}
               voiceState={voiceState}
               voiceProgress={voiceProgress}
+              voiceError={voiceError}
               inputLevel={inputLevel}
               outputLevel={outputLevel}
               persona={selectedPersona}

--- a/examples/car/react-app/src/components/VehiclePanel.jsx
+++ b/examples/car/react-app/src/components/VehiclePanel.jsx
@@ -1,7 +1,7 @@
 import CarModel3D from './CarModel3D'
 import VoiceDock from './VoiceDock'
 
-export default function VehiclePanel({ onOpenSettings, carState, voiceMuted, voiceState, voiceProgress, inputLevel, outputLevel, persona, onSelectPersona, onToggleVoiceMute }) {
+export default function VehiclePanel({ onOpenSettings, carState, voiceMuted, voiceState, voiceProgress, voiceError, inputLevel, outputLevel, persona, onSelectPersona, onToggleVoiceMute }) {
   return (
     <aside className="vehicle-panel">
       <div className="speed-readout">
@@ -15,6 +15,7 @@ export default function VehiclePanel({ onOpenSettings, carState, voiceMuted, voi
         muted={voiceMuted}
         state={voiceState}
         progress={voiceProgress}
+        error={voiceError}
         inputLevel={inputLevel}
         outputLevel={outputLevel}
         persona={persona}

--- a/examples/car/react-app/src/components/VoiceDock.jsx
+++ b/examples/car/react-app/src/components/VoiceDock.jsx
@@ -3,8 +3,9 @@ import VoiceWave from './VoiceWave'
 
 const PERSONAS = ['聊愈师', '行动派', '疯批']
 
-export default function VoiceDock({ muted, state = 'idle', progress = null, inputLevel = 0, outputLevel = 0, persona, onSelectPersona, onToggleMute, onOpenSettings }) {
-  const activeState = muted ? 'muted' : state
+export default function VoiceDock({ muted, state = 'idle', progress = null, error = null, inputLevel = 0, outputLevel = 0, persona, onSelectPersona, onToggleMute, onOpenSettings }) {
+  const activeError = !muted && error
+  const activeState = muted ? 'muted' : activeError ? 'error' : state
   const activeProgress = !muted && progress?.message ? progress : null
   const progressClass = activeProgress?.stage ? ` has-progress progress-${activeProgress.stage}` : ''
   const [personaMenuOpen, setPersonaMenuOpen] = useState(false)
@@ -41,7 +42,7 @@ export default function VoiceDock({ muted, state = 'idle', progress = null, inpu
   return (
     <section className={`voice-dock is-${activeState}${progressClass}`} aria-label="语音助手">
       <div className="voice-dock-title">
-        <span>{activeProgress?.message || '说吧，想做什么？'}</span>
+        <span>{activeError || activeProgress?.message || '说吧，想做什么？'}</span>
       </div>
 
       <div className="voice-dock-logo-slot" aria-hidden="true" />

--- a/examples/car/react-app/src/hooks/useVoiceSession.js
+++ b/examples/car/react-app/src/hooks/useVoiceSession.js
@@ -5,6 +5,7 @@ import {
   GatewayClientEvent,
   GatewayServerEvent,
 } from 'qwen-audio-agent/realtime-events'
+import { cockpitVoiceConnectionMode } from './voiceSessionMode'
 
 const INPUT_SAMPLE_RATE = 16000
 const OUTPUT_SAMPLE_RATE = 24000
@@ -289,12 +290,7 @@ export default function useVoiceSession({
       ],
       locale: navigator.language,
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      configure: () => ({
-        voiceEnabled: !mutedRef.current,
-        inputEnabled: !mutedRef.current,
-        outputEnabled: !mutedRef.current,
-        textOnly: mutedRef.current,
-      }),
+      configure: () => cockpitVoiceConnectionMode(mutedRef.current),
       onEvent: handleEvent,
       onRecovery: recovery => {
         onConversationRecoveryRef.current?.(recovery.messages || [])

--- a/examples/car/react-app/src/hooks/voiceSessionMode.js
+++ b/examples/car/react-app/src/hooks/voiceSessionMode.js
@@ -1,0 +1,12 @@
+export function cockpitVoiceConnectionMode(muted) {
+  const enabled = muted !== true
+  return {
+    voiceEnabled: enabled,
+    inputEnabled: enabled,
+    outputEnabled: enabled,
+    // `textOnly` describes a Client capability, not its current mute state.
+    // Keeping it false lets a muted cockpit Client claim voice later through
+    // the standard unmute event without reconnecting or changing protocol.
+    textOnly: false,
+  }
+}

--- a/examples/car/test/voice-session-mode.test.mjs
+++ b/examples/car/test/voice-session-mode.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { cockpitVoiceConnectionMode } from '../react-app/src/hooks/voiceSessionMode.js'
+
+test('keeps a muted cockpit Client voice-capable without claiming voice', () => {
+  assert.deepEqual(cockpitVoiceConnectionMode(true), {
+    voiceEnabled: false,
+    inputEnabled: false,
+    outputEnabled: false,
+    textOnly: false,
+  })
+})
+
+test('enables both voice directions when the cockpit microphone starts active', () => {
+  assert.deepEqual(cockpitVoiceConnectionMode(false), {
+    voiceEnabled: true,
+    inputEnabled: true,
+    outputEnabled: true,
+    textOnly: false,
+  })
+})

--- a/server/test/gateway-client-handshake.test.mjs
+++ b/server/test/gateway-client-handshake.test.mjs
@@ -62,6 +62,39 @@ async function waitFor(received, predicate, timeoutMs = 2000) {
   throw new Error(`Gateway event was not received: ${JSON.stringify(received)}`)
 }
 
+async function waitUntil(predicate, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() <= deadline) {
+    if (predicate()) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error('Gateway condition was not met')
+}
+
+test('a muted voice-capable client can claim voice after unmute', async t => {
+  const { server, gateway } = gatewayHarness()
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  t.after(async () => {
+    await gateway.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const client = await connect(server, {
+    type: 'connect',
+    clientType: 'web',
+    voiceEnabled: false,
+    inputEnabled: false,
+    outputEnabled: false,
+    textOnly: false,
+  })
+  await waitFor(client.received, event => event.type === 'voice.state')
+  assert.equal(gateway.status().activeOwners, 0)
+
+  client.socket.send(JSON.stringify({ type: 'unmute' }))
+  await waitUntil(() => gateway.status().activeOwners === 1)
+  client.socket.close()
+})
+
 test('5.x connect and 6.0 session.hello share one Gateway business path', async t => {
   const { server, gateway } = gatewayHarness()
   await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))


### PR DESCRIPTION
## Summary

- keep a muted cockpit client voice-capable instead of declaring it text-only
- let the standard unmute event claim Gateway voice ownership without reconnecting
- surface microphone and Gateway errors in the cockpit voice dock
- add cockpit and Gateway regression coverage

## Verification

- `npm run test:car`
- `node --test server/test/gateway-client-handshake.test.mjs`
- `npm run lint`
- `npm run example:car:lint`
- `npm run example:car:build`
- Web/TUI/Desktop/CLI workspace tests