### PR TITLE
docs(car): add at-a-glance structure map

### DIFF
--- a/examples/car/README.md
+++ b/examples/car/README.md
@@ -16,6 +16,27 @@ conversation, GCP Client SDK, BackendPort, A2A, and MCP seams.
 The backend Agent may derive independent Sessions as an optional third-layer
 execution space. This lightweight cockpit Agent does not implement that option.
 
+## Structure at a glance
+
+| Directory / process | Default address | Role and contract | Change it when... |
+|---|---|---|---|
+| [`react-app/`](react-app/) / cockpit-client | `http://127.0.0.1:5173` | Replaceable foreground client. Uses GCP for conversation and scenario HTTP/SSE for panels. | Replacing the cockpit UI, browser audio I/O, or panel interaction. |
+| [`gateway.mjs`](gateway.mjs) / cockpit-gateway | `http://127.0.0.1:18888` | Foreground composition root. Reuses the framework Gateway and connects the configured backend through BackendPort/A2A. | Wiring a different protocol adapter or changing scenario composition—not implementing business logic. |
+| [`agent/`](agent/) / cockpit-agent | `http://127.0.0.1:3020` | Small replaceable A2A backend example. Calls only the backend MCP surface. | Replacing or teaching the bundled backend example. |
+| [`domain/`](domain/) / cockpit-domain | `http://127.0.0.1:3010` | Scenario-owned state and external-service adapters. Serves UI HTTP/SSE and both scoped MCP surfaces. | Adding business state, validation, or an external service integration. |
+| [`tools/`](tools/) | served by cockpit-domain | Cockpit capability contract. Each group keeps its MCP manifest beside its executor; `registry.mjs` explicitly assigns it to the foreground or backend. | Adding or changing a cockpit capability. |
+
+Common changes should stay local:
+
+- **Replace the backend Agent:** point `COCKPIT_AGENT_CARD_URL` at your Agent, or
+  replace only [`agent/`](agent/) when editing the bundled example. The client,
+  Gateway core, Domain, and tool contracts do not change.
+- **Add a scenario capability:** change [`tools/`](tools/) and touch
+  [`domain/`](domain/) only when the capability needs new state or an external
+  service adapter. Do not add business branches to the Gateway or client.
+- **Replace the cockpit UI:** replace only [`react-app/`](react-app/) while
+  keeping the GCP and scenario-state contracts.
+
 ## Quick start
 
 From the repository root:
@@ -38,13 +59,7 @@ npm run example:car
 ```
 
 Open `http://localhost:5173`.
-
-| Process | Default address | Architecture role | Responsibility |
-|---|---|---|---|
-| cockpit-client | `http://127.0.0.1:5173` | Foreground client component | Scenario UI, browser audio I/O, business panels |
-| cockpit-gateway | `http://127.0.0.1:18888` | Foreground conversation core | Realtime conversation, frontend tools, Task bridge, speech, interruption, recovery |
-| cockpit-agent | `http://127.0.0.1:3020` | Backend example | Small replaceable A2A cockpit Agent |
-| cockpit-domain | `http://127.0.0.1:3010` | Scenario infrastructure, not another layer | Authoritative business state, HTTP/SSE, MCP capabilities |
+The command starts the four processes listed above.
 
 Press `Ctrl+C` to stop all processes.
 

--- a/examples/car/README_ZH.md
+++ b/examples/car/README_ZH.md
@@ -13,6 +13,25 @@ qwen-audio-agent 的基础边界是“前台对话 + 后台执行”两层。示
 后台 Agent 可以按需派生独立 Session，扩展出第三层执行空间；当前轻量座舱 Agent
 没有实现这项可选能力。
 
+## 目录职责一览
+
+| 目录 / 进程 | 默认地址 | 角色与契约 | 什么时候修改 |
+|---|---|---|---|
+| [`react-app/`](react-app/) / cockpit-client | `http://127.0.0.1:5173` | 可替换的前台客户端。对话走 GCP，业务面板走场景 HTTP/SSE。 | 替换座舱 UI、浏览器音频 I/O 或面板交互时。 |
+| [`gateway.mjs`](gateway.mjs) / cockpit-gateway | `http://127.0.0.1:18888` | 前台装配入口。复用框架 Gateway，通过 BackendPort/A2A 连接配置的后台。 | 更换协议 Adapter 或调整场景装配时；不在这里实现业务逻辑。 |
+| [`agent/`](agent/) / cockpit-agent | `http://127.0.0.1:3020` | 轻量、可替换的 A2A 后台示例，只调用后台 MCP 工具面。 | 替换或扩展示例后台 Agent 时。 |
+| [`domain/`](domain/) / cockpit-domain | `http://127.0.0.1:3010` | 场景自己的状态与外部服务适配，向 UI 提供 HTTP/SSE，并承载两个受限 MCP 工具面。 | 增加业务状态、校验或外部服务接入时。 |
+| [`tools/`](tools/) | 由 cockpit-domain 承载 | 座舱能力契约。每组把 MCP manifest 和 executor 放在一起，由 `registry.mjs` 显式分配给前台或后台。 | 增加或修改座舱能力时。 |
+
+常见修改应保持局部化：
+
+- **想换后台 Agent：**将 `COCKPIT_AGENT_CARD_URL` 指向自己的 Agent；如果修改
+  仓库自带示例，只动 [`agent/`](agent/)。客户端、Gateway 核心、Domain 和工具
+  契约都不需要变化。
+- **想加场景能力：**修改 [`tools/`](tools/)；只有需要新增状态或外部服务适配时
+  才修改 [`domain/`](domain/)。不要把业务分支写入 Gateway 或客户端。
+- **想换座舱 UI：**只替换 [`react-app/`](react-app/)，继续遵守 GCP 和场景状态契约。
+
 ## 快速开始
 
 在仓库根目录执行：
@@ -34,14 +53,7 @@ npm run example:car:install
 npm run example:car
 ```
 
-浏览器打开 `http://localhost:5173`。该命令同时启动：
-
-| 进程 | 默认地址 | 架构归属 | 职责 |
-|---|---|---|---|
-| cockpit-client | `http://127.0.0.1:5173` | 前台客户端组件 | 场景 UI、浏览器音频 I/O、业务面板 |
-| cockpit-gateway | `http://127.0.0.1:18888` | 前台对话核心 | 实时对话、前台工具、任务桥梁、播报、打断和恢复 |
-| cockpit-agent | `http://127.0.0.1:3020` | 后台执行示例 | 轻量、可替换的 A2A 座舱 Agent |
-| cockpit-domain | `http://127.0.0.1:3010` | 场景基础设施（非额外层） | 单一业务状态、HTTP/SSE 与 MCP 能力 |
+浏览器打开 `http://localhost:5173`。该命令会同时启动上表中的四个进程。
 
 按 `Ctrl+C` 会一起关闭四个进程。
 


### PR DESCRIPTION
## Summary
- put the four runtime processes and the `tools/` contract in one top-level responsibility table
- show the allowed change boundary for each directory
- add direct recipes for replacing the backend Agent, adding a scenario capability, and replacing the cockpit UI
- keep English and Chinese READMEs aligned and remove the duplicated process table

## Test
- npm run docs:build