### PR TITLE
feat(remote): add endpoint publishers and connection profiles

### DIFF
--- a/cli/src/arguments.mjs
+++ b/cli/src/arguments.mjs
@@ -102,7 +102,11 @@ export function parseArguments(argv, env = process.env) {
     realtimeModel: '',
     gatewayAction,
     url: env.QWEN_AUDIO_AGENT_URL || 'http://127.0.0.1:3101',
-    accessToken: String(env.QWEN_AUDIO_AGENT_ACCESS_TOKEN || '').trim(),
+    accessToken: String(
+      env.QWEN_AUDIO_GATEWAY_CLIENT_TOKEN
+      || env.QWEN_AUDIO_AGENT_ACCESS_TOKEN
+      || '',
+    ).trim(),
     sessionId: env.QWEN_AUDIO_AGENT_SESSION_ID || createVoiceSessionId(),
     audioMode: String(
       env.QWEN_AUDIO_AGENT_TUI_AUDIO_MODE || 'half',

--- a/cli/test/arguments.test.mjs
+++ b/cli/test/arguments.test.mjs
@@ -36,8 +36,11 @@ test('parses independent TUI and WebUI client commands', () => {
   assert.equal(tui.sessionId, 'project-one')
   assert.equal(tui.audioMode, 'full')
   assert.equal(parseArguments(['tui'], {
-    QWEN_AUDIO_AGENT_ACCESS_TOKEN: 'remote-token',
+    QWEN_AUDIO_GATEWAY_CLIENT_TOKEN: 'remote-token',
   }).accessToken, 'remote-token')
+  assert.equal(parseArguments(['tui'], {
+    QWEN_AUDIO_AGENT_ACCESS_TOKEN: 'legacy-token',
+  }).accessToken, 'legacy-token')
   assert.equal(
     parseArguments(['tui'], {
       QWEN_AUDIO_AGENT_TUI_AUDIO_MODE: 'FULL',

--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -10,7 +10,7 @@ reverse proxy.
 For one personal access key:
 
 ```dotenv
-QWEN_AUDIO_AGENT_ACCESS_TOKEN=replace-with-at-least-24-random-characters
+QWEN_AUDIO_GATEWAY_ACCESS_TOKEN=replace-with-at-least-24-random-characters
 ```
 
 Generate one with `openssl rand -base64 32`. This token authenticates Gateway
@@ -29,7 +29,7 @@ For example, a native TUI can connect without putting the credential in its URL:
 
 ```bash
 QWEN_AUDIO_AGENT_URL=https://voice.example.com \
-QWEN_AUDIO_AGENT_ACCESS_TOKEN="$ACCESS_TOKEN" \
+QWEN_AUDIO_GATEWAY_CLIENT_TOKEN="$ACCESS_TOKEN" \
 qwenaudio tui
 ```
 
@@ -57,6 +57,10 @@ previous Client and generation-fences late messages from its socket.
 
 `QWEN_AUDIO_AGENT_AUTH_SECRET` only signs local and remote session identities. It is not a
 remote access password and must never be sent to a Client.
+
+`QWEN_AUDIO_AGENT_ACCESS_TOKEN` remains a deprecated alias for both settings. New setups use
+the separate host and Client names above so a Client credential is never mistaken for Gateway
+server configuration.
 
 ## Gateway Operation
 

--- a/docs/configuration/advanced.zh.md
+++ b/docs/configuration/advanced.zh.md
@@ -9,7 +9,7 @@ Gateway 默认只监听 loopback，并只信任字面量 loopback Host/Origin。
 配置一个个人访问密钥：
 
 ```dotenv
-QWEN_AUDIO_AGENT_ACCESS_TOKEN=替换为至少24字符的随机密钥
+QWEN_AUDIO_GATEWAY_ACCESS_TOKEN=替换为至少24字符的随机密钥
 ```
 
 可用 `openssl rand -base64 32` 生成随机密钥。该密钥只用于 Gateway 访问认证，
@@ -28,7 +28,7 @@ QWEN_AUDIO_AGENT_ALLOWED_ORIGINS=https://voice.example.com
 
 ```bash
 QWEN_AUDIO_AGENT_URL=https://voice.example.com \
-QWEN_AUDIO_AGENT_ACCESS_TOKEN="$ACCESS_TOKEN" \
+QWEN_AUDIO_GATEWAY_CLIENT_TOKEN="$ACCESS_TOKEN" \
 qwenaudio tui
 ```
 
@@ -56,6 +56,9 @@ QWEN_AUDIO_AGENT_ACCESS_KEYS='[{"token":"替换为足够长的随机密钥","own
 
 `QWEN_AUDIO_AGENT_AUTH_SECRET` 只用于签署本地和远程会话身份，不是远程访问密码，
 绝不能发送给 Client。
+
+`QWEN_AUDIO_AGENT_ACCESS_TOKEN` 暂时保留为两种配置的旧别名。新配置应使用上面的宿主与
+Client 独立名称，避免把 Client 凭据误当作 Gateway 服务端配置。
 
 ## Gateway 运行方式
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -113,6 +113,8 @@ is unsupported and breaks without notice.
 | `qwen-audio-agent/gateway-client-profiles` | Reference capability profiles for WebUI, Desktop, and TUI |
 | `qwen-audio-agent/gateway-access-client` | Client helpers for creating a local one-time pairing ticket and exchanging it for a remote device token |
 | `qwen-audio-agent/gateway-remote-access` | Versioned endpoint-descriptor, connection-profile, and invitation schemas; profiles contain secure-store references rather than credentials |
+| `qwen-audio-agent/gateway-endpoint-publishers` | Provider registry plus built-in local and manual endpoint publishers |
+| `qwen-audio-agent/gateway-connection-profiles` | Versioned connection-profile persistence and the native Client credential-store port |
 | `qwen-audio-agent/client-events` | Client Event definition registry, built-in definitions, routing policies, and `GatewayEventRouter` for Gateway extensions |
 | `qwen-audio-agent/client-actions` | `ClientActionPort`, built-in action names, capability mapping, request/result correlation, deadlines, and in-flight deduplication |
 | `qwen-audio-agent/agent-delivery` | Provider-neutral `AgentDelivery` values and routing modes |

--- a/docs/contract.zh.md
+++ b/docs/contract.zh.md
@@ -96,6 +96,8 @@ Task 事件提供与 A2A 对齐的 `submitted`、
 | `qwen-audio-agent/gateway-client-profiles` | WebUI、Desktop、TUI 的参考 capability profile |
 | `qwen-audio-agent/gateway-access-client` | 创建本机一次性配对码、换取远程设备令牌的 Client Helper |
 | `qwen-audio-agent/gateway-remote-access` | 带版本的端点描述、连接配置与邀请 Schema；配置仅保存安全存储引用，不保存凭据 |
+| `qwen-audio-agent/gateway-endpoint-publishers` | Provider Registry，以及内置 local、manual Endpoint Publisher |
+| `qwen-audio-agent/gateway-connection-profiles` | 带版本的 Connection Profile 持久化与原生 Client Credential Store Port |
 | `qwen-audio-agent/client-events` | 供 Gateway 扩展使用的 Client Event Definition Registry、内置定义、路由 Policy 与 `GatewayEventRouter` |
 | `qwen-audio-agent/client-actions` | `ClientActionPort`、内置 Action 名称、capability 映射、请求/结果关联、deadline 与进行中请求去重 |
 | `qwen-audio-agent/agent-delivery` | Provider 无关的 `AgentDelivery` 值与路由模式 |

--- a/docs/roadmap/gateway-remote-access.md
+++ b/docs/roadmap/gateway-remote-access.md
@@ -76,6 +76,7 @@ credential:
 
 ```json
 {
+  "id": "phone",
   "gateway_url": "https://gateway.example.ts.net",
   "device_id": "device_example",
   "credential_ref": "platform-secure-store-key",
@@ -110,11 +111,11 @@ Mobile branches to Gateway Core.
 
 ## RA1 — Endpoint publication and connection profiles
 
-- [ ] Add a host-side `GatewayEndpointPublisher` contract and registry.
-- [ ] Implement local and manual endpoint publishers.
-- [ ] Add a versioned connection-profile store with a credential-store port.
-- [ ] Keep server access configuration separate from Client credentials.
-- [ ] Publish shared helpers for invitation creation and consumption.
+- [x] Add a host-side `GatewayEndpointPublisher` contract and registry.
+- [x] Implement local and manual endpoint publishers.
+- [x] Add a versioned connection-profile store with a credential-store port.
+- [x] Keep server access configuration separate from Client credentials.
+- [x] Publish shared helpers for invitation creation and consumption.
 
 Exit criteria: any host can publish an endpoint and any native Client can save
 and reconnect through a provider-neutral connection profile.

--- a/docs/roadmap/gateway-remote-access.zh.md
+++ b/docs/roadmap/gateway-remote-access.zh.md
@@ -67,6 +67,7 @@ Connection Profile 只保存安全存储引用，不保存凭据正文：
 
 ```json
 {
+  "id": "phone",
   "gateway_url": "https://gateway.example.ts.net",
   "device_id": "device_example",
   "credential_ref": "platform-secure-store-key",
@@ -99,11 +100,11 @@ HttpOnly、SameSite Cookie。
 
 ## RA1 — Endpoint 发布与 Connection Profile
 
-- [ ] 增加宿主侧 `GatewayEndpointPublisher` 契约和 Registry。
-- [ ] 实现 local 与 manual Publisher。
-- [ ] 增加带版本的 Connection Profile Store 与 Credential Store Port。
-- [ ] 服务端访问配置和 Client 设备凭据分别管理。
-- [ ] 发布创建和消费邀请的共享 Helper。
+- [x] 增加宿主侧 `GatewayEndpointPublisher` 契约和 Registry。
+- [x] 实现 local 与 manual Publisher。
+- [x] 增加带版本的 Connection Profile Store 与 Credential Store Port。
+- [x] 服务端访问配置和 Client 设备凭据分别管理。
+- [x] 发布创建和消费邀请的共享 Helper。
 
 完成条件：任意宿主可以发布 Endpoint，任意原生 Client 可以通过 Provider 无关的
 Connection Profile 保存并重新连接。

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "./gateway-client-profiles": "./shared/gateway-client-profiles.mjs",
     "./gateway-access-client": "./shared/gateway-access-client.mjs",
     "./gateway-remote-access": "./shared/gateway-remote-access.mjs",
+    "./gateway-endpoint-publishers": "./shared/gateway-endpoint-publishers.mjs",
+    "./gateway-connection-profiles": "./shared/gateway-connection-profiles.mjs",
     "./client-events": "./server/src/client/client-event-router.mjs",
     "./client-actions": "./server/src/client/client-action-port.mjs",
     "./agent-delivery": "./server/src/delivery/agent-delivery.mjs",

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -251,7 +251,9 @@ export const config = {
   ).toLowerCase() === 'browser' ? 'browser' : 'personal',
   personalOwnerId: process.env.QWEN_AUDIO_AGENT_PERSONAL_OWNER_ID || 'user_personal',
   gatewayAccessToken: String(
-    process.env.QWEN_AUDIO_AGENT_ACCESS_TOKEN || '',
+    process.env.QWEN_AUDIO_GATEWAY_ACCESS_TOKEN
+    || process.env.QWEN_AUDIO_AGENT_ACCESS_TOKEN
+    || '',
   ).trim(),
   gatewayAccessKeys: String(
     process.env.QWEN_AUDIO_AGENT_ACCESS_KEYS || '',

--- a/shared/gateway-access-client.mjs
+++ b/shared/gateway-access-client.mjs
@@ -2,3 +2,34 @@ export {
   createGatewayPairingTicket,
   pairGatewayDevice,
 } from './gateway-client.mjs'
+
+import { pairGatewayDevice } from './gateway-client.mjs'
+import { assertGatewayInvitationActive } from './gateway-remote-access.mjs'
+
+export async function pairGatewayInvitation(invitation, {
+  device,
+  clientInstanceId,
+  profileId = device?.id,
+  label = device?.label,
+  profileStore,
+  fetchImpl = globalThis.fetch,
+  now = Date.now(),
+} = {}) {
+  const active = assertGatewayInvitationActive(invitation, now)
+  if (!profileStore?.save) {
+    throw new TypeError('pairGatewayInvitation requires a connection profile store')
+  }
+  const paired = await pairGatewayDevice(active.gateway_url, {
+    code: active.pairing_code,
+    device,
+  }, fetchImpl)
+  const profile = await profileStore.save({
+    id: profileId,
+    gateway_url: active.gateway_url,
+    device_id: paired.device.id,
+    credential_ref: `gateway/${paired.device.id}`,
+    client_instance_id: clientInstanceId,
+    ...(label ? { label } : {}),
+  }, paired.access_token)
+  return { profile, owner_id: paired.owner_id }
+}

--- a/shared/gateway-connection-profiles.mjs
+++ b/shared/gateway-connection-profiles.mjs
@@ -1,0 +1,123 @@
+import { randomUUID } from 'node:crypto'
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname } from 'node:path'
+import { z } from 'zod'
+import { replaceFileSync, withFileTransaction } from './file-transaction-lock.mjs'
+import {
+  GATEWAY_REMOTE_ACCESS_MODEL_VERSION,
+  GatewayConnectionProfileSchema,
+  parseGatewayConnectionProfile,
+} from './gateway-remote-access.mjs'
+
+const ProfileDocumentSchema = z.object({
+  version: z.literal(GATEWAY_REMOTE_ACCESS_MODEL_VERSION),
+  profiles: z.array(GatewayConnectionProfileSchema),
+}).strict()
+
+export function defineGatewayCredentialStore({ get, set, delete: remove }) {
+  for (const [name, implementation] of Object.entries({ get, set, delete: remove })) {
+    if (typeof implementation !== 'function') {
+      throw new TypeError(`Gateway credential store requires ${name}()`)
+    }
+  }
+  return Object.freeze({ get, set, delete: remove })
+}
+
+function readProfiles(filePath) {
+  try {
+    return ProfileDocumentSchema.parse(JSON.parse(readFileSync(filePath, 'utf8'))).profiles
+  } catch (error) {
+    if (error?.code === 'ENOENT') return []
+    const wrapped = new Error(`Invalid Gateway connection profile store: ${error.message}`)
+    wrapped.code = 'gateway_connection_profiles_invalid'
+    throw wrapped
+  }
+}
+
+function writeProfiles(filePath, profiles) {
+  mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 })
+  const temporary = `${filePath}.${process.pid}.${randomUUID()}.tmp`
+  writeFileSync(temporary, `${JSON.stringify({
+    version: GATEWAY_REMOTE_ACCESS_MODEL_VERSION,
+    profiles,
+  }, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+  replaceFileSync(temporary, filePath)
+  chmodSync(filePath, 0o600)
+}
+
+export class GatewayConnectionProfileStore {
+  constructor({ filePath, credentialStore }) {
+    if (!filePath) throw new TypeError('Gateway connection profile store requires filePath')
+    this.filePath = filePath
+    this.credentials = defineGatewayCredentialStore(credentialStore)
+  }
+
+  list() {
+    return withFileTransaction(this.filePath, () => readProfiles(this.filePath))
+  }
+
+  get(id) {
+    return this.list().find(profile => profile.id === id) || null
+  }
+
+  async resolve(id) {
+    const profile = this.get(id)
+    if (!profile) return null
+    return {
+      profile,
+      credential: await this.credentials.get(profile.credential_ref),
+    }
+  }
+
+  async save(profile, credential) {
+    const parsed = parseGatewayConnectionProfile(profile)
+    if (!String(credential || '').trim()) {
+      throw new TypeError('Gateway connection profile requires a credential')
+    }
+    const previousCredential = await this.credentials.get(parsed.credential_ref)
+    await this.credentials.set(parsed.credential_ref, credential)
+    try {
+      withFileTransaction(this.filePath, () => {
+        const profiles = readProfiles(this.filePath)
+        const index = profiles.findIndex(current => current.id === parsed.id)
+        if (index === -1) profiles.push(parsed)
+        else profiles[index] = parsed
+        writeProfiles(this.filePath, profiles)
+      })
+    } catch (error) {
+      if (previousCredential === null || previousCredential === undefined) {
+        await this.credentials.delete(parsed.credential_ref)
+      } else {
+        await this.credentials.set(parsed.credential_ref, previousCredential)
+      }
+      throw error
+    }
+    return parsed
+  }
+
+  async remove(id) {
+    let removed = null
+    withFileTransaction(this.filePath, () => {
+      const profiles = readProfiles(this.filePath)
+      removed = profiles.find(profile => profile.id === id) || null
+      if (!removed) return
+      writeProfiles(this.filePath, profiles.filter(profile => profile.id !== id))
+    })
+    if (removed) await this.credentials.delete(removed.credential_ref)
+    return Boolean(removed)
+  }
+}
+
+export function createMemoryGatewayCredentialStore() {
+  const values = new Map()
+  return defineGatewayCredentialStore({
+    get: async key => values.get(key) || null,
+    set: async (key, value) => { values.set(key, value) },
+    delete: async key => values.delete(key),
+  })
+}

--- a/shared/gateway-endpoint-publishers.mjs
+++ b/shared/gateway-endpoint-publishers.mjs
@@ -1,0 +1,73 @@
+import {
+  defineGatewayEndpointPublisher,
+  parseGatewayEndpointDescriptor,
+} from './gateway-remote-access.mjs'
+
+function endpointFor(publisher, url) {
+  return parseGatewayEndpointDescriptor({
+    url,
+    secure: String(url).startsWith('https://'),
+    publisher,
+  })
+}
+
+export function createLocalGatewayEndpointPublisher({
+  url = 'http://127.0.0.1:3101',
+} = {}) {
+  const endpoint = endpointFor('local', url)
+  return defineGatewayEndpointPublisher({
+    id: 'local',
+    inspect: async () => ({ available: true, published: true, endpoint }),
+    publish: async () => endpoint,
+    unpublish: async () => ({ published: true, endpoint }),
+  })
+}
+
+export function createManualGatewayEndpointPublisher({ url } = {}) {
+  const endpoint = endpointFor('manual', url)
+  return defineGatewayEndpointPublisher({
+    id: 'manual',
+    inspect: async () => ({ available: true, published: true, endpoint }),
+    publish: async () => endpoint,
+    unpublish: async () => ({ published: true, endpoint }),
+  })
+}
+
+export function createGatewayEndpointPublisherRegistry(publishers = []) {
+  const entries = new Map()
+  const register = publisher => {
+    const defined = defineGatewayEndpointPublisher(publisher)
+    if (entries.has(defined.id)) {
+      throw new Error(`Duplicate Gateway endpoint publisher: ${defined.id}`)
+    }
+    entries.set(defined.id, defined)
+    return defined
+  }
+  for (const publisher of publishers) register(publisher)
+
+  const requirePublisher = id => {
+    const publisher = entries.get(id)
+    if (!publisher) {
+      const error = new Error(`Unknown Gateway endpoint publisher: ${id}`)
+      error.code = 'gateway_endpoint_publisher_unknown'
+      throw error
+    }
+    return publisher
+  }
+  return Object.freeze({
+    register,
+    list: () => [...entries.values()],
+    get: id => entries.get(id) || null,
+    inspect: id => requirePublisher(id).inspect(),
+    publish: async id => {
+      const endpoint = parseGatewayEndpointDescriptor(
+        await requirePublisher(id).publish(),
+      )
+      if (endpoint.publisher !== id) {
+        throw new Error(`Gateway endpoint publisher ${id} returned ${endpoint.publisher}`)
+      }
+      return endpoint
+    },
+    unpublish: id => requirePublisher(id).unpublish(),
+  })
+}

--- a/shared/gateway-remote-access.mjs
+++ b/shared/gateway-remote-access.mjs
@@ -46,6 +46,7 @@ export const GatewayEndpointDescriptorSchema = z.object({
 
 export const GatewayConnectionProfileSchema = z.object({
   version: z.literal(GATEWAY_REMOTE_ACCESS_MODEL_VERSION).default(GATEWAY_REMOTE_ACCESS_MODEL_VERSION),
+  id: IdentifierSchema,
   gateway_url: GatewayUrlSchema,
   device_id: IdentifierSchema,
   credential_ref: IdentifierSchema,
@@ -94,4 +95,14 @@ export function createGatewayInvitation({ gatewayUrl, pairingCode, expiresAt }) 
     pairing_code: pairingCode,
     expires_at: expiresAt,
   })
+}
+
+export function assertGatewayInvitationActive(invitation, now = Date.now()) {
+  const parsed = parseGatewayInvitation(invitation)
+  if (parsed.expires_at <= now) {
+    const error = new Error('Gateway invitation has expired')
+    error.code = 'gateway_invitation_expired'
+    throw error
+  }
+  return parsed
 }

--- a/shared/runtime-environment.mjs
+++ b/shared/runtime-environment.mjs
@@ -44,7 +44,7 @@ const USER_CONFIG_TEMPLATE = [
   '',
   '# 可选远程 Client 接入；Gateway 默认仍只监听 127.0.0.1',
   '# 远程部署请同时使用受信 VPN 或 HTTPS/WSS 反向代理',
-  '# QWEN_AUDIO_AGENT_ACCESS_TOKEN=至少24字符的随机密钥',
+  '# QWEN_AUDIO_GATEWAY_ACCESS_TOKEN=至少24字符的随机密钥',
   '# QWEN_AUDIO_AGENT_ALLOWED_ORIGINS=https://voice.example.com',
   '',
   '# 可选日志设置：默认 info、单文件 10 MiB、保留 5 份',

--- a/test/gateway-access-client.test.mjs
+++ b/test/gateway-access-client.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   createGatewayPairingTicket,
+  pairGatewayInvitation,
   pairGatewayDevice,
 } from '../shared/gateway-access-client.mjs'
 
@@ -47,5 +48,37 @@ test('Gateway access Client helpers preserve structured errors', async () => {
       jsonResponse({ error: 'expired', code: 'pairing_invalid' }, { status: 401 })
     )),
     error => error.code === 'pairing_invalid' && error.message === 'expired',
+  )
+})
+
+test('a Gateway invitation pairs and persists through credential abstractions', async () => {
+  const saved = []
+  const result = await pairGatewayInvitation({
+    version: 1,
+    gateway_url: 'https://gateway.example.test',
+    pairing_code: 'temporary-code',
+    expires_at: 2_000,
+  }, {
+    device: { id: 'phone-one', type: 'mobile', label: 'Phone' },
+    clientInstanceId: 'mobile-one',
+    profileStore: { save: async (...args) => { saved.push(args); return args[0] } },
+    now: 1_000,
+    fetchImpl: async () => jsonResponse({
+      access_token: 'device-token',
+      owner_id: 'user_personal',
+      device: { id: 'phone-one' },
+    }),
+  })
+  assert.equal(result.profile.id, 'phone-one')
+  assert.equal(result.profile.client_instance_id, 'mobile-one')
+  assert.equal(saved[0][1], 'device-token')
+  await assert.rejects(
+    pairGatewayInvitation({
+      version: 1,
+      gateway_url: 'https://gateway.example.test',
+      pairing_code: 'expired',
+      expires_at: 999,
+    }, { profileStore: { save: async () => {} }, now: 1_000 }),
+    error => error.code === 'gateway_invitation_expired',
   )
 })

--- a/test/gateway-connection-profiles.test.mjs
+++ b/test/gateway-connection-profiles.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import {
+  createMemoryGatewayCredentialStore,
+  GatewayConnectionProfileStore,
+} from '../shared/gateway-connection-profiles.mjs'
+
+function profile(id, overrides = {}) {
+  return {
+    id,
+    gateway_url: 'https://voice.example.test',
+    device_id: `device_${id}`,
+    credential_ref: `gateway/device_${id}`,
+    client_instance_id: `client_${id}`,
+    ...overrides,
+  }
+}
+
+test('connection profile persistence never serializes credentials', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'qwaudio-profiles-'))
+  const filePath = join(directory, 'gateway-connections.json')
+  const credentials = createMemoryGatewayCredentialStore()
+  const store = new GatewayConnectionProfileStore({ filePath, credentialStore: credentials })
+  await store.save(profile('phone'), 'device-secret')
+
+  assert.equal(store.list().length, 1)
+  assert.equal((await store.resolve('phone')).credential, 'device-secret')
+  assert.doesNotMatch(readFileSync(filePath, 'utf8'), /device-secret/)
+  assert.equal(await store.remove('phone'), true)
+  assert.equal(await store.resolve('phone'), null)
+  assert.equal(await credentials.get('gateway/device_phone'), null)
+})
+
+test('connection profiles update credentials and metadata by profile id', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'qwaudio-profiles-'))
+  const filePath = join(directory, 'gateway-connections.json')
+  const store = new GatewayConnectionProfileStore({
+    filePath,
+    credentialStore: createMemoryGatewayCredentialStore(),
+  })
+  await store.save(profile('desktop'), 'first')
+  await store.save(profile('desktop', { label: 'Remote desktop' }), 'second')
+  assert.equal(store.list().length, 1)
+  assert.equal((await store.resolve('desktop')).credential, 'second')
+})

--- a/test/gateway-endpoint-publishers.test.mjs
+++ b/test/gateway-endpoint-publishers.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  createGatewayEndpointPublisherRegistry,
+  createLocalGatewayEndpointPublisher,
+  createManualGatewayEndpointPublisher,
+} from '../shared/gateway-endpoint-publishers.mjs'
+
+test('local and manual endpoint publishers return canonical descriptors', async () => {
+  const registry = createGatewayEndpointPublisherRegistry([
+    createLocalGatewayEndpointPublisher({ url: 'http://127.0.0.1:3210/' }),
+    createManualGatewayEndpointPublisher({ url: 'https://voice.example.test/' }),
+  ])
+  assert.equal((await registry.publish('local')).url, 'http://127.0.0.1:3210')
+  assert.deepEqual(await registry.publish('manual'), {
+    version: 1,
+    url: 'https://voice.example.test',
+    transport: 'websocket',
+    secure: true,
+    publisher: 'manual',
+  })
+  assert.equal((await registry.inspect('local')).published, true)
+})
+
+test('publisher registry rejects duplicate, unknown, and mislabeled implementations', async () => {
+  const local = createLocalGatewayEndpointPublisher()
+  assert.throws(
+    () => createGatewayEndpointPublisherRegistry([local, local]),
+    /Duplicate/,
+  )
+  const registry = createGatewayEndpointPublisherRegistry([{
+    id: 'broken',
+    inspect: async () => ({}),
+    publish: async () => ({
+      url: 'https://voice.example.test',
+      secure: true,
+      publisher: 'someone-else',
+    }),
+    unpublish: async () => ({}),
+  }])
+  await assert.rejects(registry.publish('broken'), /returned someone-else/)
+  assert.throws(() => registry.inspect('missing'), error => (
+    error.code === 'gateway_endpoint_publisher_unknown'
+  ))
+})

--- a/test/gateway-remote-access.test.mjs
+++ b/test/gateway-remote-access.test.mjs
@@ -60,6 +60,7 @@ test('remote endpoint descriptors reject contaminated or inconsistent URLs', () 
 
 test('connection profiles store a credential reference and never a credential', () => {
   const profile = parseGatewayConnectionProfile({
+    id: 'phone',
     gateway_url: 'https://gateway.example.test',
     device_id: 'device_phone',
     credential_ref: 'secure-store/device_phone',

--- a/tui/src/index.mjs
+++ b/tui/src/index.mjs
@@ -76,7 +76,11 @@ function normalizeGatewayUrl(value) {
 export function parseArguments(argv, env = process.env) {
   const options = {
     url: env.QWEN_AUDIO_AGENT_URL || 'http://127.0.0.1:3101',
-    accessToken: String(env.QWEN_AUDIO_AGENT_ACCESS_TOKEN || '').trim(),
+    accessToken: String(
+      env.QWEN_AUDIO_GATEWAY_CLIENT_TOKEN
+      || env.QWEN_AUDIO_AGENT_ACCESS_TOKEN
+      || '',
+    ).trim(),
     sessionId: env.QWEN_AUDIO_AGENT_SESSION_ID || 'tui-main',
     audioMode: env.QWEN_AUDIO_AGENT_TUI_AUDIO_MODE || 'half',
   }

--- a/tui/src/text-cli.mjs
+++ b/tui/src/text-cli.mjs
@@ -22,7 +22,11 @@ const RST = `${ESC}[0m`
 export function parseArguments(argv, env = process.env) {
   const options = {
     url: env.QWEN_AUDIO_AGENT_URL || 'http://127.0.0.1:3101',
-    accessToken: String(env.QWEN_AUDIO_AGENT_ACCESS_TOKEN || '').trim(),
+    accessToken: String(
+      env.QWEN_AUDIO_GATEWAY_CLIENT_TOKEN
+      || env.QWEN_AUDIO_AGENT_ACCESS_TOKEN
+      || '',
+    ).trim(),
     sessionId: env.QWEN_AUDIO_AGENT_SESSION_ID || 'cli-main',
   }
   for (let index = 0; index < argv.length; index += 1) {

--- a/tui/test/index.test.mjs
+++ b/tui/test/index.test.mjs
@@ -130,7 +130,7 @@ test('parses a custom gateway, session and audio mode', () => {
   assert.equal(options.sessionId, 'terminal-one')
   assert.equal(options.audioMode, 'full')
   assert.equal(parseArguments([], {
-    QWEN_AUDIO_AGENT_ACCESS_TOKEN: 'remote-token',
+    QWEN_AUDIO_GATEWAY_CLIENT_TOKEN: 'remote-token',
   }).accessToken, 'remote-token')
   assert.equal(
     parseArguments([], {

--- a/tui/test/text-cli.test.mjs
+++ b/tui/test/text-cli.test.mjs
@@ -19,7 +19,7 @@ test('parseArguments 默认值与覆盖', () => {
   assert.equal(custom.url, 'http://host:9')
   assert.equal(custom.sessionId, 's1')
   assert.equal(parseArguments([], {
-    QWEN_AUDIO_AGENT_ACCESS_TOKEN: 'remote-token',
+    QWEN_AUDIO_GATEWAY_CLIENT_TOKEN: 'remote-token',
   }).accessToken, 'remote-token')
 
   assert.equal(parseArguments(['--help']).help, true)


### PR DESCRIPTION
Implements RA1 of #320.

- introduces provider-neutral Gateway endpoint publisher and registry contracts
- adds versioned connection profiles with an injected credential-store boundary
- separates Gateway server credentials from native Client credentials
- adds invitation pairing helpers and contract tests

Validation: focused remote-access tests and ESLint pass.