### PR TITLE
fix(car): synchronize navigation progress animation

### DIFF
--- a/examples/car/README.md
+++ b/examples/car/README.md
@@ -44,7 +44,7 @@ A preflight validates the Realtime configuration and all four ports before any c
 
 - The UI talks to the Gateway through GCP and knows nothing about the Realtime provider or backend Agent.
 - The primary cockpit stays voice-only. Transcripts appear only in the debug panel, and ASR displays final results only.
-- Scenario-specific HTTP/SSE projects vehicle, route, media, weather, and order state. The Gateway does not parse those objects.
+- Scenario-specific HTTP/SSE projects vehicle, route, media, weather, and order state, plus fine-grained scenario progress. The Gateway does not parse those objects.
 - The foreground Agent owns realtime conversation and submits cockpit work through the fixed `spawn_thinking` bridge. The scenario customizes only the backend capability description in [`spawn-thinking-tool.mjs`](spawn-thinking-tool.mjs), while the tool name and argument contract stay fixed.
 - The example backend attaches over A2A and invokes domain capabilities through MCP. It intentionally implements only a small intent router.
 - Customers can replace the UI, backend Agent, or domain service without changing the framework core.

--- a/examples/car/README_ZH.md
+++ b/examples/car/README_ZH.md
@@ -44,7 +44,7 @@ npm run example:car
 
 - UI 仅通过 GCP 与 Gateway 对话，不感知 Realtime Provider 或后台 Agent。
 - 主座舱区域保持纯语音交互；文字转写只进入调试面板，并且 ASR 仅展示最终结果。
-- UI 通过场景自己的 HTTP/SSE 通道展示车辆、路线、音乐、天气和订单状态；Gateway 不解析这些对象。
+- UI 通过场景自己的 HTTP/SSE 通道展示车辆、路线、音乐、天气和订单状态，以及细粒度场景进度；Gateway 不解析这些对象。
 - 前台 Agent 负责实时聊天，座舱任务通过固定的 `spawn_thinking` 桥梁提交给后台；场景只在 [`spawn-thinking-tool.mjs`](spawn-thinking-tool.mjs) 定义后台能力描述，不改工具名称和参数协议。
 - 示例后台通过 A2A 接入 Gateway，并通过 MCP 调用领域能力；它只实现少量意图路由，不模拟完整行业 Agent。
 - 客户可以替换整个 UI、后台 Agent 或领域服务，而不修改框架核心。

--- a/examples/car/domain/cockpit-domain.mjs
+++ b/examples/car/domain/cockpit-domain.mjs
@@ -95,6 +95,7 @@ export class CockpitDomain {
     this.services = services
     this.now = now
     this.random = random
+    this.activityListeners = new Map()
   }
 
   snapshot(cockpitId = 'default') {
@@ -105,12 +106,48 @@ export class CockpitDomain {
     return this.store.subscribe(cockpitId, listener)
   }
 
+  subscribeActivity(cockpitId, listener) {
+    if (typeof listener !== 'function') throw new TypeError('listener must be a function')
+    const id = clean(cockpitId) || 'default'
+    const listeners = this.activityListeners.get(id) || new Set()
+    listeners.add(listener)
+    this.activityListeners.set(id, listeners)
+    return () => {
+      listeners.delete(listener)
+      if (!listeners.size) this.activityListeners.delete(id)
+    }
+  }
+
+  #publishActivity(cockpitId, event) {
+    const id = clean(cockpitId) || 'default'
+    const published = Object.freeze({
+      type: 'cockpit.activity',
+      cockpitId: id,
+      ...event,
+    })
+    for (const listener of this.activityListeners.get(id) || []) {
+      try {
+        listener(published)
+      } catch {
+        // Scenario observers cannot interrupt domain operations.
+      }
+    }
+  }
+
   async execute(name, args = {}, {
     cockpitId = 'default',
     onActivity = null,
   } = {}) {
     if (!COCKPIT_TOOL_NAMES.includes(name)) {
       throw new Error(`Unknown cockpit tool: ${name}`)
+    }
+    const reportActivity = event => {
+      try {
+        onActivity?.(event)
+      } catch {
+        // Call-scoped observers cannot interrupt domain operations.
+      }
+      this.#publishActivity(cockpitId, event)
     }
     if (name.startsWith('vehicle_')) {
       return this.#vehicle(name, args, cockpitId)
@@ -119,12 +156,12 @@ export class CockpitDomain {
       return this.#music(name, args, cockpitId)
     }
     if (name.startsWith('navigation_')) {
-      return this.#navigation(name, args, cockpitId, onActivity)
+      return this.#navigation(name, args, cockpitId, reportActivity)
     }
     if (name === 'weather') {
-      return this.#weather(args, cockpitId, onActivity)
+      return this.#weather(args, cockpitId, reportActivity)
     }
-    return this.#flashbuy(args, cockpitId, onActivity)
+    return this.#flashbuy(args, cockpitId, reportActivity)
   }
 
   #vehicle(name, args, cockpitId) {
@@ -297,9 +334,17 @@ export class CockpitDomain {
       const state = this.snapshot(cockpitId)
       return result(`无法找到“${destination}”的位置信息`, state, [])
     }
-    const viaLocation = via
-      ? await this.services.resolvePlace(via, DEFAULT_ORIGIN.city)
-      : null
+    activity(onActivity, 'navigation', 'destination_locked', `已找到${destination}`)
+    let viaLocation = null
+    if (via) {
+      activity(onActivity, 'navigation', 'searching_via', '正在查找途经点')
+      viaLocation = await this.services.resolvePlace(via, DEFAULT_ORIGIN.city)
+      if (!viaLocation) {
+        activity(onActivity, 'navigation', 'via_not_found', `没有找到${via}`)
+        return result(`无法找到途经点“${via}”的位置信息`, this.snapshot(cockpitId), [])
+      }
+      activity(onActivity, 'navigation', 'via_locked', `已找到途经点${via}`)
+    }
     activity(onActivity, 'navigation', 'planning_route', '正在规划路线')
     const route = await this.#planRoute(destinationLocation, viaLocation, strategy)
     if (!route) {

--- a/examples/car/domain/server.mjs
+++ b/examples/car/domain/server.mjs
@@ -146,12 +146,17 @@ export class CockpitDomainServer {
       response.write(`event: ${type}\ndata: ${JSON.stringify(value)}\n\n`)
     }
     send('snapshot', this.domain.snapshot(id))
-    const unsubscribe = this.domain.subscribe(id, event => send('state', event))
+    const unsubscribeState = this.domain.subscribe(id, event => send('state', event))
+    const unsubscribeActivity = this.domain.subscribeActivity(
+      id,
+      event => send('activity', event),
+    )
     const heartbeat = setInterval(() => response.write(': heartbeat\n\n'), 15_000)
     heartbeat.unref?.()
     request.once('close', () => {
       clearInterval(heartbeat)
-      unsubscribe()
+      unsubscribeState()
+      unsubscribeActivity()
     })
   }
 

--- a/examples/car/domain/test/cockpit-domain.test.mjs
+++ b/examples/car/domain/test/cockpit-domain.test.mjs
@@ -87,9 +87,35 @@ test('projects navigation progress and route state separately', async () => {
   assert.equal(output.data.navigation.map.polylines.length, 2)
   assert.deepEqual(activities.map(event => event.status), [
     'searching_destination',
+    'destination_locked',
+    'searching_via',
+    'via_locked',
     'planning_route',
     'navigation_started',
   ])
+})
+
+test('publishes scenario activity independently from the call observer', async () => {
+  const { domain, options } = fixture()
+  const published = []
+  const unsubscribe = domain.subscribeActivity(
+    'car-one',
+    event => published.push(event),
+  )
+  await domain.execute('navigation_start', { destination: '西湖' }, options)
+  unsubscribe()
+
+  assert.deepEqual(published.map(event => event.status), [
+    'searching_destination',
+    'destination_locked',
+    'planning_route',
+    'navigation_started',
+  ])
+  assert.ok(published.every(event => (
+    event.type === 'cockpit.activity'
+    && event.cockpitId === 'car-one'
+    && event.category === 'navigation'
+  )))
 })
 
 test('queries the current route without requiring another destination', async () => {

--- a/examples/car/domain/test/server.test.mjs
+++ b/examples/car/domain/test/server.test.mjs
@@ -89,6 +89,38 @@ test('streams authoritative state changes to cockpit panels', async t => {
   await reader.cancel()
 })
 
+test('streams navigation activity to the scenario UI', async t => {
+  const server = new CockpitDomainServer({ domain: domainFixture(), port: 0 })
+  await server.start()
+  t.after(() => server.close())
+  const controller = new AbortController()
+  t.after(() => controller.abort())
+  const response = await fetch(
+    `${server.origin}/api/cockpit/events?cockpitId=progress-car`,
+    { signal: controller.signal },
+  )
+  const reader = response.body.getReader()
+  await readSseEvent(reader, 'snapshot')
+
+  const activityPromise = readSseEvent(reader, 'activity')
+  const commandPromise = fetch(`${server.origin}/api/cockpit/commands`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      cockpitId: 'progress-car',
+      name: 'navigation_start',
+      arguments: { destination: '西湖' },
+    }),
+  })
+  const activity = await activityPromise
+  await commandPromise
+
+  assert.equal(activity.category, 'navigation')
+  assert.equal(activity.status, 'searching_destination')
+  assert.equal(activity.message, '正在查找目的地')
+  await reader.cancel()
+})
+
 test('exposes the same domain operations through MCP', async t => {
   const server = new CockpitDomainServer({ domain: domainFixture(), port: 0 })
   await server.start()

--- a/examples/car/react-app/src/App.css
+++ b/examples/car/react-app/src/App.css
@@ -332,6 +332,15 @@ button {
     rgba(245, 251, 252, 0.66);
 }
 
+.voice-dock.progress-destination_locked,
+.voice-dock.progress-via_locked {
+  background:
+    radial-gradient(ellipse at 34% 100%, rgba(50, 177, 161, 0.2), transparent 44%),
+    radial-gradient(ellipse at 76% 100%, rgba(196, 168, 95, 0.16), transparent 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(237, 248, 241, 0.6)),
+    rgba(245, 251, 252, 0.66);
+}
+
 .voice-dock.progress-planning_route {
   background:
     radial-gradient(ellipse at 48% 100%, rgba(91, 148, 214, 0.24), transparent 48%),

--- a/examples/car/react-app/src/App.jsx
+++ b/examples/car/react-app/src/App.jsx
@@ -75,7 +75,11 @@ function parseHash() {
 export default function App() {
   const clientId = useMemo(() => getClientId(), [])
   const cockpitId = import.meta.env.VITE_COCKPIT_ID || 'default'
-  const { state: cockpitState, execute: executeCockpitCommand } = useCockpitState(cockpitId)
+  const {
+    state: cockpitState,
+    progress: cockpitProgress,
+    execute: executeCockpitCommand,
+  } = useCockpitState(cockpitId)
   const [screen, setScreen] = useState('main')
   const [settingsTab, setSettingsTab] = useState('persona')
   const [selectedPersona, setSelectedPersona] = useState(() => getStoredChoice(PERSONA_STORAGE_KEY, DEFAULT_PERSONA, VALID_PERSONAS))
@@ -290,15 +294,16 @@ export default function App() {
     onVoiceMessage: handleVoiceMessage,
     onConversationRecovery: handleConversationRecovery,
   })
+  const visualProgress = cockpitProgress || voiceProgress
 
   const handleTextMessage = useCallback((text) => (
     sendInput([{ type: 'text', text }])
   ), [sendInput])
 
   useEffect(() => {
-    if (!['navigation', 'flashbuy'].includes(voiceProgress?.domain)) return undefined
+    if (!['navigation', 'flashbuy'].includes(visualProgress?.domain)) return undefined
     const frame = requestAnimationFrame(() => {
-      if (voiceProgress.domain === 'navigation') {
+      if (visualProgress.domain === 'navigation') {
         setScreen('main')
         window.location.hash = '#main'
       } else {
@@ -307,7 +312,7 @@ export default function App() {
       }
     })
     return () => cancelAnimationFrame(frame)
-  }, [voiceProgress])
+  }, [visualProgress])
 
   useEffect(() => {
     const onHashChange = () => {
@@ -333,7 +338,7 @@ export default function App() {
               onTogglePart={toggleCarPart}
               voiceMuted={voiceMuted}
               voiceState={voiceState}
-              voiceProgress={voiceProgress}
+              voiceProgress={visualProgress}
               voiceError={voiceError}
               inputLevel={inputLevel}
               outputLevel={outputLevel}
@@ -342,7 +347,7 @@ export default function App() {
               onToggleVoiceMute={toggleVoiceMute}
             />
             {screen === 'main' && (
-              <MapPanel navState={navState} navProgress={voiceProgress} mapActions={mapActions} routeStrategy={routeStrategy} onStrategyChange={setRouteStrategy} />
+              <MapPanel navState={navState} navProgress={visualProgress} mapActions={mapActions} routeStrategy={routeStrategy} onStrategyChange={setRouteStrategy} />
             )}
             {screen === 'music' && (
               <MusicPanel musicState={musicState} onPlay={musicPlay} onPause={musicPause} onNext={musicNext} onPrev={musicPrev} onSelectTrack={musicSelectTrack} />

--- a/examples/car/react-app/src/components/MapPanel.jsx
+++ b/examples/car/react-app/src/components/MapPanel.jsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useMemo, useCallback, useState } from 'react'
 import AMapLoader from '@amap/amap-jsapi-loader'
+import { navigationRouteView } from '../navigation-route'
 
 window._AMapSecurityConfig = {
   securityJsCode: import.meta.env.VITE_AMAP_SECRET,
@@ -393,17 +394,7 @@ export default function MapPanel({ navState, navProgress, mapActions, routeStrat
     if (puck) puck.style.transform = `rotate(${bearing}deg)`
   }, [])
 
-  const routeInfo = useMemo(() => {
-    if (navState?.status !== 'navigating' || !navState.route) return null
-    const route = navState.route
-    return {
-      destination: route.destination,
-      distKm: route.distKm,
-      durationMin: route.durationMin,
-      arrivalStr: route.arrivalStr,
-      polyline: route.polyline,
-    }
-  }, [navState])
+  const routeInfo = useMemo(() => navigationRouteView(navState), [navState])
 
   const activeNavProgress = useMemo(() => (
     navProgress?.domain === 'navigation' && navProgress.message ? navProgress : null
@@ -576,8 +567,8 @@ export default function MapPanel({ navState, navProgress, mapActions, routeStrat
     markersRef.current = []
     clearPreview()
 
-    if (navState?.status === 'navigating' && navState.route) {
-      const route = navState.route
+    if (routeInfo) {
+      const route = routeInfo
 
       if (route.polyline) {
         const points = parsePolyline(route.polyline, AMap)
@@ -632,6 +623,7 @@ export default function MapPanel({ navState, navProgress, mapActions, routeStrat
                 animateRoute(routeLayers.animated, points, () => {
                   startRouteFlow(points)
                   setCameraStage('settle')
+                  if (route.status !== 'navigating') return
                   const followCamera = getFollowCamera(points)
                   rotateVehiclePuck(followCamera.rotation)
                   tweenCamera(followCamera, CAMERA_SETTLE_DURATION, () => setCameraStage('tracking'))
@@ -665,7 +657,9 @@ export default function MapPanel({ navState, navProgress, mapActions, routeStrat
           }, CAMERA_EXPAND_DURATION)
           scheduleCameraStep(() => {
             setCameraStage('settle')
-            tweenCamera({ center: destPos, zoom: 16.4, pitch: 54, rotation: 0 }, CAMERA_SETTLE_DURATION, () => setCameraStage('tracking'))
+            if (route.status === 'navigating') {
+              tweenCamera({ center: destPos, zoom: 16.4, pitch: 54, rotation: 0 }, CAMERA_SETTLE_DURATION, () => setCameraStage('tracking'))
+            }
           }, CAMERA_EXPAND_DURATION + CAMERA_DESTINATION_HOLD)
         }, CAMERA_FOCUS_DURATION + CAMERA_MASK_LEAD)
       }
@@ -673,7 +667,7 @@ export default function MapPanel({ navState, navProgress, mapActions, routeStrat
       scheduleCameraStep(() => setCameraStage('idle'), 0)
       tweenCamera({ center: DEFAULT_CENTER, zoom: 14, pitch: 42, rotation: 0 }, 520)
     }
-  }, [navState, mapReady, clearPreview, clearRouteLayers, createRouteLayers, animateRoute, parsePolyline, clearCameraTimeline, stopRouteFlow, scheduleCameraStep, tweenCamera, calculateBearing, getRouteCamera, getFollowCamera, getDestinationMarkerContent, startRouteFlow, rotateVehiclePuck])
+  }, [navState?.status, routeInfo, mapReady, clearPreview, clearRouteLayers, createRouteLayers, animateRoute, parsePolyline, clearCameraTimeline, stopRouteFlow, scheduleCameraStep, tweenCamera, calculateBearing, getRouteCamera, getFollowCamera, getDestinationMarkerContent, startRouteFlow, rotateVehiclePuck])
 
   useEffect(() => {
     if (!mapReady || routeInfo || !activeNavProgress) return undefined

--- a/examples/car/react-app/src/components/VoiceWave.jsx
+++ b/examples/car/react-app/src/components/VoiceWave.jsx
@@ -24,6 +24,8 @@ const STATE_STYLE = {
 const PROGRESS_STYLE = {
   searching_destination: { speed: 0.00068, color: COLORS.user, accent: COLORS.thinkingSoft, direction: 1, activity: 0.66 },
   searching_via: { speed: 0.00068, color: COLORS.user, accent: COLORS.thinkingSoft, direction: 1, activity: 0.66 },
+  destination_locked: { speed: 0.00052, color: COLORS.user, accent: COLORS.systemSoft, direction: -1, activity: 0.58, routeNodes: true },
+  via_locked: { speed: 0.00052, color: COLORS.user, accent: COLORS.systemSoft, direction: -1, activity: 0.58, routeNodes: true },
   planning_route: { speed: 0.0046, color: COLORS.thinking, accent: COLORS.systemSoft, direction: 1, activity: 0.74, oscillate: true, routeNodes: true },
   route_ready: { speed: 0.00052, color: COLORS.system, accent: COLORS.systemSoft, direction: -1, activity: 0.58, routeNodes: true },
   navigation_started: { speed: 0.00052, color: COLORS.system, accent: COLORS.systemSoft, direction: -1, activity: 0.58, routeNodes: true },

--- a/examples/car/react-app/src/hooks/useCockpitState.js
+++ b/examples/car/react-app/src/hooks/useCockpitState.js
@@ -1,4 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
+import {
+  isTerminalNavigationProgress,
+  navigationProgressFromActivity,
+} from '../navigation-progress'
 
 function domainOrigin() {
   return import.meta.env.VITE_COCKPIT_DOMAIN_ORIGIN || 'http://127.0.0.1:3010'
@@ -6,10 +10,12 @@ function domainOrigin() {
 
 export default function useCockpitState(cockpitId) {
   const [state, setState] = useState(null)
+  const [progress, setProgress] = useState(null)
   const [error, setError] = useState(null)
 
   useEffect(() => {
     let disposed = false
+    let progressTimer = null
     const query = new URLSearchParams({ cockpitId })
     const stateUrl = `${domainOrigin()}/api/cockpit/state?${query}`
     const eventsUrl = `${domainOrigin()}/api/cockpit/events?${query}`
@@ -36,6 +42,18 @@ export default function useCockpitState(cockpitId) {
     events.addEventListener('state', event => {
       if (!disposed) setState(JSON.parse(event.data).state)
     })
+    events.addEventListener('activity', event => {
+      if (disposed) return
+      const next = navigationProgressFromActivity(JSON.parse(event.data))
+      if (!next) return
+      clearTimeout(progressTimer)
+      setProgress(next)
+      if (isTerminalNavigationProgress(next)) {
+        progressTimer = setTimeout(() => {
+          if (!disposed) setProgress(null)
+        }, 1800)
+      }
+    })
     events.addEventListener('open', () => {
       if (!disposed) setError(null)
     })
@@ -44,6 +62,7 @@ export default function useCockpitState(cockpitId) {
     })
     return () => {
       disposed = true
+      clearTimeout(progressTimer)
       events.close()
     }
   }, [cockpitId])
@@ -59,5 +78,5 @@ export default function useCockpitState(cockpitId) {
     return result
   }, [cockpitId])
 
-  return { state, error, execute }
+  return { state, progress, error, execute }
 }

--- a/examples/car/react-app/src/navigation-progress.js
+++ b/examples/car/react-app/src/navigation-progress.js
@@ -1,0 +1,25 @@
+const TERMINAL_STAGES = new Set([
+  'navigation_started',
+  'route_ready',
+  'navigation_stopped',
+  'destination_not_found',
+  'via_not_found',
+  'route_failed',
+])
+
+export function navigationProgressFromActivity(activity) {
+  if (activity?.category !== 'navigation') return null
+  const stage = String(activity.status || '').trim()
+  const message = String(activity.message || '').trim()
+  if (!stage || !message) return null
+  return {
+    domain: 'navigation',
+    stage,
+    message,
+    source: 'cockpit-domain',
+  }
+}
+
+export function isTerminalNavigationProgress(progress) {
+  return TERMINAL_STAGES.has(progress?.stage)
+}

--- a/examples/car/react-app/src/navigation-route.js
+++ b/examples/car/react-app/src/navigation-route.js
@@ -1,0 +1,26 @@
+export function navigationRouteView(navigation) {
+  if (!['navigating', 'preview'].includes(navigation?.status)) return null
+  const route = navigation.route
+  if (!route) return null
+  const legs = Array.isArray(route.legs) ? route.legs : []
+  const polylines = legs
+    .map(leg => leg?.polyline)
+    .filter(Boolean)
+    .map((polyline, index) => (
+      index === 0 ? polyline : polyline.split(';').slice(1).join(';')
+    ))
+    .filter(Boolean)
+  const viaMarker = navigation.map?.markers?.find(marker => marker?.role === 'via')
+  return {
+    status: navigation.status,
+    destination: navigation.destination || '',
+    distKm: route.distKm,
+    durationMin: route.durationMin,
+    arrivalStr: route.arrival,
+    polyline: polylines.join(';'),
+    trafficSegments: legs.flatMap(leg => (
+      Array.isArray(leg?.trafficSegments) ? leg.trafficSegments : []
+    )),
+    viaLocation: viaMarker?.location || null,
+  }
+}

--- a/examples/car/test/navigation-progress.test.mjs
+++ b/examples/car/test/navigation-progress.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  isTerminalNavigationProgress,
+  navigationProgressFromActivity,
+} from '../react-app/src/navigation-progress.js'
+
+test('projects only valid navigation activity into UI animation progress', () => {
+  assert.deepEqual(navigationProgressFromActivity({
+    category: 'navigation',
+    status: 'planning_route',
+    message: '正在规划路线',
+  }), {
+    domain: 'navigation',
+    stage: 'planning_route',
+    message: '正在规划路线',
+    source: 'cockpit-domain',
+  })
+  assert.equal(navigationProgressFromActivity({
+    category: 'weather',
+    status: 'weather_querying',
+    message: '正在查询天气',
+  }), null)
+  assert.equal(navigationProgressFromActivity({
+    category: 'navigation',
+    status: '',
+    message: '缺少阶段',
+  }), null)
+})
+
+test('recognizes terminal navigation animation stages', () => {
+  assert.equal(isTerminalNavigationProgress({ stage: 'planning_route' }), false)
+  assert.equal(isTerminalNavigationProgress({ stage: 'navigation_started' }), true)
+  assert.equal(isTerminalNavigationProgress({ stage: 'route_failed' }), true)
+})

--- a/examples/car/test/navigation-route.test.mjs
+++ b/examples/car/test/navigation-route.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { navigationRouteView } from '../react-app/src/navigation-route.js'
+
+test('projects authoritative navigation state into the map view contract', () => {
+  assert.deepEqual(navigationRouteView({
+    status: 'navigating',
+    destination: '西湖',
+    route: {
+      distKm: '12.3',
+      durationMin: 25,
+      arrival: '15:10',
+      legs: [
+        {
+          polyline: '120.0,30.0;120.1,30.1',
+          trafficSegments: [{ status: '畅通', polyline: '120.0,30.0;120.1,30.1' }],
+        },
+        {
+          polyline: '120.1,30.1;120.2,30.2',
+          trafficSegments: [],
+        },
+      ],
+    },
+    map: {
+      markers: [{ role: 'via', location: '120.1,30.1' }],
+    },
+  }), {
+    status: 'navigating',
+    destination: '西湖',
+    distKm: '12.3',
+    durationMin: 25,
+    arrivalStr: '15:10',
+    polyline: '120.0,30.0;120.1,30.1;120.2,30.2',
+    trafficSegments: [{ status: '畅通', polyline: '120.0,30.0;120.1,30.1' }],
+    viaLocation: '120.1,30.1',
+  })
+})
+
+test('supports route previews and ignores idle navigation', () => {
+  assert.equal(navigationRouteView({ status: 'idle', route: null }), null)
+  assert.equal(navigationRouteView({
+    status: 'preview',
+    destination: '西湖',
+    route: { legs: [] },
+  }).status, 'preview')
+})


### PR DESCRIPTION
## Summary
- stream fine-grained cockpit navigation activity to the scenario UI without changing the generic Gateway/A2A protocol
- project authoritative navigation route state into the map view contract
- synchronize voice and map animation stages for destination, via point, route planning, preview, and active navigation

## Validation
- `npm run test:car`
- `npm run example:car:lint`
- `npm run example:car:build`
- live cockpit navigation flow in browser