### PR TITLE
fix(car): prevent weather updates from replaying map UI

### DIFF
--- a/examples/car/react-app/src/cockpit-state-update.js
+++ b/examples/car/react-app/src/cockpit-state-update.js
@@ -1,0 +1,15 @@
+const STATE_METADATA = new Set(['version', 'updatedAt'])
+
+export function applyCockpitStateUpdate(previous, event) {
+  const next = event?.state
+  if (!previous || !next || !Array.isArray(event.changed)) return next
+
+  const changed = new Set(event.changed)
+  const reconciled = { ...next }
+  for (const key of Object.keys(next)) {
+    if (!STATE_METADATA.has(key) && !changed.has(key) && key in previous) {
+      reconciled[key] = previous[key]
+    }
+  }
+  return reconciled
+}

--- a/examples/car/react-app/src/hooks/useCockpitState.js
+++ b/examples/car/react-app/src/hooks/useCockpitState.js
@@ -3,6 +3,7 @@ import {
   isTerminalNavigationProgress,
   navigationProgressFromActivity,
 } from '../navigation-progress'
+import { applyCockpitStateUpdate } from '../cockpit-state-update'
 
 function domainOrigin() {
   return import.meta.env.VITE_COCKPIT_DOMAIN_ORIGIN || 'http://127.0.0.1:3010'
@@ -40,7 +41,10 @@ export default function useCockpitState(cockpitId) {
       if (!disposed) setState(JSON.parse(event.data))
     })
     events.addEventListener('state', event => {
-      if (!disposed) setState(JSON.parse(event.data).state)
+      if (!disposed) {
+        const update = JSON.parse(event.data)
+        setState(previous => applyCockpitStateUpdate(previous, update))
+      }
     })
     events.addEventListener('activity', event => {
       if (disposed) return

--- a/examples/car/test/cockpit-state-update.test.mjs
+++ b/examples/car/test/cockpit-state-update.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { applyCockpitStateUpdate } from '../react-app/src/cockpit-state-update.js'
+
+function state(version, overrides = {}) {
+  return {
+    version,
+    updatedAt: version * 100,
+    vehicle: { ac: 1 },
+    navigation: { status: 'navigating', destination: '西湖' },
+    music: { playing: false },
+    weather: { city: '杭州市', dayweather: '多云' },
+    ...overrides,
+  }
+}
+
+test('weather updates preserve unrelated panel state identities', () => {
+  const previous = state(1)
+  const incoming = state(2, {
+    weather: { city: '杭州市', dayweather: '晴' },
+  })
+
+  const next = applyCockpitStateUpdate(previous, {
+    changed: ['weather'],
+    state: incoming,
+  })
+
+  assert.equal(next.version, 2)
+  assert.equal(next.updatedAt, 200)
+  assert.equal(next.weather, incoming.weather)
+  assert.equal(next.navigation, previous.navigation)
+  assert.equal(next.vehicle, previous.vehicle)
+  assert.equal(next.music, previous.music)
+})
+
+test('falls back to a full snapshot replacement without change metadata', () => {
+  const previous = state(1)
+  const incoming = state(2)
+
+  assert.equal(applyCockpitStateUpdate(previous, { state: incoming }), incoming)
+  assert.equal(applyCockpitStateUpdate(null, { changed: ['weather'], state: incoming }), incoming)
+})


### PR DESCRIPTION
## Summary
- preserve unchanged cockpit domain state identities when applying SSE updates
- prevent weather-only updates from retriggering navigation map effects
- add regression coverage for cross-panel state isolation

## Tests
- npm run test:car
- npm run example:car:lint
- npm run example:car:build