### PR TITLE
feat(remote): add secure browser client transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run release:check
+        env:
+          # Pull requests remain deterministic during a transient npm audit
+          # outage. The release workflow stays fail-closed.
+          QWEN_AUDIO_AGENT_AUDIT_ALLOW_UNAVAILABLE: '1'
 
   # One stable branch-protection context. The matrix job names change whenever
   # the supported OS/Node set changes; this aggregate keeps main protection

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "./gateway-tailscale-publisher": "./shared/gateway-tailscale-publisher.mjs",
     "./gateway-connection-profiles": "./shared/gateway-connection-profiles.mjs",
     "./gateway-file-credential-store": "./shared/gateway-file-credential-store.mjs",
+    "./gateway-websocket-auth": "./shared/gateway-websocket-auth.mjs",
     "./client-events": "./server/src/client/client-event-router.mjs",
     "./client-actions": "./server/src/client/client-action-port.mjs",
     "./agent-delivery": "./server/src/delivery/agent-delivery.mjs",

--- a/scripts/audit-dependencies.mjs
+++ b/scripts/audit-dependencies.mjs
@@ -2,6 +2,9 @@
 
 import { spawnSync } from 'node:child_process'
 
+const AUDIT_ATTEMPTS = 3
+const AUDIT_RETRY_DELAY_MS = 1_000
+
 // 仅记录没有上游修复版本、且不进入生产依赖的构建链问题。npm 的审计
 // 快照偶尔会漏报已有 advisory，因此例外按明确到期日收敛，不以单次缺席
 // 判定已修复。
@@ -28,7 +31,7 @@ const TEMPORARY_BUILD_ADVISORIES = new Map([
   }],
 ])
 
-function runAudit(args) {
+function runAuditOnce(args) {
   const npmExecutable = process.env.npm_execpath
   const command = npmExecutable
     ? process.execPath
@@ -40,7 +43,11 @@ function runAudit(args) {
     ...args,
   ], {
     encoding: 'utf8',
-    env: process.env,
+    env: {
+      ...process.env,
+      npm_config_fetch_retries: '0',
+      npm_config_fetch_timeout: '60000',
+    },
   })
   if (result.error) throw result.error
   let report
@@ -50,7 +57,31 @@ function runAudit(args) {
     process.stderr.write(result.stderr || result.stdout)
     throw new Error('npm audit 没有返回有效 JSON')
   }
-  return { report, status: result.status }
+  return { report, status: result.status, stderr: result.stderr }
+}
+
+function auditReportAvailable(report) {
+  return Number(report?.auditReportVersion) > 0
+    && report.metadata?.vulnerabilities
+    && report.vulnerabilities
+}
+
+function runAudit(args) {
+  let lastResult
+  for (let attempt = 1; attempt <= AUDIT_ATTEMPTS; attempt += 1) {
+    lastResult = runAuditOnce(args)
+    if (auditReportAvailable(lastResult.report)) return lastResult
+    if (attempt < AUDIT_ATTEMPTS) {
+      process.stderr.write(`npm audit 服务暂时不可用，正在重试（${attempt}/${AUDIT_ATTEMPTS}）…\n`)
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, AUDIT_RETRY_DELAY_MS)
+    }
+  }
+  const detail = lastResult?.report?.message || lastResult?.stderr?.trim() || 'unknown error'
+  if (process.env.QWEN_AUDIO_AGENT_AUDIT_ALLOW_UNAVAILABLE === '1') {
+    process.stderr.write(`npm audit 服务不可用，本次非发版检查跳过依赖审计：${detail}\n`)
+    return null
+  }
+  throw new Error(`npm audit 服务不可用：${detail}`)
 }
 
 function terminalAdvisories(name, vulnerabilities, visited = new Set()) {
@@ -72,11 +103,14 @@ function terminalAdvisories(name, vulnerabilities, visited = new Set()) {
 }
 
 function assertProductionClean() {
-  const { report, status } = runAudit(['--omit=dev', '--audit-level=high'])
+  const result = runAudit(['--omit=dev', '--audit-level=high'])
+  if (!result) return false
+  const { report, status } = result
   if (status !== 0 || report.metadata?.vulnerabilities?.high
     || report.metadata?.vulnerabilities?.critical) {
     throw new Error('生产依赖存在 high 或 critical 漏洞')
   }
+  return true
 }
 
 function assertFullAuditIsExplicitlyAccountedFor() {
@@ -85,8 +119,10 @@ function assertFullAuditIsExplicitlyAccountedFor() {
       throw new Error(`${exception.id}（${source}）例外已于 ${exception.expires} 到期`)
     }
   }
-  const { report, status } = runAudit(['--audit-level=high'])
-  if (status === 0) return
+  const result = runAudit(['--audit-level=high'])
+  if (!result) return false
+  const { report, status } = result
+  if (status === 0) return true
   const vulnerabilities = report.vulnerabilities || {}
   const unexpected = []
   const observedExceptions = new Set()
@@ -118,8 +154,11 @@ function assertFullAuditIsExplicitlyAccountedFor() {
       + `${exception.reason}。\n`,
     )
   }
+  return true
 }
 
-assertProductionClean()
-assertFullAuditIsExplicitlyAccountedFor()
-process.stdout.write('依赖审计通过。\n')
+if (assertProductionClean() && assertFullAuditIsExplicitlyAccountedFor()) {
+  process.stdout.write('依赖审计通过。\n')
+} else {
+  process.stdout.write('依赖审计服务不可用；非发版检查继续。\n')
+}

--- a/server/src/access/gateway-access.mjs
+++ b/server/src/access/gateway-access.mjs
@@ -6,6 +6,7 @@ import {
   timingSafeEqual,
 } from 'node:crypto'
 import { VersionedJsonStore } from '../core/versioned-json-store.mjs'
+import { gatewayWebSocketBearer } from '../../../shared/gateway-websocket-auth.mjs'
 
 const ACCESS_COOKIE = 'qwen_audio_agent_access'
 const DEFAULT_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000
@@ -280,11 +281,13 @@ export class GatewayAccessManager {
       const identity = this.identityManager.resolveUpgrade(req)
       return identity ? { ...identity, access: 'local' } : null
     }
-    return this.resolveRemote(req)
+    return this.resolveRemote(req, {
+      webSocketBearer: gatewayWebSocketBearer(req.headers['sec-websocket-protocol']),
+    })
   }
 
-  resolveRemote(req) {
-    const bearer = bearerToken(req.headers.authorization)
+  resolveRemote(req, { webSocketBearer = '' } = {}) {
+    const bearer = bearerToken(req.headers.authorization) || webSocketBearer
     if (bearer) {
       const credential = this.findCredential(bearer)
       if (!credential) return null
@@ -292,6 +295,7 @@ export class GatewayAccessManager {
         ownerId: credential.ownerId,
         access: 'remote',
         credentialId: credential.tokenId || credential.id,
+        clientType: credential.type || '',
       }
     }
     return this.resolveCookie(req.headers.cookie)

--- a/server/src/core/request-security.mjs
+++ b/server/src/core/request-security.mjs
@@ -1,6 +1,7 @@
 import { config } from './config.mjs'
 
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '[::1]', '::1'])
+const TRUSTED_NATIVE_CLIENT_ORIGINS = new Set(['https://qwaudio.local'])
 
 function normalizedOrigin(value) {
   try {
@@ -44,6 +45,7 @@ export function isAllowedOrigin(
     allowedOrigins = config.allowedOrigins,
     authenticatedRemote = false,
     allowSecureSameOrigin = false,
+    trustedNativeClient = false,
   } = {},
 ) {
   const requestHost = parsedHost(req.headers.host)
@@ -61,6 +63,12 @@ export function isAllowedOrigin(
       || trustedHost
       || authenticatedRemote === true
   }
+
+  if (
+    authenticatedRemote
+    && trustedNativeClient
+    && TRUSTED_NATIVE_CLIENT_ORIGINS.has(origin)
+  ) return true
 
   const originUrl = new URL(origin)
   if (configured.includes(origin)) {
@@ -91,6 +99,7 @@ export function isAllowedOrigin(
 export function enforceSameOrigin(req, res, next) {
   if (!isAllowedOrigin(req, {
     authenticatedRemote: req.identity?.access === 'remote',
+    trustedNativeClient: req.identity?.clientType === 'mobile',
   })) {
     res.status(403).json({ error: 'origin not allowed' })
     return

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -1,4 +1,5 @@
 import { WebSocket, WebSocketServer } from 'ws'
+import { selectGatewayWebSocketProtocol } from '../../../shared/gateway-websocket-auth.mjs'
 import { randomUUID } from 'node:crypto'
 import {
   GatewayClientEvent,
@@ -179,7 +180,11 @@ export function attachRealtimeGateway(server, {
   clientCommandRuntime = null,
   clientEventRouter = null,
 }) {
-  const wss = new WebSocketServer({ noServer: true, maxPayload: 20 * 1024 * 1024 })
+  const wss = new WebSocketServer({
+    noServer: true,
+    maxPayload: 20 * 1024 * 1024,
+    handleProtocols: selectGatewayWebSocketProtocol,
+  })
   const supportedClientCapabilities = GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES
     .filter(capability => {
       if (capability === GatewayClientCapability.CLIENT_EVENTS) {
@@ -240,6 +245,7 @@ export function attachRealtimeGateway(server, {
     }
     if (!isAllowedOrigin(request, {
       authenticatedRemote: identity.access === 'remote',
+      trustedNativeClient: identity.clientType === 'mobile',
     })) {
       rejectUpgrade(socket, '403 Forbidden', 'origin not allowed')
       return

--- a/server/test/gateway-access.test.mjs
+++ b/server/test/gateway-access.test.mjs
@@ -113,6 +113,7 @@ test('redeems one-time pairing tickets into persisted, revocable device tokens',
     }))
     assert.equal(pairedIdentity.ownerId, 'user_personal')
     assert.equal(pairedIdentity.credentialId, paired.credentialId)
+    assert.equal(pairedIdentity.clientType, 'mobile')
 
     const restored = new GatewayDeviceRegistry({
       filePath: resolve(directory, 'devices.json'),
@@ -126,4 +127,22 @@ test('redeems one-time pairing tickets into persisted, revocable device tokens',
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }
+})
+
+test('accepts a remote browser credential in the WebSocket subprotocol header', () => {
+  const access = runtime()
+  const identity = access.resolveUpgrade(request({
+    authorization: undefined,
+    host: 'gateway.example.test',
+  }))
+  assert.equal(identity, null)
+  const authenticated = access.resolveUpgrade({
+    ...request(),
+    headers: {
+      ...request().headers,
+      'sec-websocket-protocol': `qwaudio.gcp.v6, qwaudio.bearer.${ACCESS_TOKEN}`,
+    },
+  })
+  assert.equal(authenticated.ownerId, 'user_personal')
+  assert.equal(authenticated.access, 'remote')
 })

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -165,6 +165,7 @@ test('protects remote HTTP access and completes one-time device pairing', async 
       headers: {
         Host: 'gateway.example.test',
         Authorization: `Bearer ${paired.body.access_token}`,
+        Origin: 'https://qwaudio.local',
       },
     },
   )

--- a/server/test/gateway-client-handshake.test.mjs
+++ b/server/test/gateway-client-handshake.test.mjs
@@ -10,6 +10,10 @@ import {
   createGatewaySessionHello,
 } from '../../shared/gateway-client-protocol.mjs'
 import {
+  GATEWAY_WEBSOCKET_PROTOCOL,
+  gatewayWebSocketProtocols,
+} from '../../shared/gateway-websocket-auth.mjs'
+import {
   GatewayAccessManager,
   parseGatewayAccessKeys,
 } from '../src/access/gateway-access.mjs'
@@ -45,12 +49,12 @@ function gatewayHarness(overrides = {}) {
   return { server, gateway }
 }
 
-async function connect(server, firstMessage, { headers } = {}) {
+async function connect(server, firstMessage, { headers, protocols } = {}) {
   const { port } = server.address()
-  const socket = new WebSocket(
-    `ws://127.0.0.1:${port}/api/realtime?sessionId=protocol-test`,
-    { headers },
-  )
+  const url = `ws://127.0.0.1:${port}/api/realtime?sessionId=protocol-test`
+  const socket = protocols?.length
+    ? new WebSocket(url, protocols, { headers })
+    : new WebSocket(url, { headers })
   const received = []
   socket.on('message', raw => received.push(JSON.parse(raw.toString())))
   await new Promise((resolve, reject) => {
@@ -703,12 +707,11 @@ test('requires access authentication before a remote WebSocket can enter GCP', a
     clientInstanceId: 'remote-phone',
     capabilities: [GatewayClientCapability.INPUT_TEXT],
   }), {
-    headers: {
-      Host: 'gateway.example.test',
-      Authorization: `Bearer ${REMOTE_ACCESS_TOKEN}`,
-    },
+    headers: { Host: 'gateway.example.test' },
+    protocols: gatewayWebSocketProtocols(REMOTE_ACCESS_TOKEN),
   })
   await waitFor(accepted.received, event => event.type === 'session.ready')
   assert.equal(accepted.socket.readyState, WebSocket.OPEN)
+  assert.equal(accepted.socket.protocol, GATEWAY_WEBSOCKET_PROTOCOL)
   accepted.socket.close()
 })

--- a/server/test/request-security.test.mjs
+++ b/server/test/request-security.test.mjs
@@ -77,3 +77,20 @@ test('allows secure same-origin requests only for authenticated or pairing paths
     },
   }, { allowSecureSameOrigin: true }), false)
 })
+
+test('allows the fixed mobile app origin only for an authenticated mobile device', () => {
+  const req = {
+    headers: {
+      host: 'gateway.example.test',
+      origin: 'https://qwaudio.local',
+    },
+  }
+  assert.equal(isAllowedOrigin(req, {
+    authenticatedRemote: true,
+    trustedNativeClient: true,
+  }), true)
+  assert.equal(isAllowedOrigin(req, {
+    authenticatedRemote: true,
+    trustedNativeClient: false,
+  }), false)
+})

--- a/shared/gateway-websocket-auth.mjs
+++ b/shared/gateway-websocket-auth.mjs
@@ -1,0 +1,39 @@
+export const GATEWAY_WEBSOCKET_PROTOCOL = 'qwaudio.gcp.v6'
+
+const GATEWAY_WEBSOCKET_BEARER_PREFIX = 'qwaudio.bearer.'
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{24,256}$/
+
+function protocolValues(header = '') {
+  return String(header)
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean)
+}
+
+// Browsers cannot attach Authorization to a WebSocket upgrade. Remote web
+// clients therefore carry the revocable device token in a secondary, TLS-
+// protected subprotocol value. The server only selects the public GCP
+// protocol, so the credential is never echoed back to JavaScript.
+export function gatewayWebSocketProtocols(accessToken = '') {
+  const token = String(accessToken || '').trim()
+  if (!token) return []
+  if (!TOKEN_PATTERN.test(token)) {
+    throw new TypeError('Gateway WebSocket credential contains invalid characters')
+  }
+  return [GATEWAY_WEBSOCKET_PROTOCOL, `${GATEWAY_WEBSOCKET_BEARER_PREFIX}${token}`]
+}
+
+export function gatewayWebSocketBearer(header = '') {
+  const value = protocolValues(header).find(protocol => (
+    protocol.startsWith(GATEWAY_WEBSOCKET_BEARER_PREFIX)
+  ))
+  if (!value) return ''
+  const token = value.slice(GATEWAY_WEBSOCKET_BEARER_PREFIX.length)
+  return TOKEN_PATTERN.test(token) ? token : ''
+}
+
+export function selectGatewayWebSocketProtocol(protocols) {
+  return protocols.has(GATEWAY_WEBSOCKET_PROTOCOL)
+    ? GATEWAY_WEBSOCKET_PROTOCOL
+    : false
+}

--- a/test/audit-dependencies.test.mjs
+++ b/test/audit-dependencies.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+const directory = mkdtempSync(join(tmpdir(), 'qwa-audit-test-'))
+const mockNpm = join(directory, 'mock-npm.mjs')
+
+writeFileSync(mockNpm, `
+const mode = process.env.MOCK_NPM_AUDIT
+if (mode === 'unavailable') {
+  console.log(JSON.stringify({ message: '503 Service Unavailable', error: { summary: '' } }))
+  process.exit(1)
+}
+const high = mode === 'vulnerable' ? 1 : 0
+console.log(JSON.stringify({
+  auditReportVersion: 2,
+  vulnerabilities: high ? { example: { severity: 'high', via: [] } } : {},
+  metadata: { vulnerabilities: { high, critical: 0 } },
+}))
+process.exit(high ? 1 : 0)
+`)
+
+function audit(mode, extraEnv = {}) {
+  return spawnSync(process.execPath, ['scripts/audit-dependencies.mjs'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_execpath: mockNpm,
+      MOCK_NPM_AUDIT: mode,
+      ...extraEnv,
+    },
+  })
+}
+
+test('dependency audit passes only a valid clean report', () => {
+  const result = audit('clean')
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /依赖审计通过/)
+})
+
+test('dependency audit never treats a real high vulnerability as an outage', () => {
+  const result = audit('vulnerable', {
+    QWEN_AUDIO_AGENT_AUDIT_ALLOW_UNAVAILABLE: '1',
+  })
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /生产依赖存在 high 或 critical 漏洞/)
+})
+
+test('non-release CI can continue when the audit service is unavailable', () => {
+  const result = audit('unavailable', {
+    QWEN_AUDIO_AGENT_AUDIT_ALLOW_UNAVAILABLE: '1',
+  })
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /审计服务不可用；非发版检查继续/)
+  assert.match(result.stderr, /正在重试/)
+})

--- a/test/gateway-websocket-auth.test.mjs
+++ b/test/gateway-websocket-auth.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  GATEWAY_WEBSOCKET_PROTOCOL,
+  gatewayWebSocketBearer,
+  gatewayWebSocketProtocols,
+  selectGatewayWebSocketProtocol,
+} from '../shared/gateway-websocket-auth.mjs'
+
+const TOKEN = 'qwa_example-device-token_1234567890'
+
+test('encodes a browser-safe WebSocket bearer without selecting the credential', () => {
+  const protocols = gatewayWebSocketProtocols(TOKEN)
+  assert.deepEqual(protocols, [
+    GATEWAY_WEBSOCKET_PROTOCOL,
+    `qwaudio.bearer.${TOKEN}`,
+  ])
+  assert.equal(gatewayWebSocketBearer(protocols.join(', ')), TOKEN)
+  assert.equal(selectGatewayWebSocketProtocol(new Set(protocols)), GATEWAY_WEBSOCKET_PROTOCOL)
+})
+
+test('rejects malformed WebSocket bearer values', () => {
+  assert.deepEqual(gatewayWebSocketProtocols(), [])
+  assert.throws(() => gatewayWebSocketProtocols('not a token'))
+  assert.equal(gatewayWebSocketBearer('qwaudio.bearer.short'), '')
+  assert.equal(selectGatewayWebSocketProtocol(new Set(['other'])), false)
+})

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -69,6 +69,11 @@ import {
   applyDesktopClientSettings,
   initialDesktopClientSettings,
 } from './desktop-client-settings.js'
+import {
+  gatewayClientLabel,
+  gatewayClientType,
+  gatewayFetch,
+} from './gateway-transport.js'
 
 const desktopOrbMode = (
   new URLSearchParams(window.location.search).get('desktop') === 'orb'
@@ -78,7 +83,8 @@ const initialDesktopSurfaceMode = (
     ? 'panel'
     : 'orb'
 )
-const composerEnabled = supportsComposerInput(desktopOrbMode ? 'desktop' : 'web')
+const activeClientType = gatewayClientType(desktopOrbMode ? 'desktop' : 'web')
+const composerEnabled = supportsComposerInput(activeClientType)
 
 function getSessionId() {
   const requested = requestedSessionId(window.location.search)
@@ -111,6 +117,7 @@ function labelFor(state) {
 function frontendLabel(holder) {
   return holder?.label || {
     desktop: t('桌面端'),
+    mobile: t('移动端'),
     cli: t('终端'),
     web: 'WebUI',
   }[holder?.type] || t('其他入口')
@@ -175,6 +182,7 @@ export default function App() {
   const [sessionId, setSessionId] = useState(getSessionId)
   const [voiceEnabled, setVoiceEnabled] = useState(() => initialVoiceEnabled({
     desktopOrbMode,
+    clientType: activeClientType,
   }))
   const [waitingForVoice, setWaitingForVoice] = useState(false)
   const [messages, setMessages] = useState([])
@@ -345,7 +353,7 @@ export default function App() {
   useEffect(() => {
     let cancelled = false
     let refreshTimer
-    const refresh = () => fetch('api/health', { cache: 'no-store' })
+    const refresh = () => gatewayFetch('api/health', { cache: 'no-store' })
       .then(async response => ({ response, payload: await response.json() }))
       .then(({ response, payload }) => {
         if (cancelled) return
@@ -772,8 +780,8 @@ export default function App() {
     // microphone capture and never closes or interrupts the output stream.
     inputOnlyMute: true,
     wakeWordOnly: voiceEnabledForWakeWord,
-    clientType: desktopOrbMode ? 'desktop' : 'web',
-    clientLabel: desktopOrbMode ? t('桌面端') : 'WebUI',
+    clientType: activeClientType,
+    clientLabel: gatewayClientLabel(desktopOrbMode ? t('桌面端') : 'WebUI'),
     clientStates: desktopOrbMode ? ['sleeping'] : [],
     realtimeProvider: realtimeProviderForConnection(
       realtimeProvider,

--- a/web/src/DomainLibraryPanel.jsx
+++ b/web/src/DomainLibraryPanel.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { t } from './i18n.js'
+import { gatewayFetch } from './gateway-transport.js'
 
 // 资料库面板：把本机的手册 / 规章 / 教材交给助手。
 //
@@ -33,7 +34,7 @@ export default function DomainLibraryPanel({ onClose, getTask }) {
 
   const refresh = useCallback(async () => {
     try {
-      const response = await fetch('api/domain', { cache: 'no-store' })
+      const response = await gatewayFetch('api/domain', { cache: 'no-store' })
       if (response.status === 404) {
         setDisabled(true)
         return
@@ -79,7 +80,7 @@ export default function DomainLibraryPanel({ onClose, getTask }) {
     setError('')
     setNotice('')
     try {
-      const response = await fetch('api/domain/import', {
+      const response = await gatewayFetch('api/domain/import', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ path: trimmed }),
@@ -117,7 +118,7 @@ export default function DomainLibraryPanel({ onClose, getTask }) {
     setError('')
     setNotice('')
     try {
-      const response = await fetch(`api/domain/${encodeURIComponent(document.id)}`, {
+      const response = await gatewayFetch(`api/domain/${encodeURIComponent(document.id)}`, {
         method: 'DELETE',
       })
       if (!response.ok) throw new Error(String(response.status))

--- a/web/src/gateway-transport.js
+++ b/web/src/gateway-transport.js
@@ -1,0 +1,80 @@
+import { gatewayWebSocketProtocols } from '../../shared/gateway-websocket-auth.mjs'
+
+let runtime = Object.freeze({
+  gatewayUrl: '',
+  accessToken: '',
+  clientType: '',
+  clientLabel: '',
+})
+
+function cleanGatewayUrl(value = '') {
+  if (!String(value).trim()) return ''
+  const url = new URL(String(value))
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new TypeError('Gateway URL must use http or https')
+  }
+  if (url.pathname !== '/' || url.search || url.hash || url.username || url.password) {
+    throw new TypeError('Gateway URL must be an origin')
+  }
+  return url.origin
+}
+
+export function configureGatewayTransport(options = {}) {
+  runtime = Object.freeze({
+    gatewayUrl: cleanGatewayUrl(options.gatewayUrl),
+    accessToken: String(options.accessToken || '').trim(),
+    clientType: String(options.clientType || '').trim(),
+    clientLabel: String(options.clientLabel || '').trim(),
+  })
+  return runtime
+}
+
+export function gatewayTransportConfig() {
+  return runtime
+}
+
+export function gatewayClientType(fallback = 'web') {
+  return runtime.clientType || fallback
+}
+
+export function gatewayClientLabel(fallback = 'WebUI') {
+  return runtime.clientLabel || fallback
+}
+
+export function gatewayHttpUrl(path) {
+  if (!runtime.gatewayUrl) return path
+  return new URL(String(path).replace(/^\//, ''), `${runtime.gatewayUrl}/`).toString()
+}
+
+export function gatewayFetch(path, init = {}, fetchImpl = globalThis.fetch) {
+  const headers = new Headers(init.headers || {})
+  if (runtime.accessToken) headers.set('Authorization', `Bearer ${runtime.accessToken}`)
+  return fetchImpl(gatewayHttpUrl(path), {
+    ...init,
+    headers,
+    credentials: 'include',
+  })
+}
+
+export function gatewayRealtimeUrl(sessionId, locationValue = globalThis.location) {
+  const base = runtime.gatewayUrl
+    ? new URL(runtime.gatewayUrl)
+    : new URL(locationValue.href)
+  const protocol = base.protocol === 'https:' ? 'wss:' : 'ws:'
+  const basePath = runtime.gatewayUrl
+    ? '/'
+    : base.pathname.endsWith('/')
+      ? base.pathname
+      : base.pathname.replace(/[^/]*$/, '')
+  return `${protocol}//${base.host}${basePath}api/realtime?sessionId=${encodeURIComponent(sessionId)}`
+}
+
+export function createGatewayWebSocket(url, _options = {}, WebSocketImpl = globalThis.WebSocket) {
+  const protocols = gatewayWebSocketProtocols(runtime.accessToken)
+  if (protocols.length && new URL(url).protocol !== 'wss:') {
+    throw new Error('Remote Gateway credentials require a secure WebSocket endpoint')
+  }
+  return protocols.length
+    ? new WebSocketImpl(url, protocols)
+    : new WebSocketImpl(url)
+}

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -19,17 +19,13 @@ import { decodePcm, pcmBase64, resample } from './audio.js'
 import { createMicrophoneCaptureLifecycle } from './microphone-capture.js'
 import { confirmTrackedPlaybackStart } from './playback-lifecycle.js'
 import { t } from './i18n.js'
+import {
+  createGatewayWebSocket,
+  gatewayRealtimeUrl,
+} from './gateway-transport.js'
 
 const DEFAULT_INPUT_RATE = 16000
 const OUTPUT_RATE = 24000
-
-function socketUrl(sessionId) {
-  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-  const basePath = location.pathname.endsWith('/')
-    ? location.pathname
-    : location.pathname.replace(/[^/]*$/, '')
-  return `${protocol}//${location.host}${basePath}api/realtime?sessionId=${encodeURIComponent(sessionId)}`
-}
 
 export function acceptsVoiceState(event, currentTurnId) {
   return acceptsGatewayVoiceState(event, currentTurnId)
@@ -642,8 +638,8 @@ export default function useRealtimeVoice({
       eventRef.current?.(event)
     }
     const client = new GatewayClient({
-      url: socketUrl(sessionId),
-      createSocket: url => new WebSocket(url),
+      url: gatewayRealtimeUrl(sessionId),
+      createSocket: createGatewayWebSocket,
       clientType,
       clientLabel,
       clientInstanceId: clientInstanceId.current,

--- a/web/src/voice-defaults.js
+++ b/web/src/voice-defaults.js
@@ -1,3 +1,3 @@
-export function initialVoiceEnabled({ desktopOrbMode = false } = {}) {
-  return desktopOrbMode === true
+export function initialVoiceEnabled({ desktopOrbMode = false, clientType = 'web' } = {}) {
+  return desktopOrbMode === true || clientType === 'mobile'
 }

--- a/web/test/gateway-transport.test.mjs
+++ b/web/test/gateway-transport.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  configureGatewayTransport,
+  createGatewayWebSocket,
+  gatewayFetch,
+  gatewayHttpUrl,
+  gatewayRealtimeUrl,
+} from '../src/gateway-transport.js'
+
+test.afterEach(() => configureGatewayTransport())
+
+test('keeps the existing same-origin browser transport by default', () => {
+  assert.equal(gatewayHttpUrl('api/health'), 'api/health')
+  assert.equal(
+    gatewayRealtimeUrl('voice one', new URL('https://example.test/app/index.html')),
+    'wss://example.test/app/api/realtime?sessionId=voice%20one',
+  )
+})
+
+test('routes mobile HTTP and WebSocket traffic through a secure remote profile', async () => {
+  configureGatewayTransport({
+    gatewayUrl: 'https://machine.tailnet.ts.net',
+    accessToken: 'qwa_example-device-token_1234567890',
+    clientType: 'mobile',
+  })
+  const requests = []
+  await gatewayFetch('api/health', { cache: 'no-store' }, async (url, init) => {
+    requests.push({ url, init })
+    return { ok: true }
+  })
+  assert.equal(requests[0].url, 'https://machine.tailnet.ts.net/api/health')
+  assert.equal(
+    requests[0].init.headers.get('authorization'),
+    'Bearer qwa_example-device-token_1234567890',
+  )
+  assert.equal(
+    gatewayRealtimeUrl('mobile-session'),
+    'wss://machine.tailnet.ts.net/api/realtime?sessionId=mobile-session',
+  )
+  const sockets = []
+  class FakeWebSocket {
+    constructor(url, protocols) {
+      sockets.push({ url, protocols })
+    }
+  }
+  createGatewayWebSocket(gatewayRealtimeUrl('mobile-session'), {}, FakeWebSocket)
+  assert.equal(sockets[0].protocols[0], 'qwaudio.gcp.v6')
+  assert.match(sockets[0].protocols[1], /^qwaudio\.bearer\.qwa_/)
+})
+
+test('never sends browser credentials over an insecure remote socket', () => {
+  configureGatewayTransport({
+    gatewayUrl: 'http://machine.test:3101',
+    accessToken: 'qwa_example-device-token_1234567890',
+  })
+  assert.throws(
+    () => createGatewayWebSocket(gatewayRealtimeUrl('mobile'), {}, class {}),
+    /secure WebSocket/,
+  )
+})

--- a/web/test/voice-defaults.test.mjs
+++ b/web/test/voice-defaults.test.mjs
@@ -10,3 +10,7 @@ test('regular WebUI starts with voice disabled', () => {
   assert.equal(initialVoiceEnabled({ desktopOrbMode: false }), false)
   assert.equal(initialVoiceEnabled(), false)
 })
+
+test('mobile starts as a realtime call after pairing', () => {
+  assert.equal(initialVoiceEnabled({ clientType: 'mobile' }), true)
+})


### PR DESCRIPTION
## Summary
- add a shared Gateway transport boundary for browser-based first-party clients
- authenticate remote WebSocket sessions without placing credentials in URLs or model-visible payloads
- bind paired mobile identities to the existing Gateway access and ownership model
- preserve same-origin WebUI behavior and make mobile voice-first by client type
- distinguish transient npm audit service failures from real vulnerability reports, with bounded retries

## Verification
- focused Gateway access, request-security, WebSocket auth, and transport tests
- ESLint
- WebUI production build

Refs #320
