### PR TITLE
fix(realtime): preserve twenty turns across recovery

### DIFF
--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -160,6 +160,7 @@ export function attachRealtimeGateway(server, {
   inputArbitration = null,
   realtimeProviderRegistry = defaultRealtimeProviderRegistry,
   defaultRealtimeProvider = config.audioProvider,
+  realtimeFrontendFactory = undefined,
   frontendRetrieval = null,
   frontendKnowledge = null,
   frontendToolSources = [],
@@ -618,6 +619,9 @@ export function attachRealtimeGateway(server, {
       logger: connectionLogger,
       maxPendingAudioChunks: MAX_PENDING_AUDIO_CHUNKS,
       stableConnectionMs: REALTIME_STABLE_CONNECTION_MS,
+      ...(realtimeFrontendFactory
+        ? { createFrontend: realtimeFrontendFactory }
+        : {}),
     })
     const voiceClient = {
       ws,

--- a/server/test/conversation-sync.test.mjs
+++ b/server/test/conversation-sync.test.mjs
@@ -29,9 +29,9 @@ test('keeps recent voice context isolated by owner and voice session', () => {
   )
 })
 
-test('uses the same bounded twenty-message projection for frontend history and Realtime', () => {
+test('uses the same bounded forty-message projection for frontend history and Realtime', () => {
   const sync = new ConversationSync()
-  for (let index = 1; index <= 24; index += 1) {
+  for (let index = 1; index <= 44; index += 1) {
     sync.record({
       ownerId: 'owner',
       sessionId: 'voice',
@@ -45,7 +45,7 @@ test('uses the same bounded twenty-message projection for frontend history and R
   assert.deepEqual(
     sync.frontendContext({ ownerId: 'owner', sessionId: 'voice' })
       .map(message => message.content),
-    Array.from({ length: 20 }, (_, index) => `message ${index + 5}`),
+    Array.from({ length: 40 }, (_, index) => `message ${index + 5}`),
   )
 })
 

--- a/server/test/gateway-client-handshake.test.mjs
+++ b/server/test/gateway-client-handshake.test.mjs
@@ -95,6 +95,91 @@ test('a muted voice-capable client can claim voice after unmute', async t => {
   client.socket.close()
 })
 
+test('recovers the client and excludes only the content-safety rejected turn', async t => {
+  const frontends = []
+  const realtimeFrontendFactory = options => {
+    const provider = options.providerRegistry.resolve(options.providerName)
+    const frontend = {
+      provider,
+      capabilities: provider.capabilities,
+      ready: false,
+      inputs: [],
+      connect: async () => {
+        frontend.ready = true
+      },
+      close: () => {
+        frontend.ready = false
+      },
+      appendAudio: () => {},
+      cancel: () => {},
+      updateAgentContext: () => {},
+      ensureResponse: async () => {},
+      injectContext: async () => {},
+      whenIdle: async () => {},
+      sendUserInput: async (parts, context) => {
+        frontend.inputs.push({ parts, context })
+        return {}
+      },
+      emit: event => options.onEvent(event),
+    }
+    frontends.push({ frontend, agentContext: options.agentContext })
+    return frontend
+  }
+  const { server, gateway } = gatewayHarness({ realtimeFrontendFactory })
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  t.after(async () => {
+    await gateway.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const client = await connect(server, {
+    type: 'connect',
+    clientType: 'web',
+    voiceEnabled: true,
+    inputEnabled: true,
+    outputEnabled: true,
+    textOnly: false,
+  })
+  await waitFor(client.received, event => event.type === 'voice.ready')
+
+  client.socket.send(JSON.stringify({ type: 'text.message', text: '正常问题' }))
+  await waitUntil(() => frontends[0].frontend.inputs.length === 1)
+  client.socket.send(JSON.stringify({ type: 'text.message', text: '违规问题' }))
+  await waitUntil(() => frontends[0].frontend.inputs.length === 2)
+  const rejectedContext = frontends[0].frontend.inputs[1].context
+
+  frontends[0].frontend.emit({
+    type: 'response.created',
+    response: { id: 'response-rejected' },
+    __voiceContext: rejectedContext,
+  })
+  frontends[0].frontend.emit({
+    type: 'error',
+    response_id: 'response-rejected',
+    error: {
+      code: 'DataInspectionFailed',
+      message: 'Input data may contain inappropriate content.',
+    },
+  })
+
+  const clear = await waitFor(
+    client.received,
+    event => event.type === 'playback.clear'
+      && event.reason === 'provider_content_safety',
+  )
+  assert.equal(clear.reason, 'provider_content_safety')
+  await waitFor(
+    client.received,
+    event => event.type === 'voice.state' && event.state === 'idle',
+  )
+  await waitUntil(() => frontends.length === 2)
+  assert.deepEqual(
+    frontends[1].agentContext.recentMessages.map(message => message.content),
+    ['正常问题'],
+  )
+  client.socket.close()
+})
+
 test('5.x connect and 6.0 session.hello share one Gateway business path', async t => {
   const { server, gateway } = gatewayHarness()
   await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))

--- a/server/test/session-conversation-history.test.mjs
+++ b/server/test/session-conversation-history.test.mjs
@@ -18,7 +18,7 @@ test('restores the same recent messages for the UI and Realtime after restart', 
   })
   firstHistory.start()
 
-  for (let index = 1; index <= 24; index += 1) {
+  for (let index = 1; index <= 44; index += 1) {
     firstSync.record({
       ownerId: 'owner',
       sessionId: 'desktop',
@@ -36,7 +36,7 @@ test('restores the same recent messages for the UI and Realtime after restart', 
     conversationSync: restoredSync,
     sessionJournal: new SessionJournalRegistry({ directory }),
   })
-  assert.equal(restoredHistory.start(), 20)
+  assert.equal(restoredHistory.start(), 40)
 
   const realtimeMessages = restoredSync.frontendContext({
     ownerId: 'owner',
@@ -46,7 +46,7 @@ test('restores the same recent messages for the UI and Realtime after restart', 
     ownerId: 'owner',
     sessionId: 'desktop',
   })
-  const expected = Array.from({ length: 20 }, (_, index) => `message ${index + 5}`)
+  const expected = Array.from({ length: 40 }, (_, index) => `message ${index + 5}`)
   assert.deepEqual(realtimeMessages.map(message => message.content), expected)
   assert.deepEqual(visibleMessages.map(message => message.content), expected)
   assert.deepEqual(

--- a/shared/conversation-history.mjs
+++ b/shared/conversation-history.mjs
@@ -1,7 +1,7 @@
-// Ten user/assistant turns in the common case. This window is shared by live
+// Twenty user/assistant turns in the common case. This window is shared by live
 // frontend history and Realtime Session restoration so reconnects retain enough
 // conversational continuity without growing the injected context unboundedly.
-export const RECENT_CONVERSATION_MESSAGE_LIMIT = 20
+export const RECENT_CONVERSATION_MESSAGE_LIMIT = 40
 
 export function recentConversationMessages(
   messages = [],

--- a/web/test/message-order.test.js
+++ b/web/test/message-order.test.js
@@ -12,8 +12,8 @@ import {
   upsertUserTranscript,
 } from '../src/message-order.js'
 
-test('hydrates only the recent twenty persisted messages and keeps live duplicates', () => {
-  const history = Array.from({ length: 24 }, (_, index) => ({
+test('hydrates only the recent forty persisted messages and keeps live duplicates', () => {
+  const history = Array.from({ length: 44 }, (_, index) => ({
     id: `message-${index + 1}`,
     role: index % 2 ? 'assistant' : 'user',
     content: `persisted ${index + 1}`,
@@ -21,19 +21,19 @@ test('hydrates only the recent twenty persisted messages and keeps live duplicat
     createdAt: index + 1,
   }))
   const current = [{
-    id: 'message-24',
+    id: 'message-44',
     role: 'assistant',
-    content: 'live 24',
+    content: 'live 44',
     live: false,
   }]
 
   const messages = mergeConversationHistory(current, history)
-  assert.equal(messages.length, 20)
+  assert.equal(messages.length, 40)
   assert.deepEqual(
     messages.map(message => message.id),
-    Array.from({ length: 20 }, (_, index) => `message-${index + 5}`),
+    Array.from({ length: 40 }, (_, index) => `message-${index + 5}`),
   )
-  assert.equal(messages.at(-1).content, 'live 24')
+  assert.equal(messages.at(-1).content, 'live 44')
 })
 
 test('normalizes hard line breaks in final ASR text', () => {


### PR DESCRIPTION
## Summary
- keep the foreground UI and Realtime recovery window aligned at twenty conversation turns (forty messages)
- add an injectable Realtime frontend seam for deterministic Gateway recovery tests
- verify content-safety rejection removes only the rejected turn while retaining earlier valid context

## Validation
- node --test server/test/conversation-sync.test.mjs server/test/gateway-client-handshake.test.mjs server/test/session-conversation-history.test.mjs web/test/message-order.test.js