### PR TITLE
feat(gateway): expose frontend memory control plane

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -27,7 +27,9 @@ runtime-command plane, Agent Delivery, Client Actions, reference Client SDK,
 and bounded replay all share the same WebSocket.
 This contract index remains authoritative for implemented behavior.
 
-The current health-contract version is `5.5.0`. The additive `5.5` line ships
+The current health-contract version is `5.6.0`. The additive `5.6` line exposes
+a provider-neutral frontend memory control plane for replaceable clients. The
+additive `5.5` line ships
 the shared reference Client SDK, bounded Task-event replay, and reconnect state
 recovery. First-party WebUI, Desktop, and TUI clients now pass the same
 conformance suite and no longer use internal REST routes for Task control,
@@ -76,6 +78,7 @@ below instead of assuming the old list.
 | `tasks.structured-results-authorization` | Native Task events use A2A-aligned work states and expose factual `result`, typed `artifacts`, and `authorization`, without prescribing speech or UI | `test/gateway-event-schema.test.mjs`, `server/test/task-state.test.mjs` |
 | `tasks.unified-id-updates` | A Task exposes one short `id`; `task.updated` carries adapter-normalized incremental messages and artifacts | `test/gateway-event-schema.test.mjs`, `server/test/task-manager.test.mjs` |
 | `messages.citations` | Final assistant `transcript.final` events may carry normalized citations collected from frontend retrieval in the same turn | `test/gateway-event-schema.test.mjs`, `server/test/realtime-presentation-runtime.test.mjs` |
+| `frontend.memory-control` | `GET/PATCH /api/memory` lets replaceable clients list and exactly edit the same provider-backed USER/MEMORY documents used by Realtime, without depending on a storage implementation | `server/test/gateway-application.test.mjs` |
 | `realtime.conversation-client-v1` | `WS /api/realtime`, published event constants, and message schemas form the replaceable text/audio/multimodal Conversation Client boundary | `test/gateway-event-schema.test.mjs`, `test/custom-conversation-client.test.mjs` |
 | `realtime.gateway-client-protocol-v6-handshake` | The same WebSocket accepts an opt-in 6.0 `session.hello`, returns correlated `session.ready`, negotiates implemented capabilities, and normalizes 6.0 input aliases into the existing business path | `test/gateway-client-protocol.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-runtime-commands` | Negotiated 6.0 Clients can publish registered semantic Client Events and use correlated Task, permission, conversation-history, and session output-voice commands over the same WebSocket; existing REST routes call the same command service as compatibility aliases | `test/gateway-client-protocol.test.mjs`, `server/test/client-event-router.test.mjs`, `server/test/client-command-runtime.test.mjs`, `server/test/gateway-client-handshake.test.mjs` |
@@ -174,6 +177,8 @@ await orb.load()
 | Endpoint | Purpose |
 | --- | --- |
 | `GET /api/health` | Liveness, capability discovery and runtime status; includes `protocolVersion`, `capabilities`, `gatewayInstanceId`, `voiceConfigured`, `inputSuspension`, `voiceClients`, `backend` |
+| `GET /api/memory` | List the current owner's bounded, provider-neutral frontend memory documents |
+| `PATCH /api/memory` | Apply exact revision-checked edits to those documents; stale revisions return `409` |
 | `POST /api/input/suspend` | Take the microphone: `{ owner, reason?, ttlMs? }`; default TTL 15 s, cap 300 s |
 | `POST /api/input/resume` | Release it: `{ owner }` |
 | `GET /api/input` | Current suspension status |

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -22,7 +22,8 @@
 Delivery、Client Action、参考 Client SDK 与有限回放均落在同一条 WebSocket 上。
 已实现行为仍以本契约索引为准。
 
-当前健康契约版本为 `5.5.0`。新增的 `5.5` 能力提供共享参考 Client SDK、有限 Task
+当前健康契约版本为 `5.6.0`。新增的 `5.6` 能力为可替换客户端提供
+Provider 无关的前台记忆控制面。`5.5` 能力提供共享参考 Client SDK、有限 Task
 事件回放与断线状态恢复。第一方 WebUI、Desktop 和 TUI 已通过同一套一致性测试，
 Task 控制、权限决策和对话历史不再依赖内部 REST 路由。`5.4` 能力提供有关联关系的 Client Action 与共享
 Presence 状态机；`5.3` 增加 Provider 无关 Agent Delivery；`5.2` 在协商后的 6.0
@@ -62,6 +63,7 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `tasks.structured-results-authorization` | 原生 Task 事件使用与 A2A 对齐的工作状态，并暴露事实性 `result`、类型化 `artifacts` 与 `authorization`，不规定播报或 UI | `test/gateway-event-schema.test.mjs`、`server/test/task-state.test.mjs` |
 | `tasks.unified-id-updates` | Task 只公开一个短 `id`；`task.updated` 携带 Adapter 归一化后的增量消息与产物 | `test/gateway-event-schema.test.mjs`、`server/test/task-manager.test.mjs` |
 | `messages.citations` | 最终助手 `transcript.final` 可以携带同一轮前台检索产生的规范化 Citation | `test/gateway-event-schema.test.mjs`、`server/test/realtime-presentation-runtime.test.mjs` |
+| `frontend.memory-control` | `GET/PATCH /api/memory` 供可替换客户端列出并精确编辑 Realtime 共用的 Provider 记忆文档，不暴露具体存储实现 | `server/test/gateway-application.test.mjs` |
 | `realtime.conversation-client-v1` | `WS /api/realtime`、公开事件常量与消息 Schema 共同构成可替换的文本/音频/多模态对话客户端边界 | `test/gateway-event-schema.test.mjs`、`test/custom-conversation-client.test.mjs` |
 | `realtime.gateway-client-protocol-v6-handshake` | 同一 WebSocket 可选择以 6.0 `session.hello` 接入，返回有关联关系的 `session.ready`，协商已实现能力，并把 6.0 输入别名归一化到现有业务路径 | `test/gateway-client-protocol.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
 | `realtime.gateway-client-protocol-v6-runtime-commands` | 协商后的 6.0 Client 可以通过同一 WebSocket 发布已注册的语义 Client Event，并使用有关联结果的 Task、权限、对话历史和会话输出音色命令；现有 REST 路由调用同一命令服务作为兼容别名 | `test/gateway-client-protocol.test.mjs`、`server/test/client-event-router.test.mjs`、`server/test/client-command-runtime.test.mjs`、`server/test/gateway-client-handshake.test.mjs` |
@@ -158,6 +160,8 @@ await orb.load()
 | 接口 | 用途 |
 | --- | --- |
 | `GET /api/health` | 存活、能力探测与运行状态；含 `protocolVersion`、`capabilities`、`gatewayInstanceId`、`voiceConfigured`、`inputSuspension`、`voiceClients`、`backend` |
+| `GET /api/memory` | 列出当前 owner 有界、Provider 无关的前台记忆文档 |
+| `PATCH /api/memory` | 按 revision 精确编辑这些文档；版本过期返回 `409` |
 | `POST /api/input/suspend` | 抢占麦克风：`{ owner, reason?, ttlMs? }`，默认 15 秒，上限 300 秒 |
 | `POST /api/input/resume` | 释放抢占：`{ owner }` |
 | `GET /api/input` | 当前抢占状态 |

--- a/docs/i18n-parity.md
+++ b/docs/i18n-parity.md
@@ -5,9 +5,9 @@
 
 ## Current baseline
 
-Updated 2026-08-28 against `github/main` at `8f16eb5`:
+Updated 2026-09-02:
 
-- Gateway health contract `5.5.0`;
+- Gateway health contract `5.6.0`;
 - stable Gateway Client Protocol wire version `6.0.0`;
 - GCP1–GCP5 complete;
 - WebUI, Desktop, and TUI on the shared reference Client SDK;

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -37,6 +37,20 @@ several durable changes; the Gateway still produces only one follow-up response.
 starts from the latest document, and an exact replacement fails safely when its source fragment
 is missing or ambiguous.
 
+## Client Control Plane
+
+Replaceable clients can manage the same memory through two Gateway endpoints:
+
+- `GET /api/memory` returns the current owner's bounded `user` and `memory` documents.
+- `PATCH /api/memory` accepts the same exact edits as the Realtime memory tool, including
+  `expectedRevision`; stale revisions return `409` so a client can reload instead of
+  overwriting a concurrent change.
+
+This is a document control plane, not a second memory store. It is owner-scoped by the Gateway,
+passes writes through `FrontendMemoryRuntime`, and therefore works unchanged with the default
+Markdown provider or an injected provider. Clients should render only the formats they
+understand and preserve exact source text when issuing a delete or replacement.
+
 ## Session Digests and Recall (off by default)
 
 With `QWEN_AUDIO_SESSION_DIGEST=on`, each finished session records its topics and

--- a/docs/reference/memory.zh.md
+++ b/docs/reference/memory.zh.md
@@ -28,6 +28,18 @@ Realtime 与自动整理都通过同一个记忆服务提交受限 Markdown 变�
 一句话包含多项持久修改时，Realtime 可在同一轮逐项调用，Gateway 只生成一次
 后续回应。写入前会重新读取最新文档，精确替换找不到或匹配多处时安全失败。
 
+## 客户端控制面
+
+可替换客户端可以通过两个 Gateway 接口管理同一份记忆：
+
+- `GET /api/memory` 返回当前 owner 有界的 `user` 与 `memory` 文档。
+- `PATCH /api/memory` 接受与 Realtime 记忆工具相同的精确编辑，其中包含
+  `expectedRevision`；版本过期返回 `409`，客户端应重新读取，而不是覆盖并发修改。
+
+这是一层文档控制面，不是第二套记忆存储。Gateway 负责 owner 隔离，写入统一经过
+`FrontendMemoryRuntime`，所以默认 Markdown Provider 与外部注入 Provider 使用同一协议。
+客户端只应展示自己理解的格式，删除或替换时必须保留并提交精确原文。
+
 ## 会话摘要与回溯（默认关闭）
 
 设 `QWEN_AUDIO_SESSION_DIGEST=on` 后，会话结束时记下这一场的话题与一句不超过 50 字的

--- a/examples/smart-cockpit/README.md
+++ b/examples/smart-cockpit/README.md
@@ -106,6 +106,9 @@ A preflight validates the Realtime configuration and all four ports before any c
   explicitly reports its demo fallback; a deployment replaces only that service.
 - Route preference buttons write the authoritative cockpit state. The next route
   inherits that preference unless the user explicitly chooses another one.
+- The memory settings panel uses the Gateway's provider-neutral memory control
+  plane. It lists and exactly deletes entries from the same USER/MEMORY documents
+  used by Realtime, rather than maintaining a cockpit-only memory store.
 - Other cockpit work goes through the fixed `spawn_thinking` bridge. The example
   backend attaches over A2A, and Qwen3.8-Flash discovers the complete backend MCP
   surface for vehicle control, navigation, music, flash-buy, and custom workflows,

--- a/examples/smart-cockpit/README_ZH.md
+++ b/examples/smart-cockpit/README_ZH.md
@@ -88,6 +88,8 @@ npm run example:smart-cockpit
 - 位置查询与导航起点共用 Cockpit Service 的 `vehicleLocation()` 适配入口；
   未接车机 GPS 时会明确返回 Demo 默认位置，部署时只需替换该服务。
 - 路线偏好按钮写入座舱权威状态；用户未另行指定时，后续导航会继承该偏好。
+- 记忆设置面板调用 Gateway 的 Provider 无关记忆控制面，列出并精确删除
+  Realtime 共用的 USER/MEMORY 文档条目，不维护座舱私有的另一份记忆。
 - 其他座舱任务通过固定的 `spawn_thinking` 桥梁提交给后台。示例后台通过 A2A
   接入 Gateway，Qwen3.8-Flash 会发现并调用独立的后台 MCP 工具面，完成车控、
   导航、音乐、闪购和自定义技能任务，包括有序的多途经点导航。

--- a/examples/smart-cockpit/client/README.md
+++ b/examples/smart-cockpit/client/README.md
@@ -9,12 +9,14 @@ Web Audio、3D 车辆与业务面板保持完全自主。
 - `src/hooks/useVoiceSession.js`：GCP 连接、音频采集/播放、回执、Task 与最近对话恢复。
 - `src/hooks/useCockpitState.js`：本示例的 HTTP/SSE 业务状态适配器。
 - `src/hooks/useCockpitSkills.js`：按座舱读取、查看和删除持久化的自定义技能。
+- `src/hooks/useGatewayMemory.js`：通过 Gateway 通用记忆控制面列出/删除前台记忆。
 - `src/config/`：客户端拥有的人设展示和音色选项；不包含实际 Assistant Prompt。
 - `src/projections/`：把 GCP/座舱 Service 事件投影为客户端展示状态。
 - `src/App.jsx`：页面状态和对话/业务投影，不包含 Agent 或 Realtime Provider 逻辑。
 
 “技能”设置页只负责展示和管理。技能创建与运行仍从语音对话进入 Gateway，
 再通过固定的 `spawn_thinking` 桥梁交给后台座舱 Agent。
+“记忆”设置页不创建独立座舱存储，而是管理 Realtime 实际使用的前台记忆文档。
 
 从仓库根目录使用 `npm run example:smart-cockpit` 启动完整链路。单独开发 UI 时运行：
 

--- a/examples/smart-cockpit/client/src/App.css
+++ b/examples/smart-cockpit/client/src/App.css
@@ -2554,6 +2554,26 @@ button {
   gap: 18px;
 }
 
+.memory-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 32px;
+  color: #7f8d93;
+  font-size: 13px;
+}
+
+.memory-toolbar button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.settings-error {
+  margin: 12px 0 0;
+  color: #b54a62;
+  font-size: 13px;
+}
+
 .memory-item {
   display: grid;
   grid-template-columns: 1fr 34px;
@@ -2571,7 +2591,9 @@ button {
   line-height: 1.35;
 }
 
-.memory-item time {
+.memory-item time,
+.memory-meta {
+  display: block;
   color: #9aa6ab;
   font-size: 12px;
 }

--- a/examples/smart-cockpit/client/src/App.jsx
+++ b/examples/smart-cockpit/client/src/App.jsx
@@ -12,6 +12,7 @@ import MusicPanel, { PLAYLIST } from './components/MusicPanel'
 import FlashBuyPanel from './components/FlashBuyPanel'
 import useCockpitState from './hooks/useCockpitState'
 import useCockpitSkills from './hooks/useCockpitSkills'
+import useGatewayMemory from './hooks/useGatewayMemory'
 import useVoiceSession from './hooks/useVoiceSession'
 import {
   finalUserTranscript,
@@ -41,7 +42,7 @@ const INITIAL_CAR_STATE = {
   acFan: 3,
 }
 
-const VALID_TABS = ['persona', 'skills']
+const VALID_TABS = ['persona', 'skills', 'memory']
 const PERSONA_STORAGE_KEY = 'selectedPersona'
 const VOICE_STORAGE_KEY = 'selectedVoice'
 const INITIAL_WEATHER_STATE = {
@@ -107,6 +108,13 @@ export default function App() {
     load: loadCustomSkill,
     remove: deleteCustomSkill,
   } = useCockpitSkills(cockpitId, cockpitActivity)
+  const {
+    items: memories,
+    loading: memoryLoading,
+    error: memoryError,
+    load: loadMemories,
+    remove: deleteMemory,
+  } = useGatewayMemory()
   const [screen, setScreen] = useState('main')
   const [settingsTab, setSettingsTab] = useState('persona')
   const [selectedPersona, setSelectedPersona] = useState(() => getStoredChoice(
@@ -410,6 +418,10 @@ export default function App() {
     return () => window.removeEventListener('hashchange', onHashChange)
   }, [])
 
+  useEffect(() => {
+    if (screen === 'settings' && settingsTab === 'memory') loadMemories()
+  }, [loadMemories, screen, settingsTab])
+
   return (
     <main className="device" aria-label="车机语音交互原型">
       <section className="screen">
@@ -459,6 +471,11 @@ export default function App() {
                 skillsError={customSkillsError}
                 onLoadSkill={loadCustomSkill}
                 onDeleteSkill={deleteCustomSkill}
+                memories={memories}
+                memoryLoading={memoryLoading}
+                memoryError={memoryError}
+                onDeleteMemory={deleteMemory}
+                onRefreshMemory={loadMemories}
               />
             )}
           </div>

--- a/examples/smart-cockpit/client/src/components/MemoryTab.jsx
+++ b/examples/smart-cockpit/client/src/components/MemoryTab.jsx
@@ -1,0 +1,39 @@
+const TrashIcon = () => (
+  <svg className="icon icon-sm" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 3h6l1 2h4v2H4V5h4l1-2Zm1 6h2v9h-2V9Zm4 0h2v9h-2V9ZM7 9h2v10h8V9h2v10a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V9Z" fill="currentColor" /></svg>
+)
+
+export default function MemoryTab({ items, loading, error, onDelete, onRefresh }) {
+  return (
+    <div className="memory-scroll">
+      <div className="memory-toolbar">
+        <span>与前台对话共用的长期记忆</span>
+        <button className="collapse-link" onClick={onRefresh} disabled={loading}>
+          {loading ? '同步中' : '刷新'}
+        </button>
+      </div>
+      {error && <p className="settings-error" role="status">{error}</p>}
+      <ul className="memory-list" aria-label="智能体记忆列表">
+        {items.map(item => (
+          <li key={item.id} className="memory-item">
+            <span>
+              <strong>{item.text}</strong>
+              <span className="memory-meta">
+                {item.scopeLabel}{item.section ? ` · ${item.section}` : ''}
+              </span>
+            </span>
+            <button
+              className="trash-btn"
+              aria-label={`删除记忆：${item.text}`}
+              onClick={() => onDelete(item)}
+            >
+              <TrashIcon />
+            </button>
+          </li>
+        ))}
+      </ul>
+      {!loading && items.length === 0 && !error && (
+        <div className="empty-state" style={{ display: 'block' }}>暂无智能体记忆</div>
+      )}
+    </div>
+  )
+}

--- a/examples/smart-cockpit/client/src/components/SettingsPanel.jsx
+++ b/examples/smart-cockpit/client/src/components/SettingsPanel.jsx
@@ -1,9 +1,11 @@
 import PersonaTab from './PersonaTab'
 import SkillTab from './SkillTab'
+import MemoryTab from './MemoryTab'
 
 const TABS = [
   { id: 'persona', label: '个性化' },
   { id: 'skills', label: '技能' },
+  { id: 'memory', label: '记忆' },
 ]
 
 export default function SettingsPanel({
@@ -12,6 +14,7 @@ export default function SettingsPanel({
   selectedVoice, onSelectVoice,
   selectedWake, onSelectWake,
   skills, skillsError, onLoadSkill, onDeleteSkill,
+  memories, memoryLoading, memoryError, onDeleteMemory, onRefreshMemory,
 }) {
   return (
     <section className="settings-panel">
@@ -41,6 +44,15 @@ export default function SettingsPanel({
           error={skillsError}
           onLoad={onLoadSkill}
           onDelete={onDeleteSkill}
+        />
+      </div>
+      <div className={`tab-page ${activeTab === 'memory' ? 'is-active' : ''}`}>
+        <MemoryTab
+          items={memories}
+          loading={memoryLoading}
+          error={memoryError}
+          onDelete={onDeleteMemory}
+          onRefresh={onRefreshMemory}
         />
       </div>
     </section>

--- a/examples/smart-cockpit/client/src/config/gateway.js
+++ b/examples/smart-cockpit/client/src/config/gateway.js
@@ -1,0 +1,13 @@
+function gatewayOrigin() {
+  return import.meta.env.VITE_GATEWAY_ORIGIN || window.location.origin
+}
+
+export function gatewayHttpUrl(path) {
+  return new URL(path, gatewayOrigin()).toString()
+}
+
+export function gatewayWebSocketUrl(path) {
+  const url = new URL(path, gatewayOrigin())
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  return url
+}

--- a/examples/smart-cockpit/client/src/hooks/useGatewayMemory.js
+++ b/examples/smart-cockpit/client/src/hooks/useGatewayMemory.js
@@ -1,0 +1,65 @@
+import { useCallback, useMemo, useState } from 'react'
+import { gatewayHttpUrl } from '../config/gateway'
+import { memoryItemsFromDocuments } from '../projections/memory-items'
+
+async function responsePayload(response) {
+  return response.json().catch(() => ({}))
+}
+
+export default function useGatewayMemory() {
+  const [documents, setDocuments] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch(gatewayHttpUrl('/api/memory'))
+      const payload = await responsePayload(response)
+      if (!response.ok) throw new Error(payload.error || `HTTP ${response.status}`)
+      setDocuments(Array.isArray(payload.documents) ? payload.documents : [])
+      setError(null)
+    } catch (reason) {
+      setError(reason?.message || '记忆服务不可用')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const remove = useCallback(async (item) => {
+    try {
+      const response = await fetch(gatewayHttpUrl('/api/memory'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          changes: [{
+            document: item.scope,
+            expectedRevision: item.revision,
+            edits: [{ old_text: item.oldText, new_text: '' }],
+          }],
+        }),
+      })
+      const payload = await responsePayload(response)
+      if (!response.ok) {
+        throw Object.assign(
+          new Error(payload.error || `HTTP ${response.status}`),
+          { stale: response.status === 409 },
+        )
+      }
+      await load()
+      return true
+    } catch (reason) {
+      setError(reason?.message || '删除记忆失败')
+      if (reason?.stale) await load()
+      return false
+    }
+  }, [load])
+
+  return {
+    items: useMemo(() => memoryItemsFromDocuments(documents), [documents]),
+    loading,
+    error,
+    load,
+    remove,
+  }
+}

--- a/examples/smart-cockpit/client/src/hooks/useVoiceSession.js
+++ b/examples/smart-cockpit/client/src/hooks/useVoiceSession.js
@@ -23,6 +23,7 @@ import {
   cockpitPersonaId,
 } from '../config/personas'
 import { activateAudioContext } from '../audio/activation'
+import { gatewayWebSocketUrl } from '../config/gateway'
 
 const INPUT_SAMPLE_RATE = 16000
 const OUTPUT_SAMPLE_RATE = 24000
@@ -39,9 +40,7 @@ const TASK_TERMINAL_EVENTS = new Set([
 ])
 
 function gatewayWsUrl(sessionId) {
-  const origin = import.meta.env.VITE_GATEWAY_ORIGIN || window.location.origin
-  const url = new URL('/api/realtime', origin)
-  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  const url = gatewayWebSocketUrl('/api/realtime')
   url.searchParams.set('sessionId', sessionId)
   return url.toString()
 }

--- a/examples/smart-cockpit/client/src/projections/memory-items.js
+++ b/examples/smart-cockpit/client/src/projections/memory-items.js
@@ -1,0 +1,60 @@
+const SCOPE_LABELS = Object.freeze({
+  user: '交互偏好',
+  memory: '长期记忆',
+})
+
+function visibleLines(content) {
+  let inComment = false
+  return String(content || '').split('\n').map(raw => {
+    let visible = raw
+    if (inComment) {
+      const end = visible.indexOf('-->')
+      if (end < 0) return { raw, visible: '' }
+      visible = visible.slice(end + 3)
+      inComment = false
+    }
+    while (visible.includes('<!--')) {
+      const start = visible.indexOf('<!--')
+      const end = visible.indexOf('-->', start + 4)
+      if (end < 0) {
+        visible = visible.slice(0, start)
+        inComment = true
+        break
+      }
+      visible = `${visible.slice(0, start)}${visible.slice(end + 3)}`
+    }
+    return { raw, visible: visible.trim() }
+  })
+}
+
+export function memoryItemsFromDocuments(documents = []) {
+  const items = []
+  for (const document of documents) {
+    if (!document?.editable || !SCOPE_LABELS[document.scope]) continue
+    let section = ''
+    const lines = visibleLines(document.content)
+    for (let index = 0; index < lines.length; index += 1) {
+      const { raw, visible } = lines[index]
+      if (!visible) continue
+      const heading = visible.match(/^#{2,6}\s+(.+)$/u)
+      if (heading) {
+        section = heading[1].trim()
+        continue
+      }
+      if (/^#\s+/u.test(visible)) continue
+      const bullet = visible.match(/^[-*+]\s+(.+)$/u)
+      const text = (bullet?.[1] || visible).trim()
+      if (!text) continue
+      items.push({
+        id: `${document.scope}:${document.revision}:${index}`,
+        scope: document.scope,
+        scopeLabel: SCOPE_LABELS[document.scope],
+        section,
+        text,
+        oldText: raw,
+        revision: document.revision,
+      })
+    }
+  }
+  return items
+}

--- a/examples/smart-cockpit/client/test/memory-items.test.mjs
+++ b/examples/smart-cockpit/client/test/memory-items.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { memoryItemsFromDocuments } from '../src/projections/memory-items.js'
+
+test('projects editable Markdown memory without exposing templates or comments', () => {
+  const items = memoryItemsFromDocuments([{
+    scope: 'user',
+    revision: 'r1',
+    editable: true,
+    content: [
+      '# USER',
+      '<!-- template hint -->',
+      '## 交互偏好',
+      '- 默认使用简短中文回答',
+    ].join('\n'),
+  }, {
+    scope: 'memory',
+    revision: 'r2',
+    editable: true,
+    content: '# MEMORY\n\n## 项目\n\n- 正在做语音助手',
+  }])
+
+  assert.deepEqual(items.map(item => ({
+    scope: item.scope,
+    section: item.section,
+    text: item.text,
+    oldText: item.oldText,
+  })), [{
+    scope: 'user',
+    section: '交互偏好',
+    text: '默认使用简短中文回答',
+    oldText: '- 默认使用简短中文回答',
+  }, {
+    scope: 'memory',
+    section: '项目',
+    text: '正在做语音助手',
+    oldText: '- 正在做语音助手',
+  }])
+})
+
+test('ignores read-only and unsupported provider documents', () => {
+  assert.deepEqual(memoryItemsFromDocuments([
+    { scope: 'memory', revision: 'r', editable: false, content: '- hidden' },
+    { scope: 'custom', revision: 'r', editable: true, content: '- hidden' },
+  ]), [])
+})

--- a/examples/smart-cockpit/client/vite.config.js
+++ b/examples/smart-cockpit/client/vite.config.js
@@ -15,6 +15,9 @@ export default defineConfig(({ mode }) => {
           target: `http://${env.COCKPIT_GATEWAY_HOST || '127.0.0.1'}:${Number(env.COCKPIT_GATEWAY_PORT) || 18888}`,
           ws: true,
         },
+        '/api/memory': {
+          target: `http://${env.COCKPIT_GATEWAY_HOST || '127.0.0.1'}:${Number(env.COCKPIT_GATEWAY_PORT) || 18888}`,
+        },
         '/api': {
           target: env.COCKPIT_SERVICE_ORIGIN || 'http://127.0.0.1:3010',
           ws: true,

--- a/examples/smart-cockpit/docs/architecture.md
+++ b/examples/smart-cockpit/docs/architecture.md
@@ -63,6 +63,10 @@ cockpit-client ── GCP 6.0 ──► cockpit-gateway ── A2A ──► coc
 
 因此后台任务还可以把详细状态发送给客户自己的座舱系统；Gateway 只接收适合继续对话和播报的 Task 进展与结果。
 
+记忆属于前台对话面，不属于座舱 Service。客户端的记忆列表/删除面板使用
+Gateway `GET/PATCH /api/memory` 控制面，与 Realtime 记忆工具共用同一个
+`MemoryProvider`；默认 Markdown 与外部 Provider 对客户端是同一份协议。
+
 ## 自定义技能
 
 座舱自定义技能是用户通过语音保存的场景工作流。记录由 `cockpit-service` 按

--- a/examples/smart-cockpit/docs/test-matrix.md
+++ b/examples/smart-cockpit/docs/test-matrix.md
@@ -12,7 +12,7 @@
 | 启动预检 | Realtime 配置、四进程端口、无效端口 | `examples/smart-cockpit/bootstrap/test/preflight.test.mjs` |
 | GCP 客户端 | 握手、重连、回放、播放回执、Task 与会话恢复 | 根目录 Gateway Client SDK / protocol tests |
 | BackendPort/A2A | 取消、超时、断线、重复终态、输入与权限映射 | `server/test/a2a-backend-adapter.test.mjs` 及 Backend tests |
-| cockpit-client | 场景活动到导航/音乐/闪购面板的投影、路线动画终止、解除静音意图与麦克风权限解耦、自定义技能列表/详情/删除、Task 进度语义去重、ESLint 与生产构建 | `examples/smart-cockpit/client/test/`、`npm run example:smart-cockpit:lint`、`npm run example:smart-cockpit:build` |
+| cockpit-client | 场景活动到导航/音乐/闪购面板的投影、路线动画终止、解除静音意图与麦克风权限解耦、自定义技能列表/详情/删除、前台记忆投影/删除、Task 进度语义去重、ESLint 与生产构建 | `examples/smart-cockpit/client/test/`、`server/test/gateway-application.test.mjs`、`npm run example:smart-cockpit:lint`、`npm run example:smart-cockpit:build` |
 
 统一运行：
 

--- a/examples/smart-cockpit/gateway/test/composition.test.mjs
+++ b/examples/smart-cockpit/gateway/test/composition.test.mjs
@@ -42,7 +42,7 @@ test('composes the public Gateway API with the replaceable A2A Agent', async t =
 
   assert.equal(response.status, 200)
   assert.equal(health.ok, true)
-  assert.equal(health.protocolVersion, '5.5.0')
+  assert.equal(health.protocolVersion, '5.6.0')
   assert.equal(health.frontendProfile.name, 'cockpit-example')
   assert.equal(health.backend.protocol, 'a2a')
   assert.equal(health.backend.status, 'ready')

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -619,6 +619,47 @@ app.get('/api/health', (req, res) => {
   })
 })
 
+// Provider-neutral memory control plane for replaceable Conversation Clients.
+// It exposes the same bounded documents used by Realtime without leaking the
+// Markdown default or any injected provider's persistence details.
+app.get('/api/memory', (req, res, next) => {
+  if (!frontendMemoryRuntime) {
+    return res.status(404).json({ error: 'frontend memory is not configured' })
+  }
+  try {
+    return res.json({
+      documents: frontendMemoryRuntime.list(req.identity.ownerId),
+    })
+  } catch (error) {
+    return next(error)
+  }
+})
+
+app.patch('/api/memory', async (req, res, next) => {
+  if (!frontendMemoryRuntime) {
+    return res.status(404).json({ error: 'frontend memory is not configured' })
+  }
+  const changes = req.body?.changes
+  if (!Array.isArray(changes) || changes.length === 0) {
+    return res.status(400).json({ error: 'changes must be a non-empty array' })
+  }
+  try {
+    return res.json(await frontendMemoryRuntime.apply(
+      req.identity.ownerId,
+      changes,
+      { source: 'gateway-memory-api' },
+    ))
+  } catch (error) {
+    if (error?.code === 'stale_document') {
+      return res.status(409).json({ error: error.message, code: error.code })
+    }
+    if (['invalid_edit', 'ambiguous_edit', 'edit_not_found'].includes(error?.code)) {
+      return res.status(400).json({ error: error.message, code: error.code })
+    }
+    return next(error)
+  }
+})
+
 // Host control plane for microphone arbitration. The host announces that it is
 // taking the microphone and the Gateway commands its clients to stop capturing.
 // Both calls are idempotent per owner, and a suspension expires on its own so a

--- a/server/src/conversation/memory-extractor.mjs
+++ b/server/src/conversation/memory-extractor.mjs
@@ -215,24 +215,41 @@ export function createExtractorLlmCall({
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeoutMs)
     try {
-      const response = await fetchImpl(`${baseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
+      const request = async (includeTemperature) => fetchImpl(
+        `${baseUrl}/chat/completions`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model,
+            messages: [
+              { role: 'system', content: system },
+              { role: 'user', content: user },
+            ],
+            ...(includeTemperature ? { temperature: 0 } : {}),
+          }),
+          signal: controller.signal,
         },
-        body: JSON.stringify({
-          model,
-          messages: [
-            { role: 'system', content: system },
-            { role: 'user', content: user },
-          ],
-          temperature: 0,
-        }),
-        signal: controller.signal,
-      })
+      )
+      // Some OpenAI-compatible models reject optional sampling parameters.
+      // Retry once with the smallest common request shape; the timeout remains
+      // shared so a compatibility retry cannot double the caller's deadline.
+      let response = await request(true)
+      if (response.status === 400) {
+        await response.body?.cancel?.()
+        response = await request(false)
+      }
       if (!response.ok) {
-        throw new Error(`memory extractor request failed: ${response.status}`)
+        const detail = String(await response.text().catch(() => ''))
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, 300)
+        throw new Error(
+          `memory extractor request failed: ${response.status}${detail ? ` ${detail}` : ''}`,
+        )
       }
       const payload = await response.json()
       return String(payload?.choices?.[0]?.message?.content || '')

--- a/server/src/core/gateway-protocol.mjs
+++ b/server/src/core/gateway-protocol.mjs
@@ -10,6 +10,8 @@
 // Every capability listed here is locked by a test (see docs/contract.md);
 // anything not listed is internal and may change in any release.
 //
+// 5.6.0 adds a provider-neutral frontend memory control plane for replaceable
+// clients to list and edit the same documents used by Realtime.
 // 5.5.0 adds the GCP5 reference Client SDK, bounded Task-event replay, and
 // migrates first-party task/history/permission recovery to the WebSocket.
 // 5.4.0 adds GCP4 ClientActionPort request/result correlation and the shared
@@ -41,7 +43,7 @@
 // desktop.settings-window, …) are not part of this contract, and a removed
 // capability is a breaking change. Hosts migrating from the fork must branch
 // on the capability list below, never on the version number.
-export const GATEWAY_PROTOCOL_VERSION = '5.5.0'
+export const GATEWAY_PROTOCOL_VERSION = '5.6.0'
 
 export const GATEWAY_CAPABILITIES = Object.freeze([
   // The Gateway statically hosts web/dist at its own origin, so a client may
@@ -93,6 +95,9 @@ export const GATEWAY_CAPABILITIES = Object.freeze([
   // Final assistant transcript events may carry bounded, normalized citations
   // collected from frontend retrieval tools during the same user turn.
   'messages.citations',
+  // GET/PATCH /api/memory lists and edits the provider-backed frontend memory
+  // documents used by Realtime; no storage implementation leaks to clients.
+  'frontend.memory-control',
   // WS /api/realtime plus the published event constants and schemas form the
   // replaceable Conversation Client boundary for audio, text, multimodal
   // input, transcripts, playback receipts, voice state and Task projections.

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -388,6 +388,104 @@ test('can disable memory without constructing the default provider', async () =>
   await application.close()
 })
 
+test('serves and edits frontend memory through the generic client control plane', async () => {
+  const calls = []
+  const documents = [{
+    id: 'memory_document',
+    scope: 'memory',
+    content: '# MEMORY\n\n- 用户喜欢茶',
+    format: 'markdown',
+    revision: 'revision-one',
+    editable: true,
+  }]
+  const frontendMemory = {
+    list: ownerId => {
+      calls.push({ kind: 'list', ownerId })
+      return documents
+    },
+    apply: async (ownerId, changes, context) => {
+      calls.push({ kind: 'apply', ownerId, changes, context })
+      if (changes[0]?.expectedRevision === 'stale') {
+        throw Object.assign(new Error('memory document changed'), {
+          code: 'stale_document',
+        })
+      }
+      return { changed: 1, documents: [] }
+    },
+    health: () => ({ ok: true, configured: true, provider: { key: 'test' } }),
+    close: async () => {},
+  }
+  const application = createGatewayApplication({
+    config: {
+      ...config,
+      port: 0,
+      memoryAutoEnabled: false,
+      webSearchProvider: 'none',
+      webSearchMcpUrl: '',
+    },
+    parentPort: null,
+    autoStart: false,
+    agent: disabledBackend(),
+    frontendMemory,
+    frontendMcp: null,
+    frontendOpenApi: null,
+  })
+  application.start()
+  if (!application.server.listening) await once(application.server, 'listening')
+  const { port } = application.server.address()
+  const origin = `http://127.0.0.1:${port}`
+  try {
+    const listed = await fetch(`${origin}/api/memory`)
+    assert.equal(listed.status, 200)
+    assert.deepEqual(await listed.json(), { documents })
+
+    const invalid = await fetch(`${origin}/api/memory`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ changes: [] }),
+    })
+    assert.equal(invalid.status, 400)
+
+    const stale = await fetch(`${origin}/api/memory`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        changes: [{
+          document: 'memory',
+          expectedRevision: 'stale',
+          edits: [{ old_text: '- 用户喜欢茶', new_text: '' }],
+        }],
+      }),
+    })
+    assert.equal(stale.status, 409)
+    assert.deepEqual(await stale.json(), {
+      error: 'memory document changed',
+      code: 'stale_document',
+    })
+
+    const changes = [{
+      document: 'memory',
+      expectedRevision: 'revision-one',
+      edits: [{ old_text: '- 用户喜欢茶', new_text: '' }],
+    }]
+    const edited = await fetch(`${origin}/api/memory`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ changes }),
+    })
+    assert.equal(edited.status, 200)
+    assert.deepEqual(await edited.json(), { changed: 1, documents: [] })
+    assert.deepEqual(calls.at(-1), {
+      kind: 'apply',
+      ownerId: config.personalOwnerId,
+      changes,
+      context: { source: 'gateway-memory-api' },
+    })
+  } finally {
+    await application.close()
+  }
+})
+
 // 接线契约：新增的记忆模块默认关闭，显式开启时才装配。
 // config 是模块级单例（import 时已读完 env），所以这里注入伪 config
 // 而不是改 process.env —— 后者在同一进程内无效。

--- a/server/test/memory-extractor.test.mjs
+++ b/server/test/memory-extractor.test.mjs
@@ -335,12 +335,29 @@ test('createExtractorLlmCall posts to chat completions and surfaces errors', asy
   assert.equal(await llmCall({ system: 's', user: 'u' }), '{}')
   assert.equal(requests[0].url, 'https://example.com/v1/chat/completions')
   assert.equal(requests[0].options.headers.Authorization, 'Bearer test-key')
+  assert.equal(JSON.parse(requests[0].options.body).temperature, 0)
+
+  const retriedRequests = []
+  const compatible = createExtractorLlmCall({
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'test-key',
+    model: 'strict-compatible-model',
+    fetchImpl: async (url, options) => {
+      retriedRequests.push({ url, options })
+      return retriedRequests.length === 1
+        ? { ok: false, status: 400, text: async () => 'unsupported temperature' }
+        : { ok: true, json: async () => ({ choices: [{ message: { content: '[]' } }] }) }
+    },
+  })
+  assert.equal(await compatible({ system: 's', user: 'u' }), '[]')
+  assert.equal(retriedRequests.length, 2)
+  assert.equal('temperature' in JSON.parse(retriedRequests[1].options.body), false)
 
   const failing = createExtractorLlmCall({
     baseUrl: 'https://example.com/v1',
     apiKey: 'test-key',
     model: 'qwen-flash',
-    fetchImpl: async () => ({ ok: false, status: 429 }),
+    fetchImpl: async () => ({ ok: false, status: 429, text: async () => 'rate limited' }),
   })
-  await assert.rejects(() => failing({ system: 's', user: 'u' }), /request failed: 429/)
+  await assert.rejects(() => failing({ system: 's', user: 'u' }), /request failed: 429 rate limited/)
 })


### PR DESCRIPTION
## Summary
- add a provider-neutral, owner-scoped GET/PATCH memory control plane over the existing FrontendMemoryRuntime
- let the smart-cockpit client list and exactly delete the same USER/MEMORY entries used by Realtime
- retry automatic memory extraction once without optional temperature when an OpenAI-compatible model rejects it with HTTP 400
- publish the additive 5.6.0 health contract and document the client/provider boundaries

## Validation
- npm run lint
- npm test
- npm run build
- npm run example:smart-cockpit:build
- targeted Gateway API and memory extractor tests