### PR TITLE
docs(cockpit): standardize scenario documentation

### DIFF
--- a/docs/scenarios/smart-cockpit.md
+++ b/docs/scenarios/smart-cockpit.md
@@ -1,29 +1,70 @@
 # Smart Cockpit
 
-[`examples/smart-cockpit/`](https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/smart-cockpit) is a runnable cockpit scenario built on qwen-audio-agent's foreground/backend boundary. It preserves the car UI, browser voice interaction, vehicle controls, navigation, music, weather, and flash-buy flow without maintaining a second Realtime server, conversation history, or Agent loop.
+Smart Cockpit is a runnable qwen-audio-agent scenario example. Users can
+naturally control the vehicle, plan routes, play music, check the weather,
+place flash-buy orders, and run custom workflows while the cockpit UI reflects
+vehicle and task state.
 
-## Component mapping
+## Demo
 
-| Component | Example implementation | Replaceable boundary |
+Use natural voice to start vehicle-control and navigation tasks, showing how
+foreground realtime conversation, backend Agent execution, and cockpit UI state
+work together.
+
+<video controls preload="metadata" style="width: 100%; border-radius: 12px;">
+  <source src="https://github.com/user-attachments/assets/0136b6ec-2ff8-49ba-8f07-55e7006d2e7d" type="video/mp4">
+</video>
+
+## Core features
+
+- Continuous conversation, natural interruption, multi-turn context, and
+  runtime voice and persona switching.
+- MCP-based vehicle control, navigation, music, weather, flash-buy, and custom
+  workflow tools.
+- A foreground Realtime fast path for low-latency operations and a backend
+  Agent for flash-buy and custom workflow tasks.
+- A replaceable backend Agent connected through A2A 1.0, with ACP and custom
+  adapters available as alternatives.
+- Scenario-owned HTTP/SSE channels for vehicle, route, music, and order state.
+
+## Architecture
+
+![Smart cockpit framework architecture](https://raw.githubusercontent.com/QwenAudio/qwen-audio-agent/main/examples/smart-cockpit/docs/framework-architecture.svg)
+
+The base qwen-audio-agent boundary is foreground conversation plus backend
+execution. The cockpit client and Gateway form the foreground, the cockpit Agent
+handles backend tasks, and the Service supplies scenario state, business rules,
+and the tool execution environment.
+
+| Component | Example implementation | Main interfaces |
 |---|---|---|
 | `client/` | React cockpit UI + Browser Audio | GCP 6.0 / Gateway Client SDK |
-| `gateway/` | qwen-audio-agent Gateway + foreground Realtime Agent | Framework reuse and scenario composition |
-| `agent/` | Qwen3.8-Flash A2A cockpit Agent | BackendPort / A2A / ACP / custom Adapter |
-| `service/` | Cockpit environment, state, rules, tools, and external integrations | HTTP/SSE / MCP / customer protocols |
+| `gateway/` | qwen-audio-agent Gateway + foreground Realtime Agent | GCP / MCP / BackendPort |
+| `agent/` | Qwen3.8-Flash backend Agent | A2A 1.0 / MCP |
+| `service/` | Cockpit state, rules, tools, and external integrations | HTTP/SSE / MCP |
 
-An independent cockpit service owns vehicle, route, media, and order state. The UI observes it over HTTP/SSE while the foreground and backend Agents use scoped MCP surfaces. The Gateway neither parses scenario objects nor acts as a business-state event bus.
+See
+[`examples/smart-cockpit/docs/architecture.md`](https://github.com/QwenAudio/qwen-audio-agent/blob/main/examples/smart-cockpit/docs/architecture.md)
+for complete boundaries and data flows.
 
-The example also supports voice-created, cockpit-scoped custom workflows. The backend Agent loads a workflow and composes existing MCP tools; user workflows do not dynamically change the Gateway protocol, MCP tool set, or A2A Agent Card.
+## Tool calling
 
-The foreground can also switch among the Healer, Action, and Sharp Assistant
-Profiles inside the current Realtime Session. A GCP Client Event carries only
-an allowlisted ID; the Gateway maps it to deployment-owned Markdown under
-`gateway/assistant/` and applies it to the next turn with `session.update`. Arbitrary
-Client-supplied prompt text is never accepted.
+The cockpit Service provides 38 MCP tools across six scenario domains:
 
-In a customer deployment, the conversation layer may be the only retained implementation. The cockpit UI and backend Agent can both be customer-owned. A custom UI does not inherit the framework WebUI; it implements GCP plus its own audio, page, and business-state channels.
+| Domain | Count | Main capabilities |
+|---|---:|---|
+| `vehicle` | 11 | Location and state, climate, windows, lights, charging, and other controls. |
+| `navigation` | 12 | Place search, routing, waypoints, favorites, and route preferences. |
+| `music` | 10 | Search, playback, previous/next track, volume, media source, and favorites. |
+| `weather` | 1 | City weather lookup. |
+| `flashbuy` | 1 | Flash-buy product search and ordering demonstration. |
+| `custom-skills` | 3 | List, create, and load user-defined workflows. |
 
-## Run
+By default, vehicle, navigation, music, and weather use the foreground Realtime
+fast path, while flash-buy and custom skills run through the backend Agent.
+Scenario developers can change this routing in `service/tools/surface-routing.json`.
+
+## Run the example
 
 ```bash
 cp examples/smart-cockpit/.env.example examples/smart-cockpit/.env.local
@@ -32,6 +73,53 @@ npm run example:smart-cockpit:install
 npm run example:smart-cockpit
 ```
 
-Open `http://localhost:5173`. The command starts service, agent, gateway, and client together.
+Open `http://localhost:5173`. The command starts service, agent, gateway, and
+client together.
 
-See [`examples/smart-cockpit/README.md`](https://github.com/QwenAudio/qwen-audio-agent/blob/main/examples/smart-cockpit/README.md) for architecture, replacement, and test details.
+## Benchmark
+
+The cockpit benchmark compares text and Realtime model tool calling with the
+same tools, prompt, deterministic cockpit state, and scorer. It measures tool
+selection, arguments, execution-path routing, and final state.
+
+- Short suite: 86 cases across vehicle, navigation, music, and weather.
+- Long-context suite: 10 mixed-domain conversations and 500 total turns,
+  including 250 expected tool calls and 250 no-tool turns.
+- Runners: Gold Replay, text model, controlled Realtime model, and the complete
+  Realtime voice path.
+
+```bash
+node examples/smart-cockpit/bench/runner/run-gold.mjs
+node examples/smart-cockpit/bench/runner/run-text.mjs
+node examples/smart-cockpit/bench/runner/run-realtime.mjs
+node examples/smart-cockpit/bench/runner/run-voice.mjs
+```
+
+See
+[`examples/smart-cockpit/bench/README.md`](https://github.com/QwenAudio/qwen-audio-agent/blob/main/examples/smart-cockpit/bench/README.md)
+for the latest results, datasets, and scoring details.
+
+## Replace and extend
+
+| Goal | Change |
+|---|---|
+| Replace the cockpit UI or audio I/O | `client/` |
+| Replace the backend Agent | Change `COCKPIT_AGENT_CARD_URL` or replace `agent/` |
+| Add scenario tools, state, or external services | `service/` and `service/tools/` |
+| Change foreground personas or backend-task semantics | `gateway/` |
+
+See the
+[component replacement guide](https://github.com/QwenAudio/qwen-audio-agent/blob/main/examples/smart-cockpit/docs/replacing-components.md)
+for the complete migration path.
+
+## Authors and acknowledgements
+
+- [Zhang Binbin](https://github.com/robin1001): designed and expanded the
+  cockpit domain capabilities, including navigation, vehicle-control and music
+  tools, foreground/backend routing, and evaluation cases.
+- [Li Xu](https://github.com/x-lixu): designed and implemented the scenario on
+  qwen-audio-agent, including the client, Gateway and backend Agent boundaries,
+  realtime voice path, and A2A/MCP integrations.
+- [Peng Zhendong](https://github.com/pengzhendong): provided the original
+  cockpit UI and visual assets, including the overall interface design,
+  interaction patterns, and related visual materials.

--- a/docs/scenarios/smart-cockpit.zh.md
+++ b/docs/scenarios/smart-cockpit.zh.md
@@ -1,27 +1,59 @@
 # 智能座舱
 
-[`examples/smart-cockpit/`](https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/smart-cockpit) 是基于 qwen-audio-agent 前后台边界的可运行座舱参考场景。它保留车机界面、浏览器语音、车控、导航、音乐、天气和闪购体验，但不再维护独立 Realtime Server 或前台对话历史；后台模型循环位于可替换的 `agent/` 进程。
+智能座舱是 qwen-audio-agent 的可运行场景示例。用户可以通过自然语音控制车辆、
+规划导航、播放音乐、查询天气、使用闪购和自定义技能，座舱界面会同步展示
+车辆与任务状态。
 
-## 组件对应关系
+## 演示
 
-| 组件 | 示例实现 | 可替换边界 |
+通过自然语音发起车控和导航任务，展示前台实时对话、后台 Agent 执行与座舱 UI 状态联动。
+
+<video controls preload="metadata" style="width: 100%; border-radius: 12px;">
+  <source src="https://github.com/user-attachments/assets/0136b6ec-2ff8-49ba-8f07-55e7006d2e7d" type="video/mp4">
+</video>
+
+## 核心特点
+
+- 支持连续对话、自然打断、多轮上下文、音色和人设切换。
+- 使用 MCP 统一扩展车控、导航、音乐、天气、闪购和自定义技能。
+- 前台 Realtime 直接执行低延迟操作，后台 Agent 处理闪购和自定义工作流等任务。
+- 示例后台 Agent 通过 A2A 1.0 接入，也可替换为 ACP 或定制后台。
+- 座舱 UI 使用场景 HTTP/SSE 通道展示车辆、路线、音乐和订单状态。
+
+## 架构
+
+![智能座舱框架架构图](https://raw.githubusercontent.com/QwenAudio/qwen-audio-agent/main/examples/smart-cockpit/docs/framework-architecture.svg)
+
+qwen-audio-agent 的基础边界是“前台对话 + 后台执行”。座舱客户端与 Gateway 组成前台，
+座舱 Agent 负责后台任务，Service 提供场景状态、业务规则和工具执行环境。
+
+| 组件 | 示例实现 | 主要接口 |
 |---|---|---|
 | `client/` | React 座舱 UI + Browser Audio | GCP 6.0 / Gateway Client SDK |
-| `gateway/` | qwen-audio-agent Gateway + 前台 Realtime Agent | 复用框架核心并进行场景装配 |
-| `agent/` | Qwen3.8-Flash 驱动的 A2A 座舱 Agent | BackendPort / A2A / ACP / 定制 Adapter |
-| `service/` | 座舱环境、状态、规则、工具和外部服务适配 | HTTP/SSE / MCP / 客户协议 |
+| `gateway/` | qwen-audio-agent Gateway + 前台 Realtime Agent | GCP / MCP / BackendPort |
+| `agent/` | Qwen3.8-Flash 驱动的后台 Agent | A2A 1.0 / MCP |
+| `service/` | 座舱状态、规则、工具和外部服务适配 | HTTP/SSE / MCP |
 
-座舱 Service 独立维护车辆、路线、媒体和订单状态。UI 通过 HTTP/SSE 展示，前台和后台 Agent 通过受限 MCP 工具面调用；Gateway 不解析场景对象，也不承担业务状态总线。
+完整边界和数据流见
+[`examples/smart-cockpit/docs/architecture.md`](https://github.com/QwenAudio/qwen-audio-agent/blob/main/examples/smart-cockpit/docs/architecture.md)。
 
-示例也支持通过语音创建和运行按座舱持久化的自定义技能。后台 Agent 加载技能工作流后编排现有 MCP 工具；不会为用户技能动态修改 Gateway 协议、MCP 工具集或 A2A Agent Card。
+## 工具调用
 
-前台还支持在当前 Realtime Session 中切换“聊愈师 / 行动派 / 疯批”。客户端通过
-GCP Client Event 只发送白名单 ID，Gateway 映射到 `gateway/assistant/` 下部署方拥有的 Markdown，
-再以 `session.update` 对下一轮生效；不允许客户端注入任意 Prompt。
+座舱 Service 在 6 个场景领域共提供 38 个 MCP 工具：
 
-这说明客户通常只保留框架的对话中控：座舱 UI 和后台 Agent 都可以换成自己的实现。客户 UI 不需要继承框架 WebUI，只需实现 GCP 客户端和自己的音频、页面及业务状态通道。
+| 领域 | 数量 | 主要能力 |
+|---|---:|---|
+| `vehicle` | 11 | 位置、车况、空调、车窗、车灯和充电等。 |
+| `navigation` | 12 | 地点搜索、路线规划、途经点、常用地点和路线偏好等。 |
+| `music` | 10 | 搜索、播放、上下曲、音量、媒体源和收藏。 |
+| `weather` | 1 | 城市天气查询。 |
+| `flashbuy` | 1 | 闪购商品搜索与下单演示。 |
+| `custom-skills` | 3 | 列出、创建和加载用户自定义工作流。 |
 
-## 运行
+默认情况下，车控、导航、音乐和天气走前台 Realtime 快路径，闪购与自定义技能
+交给后台 Agent。场景方可通过 `service/tools/surface-routing.json` 调整分流。
+
+## 运行示例
 
 ```bash
 cp examples/smart-cockpit/.env.example examples/smart-cockpit/.env.local
@@ -32,4 +64,42 @@ npm run example:smart-cockpit
 
 打开 `http://localhost:5173`。一条命令会同时启动 service、agent、gateway 和 client。
 
-完整架构、组件替换方式和测试矩阵见 [`examples/smart-cockpit/README_ZH.md`](https://github.com/QwenAudio/qwen-audio-agent/blob/main/examples/smart-cockpit/README_ZH.md)。
+## Benchmark
+
+座舱 Benchmark 使用相同的工具集、Prompt、确定性座舱状态和评分器，对比文本模型与
+Realtime 模型的工具选择、参数、执行路径和最终状态。
+
+- 短用例集：86 个用例，覆盖车控、导航、音乐和天气。
+- 长上下文集：10 段混合领域对话，共 500 轮，包含 250 次预期工具调用和 250 个无工具轮次。
+- Runner：Gold Replay、文本模型、受控 Realtime 模型和完整 Realtime 语音链路。
+
+```bash
+node examples/smart-cockpit/bench/runner/run-gold.mjs
+node examples/smart-cockpit/bench/runner/run-text.mjs
+node examples/smart-cockpit/bench/runner/run-realtime.mjs
+node examples/smart-cockpit/bench/runner/run-voice.mjs
+```
+
+最新结果、数据集和评分方法见
+[`examples/smart-cockpit/bench/README.md`](https://github.com/QwenAudio/qwen-audio-agent/blob/main/examples/smart-cockpit/bench/README.md)。
+
+## 替换和扩展
+
+| 需求 | 修改位置 |
+|---|---|
+| 替换座舱 UI 或音频 I/O | `client/` |
+| 替换后台 Agent | 修改 `COCKPIT_AGENT_CARD_URL`，或替换 `agent/` |
+| 增加场景工具、状态或外部服务 | `service/` 与 `service/tools/` |
+| 调整前台人设或后台任务语义 | `gateway/` |
+
+参考[组件替换指南](https://github.com/QwenAudio/qwen-audio-agent/blob/main/examples/smart-cockpit/docs/replacing-components.md)
+了解完整迁移方法。
+
+## 作者与致谢
+
+- [Zhang Binbin](https://github.com/robin1001)：负责座舱领域能力的设计与扩展，包括导航、车控、
+  音乐工具体系、前后台工具分流与评测用例。
+- [Li Xu](https://github.com/x-lixu)：负责基于 qwen-audio-agent 的场景架构与整体实现，包括客户端、
+  Gateway、后台 Agent 的边界，实时语音链路以及 A2A/MCP 接入。
+- [Peng Zhendong](https://github.com/pengzhendong)：提供原始座舱 UI 与视觉资源，包括整体界面设计、
+  交互形态和相关视觉素材。

--- a/examples/smart-cockpit/README.md
+++ b/examples/smart-cockpit/README.md
@@ -2,22 +2,11 @@
 
 English | [中文](README_ZH.md)
 
-![Smart cockpit framework architecture](docs/framework-architecture.svg)
-
-This is qwen-audio-agent's runnable smart-cockpit showcase. It reimplements the
-complete cockpit path through public framework APIs while reusing suitable UI
-code and visual assets from an earlier cockpit prototype to save implementation
-effort. It is not a migration or compatibility retrofit, and it does not
-maintain a second Realtime gateway or foreground conversation history. The
-backend model loop lives only in the replaceable `agent/` process.
-
-The base qwen-audio-agent boundary has two layers: foreground conversation and backend execution.
-The cockpit UI is a replaceable client component inside the foreground, and the
-cockpit Agent is a replaceable backend example. Neither is a mandatory framework
-implementation. The reusable core is the Gateway, foreground realtime
-conversation, GCP Client SDK, BackendPort, A2A, and MCP seams.
-The backend Agent may derive independent Sessions as an optional third-layer
-execution space. The bundled example instead runs a compact Qwen3.8-Flash tool loop.
+This runnable smart-cockpit Agent example is built with qwen-audio-agent. Users
+can naturally control the vehicle, plan routes, play music, check the weather,
+place flash-buy orders, and run custom workflows while the cockpit UI reflects
+vehicle and task state. It shows how to combine foreground realtime conversation,
+tool calling, and a replaceable backend Agent with the framework.
 
 ## Demo
 
@@ -29,48 +18,40 @@ work together.
 
 https://github.com/user-attachments/assets/0136b6ec-2ff8-49ba-8f07-55e7006d2e7d
 
-## Structure at a glance
+## Core features
 
-| Directory / process | Default address | Role and contract | Change it when... |
-|---|---|---|---|
-| [`client/`](client/) / cockpit-client | `http://127.0.0.1:5173` | Replaceable foreground client. Uses GCP for conversation and scenario HTTP/SSE for panels. | Replacing the cockpit UI, browser audio I/O, or panel interaction. |
-| [`gateway/`](gateway/) / cockpit-gateway | `http://127.0.0.1:18888` | Foreground Agent and Gateway composition. Trusted personas, the frontend Profile, and the `spawn_thinking` description belong here. | Wiring a protocol adapter, changing a foreground Prompt, or changing scenario composition—not implementing business logic. |
-| [`agent/`](agent/) / cockpit-agent | `http://127.0.0.1:3020` | Replaceable model-powered A2A backend example. Qwen3.8-Flash plans and calls only the backend MCP surface. | Replacing or extending the bundled backend Agent. |
-| [`service/`](service/) / cockpit-service | `http://127.0.0.1:3010` | Cockpit environment and infrastructure: scenario state, business rules, external-service adapters, and [`tools/`](service/tools/) capability contracts. Exposes scoped interfaces to the UI, foreground, and cockpit Agent. | Adding a cockpit capability, business state, validation, or external integration. |
-| [`bootstrap/`](bootstrap/) | — | Shared environment loading and startup preflight for all four processes. | Changing local-example startup requirements or port checks. |
+- **Realtime voice conversation:** continuous dialogue, natural interruption,
+  multi-turn context, and runtime voice and persona switching.
+- **Standard tool calling:** vehicle control, navigation, music, weather,
+  flash-buy, and custom workflows are exposed as MCP tools.
+- **Foreground/backend routing:** low-latency operations run directly in the
+  foreground Realtime path; flash-buy and custom workflows go to the backend Agent.
+- **Standard backend integration:** the example Agent connects through A2A 1.0
+  and can be replaced by a customer-owned A2A, ACP, or custom backend.
+- **Scenario-state projection:** the cockpit UI receives vehicle, route, music,
+  and order state through scenario-owned HTTP/SSE channels.
+- **Replaceable components:** the client, backend Agent, and scenario service can
+  each be replaced without changing the framework core.
 
-## Function call surface
+## Architecture
 
-The bundled cockpit service exposes 34 domain tools across vehicle, navigation,
-music, and weather.
+![Smart cockpit framework architecture](docs/framework-architecture.svg)
 
-| Domain | Total functions | Function description and examples |
-|---|---:|---|
-| `vehicle` | 11 | Vehicle location/state and strict vehicle controls, including climate, temperature, windows, sunroof, closures, comfort, lights, sound, and charging. Examples: “Where is the car?”, “Set the cabin to 22 degrees”, “Open the front trunk”, “Start charging”. |
-| `navigation` | 12 | Destination routing, route preview, waypoint edits, favorites, route preferences, map view, navigation voice, and stop-navigation. Examples: “Navigate to West Lake via Huanglong Stadium”, “Avoid highways”, “Show the full route”, “Stop navigation”. |
-| `music` | 10 | Playback, search, status query, volume, media source, favorites, and next/previous track controls. Examples: “Play 晴天”, “Turn the volume up”, “Switch to Bluetooth”, “Favorite this song”. |
-| `weather` | 1 | City weather lookup for travel context. Examples: “How is the weather in Hangzhou today?”, “Will it rain in Shanghai?”. |
-| **Total** | **34** | Covers cross-domain tool selection, argument extraction, execution path choice, and final cockpit state outcome for benchmark evaluation. |
+The base qwen-audio-agent boundary is foreground conversation plus backend
+execution. The cockpit client and Gateway form the foreground, the cockpit Agent
+handles backend tasks, and the Service supplies scenario state, business rules,
+and the tool execution environment.
 
-Frontend and backend execution surfaces are selected by domain in
-`service/tools/surface-routing.json`. The default routing keeps `vehicle`,
-`navigation`, `music`, and `weather` on the foreground Realtime fast path,
-while `flashbuy` and `custom-skills` run through the backend Agent.
-Override the defaults with `COCKPIT_TOOL_SURFACE_ROUTING=/absolute/path.json`
-or an inline `COCKPIT_DOMAIN_SURFACES` JSON value.
+| Directory / process | Default address | Responsibility |
+|---|---|---|
+| [`client/`](client/) / cockpit-client | `http://127.0.0.1:5173` | Replaceable cockpit client responsible for audio I/O, conversation interaction, and business panels. |
+| [`gateway/`](gateway/) / cockpit-gateway | `http://127.0.0.1:18888` | Foreground Agent and Gateway composition for realtime conversation, foreground tools, and backend task submission. |
+| [`agent/`](agent/) / cockpit-agent | `http://127.0.0.1:3020` | Replaceable A2A backend Agent; Qwen3.8-Flash interprets and orchestrates tasks. |
+| [`service/`](service/) / cockpit-service | `http://127.0.0.1:3010` | Cockpit environment and infrastructure for state, rules, external integrations, and MCP tools. |
+| [`bootstrap/`](bootstrap/) | — | Shared environment loading and startup preflight for all four processes. |
 
-For a future benchmark comparing Realtime and text-only model tool-calling
-accuracy, this table defines the shared tool surface to evaluate:
-
-- **Tool selection accuracy:** whether the model chooses the correct domain and
-  function for a user utterance.
-- **Argument accuracy:** whether slots such as destination, route strategy,
-  temperature zone, window target, media source, volume, and song query are
-  extracted correctly.
-- **Execution path choice:** whether each domain follows the active
-  frontend/backend surface routing.
-- **State outcome:** whether the resulting cockpit state matches the requested
-  operation after the tool call.
+See the [architecture document](docs/architecture.md) for complete boundaries
+and data flows.
 
 ## Quick start
 
@@ -86,73 +67,81 @@ Set at least:
 DASHSCOPE_API_KEY=your_dashscope_api_key
 ```
 
-The backend Agent uses `qwen3.8-flash` with thinking enabled by default. Override it with
-`DASHSCOPE_MODEL` when needed.
-
-Optionally configure `VITE_AMAP_KEY`, `VITE_AMAP_SECRET`, and `AMAP_MCP_KEY` for AMap rendering and route services. Install the example dependencies and start all four processes:
+Optionally configure `VITE_AMAP_KEY`, `VITE_AMAP_SECRET`, and `AMAP_MCP_KEY`
+for AMap rendering and route services. Then install dependencies and start the
+example:
 
 ```bash
 npm run example:smart-cockpit:install
 npm run example:smart-cockpit
 ```
 
-Open `http://localhost:5173`.
-The command starts the four processes listed above.
+Open `http://localhost:5173`. Press `Ctrl+C` to stop all example processes.
 
-Press `Ctrl+C` to stop all processes.
+## Tool calling
 
-A preflight validates the Realtime configuration and all four ports before any child process starts. Missing credentials and stale instances therefore produce one actionable error instead of several child-process stack traces.
+The cockpit Service provides 38 tools across six scenario domains. Tool
+definitions, executors, and foreground/backend routing remain independent.
 
-## Boundaries
+| Domain | Count | Example capabilities |
+|---|---:|---|
+| `vehicle` | 11 | Vehicle location and state, climate, windows, sunroof, lights, charging, and other controls. |
+| `navigation` | 12 | Place search, routing, ordered waypoints, favorites, route preferences, and stop-navigation. |
+| `music` | 10 | Search and playback, previous/next track, volume, media source, and favorites. |
+| `weather` | 1 | City weather lookup. |
+| `flashbuy` | 1 | Flash-buy product search and ordering demonstration. |
+| `custom-skills` | 3 | List, create, and load user-defined cockpit workflows. |
+| **Total** | **38** | Foreground low-latency operations and backend composed tasks. |
 
-- The cockpit client and Gateway/Realtime conversation runtime are components
-  of one foreground layer, not separate Agent layers.
-- The UI talks to the Gateway through GCP and knows nothing about the Realtime provider or backend Agent.
-- Voice settings expose only Qwen Audio 3.0 Realtime's sweet female
-  (`longanqian`) and sunny male (`longanlufeng`) voices. Changing the selection
-  uses the formal GCP/Client SDK voice capability and refreshes only the
-  upstream Realtime Session without restarting the cockpit app.
-- The UI publishes only the allowlisted `healer`, `action`, or `sharp` ID through
-  a registered `client.event.publish`. The Gateway maps it to deployment-owned
-  Markdown and applies it to the current Realtime Session with `session.update`
-  from the next turn. The Client cannot submit arbitrary prompt text, files are
-  not rewritten, and switching neither drops conversation state nor speaks an acknowledgement.
-- The primary cockpit stays voice-only. Transcripts appear only in the debug panel, and ASR displays final results only.
-- Scenario-specific HTTP/SSE projects vehicle, route, media, weather, and order state, plus fine-grained scenario progress. The Gateway does not parse those objects.
-- Users can create and run persistent cockpit-specific workflows by voice. The
-  backend Agent loads these workflows and composes existing MCP tools; they are
-  not dynamic MCP plugins, A2A Agent Card entries, or globally installed Agent Skills.
-- The foreground Agent directly calls weather, vehicle location/state, vehicle
-  controls, navigation-stop, route-view, navigation voice/preference, and
-  single-step music controls through standard MCP. These low-latency commands
-  execute inline without a redundant second confirmation.
-- Vehicle-location queries and navigation origins share the Cockpit Service's
-  `vehicleLocation()` adapter. Without a vehicle GPS integration the example
-  explicitly reports its demo fallback; a deployment replaces only that service.
-- Route preference buttons write the authoritative cockpit state. The next route
-  inherits that preference unless the user explicitly chooses another one.
-- The memory settings panel uses the Gateway's provider-neutral memory control
-  plane. It lists and exactly deletes entries from the same USER/MEMORY documents
-  used by Realtime, rather than maintaining a cockpit-only memory store.
-- Other cockpit work goes through the fixed `spawn_thinking` bridge. The example
-  backend attaches over A2A, and Qwen3.8-Flash discovers the complete backend MCP
-  surface for vehicle control, navigation, music, flash-buy, and custom workflows,
-  including ordered multi-stop navigation.
-- How the backend invokes tools and organizes work is backend-private. If it
-  creates independent derived Sessions, they form an optional third-layer
-  execution space extended by the backend without changing the foreground protocol.
-- Scenario tools live in domain-oriented packages under [`service/tools/`](service/tools/README.md).
-  One explicit registry adds domain groups and selects individual tools for an
-  additional foreground low-latency path. The backend retains the complete
-  orchestration surface without changing Gateway protocols or duplicating executors.
-- Customers can replace the UI, cockpit Agent, or cockpit service without changing the framework core.
+By default, `vehicle`, `navigation`, `music`, and `weather` use the foreground
+Realtime fast path, while `flashbuy` and `custom-skills` run through the backend
+Agent. Change the scenario routing in
+[`surface-routing.json`](service/tools/surface-routing.json); see the
+[tool directory guide](service/tools/README.md) for extension details.
 
-## Development and tests
+## Benchmark
+
+The example includes a reproducible cockpit tool-calling benchmark. It uses the
+same tools, prompt, deterministic state, and scorer to evaluate tool selection,
+argument generation, and no-tool decisions in both single-turn and long-context
+conversations:
+
+- Short suite: 86 cockpit instructions.
+- Long-context suite: 10 conversations and 500 turns, including 250 expected
+  tool calls and 250 no-tool turns.
+- Four runners: Gold, text model, controlled Realtime, and full voice pipeline.
 
 ```bash
-npm run example:smart-cockpit:lint
-npm run example:smart-cockpit:build
-npm run test:smart-cockpit
+node examples/smart-cockpit/bench/runner/run-gold.mjs
+node examples/smart-cockpit/bench/runner/run-text.mjs
+node examples/smart-cockpit/bench/runner/run-realtime.mjs
+node examples/smart-cockpit/bench/runner/run-voice.mjs
 ```
 
-See [architecture and data flow](docs/architecture.md), [component replacement](docs/replacing-components.md), and the [test matrix](docs/test-matrix.md).
+See the [Benchmark guide](bench/README.md) for datasets, runtime options, and
+scoring rules.
+
+## Replace and extend
+
+| Goal | Change |
+|---|---|
+| Replace the cockpit UI or audio I/O | [`client/`](client/) |
+| Replace the backend Agent | Change `COCKPIT_AGENT_CARD_URL` or replace [`agent/`](agent/) |
+| Add scenario tools, state, or external services | [`service/`](service/) and [`service/tools/`](service/tools/) |
+| Change foreground personas or backend-task semantics | [`gateway/`](gateway/) |
+| Change foreground/backend tool routing | [`surface-routing.json`](service/tools/surface-routing.json) |
+
+See the [component replacement guide](docs/replacing-components.md) for the
+complete migration path.
+
+## Authors and acknowledgements
+
+- [Zhang Binbin](https://github.com/robin1001): designed and expanded the
+  cockpit domain capabilities, including the navigation, vehicle-control and
+  music tool suites, foreground/backend routing, and evaluation cases.
+- [Li Xu](https://github.com/x-lixu): designed and implemented the scenario on
+  qwen-audio-agent, including the client, Gateway and backend Agent boundaries,
+  the realtime voice path, and the A2A/MCP integrations.
+- [Peng Zhendong](https://github.com/pengzhendong): provided the original
+  cockpit UI and visual assets, including the overall interface design,
+  interaction patterns, and related visual materials.

--- a/examples/smart-cockpit/README_ZH.md
+++ b/examples/smart-cockpit/README_ZH.md
@@ -2,18 +2,9 @@
 
 [English](README.md) | 中文
 
-![智能座舱框架架构图](docs/framework-architecture.svg)
-
-这是 qwen-audio-agent 在智能座舱领域的可运行落地示范。它使用框架公开能力
-重新实现完整座舱链路，并在边界合适的地方复用早期座舱原型的 UI 代码和视觉资源，
-以节约实现成本。它不是对旧 Demo 的迁移或兼容改造，也没有自建第二套 Realtime
-或前台对话历史；后台模型循环只存在于可替换的 `agent/` 进程中。
-
-qwen-audio-agent 的基础边界是“前台对话 + 后台执行”两层。示例中的座舱 UI 是前台的
-可替换客户端组件，座舱 Agent 是可替换后台；二者都不是框架强制实现。真正复用的
-框架能力是 Gateway、前台实时对话、GCP Client SDK、BackendPort、A2A 和 MCP 接缝。
-后台 Agent 可以按需派生独立 Session，扩展出第三层执行空间；仓库自带示例则使用
-紧凑的 Qwen3.8-Flash 工具调用循环。
+这是一个基于 qwen-audio-agent 的可运行智能座舱 Agent 示例。用户可以通过自然语音
+控制车辆、规划导航、播放音乐、查询天气、使用闪购和自定义技能，座舱界面会同步展示
+车辆与任务状态。它展示了如何使用框架组合前台实时对话、工具调用和可替换的后台 Agent。
 
 ## 座舱演示
 
@@ -23,38 +14,31 @@ qwen-audio-agent 的基础边界是“前台对话 + 后台执行”两层。示
 
 https://github.com/user-attachments/assets/0136b6ec-2ff8-49ba-8f07-55e7006d2e7d
 
-## 目录职责一览
+## 核心特点
 
-| 目录 / 进程 | 默认地址 | 角色与契约 | 什么时候修改 |
-|---|---|---|---|
-| [`client/`](client/) / cockpit-client | `http://127.0.0.1:5173` | 可替换的前台客户端。对话走 GCP，业务面板走场景 HTTP/SSE。 | 替换座舱 UI、浏览器音频 I/O 或面板交互时。 |
-| [`gateway/`](gateway/) / cockpit-gateway | `http://127.0.0.1:18888` | 前台 Agent 与 Gateway 的场景装配；可信人设、前台 Profile 和 `spawn_thinking` 描述都归这里。 | 更换协议 Adapter、前台 Prompt 或场景装配时；不在这里实现业务逻辑。 |
-| [`agent/`](agent/) / cockpit-agent | `http://127.0.0.1:3020` | 可替换、由模型驱动的 A2A 后台示例。Qwen3.8-Flash 规划任务并调用后台 MCP 工具面。 | 替换或扩展示例后台 Agent 时。 |
-| [`service/`](service/) / cockpit-service | `http://127.0.0.1:3010` | 座舱环境与基础设施：集中管理场景状态、业务规则、外部服务适配和 [`tools/`](service/tools/) 能力契约，并向 UI、前台和座舱 Agent 提供受限接口。 | 增加座舱能力、业务状态、校验或外部服务接入时。 |
-| [`bootstrap/`](bootstrap/) | — | 四个进程共用的环境加载与启动预检。 | 调整本地示例的启动条件或端口检查时。 |
+- **实时语音对话：**支持连续交流、自然打断、多轮上下文、音色和人设切换。
+- **标准工具调用：**车控、导航、音乐、天气、闪购和自定义技能统一定义为 MCP 工具。
+- **前后台分工：**低延迟操作由前台 Realtime 直接执行，闪购和自定义工作流等任务交给后台 Agent。
+- **标准后台接入：**示例 Agent 通过 A2A 1.0 连接 Gateway，可替换为客户自己的 A2A、ACP 或定制后台。
+- **场景状态联动：**座舱 UI 通过场景 HTTP/SSE 通道展示车辆、路线、音乐和订单状态。
+- **组件可替换：**客户可以独立替换座舱客户端、后台 Agent 或场景 Service，无需修改框架核心。
 
-## Function call 工具面
+## 架构
 
-当前座舱服务在 vehicle、navigation、music、weather 四个领域共暴露 34 个领域工具。
-默认领域执行面配置在 `service/tools/surface-routing.json`：`vehicle`、`navigation`、
-`music`、`weather` 走前台 Realtime 快路径，`flashbuy` 和 `custom-skills` 走后台
-Agent。可通过 `COCKPIT_TOOL_SURFACE_ROUTING` 指向自定义 JSON，或用
-`COCKPIT_DOMAIN_SURFACES` 内联 JSON 覆盖。
+![智能座舱框架架构图](docs/framework-architecture.svg)
 
-| 领域 | Function 数量 | 功能描述和示例 |
-|---|---:|---|
-| `vehicle` | 11 | 车辆位置/车况查询和严格车控，包括空调、温度、车窗、天窗、开闭件、舒适控制、灯光、声音和充电。示例：“车在哪？”、“空调调到 22 度”、“打开前备箱”、“开始充电”。 |
-| `navigation` | 12 | 目的地导航、路线预览、途经点修改、常用地点、路线偏好、地图视图、导航播报和停止导航。示例：“导航到西湖，途经黄龙体育中心”、“避开高速”、“查看全程路线”、“停止导航”。 |
-| `music` | 10 | 播放、搜索、状态查询、音量、媒体来源、收藏和上一首/下一首控制。示例：“播放晴天”、“音量大一点”、“切到蓝牙”、“收藏这首歌”。 |
-| `weather` | 1 | 查询城市天气，用于出行上下文。示例：“杭州今天天气怎么样？”、“上海会下雨吗？”。 |
-| **总计** | **34** | 覆盖跨领域工具选择、参数抽取、执行路径选择和最终座舱状态结果，可作为后续 benchmark 的共同工具面。 |
+qwen-audio-agent 的基础边界是“前台对话 + 后台执行”。座舱客户端与 Gateway 组成前台，
+座舱 Agent 负责后台任务，Service 提供场景状态、业务规则和工具执行环境。
 
-后续如果要 benchmark Realtime 和纯文本模型的工具调用准确率，可以基于这张表定义统一工具面：
+| 目录 / 进程 | 默认地址 | 职责 |
+|---|---|---|
+| [`client/`](client/) / cockpit-client | `http://127.0.0.1:5173` | 可替换的座舱客户端；负责音频 I/O、对话交互和业务面板。 |
+| [`gateway/`](gateway/) / cockpit-gateway | `http://127.0.0.1:18888` | 前台 Agent 与 Gateway 场景装配；处理实时对话、前台工具和后台任务提交。 |
+| [`agent/`](agent/) / cockpit-agent | `http://127.0.0.1:3020` | 可替换的 A2A 后台 Agent；Qwen3.8-Flash 负责理解和编排任务。 |
+| [`service/`](service/) / cockpit-service | `http://127.0.0.1:3010` | 座舱环境与基础设施；管理状态、规则、外部服务适配和 MCP 工具。 |
+| [`bootstrap/`](bootstrap/) | — | 四个进程共用的环境加载和启动预检。 |
 
-- **工具选择准确率：**模型是否为用户话术选择了正确领域和 function。
-- **参数准确率：**目的地、路线偏好、温区、车窗目标、媒体来源、音量、歌曲关键词等槽位是否抽取正确。
-- **执行路径选择：**简单低延迟动作是否留在前台 Realtime 路径，组合任务是否交给后台 Agent。
-- **状态结果：**工具调用后的座舱状态是否符合用户请求。
+完整的边界与数据流见[架构文档](docs/architecture.md)。
 
 ## 快速开始
 
@@ -70,63 +54,70 @@ cp examples/smart-cockpit/.env.example examples/smart-cockpit/.env.local
 DASHSCOPE_API_KEY=your_dashscope_api_key
 ```
 
-后台 Agent 默认使用 `qwen3.8-flash` 并开启思考模式；需要时可通过 `DASHSCOPE_MODEL` 覆盖。
-
-高德地图和路线服务可按需填写 `VITE_AMAP_KEY`、`VITE_AMAP_SECRET` 与 `AMAP_MCP_KEY`。然后安装示例依赖并一键启动：
+高德地图和路线服务可按需填写 `VITE_AMAP_KEY`、`VITE_AMAP_SECRET` 与 `AMAP_MCP_KEY`。
+然后安装依赖并启动示例：
 
 ```bash
 npm run example:smart-cockpit:install
 npm run example:smart-cockpit
 ```
 
-浏览器打开 `http://localhost:5173`。该命令会同时启动上表中的四个进程。
+浏览器打开 `http://localhost:5173`。按 `Ctrl+C` 可一起关闭全部示例进程。
 
-按 `Ctrl+C` 会一起关闭四个进程。
+## 工具调用
 
-启动前会一次性检查 Realtime 配置和四个默认端口；缺少 Key 或存在旧实例时会给出明确提示，不会再让四个子进程分别输出错误堆栈。
+座舱 Service 在 6 个场景领域共提供 38 个工具，工具定义、执行器和前后台分流均保持独立。
 
-## 边界
+| 领域 | 数量 | 能力示例 |
+|---|---:|---|
+| `vehicle` | 11 | 车辆位置与车况、空调、车窗、天窗、车灯、充电等。 |
+| `navigation` | 12 | 地点搜索、路线规划、多途经点、常用地点、路线偏好和停止导航。 |
+| `music` | 10 | 搜索与播放、上下曲、音量、媒体源和收藏。 |
+| `weather` | 1 | 城市天气查询。 |
+| `flashbuy` | 1 | 闪购商品搜索与下单演示。 |
+| `custom-skills` | 3 | 列出、创建和加载用户自定义座舱工作流。 |
+| **合计** | **38** | 覆盖前台低延迟操作与后台组合任务。 |
 
-- 前台由座舱客户端和 Gateway/Realtime 对话中控组成；两者是一个前台层内的
-  组件边界，不是两个 Agent 层。
-- UI 仅通过 GCP 与 Gateway 对话，不感知 Realtime Provider 或后台 Agent。
-- 音色设置只提供 Qwen Audio 3.0 Realtime 的“甜美女声”（`longanqian`）和
-  “阳光男声”（`longanlufeng`）；客户端通过正式 GCP/SDK 音色能力切换，Gateway
-  只刷新上游 Realtime 会话，不会重启座舱应用。
-- UI 通过已注册的 `client.event.publish` 只发送 `healer`、`action` 或 `sharp`；
-  Gateway 将其映射到已有 Markdown，并通过 `session.update` 从下一轮起刷新当前会话人设。
-  客户端不能传入任意 Prompt，切换不会修改磁盘文件、丢失对话或产生额外播报。
-- 主座舱区域保持纯语音交互；文字转写只进入调试面板，并且 ASR 仅展示最终结果。
-- UI 通过场景自己的 HTTP/SSE 通道展示车辆、路线、音乐、天气和订单状态，以及细粒度场景进度；Gateway 不解析这些对象。
-- 用户可以通过语音创建和运行持久化的座舱自定义技能；技能是按座舱隔离的用户工作流，
-  由后台 Agent 加载后编排现有 MCP 工具。它不是动态 MCP 插件、A2A Agent Card 或全局 Agent Skill。
-- 前台 Agent 通过标准 MCP 直接调用天气、车辆位置/车况、车辆控制、停止导航、
-  导航视图/播报/偏好和单步音乐控制工具；这些低延迟指令直接执行，不再增加重复确认。
-- 位置查询与导航起点共用 Cockpit Service 的 `vehicleLocation()` 适配入口；
-  未接车机 GPS 时会明确返回 Demo 默认位置，部署时只需替换该服务。
-- 路线偏好按钮写入座舱权威状态；用户未另行指定时，后续导航会继承该偏好。
-- 记忆设置面板调用 Gateway 的 Provider 无关记忆控制面，列出并精确删除
-  Realtime 共用的 USER/MEMORY 文档条目，不维护座舱私有的另一份记忆。
-- 其他座舱任务通过固定的 `spawn_thinking` 桥梁提交给后台。示例后台通过 A2A
-  接入 Gateway，Qwen3.8-Flash 会发现并调用独立的后台 MCP 工具面，完成车控、
-  导航、音乐、闪购和自定义技能任务，包括有序的多途经点导航。
-- 后台 Agent 如何调用工具和组织工作是后台内部实现；若创建独立派生 Session，
-  可以形成由后台扩展出的第三层执行空间，不改变前台协议。
-- 场景工具按领域收敛在 [`service/tools/`](service/tools/README.md)，开发者通过显式
-  注册表增加领域工具包，并按工具名选择哪些额外暴露给前台作为低延迟快路径；
-  后台保留完整工具面用于组合任务，不需要修改 Gateway 协议或复制执行逻辑。
-- 客户可以替换整个 UI、座舱 Agent 或座舱 Service，而不修改框架核心。
+默认情况下，`vehicle`、`navigation`、`music` 和 `weather` 走前台 Realtime 快路径，
+`flashbuy` 和 `custom-skills` 由后台 Agent 执行。通过
+[`surface-routing.json`](service/tools/surface-routing.json) 即可调整场景分流；扩展方式见
+[工具目录说明](service/tools/README.md)。
 
-## 开发与测试
+## Benchmark
+
+示例内置可复现的座舱工具调用评测，使用同一套工具、Prompt、确定性状态和评分器，
+验证模型在单轮及长上下文对话中的工具选择、参数生成与无工具判断：
+
+- 短用例集：86 个座舱指令。
+- 长上下文集：10 段对话、500 轮，其中包含 250 次预期工具调用和 250 个无工具轮次。
+- 支持 Gold、文本模型、受控 Realtime 和完整语音链路四种运行方式。
 
 ```bash
-npm run example:smart-cockpit:lint
-npm run example:smart-cockpit:build
-npm run test:smart-cockpit
+node examples/smart-cockpit/bench/runner/run-gold.mjs
+node examples/smart-cockpit/bench/runner/run-text.mjs
+node examples/smart-cockpit/bench/runner/run-realtime.mjs
+node examples/smart-cockpit/bench/runner/run-voice.mjs
 ```
 
-更多说明：
+数据集、运行参数和评分规则见 [Benchmark 说明](bench/README.md)。
 
-- [架构与数据流](docs/architecture.md)
-- [替换 UI、Agent 或座舱 Service](docs/replacing-components.md)
-- [测试矩阵](docs/test-matrix.md)
+## 替换和扩展
+
+| 需求 | 修改位置 |
+|---|---|
+| 替换座舱 UI 或音频 I/O | [`client/`](client/) |
+| 替换后台 Agent | 修改 `COCKPIT_AGENT_CARD_URL`，或替换 [`agent/`](agent/) |
+| 增加场景工具、状态或外部服务 | [`service/`](service/) 与 [`service/tools/`](service/tools/) |
+| 调整前台人设或后台任务语义 | [`gateway/`](gateway/) |
+| 调整前后台工具分流 | [`surface-routing.json`](service/tools/surface-routing.json) |
+
+更完整的迁移方法见[组件替换指南](docs/replacing-components.md)。
+
+## 作者与致谢
+
+- [Zhang Binbin](https://github.com/robin1001)：负责座舱领域能力的设计与扩展，包括导航、
+  车控、音乐工具体系、前后台工具分流与评测用例。
+- [Li Xu](https://github.com/x-lixu)：负责基于 qwen-audio-agent 的场景架构与整体实现，
+  包括客户端、Gateway、后台 Agent 的边界，实时语音链路以及 A2A/MCP 接入。
+- [Peng Zhendong](https://github.com/pengzhendong)：提供原始座舱 UI 与视觉资源，包括整体界面设计、
+  交互形态和相关视觉素材。


### PR DESCRIPTION
## Summary

- standardize the Smart Cockpit example README as a reusable scenario-example template
- add concise demo, architecture, tool routing, benchmark, extension, and contributor guidance in English and Chinese
- align the user manual pages with the example README, including the demo video and benchmark overview

## Validation

- `npm run docs:build`
- `git diff --check`