### PR TITLE
fix(car): clear recovered Gateway errors

### DIFF
--- a/examples/car/react-app/src/hooks/useVoiceSession.js
+++ b/examples/car/react-app/src/hooks/useVoiceSession.js
@@ -5,7 +5,10 @@ import {
   GatewayClientEvent,
   GatewayServerEvent,
 } from 'qwen-audio-agent/realtime-events'
-import { cockpitVoiceConnectionMode } from './voiceSessionMode'
+import {
+  cockpitConnectionError,
+  cockpitVoiceConnectionMode,
+} from './voiceSessionMode'
 
 const INPUT_SAMPLE_RATE = 16000
 const OUTPUT_SAMPLE_RATE = 24000
@@ -108,6 +111,7 @@ export default function useVoiceSession({
   const [outputLevel, setOutputLevel] = useState(0)
   const [progress, setProgress] = useState(null)
   const [error, setError] = useState(null)
+  const [connectionError, setConnectionError] = useState(null)
   const clientRef = useRef(null)
   const audioContextRef = useRef(null)
   const inputSampleRateRef = useRef(INPUT_SAMPLE_RATE)
@@ -296,11 +300,13 @@ export default function useVoiceSession({
         onConversationRecoveryRef.current?.(recovery.messages || [])
       },
       onStatus: status => {
-        if (status.state === 'ready') {
-          setError(null)
-        } else if (status.state === 'unavailable' || status.state === 'disconnected') {
-          setError('对话中控连接中断，正在重连')
+        const nextConnectionError = cockpitConnectionError(status.state)
+        if (nextConnectionError === undefined) return
+        setConnectionError(nextConnectionError)
+        if (nextConnectionError) {
           setVoiceState('error')
+        } else {
+          setVoiceState(current => current === 'error' ? 'idle' : current)
         }
       },
     })
@@ -427,7 +433,7 @@ export default function useVoiceSession({
     inputLevel,
     outputLevel,
     progress,
-    error,
+    error: connectionError || error,
     sendInput,
   }
 }

--- a/examples/car/react-app/src/hooks/voiceSessionMode.js
+++ b/examples/car/react-app/src/hooks/voiceSessionMode.js
@@ -1,3 +1,5 @@
+export const COCKPIT_CONNECTION_INTERRUPTED = '对话中控连接中断，正在重连'
+
 export function cockpitVoiceConnectionMode(muted) {
   const enabled = muted !== true
   return {
@@ -9,4 +11,12 @@ export function cockpitVoiceConnectionMode(muted) {
     // the standard unmute event without reconnecting or changing protocol.
     textOnly: false,
   }
+}
+
+export function cockpitConnectionError(state) {
+  if (state === 'unavailable' || state === 'disconnected') {
+    return COCKPIT_CONNECTION_INTERRUPTED
+  }
+  if (state === 'connected' || state === 'ready') return null
+  return undefined
 }

--- a/examples/car/test/voice-session-mode.test.mjs
+++ b/examples/car/test/voice-session-mode.test.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { cockpitVoiceConnectionMode } from '../react-app/src/hooks/voiceSessionMode.js'
+import {
+  COCKPIT_CONNECTION_INTERRUPTED,
+  cockpitConnectionError,
+  cockpitVoiceConnectionMode,
+} from '../react-app/src/hooks/voiceSessionMode.js'
 
 test('keeps a muted cockpit Client voice-capable without claiming voice', () => {
   assert.deepEqual(cockpitVoiceConnectionMode(true), {
@@ -18,4 +22,18 @@ test('enables both voice directions when the cockpit microphone starts active', 
     outputEnabled: true,
     textOnly: false,
   })
+})
+
+test('clears a transient connection error as soon as the Gateway reconnects', () => {
+  assert.equal(
+    cockpitConnectionError('disconnected'),
+    COCKPIT_CONNECTION_INTERRUPTED,
+  )
+  assert.equal(
+    cockpitConnectionError('unavailable'),
+    COCKPIT_CONNECTION_INTERRUPTED,
+  )
+  assert.equal(cockpitConnectionError('connected'), null)
+  assert.equal(cockpitConnectionError('ready'), null)
+  assert.equal(cockpitConnectionError('recovery_failed'), undefined)
 })


### PR DESCRIPTION
## Summary

- keep Gateway connection errors separate from microphone and playback errors
- clear transient reconnect UI at both connected and protocol-ready states
- restore the cockpit voice state after recovery
- add regression coverage for the connection status mapping

## Verification

- `npm run test:car`
- `npm run example:car:lint`
- `npm run example:car:build`