### PR TITLE
fix(realtime): stabilize client replacement and latency tracing

### DIFF
--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -81,6 +81,13 @@ keys, tokens, Authorization, cookies, passwords, and secret fields are desensiti
 writing; by default, microphone audio, user transcription text, model reply text, task
 objectives, and task results are not recorded.
 
+For foreground-tool latency analysis, correlate `realtime.provider.speech_stopped`,
+`realtime.tool_call.received`, `realtime.tool_call.result_ready`, and
+`realtime.playback.started` by `sessionId` and `turnId`; failed calls use
+`realtime.tool_call.failed`. The first event is the Realtime provider's endpoint decision,
+not the user's physical last speech sample. Measuring the earlier acoustic-to-endpoint interval
+requires a Client-side capture timestamp or a controlled real-time PCM replay.
+
 The desktop edition can open the log directory in "Settings → App → Logs". The default
 log level is `info`; individual files rotate after reaching 10 MiB, with a total of 5 files
 retained. These can be adjusted via the following environment variables:

--- a/docs/configuration/advanced.zh.md
+++ b/docs/configuration/advanced.zh.md
@@ -74,6 +74,13 @@ qwen-audio-agent 使用统一的本地结构化日志，默认写入：
 Authorization、Cookie、密码和 Secret 字段会在写入前脱敏；默认不记录麦克风音频、
 用户转写正文、模型回复正文、任务目标或任务结果。
 
+分析前台工具延迟时，可以按 `sessionId` 和 `turnId` 串联
+`realtime.provider.speech_stopped`、`realtime.tool_call.received`、
+`realtime.tool_call.result_ready` 与 `realtime.playback.started`；工具失败记为
+`realtime.tool_call.failed`。其中第一个事件表示 Realtime Provider 确认的
+端点，不是用户真实发声的最后一个采样；如需测量更早的“真实话音结束→端点检测”，
+需使用客户端采集时间戳或受控的实时 PCM 回放。
+
 桌面版可在“设置 → 应用 → 日志”中打开日志目录。默认日志级别为 `info`，单个文件
 达到 10 MiB 后轮转，总共保留 5 份。可通过以下环境变量调整：
 

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -57,6 +57,7 @@ import {
 import { GatewayClientProtocolSession } from '../transport/gateway-client-protocol-session.mjs'
 import {
   GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES,
+  GATEWAY_CLIENT_REPLACED_CLOSE_CODE,
   GatewayClientCapability,
   GatewayClientProtocolEvent,
 } from '../../../shared/gateway-client-protocol.mjs'
@@ -185,7 +186,7 @@ export function attachRealtimeGateway(server, {
     })
   const activeVoiceClients = new ActiveVoiceClients()
   const voiceConnections = new Map()
-  const activeClientSockets = new Set()
+  const activeClientSockets = new Map()
   const replayBuffers = new Map()
   const frontendToolSourcesReady = Promise.all(
     frontendToolSources.map(source => source.initialize()),
@@ -238,20 +239,6 @@ export function attachRealtimeGateway(server, {
   })
 
   wss.on('connection', (ws, url, identity) => {
-    if (activeClientSockets.size > 0) {
-      ws.send(JSON.stringify({
-        type: 'error',
-        event_id: `evt_gateway_${randomUUID().replaceAll('-', '')}`,
-        message: 'Gateway 已由另一个 Client 使用',
-        error: {
-          code: 'client_occupied',
-          message: 'Gateway already has an active Client connection',
-        },
-      }))
-      ws.close(1008, 'client_occupied')
-      return
-    }
-    activeClientSockets.add(ws)
     const ownerId = identity.ownerId
     const sessionId = url.searchParams.get('sessionId') || 'main'
     const replayKey = `${ownerId}\u0000${sessionId}`
@@ -286,6 +273,7 @@ export function attachRealtimeGateway(server, {
     let inputSuspended = inputArbitration?.suspended === true
     let nonVoiceClient = false
     let descriptor = clientDescriptor()
+    let admitted = false
     let responseTurnCandidate = null
     let responseStartWatchdog = null
     let permissionResponseTimer = null
@@ -698,6 +686,7 @@ export function attachRealtimeGateway(server, {
         broadcastVoiceOwnership(ownerId)
       }
     }
+    const toolCallTimings = new Map()
     const toolCalls = new ToolCallHandler({
       taskManager,
       ownerId,
@@ -734,6 +723,17 @@ export function attachRealtimeGateway(server, {
         })
         announcedPermissions.delete(authorizationId)
         announcePendingPermissions()
+      },
+      onToolResultReady: ({ callId, turnId, toolName }) => {
+        const timing = toolCallTimings.get(callId)
+        if (!timing || timing.resultReady) return
+        timing.resultReady = true
+        connectionLogger.info('realtime.tool_call.result_ready', {
+          ...timing.fields,
+          turnId: turnId || timing.fields.turnId,
+          toolName: toolName || timing.fields.toolName,
+          durationMs: Math.max(0, Date.now() - timing.startedAt),
+        })
       },
       presenceController,
       onAgentActivity: activity => send(ws, {
@@ -824,6 +824,9 @@ export function attachRealtimeGateway(server, {
       shouldEnsurePermissionResponse: context => responseTurnCandidate === context,
       ensurePermissionResponseFor,
       reportFrontendError,
+      onSpeechStopped: fields => {
+        connectionLogger.info('realtime.provider.speech_stopped', fields)
+      },
     })
 
     const presentationRuntime = new RealtimePresentationRuntime({
@@ -982,16 +985,29 @@ export function attachRealtimeGateway(server, {
         const id = realtimeResponseId(event)
         const callContext = presentationRuntime.get(id)
           || { turnId: '', turnGeneration: -1 }
-        logger.info('realtime.tool_call.received', {
+        const callFields = {
           responseId: id,
           callId: event.call_id || event.item?.call_id || '',
           toolName: event.name || event.item?.name || '',
           turnId: callContext.turnId || '',
-        })
+        }
+        connectionLogger.info('realtime.tool_call.received', callFields)
         presentationRuntime.markFunctionCall(id)
-        toolCalls.handle(event, { ...callContext, responseId: id }).catch(error => {
-          send(ws, { type: 'error', message: error.message })
+        const startedAt = Date.now()
+        toolCallTimings.set(callFields.callId, {
+          fields: callFields,
+          startedAt,
+          resultReady: false,
         })
+        toolCalls.handle(event, { ...callContext, responseId: id })
+          .catch(error => {
+            connectionLogger.warn('realtime.tool_call.failed', {
+              ...callFields,
+              durationMs: Math.max(0, Date.now() - startedAt),
+            })
+            send(ws, { type: 'error', message: error.message })
+          })
+          .finally(() => toolCallTimings.delete(callFields.callId))
       } else if (presentationRuntime.handle(event)) {
         return
       } else if (event.type === 'error') {
@@ -1154,6 +1170,57 @@ export function attachRealtimeGateway(server, {
       clientType: descriptor.type,
       clientInstanceId: descriptor.instanceId,
     })
+    const admitClientConnection = nextDescriptor => {
+      const occupied = activeClientSockets.entries().next().value
+      if (!occupied) {
+        activeClientSockets.set(ws, {
+          ownerId,
+          sessionId,
+          instanceId: nextDescriptor.instanceId,
+        })
+        admitted = true
+        return true
+      }
+      const [occupiedSocket, occupiedClient] = occupied
+      if (occupiedSocket === ws) return true
+      const replacesSameClient = Boolean(
+        nextDescriptor.instanceId
+        && occupiedClient.instanceId === nextDescriptor.instanceId
+        && occupiedClient.ownerId === ownerId
+        && occupiedClient.sessionId === sessionId
+      )
+      if (!replacesSameClient) return false
+
+      // Remove before closing: the replacement may claim voice ownership while
+      // the superseded socket is still completing its asynchronous close.
+      activeClientSockets.delete(occupiedSocket)
+      activeClientSockets.set(ws, {
+        ownerId,
+        sessionId,
+        instanceId: nextDescriptor.instanceId,
+      })
+      admitted = true
+      occupiedSocket.close(
+        GATEWAY_CLIENT_REPLACED_CLOSE_CODE,
+        'client_replaced',
+      )
+      connectionLogger.info('voice_client.replaced', {
+        clientType: nextDescriptor.type,
+        clientInstanceId: nextDescriptor.instanceId,
+      })
+      return true
+    }
+    const rejectOccupiedClient = () => {
+      send(ws, {
+        type: 'error',
+        message: 'Gateway 已由另一个 Client 使用',
+        error: {
+          code: 'client_occupied',
+          message: 'Gateway already has an active Client connection',
+        },
+      })
+      ws.close(1008, 'client_occupied')
+    }
     const sendRuntimeError = (message, error) => {
       connectionLogger.warn('client_runtime.command_failed', {
         type: String(message?.type || ''),
@@ -1308,11 +1375,23 @@ export function attachRealtimeGateway(server, {
         return
       }
       const protocolOutcome = clientProtocol.receive(event)
-      if (protocolOutcome.reply) send(ws, protocolOutcome.reply)
       if (protocolOutcome.close) {
+        if (protocolOutcome.reply) send(ws, protocolOutcome.reply)
         ws.close(1002, protocolOutcome.reply?.error?.code || 'protocol error')
         return
       }
+      const negotiatedEvent = protocolOutcome.event
+      if (
+        negotiatedEvent?.type === GatewayClientEvent.CONNECT
+        && !admitted
+      ) {
+        const nextDescriptor = clientDescriptor(negotiatedEvent)
+        if (!admitClientConnection(nextDescriptor)) {
+          rejectOccupiedClient()
+          return
+        }
+      }
+      if (protocolOutcome.reply) send(ws, protocolOutcome.reply)
       for (const pendingEvent of protocolOutcome.pending || []) {
         send(ws, pendingEvent)
       }
@@ -1323,7 +1402,7 @@ export function attachRealtimeGateway(server, {
           .catch(error => sendRuntimeError(runtimeMessage, error))
         return
       }
-      event = protocolOutcome.event
+      event = negotiatedEvent
       if (!event) return
       if (event.type === GatewayClientEvent.CONNECT) {
         descriptor = clientDescriptor(event)
@@ -1492,11 +1571,19 @@ export function attachRealtimeGateway(server, {
         realtimeSession.cancelResponse()
       } else if (event.type === GatewayClientEvent.PLAYBACK_STARTED) {
         const id = String(event.responseId || '')
+        const playbackContext = presentationRuntime.get(id)
         if (acceptsPlaybackReceipt({
           outputEnabled,
           active: activeVoiceClients.isActive(ownerId, voiceClient),
           responseKnown: presentationRuntime.has(id),
-        })) presentationRuntime.startPlayback(id)
+        })) {
+          connectionLogger.info('realtime.playback.started', {
+            responseId: id,
+            turnId: playbackContext?.turnId || '',
+            origin: playbackContext?.origin || 'model',
+          })
+          presentationRuntime.startPlayback(id)
+        }
       } else if (event.type === GatewayClientEvent.PLAYBACK_ENDED) {
         const id = String(event.responseId || '')
         if (acceptsPlaybackReceipt({

--- a/server/src/voice/realtime-input-runtime.mjs
+++ b/server/src/voice/realtime-input-runtime.mjs
@@ -45,6 +45,7 @@ export class RealtimeInputRuntime {
     shouldEnsurePermissionResponse,
     ensurePermissionResponseFor,
     reportFrontendError,
+    onSpeechStopped = () => {},
     createInputTurnId = () => `text_${randomUUID().replaceAll('-', '')}`,
   }) {
     this.ownerId = ownerId
@@ -63,6 +64,7 @@ export class RealtimeInputRuntime {
     this.shouldEnsurePermissionResponse = shouldEnsurePermissionResponse
     this.ensurePermissionResponseFor = ensurePermissionResponseFor
     this.reportFrontendError = reportFrontendError
+    this.onSpeechStopped = onSpeechStopped
     this.createInputTurnId = createInputTurnId
   }
 
@@ -131,6 +133,11 @@ export class RealtimeInputRuntime {
       this.turns.invalidateInput(event.item_id)
       return
     }
+    this.onSpeechStopped({
+      turnId: stoppedTurn.turnId,
+      source: 'realtime_provider',
+      ...(event.reason ? { reason: String(event.reason) } : {}),
+    })
     this.turns.endSpeech()
     this.announcementWindow.endSpeech()
     if (event.reason === 'turn_invalid') {

--- a/server/src/voice/tools/tool-call-handler.mjs
+++ b/server/src/voice/tools/tool-call-handler.mjs
@@ -121,6 +121,7 @@ export class ToolCallHandler {
     respondInput,
     permissionPolicy,
     onPermissionDeliveryFailed = () => {},
+    onToolResultReady = () => {},
     presenceController = null,
     onAgentActivity = () => {},
     inputAssets = null,
@@ -147,6 +148,7 @@ export class ToolCallHandler {
     this.respondInput = respondInput
     this.permissionPolicy = permissionPolicy
     this.onPermissionDeliveryFailed = onPermissionDeliveryFailed
+    this.onToolResultReady = onToolResultReady
     this.presenceController = presenceController
     this.onAgentActivity = onAgentActivity
     this.inputAssets = inputAssets
@@ -324,6 +326,16 @@ export class ToolCallHandler {
       ...frontendOptions
     } = options || {}
     const tool = this.activeToolEntries.get(callId)
+    try {
+      this.onToolResultReady({
+        callId,
+        turnId,
+        toolName: tool?.name || '',
+        ...(taskId ? { taskId } : {}),
+      })
+    } catch {
+      // Observability hooks must never affect tool execution or delivery.
+    }
     const bounded = boundFrontendToolResult(
       output,
       tool?.policy.maxResultBytes,

--- a/server/test/gateway-client-handshake.test.mjs
+++ b/server/test/gateway-client-handshake.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import WebSocket from 'ws'
 import {
   GatewayClientCapability,
+  GATEWAY_CLIENT_REPLACED_CLOSE_CODE,
   GatewayClientProtocolEvent,
   createGatewaySessionHello,
 } from '../../shared/gateway-client-protocol.mjs'
@@ -537,7 +538,38 @@ test('allows only one active Gateway Client connection', async t => {
     event => event.error?.code === 'client_occupied',
   )
   assert.equal(occupied.type, 'error')
-  await new Promise(resolve => second.socket.once('close', resolve))
+  await waitUntil(() => second.socket.readyState === WebSocket.CLOSED)
   assert.equal(first.socket.readyState, WebSocket.OPEN)
   first.socket.close()
+})
+
+test('replaces a stale socket after the same logical Client reconnects', async t => {
+  const { server, gateway } = gatewayHarness()
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  t.after(async () => {
+    await gateway.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+  const hello = () => createGatewaySessionHello({
+    clientInstanceId: 'same-client',
+    capabilities: [GatewayClientCapability.INPUT_TEXT],
+  })
+  const first = await connect(server, hello())
+  await waitFor(first.received, event => event.type === 'session.ready')
+  const firstClosed = new Promise(resolve => {
+    first.socket.once('close', (code, reason) => resolve({
+      code,
+      reason: reason.toString(),
+    }))
+  })
+
+  const second = await connect(server, hello())
+  await waitFor(second.received, event => event.type === 'session.ready')
+  assert.deepEqual(await firstClosed, {
+    code: GATEWAY_CLIENT_REPLACED_CLOSE_CODE,
+    reason: 'client_replaced',
+  })
+  await waitUntil(() => gateway.status().connected === 1)
+  assert.equal(second.socket.readyState, WebSocket.OPEN)
+  second.socket.close()
 })

--- a/server/test/realtime-input-runtime.test.mjs
+++ b/server/test/realtime-input-runtime.test.mjs
@@ -9,6 +9,7 @@ function harness({ responseOutcome } = {}) {
   const events = []
   const records = []
   const calls = []
+  const speechStops = []
   const frontend = {
     cancel: () => calls.push(['cancel']),
     sendUserInput: async (parts, context) => {
@@ -48,9 +49,10 @@ function harness({ responseOutcome } = {}) {
       context,
     ]),
     reportFrontendError: error => calls.push(['reportFrontendError', error]),
+    onSpeechStopped: fields => speechStops.push(fields),
     createInputTurnId: () => 'text-1',
   })
-  return { runtime, turns, events, records, calls }
+  return { runtime, turns, events, records, calls, speechStops }
 }
 
 test('handles only provider input lifecycle events', () => {
@@ -64,7 +66,7 @@ test('handles only provider input lifecycle events', () => {
 })
 
 test('projects one voice turn from speech start through final transcript', () => {
-  const { runtime, turns, events, records, calls } = harness()
+  const { runtime, turns, events, records, calls, speechStops } = harness()
 
   runtime.handleProviderEvent({
     type: 'input_audio_buffer.speech_started',
@@ -101,6 +103,10 @@ test('projects one voice turn from speech start through final transcript', () =>
   assert.equal(records.length, 1)
   assert.equal(records[0].content, '你好')
   assert.equal(records[0].source, 'voice-user')
+  assert.deepEqual(speechStops, [{
+    turnId: 'voice-1',
+    source: 'realtime_provider',
+  }])
   assert.equal(
     calls.some(([name]) => name === 'ensurePermissionResponseFor'),
     true,

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -28,6 +28,7 @@ function harness({
   getTurnId = () => 'turn-one',
 } = {}) {
   const outputs = []
+  const toolResultsReady = []
   const ensuredResponses = []
   const transcripts = new TurnTranscripts({ waitMs: 5 })
   const frontend = {
@@ -65,8 +66,16 @@ function harness({
     frontendRetrieval,
     frontendKnowledge,
     frontendToolSources,
+    onToolResultReady: fields => toolResultsReady.push(fields),
   })
-  return { outputs, ensuredResponses, manager, transcripts, handler }
+  return {
+    outputs,
+    toolResultsReady,
+    ensuredResponses,
+    manager,
+    transcripts,
+    handler,
+  }
 }
 
 test('executes discovered external tools through the shared boundary', async () => {
@@ -147,6 +156,11 @@ test('executes an explicitly enabled state-changing external tool inline', async
   ]])
   assert.equal(kit.outputs[0][1].text, '已打开主驾车窗')
   assert.equal(kit.outputs[0][1].status, 'ok')
+  assert.deepEqual(kit.toolResultsReady, [{
+    callId: 'window-control',
+    turnId: 'turn-one',
+    toolName: 'mcp__cockpit__vehicle_window_control',
+  }])
 })
 
 function taskForId(manager, taskId) {

--- a/shared/gateway-client-protocol.mjs
+++ b/shared/gateway-client-protocol.mjs
@@ -10,6 +10,7 @@ import {
 } from './protocol/gateway-events.mjs'
 
 export const GATEWAY_CLIENT_PROTOCOL_VERSION = '6.0.0'
+export const GATEWAY_CLIENT_REPLACED_CLOSE_CODE = 4001
 
 export const GatewayClientProtocolEvent = Object.freeze({
   SESSION_HELLO: 'session.hello',

--- a/shared/gateway-client-sdk.mjs
+++ b/shared/gateway-client-sdk.mjs
@@ -1,5 +1,6 @@
 import {
   GATEWAY_CLIENT_PROTOCOL_VERSION,
+  GATEWAY_CLIENT_REPLACED_CLOSE_CODE,
   GatewayClientCapability,
   GatewayClientProtocolEvent,
   createGatewayClientProtocolMessage,
@@ -273,7 +274,7 @@ export class GatewayClient {
       if (this.socket !== socket || this.stopped) return
       this.onStatus?.({ state: 'unavailable', error })
     })
-    addSocketListener(socket, 'close', () => {
+    addSocketListener(socket, 'close', eventOrCode => {
       if (this.socket !== socket) return
       this.socket = null
       this.ready = false
@@ -281,6 +282,16 @@ export class GatewayClient {
       this.#rejectPending('connection_closed', 'Gateway connection closed')
       if (this.stopped) return
       this.onStatus?.({ state: 'disconnected' })
+      const closeCode = typeof eventOrCode === 'number'
+        ? eventOrCode
+        : Number(eventOrCode?.code)
+      if (closeCode === GATEWAY_CLIENT_REPLACED_CLOSE_CODE) {
+        // A newer connection from this logical Client has taken ownership.
+        // Retrying this superseded socket would make the two instances evict
+        // each other forever during a page refresh or development hot reload.
+        this.stopped = true
+        return
+      }
       if (!this.reconnect) return
       this.reconnectTimer = setTimeout(() => this.#connect(), this.reconnectDelay)
       this.reconnectDelay = Math.min(this.reconnectMaxMs, this.reconnectDelay * 2)

--- a/test/gateway-client-sdk.test.mjs
+++ b/test/gateway-client-sdk.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { GatewayClient } from '../shared/gateway-client-sdk.mjs'
 import {
+  GATEWAY_CLIENT_REPLACED_CLOSE_CODE,
   GatewayClientCapability,
   GatewayClientProtocolEvent,
 } from '../shared/gateway-client-protocol.mjs'
@@ -286,4 +287,28 @@ test('reference Client reconnects, replays from its cursor, then reconciles snap
   assert.deepEqual(received.map(event => event.sequence), [1, 2])
   assert.deepEqual(recovered.events.map(event => event.sequence), [2])
   client.stop()
+})
+
+test('reference Client does not reconnect after a newer instance replaces it', async () => {
+  const sockets = []
+  const client = new GatewayClient({
+    url: 'ws://gateway.test/api/realtime',
+    createSocket: () => {
+      const socket = new FakeSocket()
+      sockets.push(socket)
+      return socket
+    },
+    clientInstanceId: 'sdk-replaced-test',
+    reconnectMinMs: 50,
+    reconnectMaxMs: 50,
+  }).start()
+  const socket = sockets[0]
+  socket.open()
+  socket.readyState = 3
+  socket.emit('close', { code: GATEWAY_CLIENT_REPLACED_CLOSE_CODE })
+
+  await new Promise(resolve => setTimeout(resolve, 70))
+
+  assert.equal(sockets.length, 1)
+  assert.equal(client.readyState, 3)
 })


### PR DESCRIPTION
## Summary

- let a reconnecting logical Gateway Client replace its stale socket without entering a reconnect eviction loop
- add lightweight, correlated Realtime tool-latency events from provider endpointing through playback start
- document how to interpret the latency chain and its acoustic endpoint boundary

## Validation

- `npm run lint`
- `npm run test` (all workspaces; server isolated from local user config)
- `npm run test:smart-cockpit`
- `npm run example:smart-cockpit:lint`
- `npm run example:smart-cockpit:build`
- `npm run docs:build`
- focused gateway/runtime/tool/SDK tests: 82/82 passed