### PR TITLE
fix(desktop): recover microphone after input device changes

### DIFF
--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -136,6 +136,8 @@ const translations = {
   '语音前台连接异常，正在重试': 'Voice frontend connection error, retrying',
   '实时语音连接中断，正在重连': 'Realtime voice connection lost, reconnecting',
   '无法打开麦克风': 'Could not open the microphone',
+  '正在切换麦克风': 'Switching microphone',
+  '未检测到可用麦克风，连接设备后会自动恢复': 'No microphone detected. Input will recover automatically when a device is connected.',
   '无法初始化实时语音播放': 'Could not initialize realtime voice playback',
   '加载远程图片': 'Load remote image',
   '加载远程音频': 'Load remote audio',

--- a/web/src/microphone-capture.js
+++ b/web/src/microphone-capture.js
@@ -1,0 +1,166 @@
+const DEFAULT_RETRY_DELAYS = Object.freeze([500, 1_000, 2_000, 4_000])
+
+export function recoverableMicrophoneError(error) {
+  return ![
+    'NotAllowedError',
+    'NotSupportedError',
+    'SecurityError',
+    'TypeError',
+  ].includes(String(error?.name || ''))
+}
+
+function audioTrack(capture) {
+  return capture?.track || capture?.media?.getAudioTracks?.()[0] || null
+}
+
+/**
+ * Owns only microphone capture. Gateway, Realtime, and output playback remain
+ * outside this lifecycle so changing an input device cannot reconnect or
+ * interrupt them.
+ */
+export function createMicrophoneCaptureLifecycle({
+  mediaDevices,
+  acquire,
+  release = capture => capture?.close?.(),
+  onState = () => {},
+  onFatalError = () => {},
+  debounceMs = 300,
+  muteGraceMs = 1_500,
+  retryDelays = DEFAULT_RETRY_DELAYS,
+  schedule = (callback, delay) => setTimeout(callback, delay),
+  cancel = timer => clearTimeout(timer),
+} = {}) {
+  if (!mediaDevices?.getUserMedia || typeof acquire !== 'function') {
+    throw new Error('microphone capture requires mediaDevices and acquire')
+  }
+
+  let running = false
+  let generation = 0
+  let currentCapture = null
+  let restartTimer = null
+  let retryTimer = null
+  let muteTimer = null
+  let retryAttempt = 0
+
+  const clearTimer = name => {
+    const timer = name === 'restart'
+      ? restartTimer
+      : name === 'retry'
+        ? retryTimer
+        : muteTimer
+    if (timer !== null) cancel(timer)
+    if (name === 'restart') restartTimer = null
+    else if (name === 'retry') retryTimer = null
+    else muteTimer = null
+  }
+
+  const detachCapture = () => {
+    const capture = currentCapture
+    if (!capture) return
+    currentCapture = null
+    clearTimer('mute')
+    const track = audioTrack(capture)
+    track?.removeEventListener?.('ended', capture.handleEnded)
+    track?.removeEventListener?.('mute', capture.handleMute)
+    track?.removeEventListener?.('unmute', capture.handleUnmute)
+    release(capture)
+  }
+
+  const installTrackListeners = capture => {
+    const track = audioTrack(capture)
+    if (!track?.addEventListener) return
+    capture.handleEnded = () => requestRestart('track-ended', 0)
+    capture.handleMute = () => {
+      clearTimer('mute')
+      muteTimer = schedule(() => {
+        muteTimer = null
+        if (track.muted !== false) requestRestart('track-muted', 0)
+      }, muteGraceMs)
+    }
+    capture.handleUnmute = () => clearTimer('mute')
+    track.addEventListener('ended', capture.handleEnded)
+    track.addEventListener('mute', capture.handleMute)
+    track.addEventListener('unmute', capture.handleUnmute)
+  }
+
+  const replaceCapture = async reason => {
+    if (!running) return
+    clearTimer('restart')
+    clearTimer('retry')
+    const attemptGeneration = ++generation
+    detachCapture()
+    onState({
+      state: reason === 'initial' ? 'starting' : 'recovering',
+      reason,
+    })
+    try {
+      const capture = await acquire({ reason, generation: attemptGeneration })
+      if (!running || attemptGeneration !== generation) {
+        release(capture)
+        return
+      }
+      currentCapture = capture
+      retryAttempt = 0
+      installTrackListeners(capture)
+      onState({ state: 'ready', reason })
+    } catch (error) {
+      if (!running || attemptGeneration !== generation) return
+      if (!recoverableMicrophoneError(error)) {
+        onState({ state: 'unavailable', reason, error, recoverable: false })
+        onFatalError(error)
+        return
+      }
+      const delay = retryDelays[retryAttempt]
+      retryAttempt += 1
+      const retrying = Number.isFinite(delay)
+      onState({
+        state: retrying ? 'recovering' : 'unavailable',
+        reason,
+        error,
+        recoverable: true,
+      })
+      if (retrying) {
+        retryTimer = schedule(() => {
+          retryTimer = null
+          void replaceCapture('retry')
+        }, delay)
+      }
+    }
+  }
+
+  function requestRestart(reason = 'devicechange', delay = debounceMs) {
+    if (!running) return
+    if (reason === 'devicechange') retryAttempt = 0
+    clearTimer('restart')
+    clearTimer('retry')
+    restartTimer = schedule(() => {
+      restartTimer = null
+      void replaceCapture(reason)
+    }, delay)
+  }
+
+  const handleDeviceChange = () => requestRestart('devicechange')
+
+  return {
+    start() {
+      if (running) return
+      running = true
+      mediaDevices.addEventListener?.('devicechange', handleDeviceChange)
+      void replaceCapture('initial')
+    },
+    stop() {
+      if (!running) return
+      running = false
+      generation += 1
+      mediaDevices.removeEventListener?.('devicechange', handleDeviceChange)
+      clearTimer('restart')
+      clearTimer('retry')
+      clearTimer('mute')
+      detachCapture()
+    },
+    restart(reason = 'manual') {
+      retryAttempt = 0
+      requestRestart(reason, 0)
+    },
+  }
+}

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -16,6 +16,7 @@ import {
 import { GatewayClient } from '../../shared/gateway-client-sdk.mjs'
 import { gatewayReferenceClientCapabilities } from '../../shared/gateway-client-profiles.mjs'
 import { decodePcm, pcmBase64, resample } from './audio.js'
+import { createMicrophoneCaptureLifecycle } from './microphone-capture.js'
 import { confirmTrackedPlaybackStart } from './playback-lifecycle.js'
 import { t } from './i18n.js'
 
@@ -759,10 +760,19 @@ export default function useRealtimeVoice({
     }
 
     let disposed = false
-    let media
-    let source
-    let processor
     inputReadyRef.current = false
+    const setCaptureReady = ready => {
+      if (disposed) return
+      const changed = inputReadyRef.current !== ready
+      inputReadyRef.current = ready
+      setInputReady(ready)
+      if (!changed) return
+      sendSocketEvent(microphoneControlEvent({
+        enabled: ready,
+        inputOnlyMute,
+        wakeWordOnly: ready && wakeWordOnlyRef.current,
+      }))
+    }
     const failInput = reason => {
       const message = reason?.message || String(reason || t('无法打开麦克风'))
       inputReadyRef.current = false
@@ -772,86 +782,118 @@ export default function useRealtimeVoice({
         inputOnlyMute,
         wakeWordOnly: false,
       }))
-      media?.getTracks().forEach(track => track.stop())
-      processor?.disconnect()
-      source?.disconnect()
       setError(message)
       setVisualError(true)
       inputErrorRef.current?.(message)
     }
-    const startAudio = async () => {
-      try {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      failInput(t('无法打开麦克风'))
+      return undefined
+    }
+    const unsupportedInput = message => {
+      const error = new Error(message)
+      error.name = 'NotSupportedError'
+      return error
+    }
+    const capture = createMicrophoneCaptureLifecycle({
+      mediaDevices: navigator.mediaDevices,
+      acquire: async () => {
         if (!activateAudio()) {
-          failInput(t('当前浏览器不支持实时语音播放'))
-          return
+          throw unsupportedInput(t('当前浏览器不支持实时语音播放'))
         }
         const context = audioRef.current
-        if (!context) {
-          failInput(t('无法初始化实时语音播放'))
-          return
-        }
+        if (!context) throw unsupportedInput(t('无法初始化实时语音播放'))
         if (context.state === 'suspended') await context.resume()
-        media = await navigator.mediaDevices.getUserMedia({
+        const media = await navigator.mediaDevices.getUserMedia({
           audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
         })
-        if (disposed) return media.getTracks().forEach(track => track.stop())
-        setVisualError(false)
-        source = context.createMediaStreamSource(media)
-        processor = context.createScriptProcessor(2048, 1, 1)
-        processor.onaudioprocess = event => {
-          const samples = microphoneSamplesDuringManualInput(
-            event.inputBuffer.getChannelData(0),
-            manualInputPendingRef.current,
-          )
-          if (wakeWordOnlyRef.current) {
-            const wakeAudio = resample(samples, context.sampleRate, 16_000)
-            wakeWordAudioRef.current?.(pcmBase64(wakeAudio), 16_000)
-            return
+        let source
+        let processor
+        try {
+          source = context.createMediaStreamSource(media)
+          processor = context.createScriptProcessor(2048, 1, 1)
+          processor.onaudioprocess = event => {
+            const samples = microphoneSamplesDuringManualInput(
+              event.inputBuffer.getChannelData(0),
+              manualInputPendingRef.current,
+            )
+            if (wakeWordOnlyRef.current) {
+              const wakeAudio = resample(samples, context.sampleRate, 16_000)
+              wakeWordAudioRef.current?.(pcmBase64(wakeAudio), 16_000)
+              return
+            }
+            const socket = socketRef.current
+            if (socket?.readyState !== WebSocket.OPEN) return
+            const audio = resample(
+              samples,
+              context.sampleRate,
+              inputSampleRate.current,
+            )
+            socket.send({
+              type: GatewayClientEvent.AUDIO_APPEND,
+              audio: pcmBase64(audio),
+            })
           }
-          const socket = socketRef.current
-          if (socket?.readyState !== WebSocket.OPEN) return
-          const audio = resample(
-            samples,
-            context.sampleRate,
-            inputSampleRate.current,
-          )
-          socket.send({
-            type: GatewayClientEvent.AUDIO_APPEND,
-            audio: pcmBase64(audio),
-          })
+          source.connect(processor)
+          processor.connect(context.destination)
+          return {
+            media,
+            track: media.getAudioTracks()[0],
+            close() {
+              media.getTracks().forEach(track => track.stop())
+              processor?.disconnect()
+              source?.disconnect()
+            },
+          }
+        } catch (error) {
+          media.getTracks().forEach(track => track.stop())
+          processor?.disconnect()
+          source?.disconnect()
+          throw error
         }
-        source.connect(processor)
-        processor.connect(context.destination)
-        inputReadyRef.current = true
-        setInputReady(true)
-        sendSocketEvent(microphoneControlEvent({
-          enabled: true,
-          inputOnlyMute,
-          wakeWordOnly,
-        }))
-      } catch (reason) {
-        if (!disposed) failInput(reason)
-      }
-    }
-    startAudio()
+      },
+      onState: captureState => {
+        if (captureState.state === 'ready') {
+          setError('')
+          setVisualError(false)
+          setCaptureReady(true)
+          return
+        }
+        setCaptureReady(false)
+        if (captureState.error && captureState.recoverable) {
+          setError(captureState.state === 'unavailable'
+            ? t('未检测到可用麦克风，连接设备后会自动恢复')
+            : t('正在切换麦克风'))
+          setVisualError(true)
+        }
+      },
+      onFatalError: failInput,
+    })
+    capture.start()
 
     return () => {
       disposed = true
       inputReadyRef.current = false
       setInputReady(false)
-      media?.getTracks().forEach(track => track.stop())
-      processor?.disconnect()
-      source?.disconnect()
+      capture.stop()
     }
   }, [
     activateAudio,
     enabled,
     inputOnlyMute,
-    wakeWordOnly,
     sendSocketEvent,
     sessionId,
     suspended,
   ])
+
+  useEffect(() => {
+    if (!enabled || suspended || !inputReadyRef.current) return
+    sendSocketEvent(microphoneControlEvent({
+      enabled: true,
+      inputOnlyMute,
+      wakeWordOnly,
+    }))
+  }, [enabled, inputOnlyMute, sendSocketEvent, suspended, wakeWordOnly])
 
   useEffect(() => {
     if (!suspended) return

--- a/web/test/microphone-capture.test.mjs
+++ b/web/test/microphone-capture.test.mjs
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  createMicrophoneCaptureLifecycle,
+  recoverableMicrophoneError,
+} from '../src/microphone-capture.js'
+
+class FakeEventTarget {
+  constructor() {
+    this.listeners = new Map()
+  }
+
+  addEventListener(name, listener) {
+    if (!this.listeners.has(name)) this.listeners.set(name, new Set())
+    this.listeners.get(name).add(listener)
+  }
+
+  removeEventListener(name, listener) {
+    this.listeners.get(name)?.delete(listener)
+  }
+
+  emit(name) {
+    for (const listener of this.listeners.get(name) || []) listener()
+  }
+}
+
+class FakeTrack extends FakeEventTarget {
+  constructor() {
+    super()
+    this.muted = false
+    this.stopped = 0
+  }
+
+  stop() {
+    this.stopped += 1
+  }
+}
+
+function fakeClock() {
+  let sequence = 0
+  const timers = new Map()
+  return {
+    schedule(callback, delay) {
+      const id = ++sequence
+      timers.set(id, { callback, delay, id })
+      return id
+    },
+    cancel(id) {
+      timers.delete(id)
+    },
+    runAll() {
+      while (timers.size) {
+        const next = [...timers.values()].sort((left, right) => (
+          left.delay - right.delay || left.id - right.id
+        ))[0]
+        timers.delete(next.id)
+        next.callback()
+      }
+    },
+    size: () => timers.size,
+  }
+}
+
+function capture(track = new FakeTrack()) {
+  return {
+    track,
+    close() {
+      track.stop()
+    },
+  }
+}
+
+async function settle() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function fixture({ acquire, retryDelays = [1, 2] } = {}) {
+  const mediaDevices = new FakeEventTarget()
+  mediaDevices.getUserMedia = () => {}
+  const clock = fakeClock()
+  const captures = []
+  const states = []
+  const fatal = []
+  const lifecycle = createMicrophoneCaptureLifecycle({
+    mediaDevices,
+    acquire: acquire || (async () => {
+      const next = capture()
+      captures.push(next)
+      return next
+    }),
+    onState: state => states.push(state),
+    onFatalError: error => fatal.push(error),
+    retryDelays,
+    schedule: clock.schedule,
+    cancel: clock.cancel,
+  })
+  return { captures, clock, fatal, lifecycle, mediaDevices, states }
+}
+
+test('coalesces device changes and reacquires the current default microphone', async () => {
+  const target = fixture()
+  target.lifecycle.start()
+  await settle()
+  assert.equal(target.captures.length, 1)
+
+  target.mediaDevices.emit('devicechange')
+  target.mediaDevices.emit('devicechange')
+  target.mediaDevices.emit('devicechange')
+  assert.equal(target.clock.size(), 1)
+  target.clock.runAll()
+  await settle()
+
+  assert.equal(target.captures.length, 2)
+  assert.equal(target.captures[0].track.stopped, 1)
+  assert.deepEqual(
+    target.states.map(state => state.state),
+    ['starting', 'ready', 'recovering', 'ready'],
+  )
+  target.lifecycle.stop()
+})
+
+test('recovers an ended or persistently muted track and ignores a short mute', async () => {
+  const target = fixture()
+  target.lifecycle.start()
+  await settle()
+  const first = target.captures[0].track
+
+  first.muted = true
+  first.emit('mute')
+  first.muted = false
+  first.emit('unmute')
+  target.clock.runAll()
+  await settle()
+  assert.equal(target.captures.length, 1)
+
+  first.emit('ended')
+  target.clock.runAll()
+  await settle()
+  assert.equal(target.captures.length, 2)
+
+  const second = target.captures[1].track
+  second.muted = true
+  second.emit('mute')
+  target.clock.runAll()
+  await settle()
+  assert.equal(target.captures.length, 3)
+  target.lifecycle.stop()
+})
+
+test('keeps a missing replacement recoverable until another device appears', async () => {
+  let attempts = 0
+  const created = []
+  const target = fixture({
+    retryDelays: [1],
+    acquire: async () => {
+      attempts += 1
+      if ([2, 3].includes(attempts)) {
+        const error = new Error('no input device')
+        error.name = 'NotFoundError'
+        throw error
+      }
+      const next = capture()
+      created.push(next)
+      return next
+    },
+  })
+  target.lifecycle.start()
+  await settle()
+
+  target.mediaDevices.emit('devicechange')
+  target.clock.runAll()
+  await settle()
+  target.clock.runAll()
+  await settle()
+  assert.equal(target.states.at(-1).state, 'unavailable')
+  assert.equal(target.states.at(-1).recoverable, true)
+
+  target.mediaDevices.emit('devicechange')
+  target.clock.runAll()
+  await settle()
+  assert.equal(attempts, 4)
+  assert.equal(target.states.at(-1).state, 'ready')
+  target.lifecycle.stop()
+})
+
+test('manual stop releases capture and prevents hot-plug reacquisition', async () => {
+  const target = fixture()
+  target.lifecycle.start()
+  await settle()
+  target.lifecycle.stop()
+  assert.equal(target.captures[0].track.stopped, 1)
+
+  target.mediaDevices.emit('devicechange')
+  target.clock.runAll()
+  await settle()
+  assert.equal(target.captures.length, 1)
+})
+
+test('releases an acquisition that resolves after capture has stopped', async () => {
+  let resolveAcquire
+  const pending = new Promise(resolve => { resolveAcquire = resolve })
+  const late = capture()
+  const target = fixture({ acquire: () => pending })
+  target.lifecycle.start()
+  target.lifecycle.stop()
+  resolveAcquire(late)
+  await settle()
+  assert.equal(late.track.stopped, 1)
+})
+
+test('treats denied permission as terminal and device absence as recoverable', async () => {
+  assert.equal(recoverableMicrophoneError({ name: 'NotFoundError' }), true)
+  assert.equal(recoverableMicrophoneError({ name: 'NotReadableError' }), true)
+  assert.equal(recoverableMicrophoneError({ name: 'NotAllowedError' }), false)
+  assert.equal(recoverableMicrophoneError({ name: 'NotSupportedError' }), false)
+
+  const denied = new Error('permission denied')
+  denied.name = 'NotAllowedError'
+  const target = fixture({ acquire: async () => { throw denied } })
+  target.lifecycle.start()
+  await settle()
+  assert.deepEqual(target.fatal, [denied])
+  assert.equal(target.clock.size(), 0)
+  target.lifecycle.stop()
+})


### PR DESCRIPTION
## Summary

- add an input-only microphone capture lifecycle around standard MediaDevices and MediaStreamTrack events
- debounce device changes and reacquire the current system-default microphone
- recover ended and persistently muted tracks with bounded retry
- keep temporary device absence recoverable while treating permission denial as terminal
- preserve the Gateway connection, Realtime session, output AudioContext, and playback queue during input recovery
- use the same recovery path for Desktop, WebUI, and hidden wake-word capture

## Tests

- `npm run lint -- --no-cache`
- `npm run test --workspace web` (106 passed)
- `npm run test --workspace desktop` (215 passed)
- `node --test test/*.test.mjs` (97 passed, 1 skipped)
- `npm run build`

Fixes #292