### PR TITLE
fix: announce realtime content rejection after recovery

### DIFF
--- a/docs/gateway-protocol.md
+++ b/docs/gateway-protocol.md
@@ -474,6 +474,13 @@ Routing modes are:
 
 `AgentDeliveryRuntime` owns user-speech blocking, response serialization, sleep deferral, retry, and playback acknowledgement. Realtime Provider adapters translate the delivery into their own wire protocol. Raw Client JSON is never pasted into a model prompt.
 
+Gateway-originated events that the frontend Agent must perceive use the same
+boundary. For example, after Realtime content is rejected, the Gateway excludes
+the failed turn, restores the connection, and then delivers
+`realtime.content_rejected`. The model receives only a sanitized instruction to
+ask the user to change topics; provider errors, error codes, and rejected source
+content never enter the replacement Session.
+
 ## 7. Presence and sleep
 
 Both sleep modes converge on the same PresenceController and Client Action path, but only user-requested sleep requires a model Tool Call.

--- a/docs/gateway-protocol.zh.md
+++ b/docs/gateway-protocol.zh.md
@@ -453,6 +453,11 @@ Provider 的 response 对象。
 
 `AgentDeliveryRuntime` 管理用户说话阻塞、回复串行化、休眠暂存、重试和播放确认。Realtime Provider Adapter 再转换成自己的线协议。不能把 Client 原始 JSON 直接粘贴进模型 Prompt。
 
+Gateway 自身产生且需要前台 Agent 感知的事件也使用同一边界。例如 Realtime
+内容被拒绝后，Gateway 先排除失败轮次并恢复连接，再投递
+`realtime.content_rejected`。模型只会收到脱敏的“上一轮内容无法回复，请换个话题”，
+不会收到供应商错误对象、错误码或被拒绝的原始内容。
+
 ## 7. Presence 与休眠
 
 两种休眠最终进入同一个 PresenceController 和 Client Action 链路，但只有用户主动休眠需要模型工具调用。

--- a/package-lock.json
+++ b/package-lock.json
@@ -3068,9 +3068,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3165,6 +3165,22 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/algoliasearch": {
       "version": "5.57.0",
@@ -5198,22 +5214,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -8174,9 +8174,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -273,8 +273,11 @@
     "vitepress": "^1.6.4"
   },
   "overrides": {
+    "@xmldom/xmldom": "0.8.15",
     "@hono/node-server": "2.0.12",
     "@electron/asar": "4.2.1",
-    "@electron/universal": "3.0.6"
+    "@electron/universal": "3.0.6",
+    "fast-uri": "3.1.6",
+    "qs": "6.16.0"
   }
 }

--- a/server/src/delivery/gateway-system-event.mjs
+++ b/server/src/delivery/gateway-system-event.mjs
@@ -1,0 +1,48 @@
+import { createAgentDelivery } from './agent-delivery.mjs'
+
+export const GatewaySystemEvent = Object.freeze({
+  REALTIME_CONTENT_REJECTED: 'realtime.content_rejected',
+})
+
+const DEFINITIONS = Object.freeze({
+  [GatewaySystemEvent.REALTIME_CONTENT_REJECTED]: Object.freeze({
+    text: [
+      '<gateway_system_event>',
+      '上一轮内容无法回复，请换个话题。',
+      '</gateway_system_event>',
+    ].join('\n'),
+    instructions: [
+      '这是 Gateway 提供的系统事件，不是用户的新请求。',
+      '用一句自然口语告知用户，不调用工具，不朗读协议标签，也不要猜测或补充具体原因。',
+    ].join(' '),
+  }),
+})
+
+/**
+ * Converts one Gateway-owned semantic event into a provider-neutral delivery.
+ * Provider errors and raw rejected content must never cross this boundary.
+ */
+export function createGatewaySystemEventDelivery(name, {
+  id,
+  causeEventId,
+  correlation = {},
+} = {}) {
+  const definition = DEFINITIONS[name]
+  if (!definition) throw new TypeError(`unknown Gateway system event: ${name}`)
+  return createAgentDelivery({
+    ...(id ? { id } : {}),
+    ...(causeEventId ? { causeEventId } : {}),
+    mode: 'respond',
+    origin: 'gateway-system-event',
+    text: definition.text,
+    correlation: {
+      ...correlation,
+      eventName: name,
+    },
+    presentation: {
+      instructions: definition.instructions,
+      allowTools: false,
+      contextTiming: 'immediate',
+    },
+  })
+}

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -62,6 +62,10 @@ import {
   GatewayClientProtocolEvent,
 } from '../../../shared/gateway-client-protocol.mjs'
 import { createAgentDelivery } from '../delivery/agent-delivery.mjs'
+import {
+  createGatewaySystemEventDelivery,
+  GatewaySystemEvent,
+} from '../delivery/gateway-system-event.mjs'
 import { RealtimeAgentDeliveryRuntime } from './realtime-agent-delivery-runtime.mjs'
 import {
   ClientActionName,
@@ -1059,10 +1063,28 @@ export function attachRealtimeGateway(server, {
             type: 'error',
             message: '这次内容未能处理，语音会话已自动恢复，请换个说法再试。',
           })
-          realtimeSession.reconnect().catch(error => send(ws, {
-            type: 'error',
-            message: error.message,
-          }))
+          const recoveryTurnId = gatewayTurnId()
+          const recoveryDelivery = createGatewaySystemEventDelivery(
+            GatewaySystemEvent.REALTIME_CONTENT_REJECTED,
+            {
+              id: `content_recovery_${recoveryTurnId}`,
+              correlation: { turnId: recoveryTurnId },
+            },
+          )
+          realtimeSession.reconnect()
+            .then(() => agentDeliveries.deliver(recoveryDelivery))
+            .then(outcome => {
+              if (outcome?.completed) return
+              connectionLogger.warn('realtime.content_safety_delivery_skipped', {
+                provider: realtimeSession.providerKey,
+                blocked: outcome?.blocked === true,
+                unavailable: outcome?.unavailable === true,
+              })
+            })
+            .catch(error => send(ws, {
+              type: 'error',
+              message: error.message,
+            }))
           return
         }
         if (providerError === 'fatal') {

--- a/server/test/gateway-client-handshake.test.mjs
+++ b/server/test/gateway-client-handshake.test.mjs
@@ -116,6 +116,11 @@ test('recovers the client and excludes only the content-safety rejected turn', a
       updateAgentContext: () => {},
       ensureResponse: async () => {},
       injectContext: async () => {},
+      deliveries: [],
+      injectDelivery: async (text, origin, context, deliveryOptions) => {
+        frontend.deliveries.push({ text, origin, context, deliveryOptions })
+        return { completed: true, route: deliveryOptions.route }
+      },
       whenIdle: async () => {},
       sendUserInput: async (parts, context) => {
         frontend.inputs.push({ parts, context })
@@ -178,6 +183,14 @@ test('recovers the client and excludes only the content-safety rejected turn', a
     frontends[1].agentContext.recentMessages.map(message => message.content),
     ['正常问题'],
   )
+  await waitUntil(() => frontends[1].frontend.deliveries.length === 1)
+  const [recovery] = frontends[1].frontend.deliveries
+  assert.match(recovery.text, /上一轮内容无法回复，请换个话题/u)
+  assert.equal(recovery.origin, 'gateway-system-event')
+  assert.equal(recovery.context.eventName, 'realtime.content_rejected')
+  assert.equal(recovery.deliveryOptions.route, 'respond')
+  assert.equal(recovery.deliveryOptions.allowTools, false)
+  assert.equal(recovery.deliveryOptions.contextTiming, 'immediate')
   client.socket.close()
 })
 

--- a/server/test/gateway-system-event.test.mjs
+++ b/server/test/gateway-system-event.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  createGatewaySystemEventDelivery,
+  GatewaySystemEvent,
+} from '../src/delivery/gateway-system-event.mjs'
+
+test('creates a provider-neutral and sanitized content rejection delivery', () => {
+  const delivery = createGatewaySystemEventDelivery(
+    GatewaySystemEvent.REALTIME_CONTENT_REJECTED,
+    {
+      id: 'recovery-1',
+      correlation: { turnId: 'turn-recovery' },
+    },
+  )
+
+  assert.equal(delivery.id, 'recovery-1')
+  assert.equal(delivery.mode, 'respond')
+  assert.equal(delivery.origin, 'gateway-system-event')
+  assert.equal(delivery.correlation.eventName, 'realtime.content_rejected')
+  assert.equal(delivery.correlation.turnId, 'turn-recovery')
+  assert.match(delivery.text, /上一轮内容无法回复，请换个话题/u)
+  assert.doesNotMatch(delivery.text, /DataInspection|provider|违规原文/iu)
+  assert.equal(delivery.presentation.allowTools, false)
+  assert.equal(delivery.presentation.contextTiming, 'immediate')
+})
+
+test('rejects unknown Gateway system events', () => {
+  assert.throws(
+    () => createGatewaySystemEventDelivery('provider.private_error'),
+    /unknown Gateway system event/u,
+  )
+})


### PR DESCRIPTION
## Summary
- normalize content rejection as a provider-neutral Gateway system event
- deliver a sanitized message only after the replacement Realtime Session is ready
- preserve deterministic client error presentation and exclude rejected content from restored context
- document the system-event delivery boundary in Chinese and English

## Verification
- `node --test server/test/gateway-system-event.test.mjs server/test/gateway-client-handshake.test.mjs server/test/realtime-provider.test.mjs`
- `npm run lint`