### PR TITLE
feat(mobile): add native iOS Gateway client foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,19 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+      - name: Test native iOS Gateway client package
+        if: ${{ matrix.os == 'macos-latest' && matrix.node == '22.22.2' }}
+        working-directory: mobile/ios
+        run: swift test
+      - name: Build native iOS Gateway client package
+        if: ${{ matrix.os == 'macos-latest' && matrix.node == '22.22.2' }}
+        working-directory: mobile/ios
+        run: >-
+          xcodebuild
+          -scheme QwenAudioAgentMobile
+          -destination 'generic/platform=iOS'
+          CODE_SIGNING_ALLOWED=NO
+          build
       - if: ${{ matrix.os == 'macos-latest' && matrix.node == '22.22.2' }}
         run: npm run test:desktop-smoke
       # 真实消费者验收：打包 → 装进只含已声明依赖的裸消费者 → CLI 与

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ Thumbs.db
 *.key
 *.cer
 *.mobileprovision
+
+# SwiftPM / Xcode local state
+.build/
+.swiftpm/
+xcuserdata/
+*.xcuserstate
 config/openclaw-workspace/
 config/openclaw.json5.last-good
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- 新增原生 iOS Gateway Client 基础层：支持短时邀请深链校验、一次性设备配对、
+  Keychain 凭据隔离，以及携带设备凭据的 GCP 6.0 WebSocket 握手；远程地址默认要求
+  HTTPS，不包含公网 Relay、Provider API Key 或后台 Agent 配置。
 - 后台 Session 模型覆盖统一使用 ACP `configOptions` 与
   `session/set_config_option`，不再调用私有模型接口或生成后台配置文件；未声明标准
   模型选项的 Agent 将沿用自身配置。OpenCode/OpenClaw 一键托管初始化保持不变。

--- a/docs/roadmap/gateway-remote-access.md
+++ b/docs/roadmap/gateway-remote-access.md
@@ -152,7 +152,9 @@ and remotely.
 
 ## RA4 — Mobile Client
 
-- [ ] Reuse the public Gateway Client SDK and capability profiles; do not import
+- [x] Add a native iOS foundation for invitation validation, one-time pairing,
+  Keychain credential storage, connection profiles, and the GCP 6.0 handshake.
+- [ ] Reuse the public Gateway Client SDK semantics and capability profiles; do not import
   Gateway, Realtime, ACP, A2A, or Electron internals.
 - [ ] Provide QR/deep-link pairing and secure credential storage.
 - [ ] Support realtime microphone capture, audio playback, voice interruption,

--- a/docs/roadmap/gateway-remote-access.zh.md
+++ b/docs/roadmap/gateway-remote-access.zh.md
@@ -134,7 +134,9 @@ Tailscale 远程访问。
 
 ## RA4 — Mobile Client
 
-- [ ] 只复用公开 Gateway Client SDK 与 capability profile，不导入 Gateway、Realtime、
+- [x] 增加原生 iOS 基础层，支持邀请校验、一次性配对、Keychain 凭据保存、
+  Connection Profile 与 GCP 6.0 握手。
+- [ ] 只复用公开 Gateway Client SDK 语义与 capability profile，不导入 Gateway、Realtime、
   ACP、A2A 或 Electron 内部实现。
 - [ ] 支持二维码/Deep Link 配对与安全凭据存储。
 - [ ] 支持实时麦克风、音频播放、语音打断、静音、文本、图片/文件、对话历史、Task

--- a/mobile/ios/Package.swift
+++ b/mobile/ios/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "QwenAudioAgentMobile",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v13),
+    ],
+    products: [
+        .library(name: "QwenAudioAgentMobile", targets: ["QwenAudioAgentMobile"]),
+    ],
+    targets: [
+        .target(
+            name: "QwenAudioAgentMobile",
+            linkerSettings: [.linkedFramework("Security")]
+        ),
+        .testTarget(
+            name: "QwenAudioAgentMobileTests",
+            dependencies: ["QwenAudioAgentMobile"]
+        ),
+    ]
+)

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -1,0 +1,78 @@
+# iOS Gateway client foundation
+
+This Swift package is the first native iOS slice of
+[RA4 — Mobile Client](../../docs/roadmap/gateway-remote-access.md#ra4--mobile-client).
+It implements the security-sensitive boundary needed before microphone and UI
+work can safely connect to a personal qwen-audio-agent Gateway:
+
+- decode the versioned `qwaudio://connect#...` invitation without sending its
+  fragment to a server;
+- reject expired, contaminated, or remotely insecure Gateway origins;
+- redeem the short-lived one-time pairing code at `/api/access/pair`;
+- store only a credential reference in the connection profile and keep the
+  revocable device token in the iOS Keychain with
+  `AfterFirstUnlockThisDeviceOnly` accessibility;
+- open the authenticated `/api/realtime` WebSocket and negotiate GCP 6.0 with a
+  `mobile` `session.hello`.
+
+The package deliberately contains no Realtime-provider API key, Backend Agent
+configuration, public relay, or vendor-specific device protocol. A phone must
+reach an HTTPS Gateway endpoint through the documented Tailscale path (or an
+equivalently authenticated private deployment). Never expose the loopback
+Gateway directly to the public Internet.
+
+## Integrate
+
+Add `mobile/ios` as a local Swift package in Xcode, then handle the deep link:
+
+```swift
+let invitation = try GatewayInvitationCodec.decode(url)
+let credentials = KeychainGatewayCredentialStore()
+let profiles = UserDefaultsGatewayProfileStore()
+let outcome = try await GatewayPairingClient().pair(
+    invitation: invitation,
+    device: GatewayDevice(id: deviceID, label: UIDevice.current.name),
+    clientInstanceID: clientInstanceID,
+    credentialStore: credentials,
+    profileStore: profiles
+)
+```
+
+Connect later without displaying or copying the token:
+
+```swift
+let client = GatewaySessionClient()
+let ready = try await client.connect(
+    profile: outcome.profile,
+    credentialStore: credentials,
+    configuration: GatewaySessionConfiguration(clientInstanceID: clientInstanceID)
+)
+```
+
+The host creates the invitation locally:
+
+```bash
+qwenaudio gateway remote enable
+qwenaudio gateway remote invite
+```
+
+Install and sign in to Tailscale on both the Gateway host and iPhone before
+pairing. The invitation is short-lived and one-time. If a phone is lost, revoke
+it from the host with `qwenaudio gateway remote revoke DEVICE_ID`.
+
+## Verify
+
+```bash
+cd mobile/ios
+swift test
+```
+
+The package targets iOS 17 or later. macOS 13 is enabled only so the pure codec,
+pairing, persistence, and handshake models can run in local and CI tests.
+
+## Scope still to add
+
+RA4 still needs the user-facing iOS application: QR scanning, microphone
+capture, audio playback and interruption, text and file input, Task and
+permission surfaces, replay recovery, explicit takeover UI, and reproducible
+signed development builds. Those changes should remain separate review units.

--- a/mobile/ios/README.zh.md
+++ b/mobile/ios/README.zh.md
@@ -1,0 +1,71 @@
+# iOS Gateway Client 基础层
+
+这个 Swift Package 是
+[RA4 — Mobile Client](../../docs/roadmap/gateway-remote-access.zh.md#ra4--mobile-client)
+的第一块原生 iOS 实现。它先落地麦克风与 UI 接入之前必须具备的安全边界：
+
+- 在本地解析带版本的 `qwaudio://connect#...` 邀请，不把 URL fragment 发送给服务器；
+- 拒绝已过期、夹带额外字段或远程非 HTTPS 的 Gateway 地址；
+- 使用短时、一次性配对码请求 `/api/access/pair`；
+- Connection Profile 只保存凭据引用，可撤销的设备 Token 使用 iOS Keychain 的
+  `AfterFirstUnlockThisDeviceOnly` 级别保存；
+- 通过认证后的 `/api/realtime` WebSocket，以 `mobile` 身份发送
+  `session.hello` 并协商 GCP 6.0。
+
+这个 Package 刻意不包含 Realtime Provider API Key、后台 Agent 配置、公网 Relay
+或厂商私有设备协议。手机必须通过文档中的 Tailscale 路径（或安全性等价的私有部署）
+访问 HTTPS Gateway，不能把 loopback Gateway 直接暴露到公网。
+
+## 接入
+
+在 Xcode 中把 `mobile/ios` 添加为本地 Swift Package，然后处理深链：
+
+```swift
+let invitation = try GatewayInvitationCodec.decode(url)
+let credentials = KeychainGatewayCredentialStore()
+let profiles = UserDefaultsGatewayProfileStore()
+let outcome = try await GatewayPairingClient().pair(
+    invitation: invitation,
+    device: GatewayDevice(id: deviceID, label: UIDevice.current.name),
+    clientInstanceID: clientInstanceID,
+    credentialStore: credentials,
+    profileStore: profiles
+)
+```
+
+后续连接时不需要展示或复制 Token：
+
+```swift
+let client = GatewaySessionClient()
+let ready = try await client.connect(
+    profile: outcome.profile,
+    credentialStore: credentials,
+    configuration: GatewaySessionConfiguration(clientInstanceID: clientInstanceID)
+)
+```
+
+宿主机在本地创建邀请：
+
+```bash
+qwenaudio gateway remote enable
+qwenaudio gateway remote invite
+```
+
+配对前需要在 Gateway 宿主机和 iPhone 上安装并登录 Tailscale。邀请短时有效且只能
+使用一次；手机丢失时，在宿主机执行 `qwenaudio gateway remote revoke DEVICE_ID` 撤销。
+
+## 验证
+
+```bash
+cd mobile/ios
+swift test
+```
+
+Package 面向 iOS 17 及以上；同时声明 macOS 13 仅用于在本地和 CI 中运行纯编解码、
+配对、持久化及握手模型测试。
+
+## 后续范围
+
+RA4 后续还需要独立提交完整 iOS App：扫码、麦克风采集、音频播放与打断、文本及文件
+输入、Task 与权限界面、断线 Replay、显式接管，以及可复现的签名开发构建。这些内容
+应继续保持为可独立评审的改动。

--- a/mobile/ios/Sources/QwenAudioAgentMobile/GatewayInvitationCodec.swift
+++ b/mobile/ios/Sources/QwenAudioAgentMobile/GatewayInvitationCodec.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public enum GatewayInvitationCodec {
+    private static let allowedKeys: Set<String> = [
+        "version", "gateway_url", "pairing_code", "expires_at",
+    ]
+
+    public static func decode(_ deepLink: URL, now: Date = Date()) throws -> GatewayInvitation {
+        guard deepLink.scheme == "qwaudio",
+              deepLink.host == "connect",
+              let components = URLComponents(url: deepLink, resolvingAgainstBaseURL: false),
+              let encodedFragment = components.percentEncodedFragment,
+              let fragment = encodedFragment.removingPercentEncoding,
+              let data = fragment.data(using: .utf8),
+              let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == allowedKeys,
+              let version = object["version"] as? Int,
+              let gatewayURLValue = object["gateway_url"] as? String,
+              let gatewayURL = URL(string: gatewayURLValue),
+              let pairingCode = object["pairing_code"] as? String,
+              let expiresNumber = object["expires_at"] as? NSNumber else {
+            throw GatewayMobileError.invalidInvitation
+        }
+        let invitation = try GatewayInvitation(
+            version: version,
+            gatewayURL: gatewayURL,
+            pairingCode: pairingCode,
+            expiresAt: expiresNumber.int64Value
+        )
+        try invitation.requireActive(now: now)
+        try GatewayURLPolicy.requireSecureRemote(invitation.gatewayURL)
+        return invitation
+    }
+
+    public static func encode(_ invitation: GatewayInvitation) throws -> URL {
+        let data = try JSONEncoder.gateway.encode(invitation)
+        guard let payload = String(data: data, encoding: .utf8),
+              let encoded = payload.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed),
+              let url = URL(string: "qwaudio://connect#\(encoded)") else {
+            throw GatewayMobileError.invalidInvitation
+        }
+        return url
+    }
+}
+
+extension JSONEncoder {
+    static var gateway: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+}

--- a/mobile/ios/Sources/QwenAudioAgentMobile/GatewayModels.swift
+++ b/mobile/ios/Sources/QwenAudioAgentMobile/GatewayModels.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+public let gatewayRemoteAccessModelVersion = 1
+public let gatewayClientProtocolVersion = "6.0.0"
+
+public enum GatewayMobileError: Error, Equatable, LocalizedError, Sendable {
+    case invalidInvitation
+    case invitationExpired
+    case invalidGatewayURL
+    case insecureRemoteGateway
+    case invalidPairingResponse
+    case pairingFailed(status: Int, code: String?, message: String)
+    case missingCredential
+    case invalidServerMessage
+    case gatewayError(code: String, message: String)
+    case unexpectedReadyMessage
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidInvitation:
+            "The Gateway invitation is invalid."
+        case .invitationExpired:
+            "The Gateway invitation has expired."
+        case .invalidGatewayURL:
+            "The Gateway URL must be an HTTP origin without credentials, path, query, or fragment."
+        case .insecureRemoteGateway:
+            "A remote Gateway must use HTTPS."
+        case .invalidPairingResponse:
+            "The Gateway returned an invalid pairing response."
+        case let .pairingFailed(status, _, message):
+            "Gateway pairing failed with HTTP \(status): \(message)"
+        case .missingCredential:
+            "The Gateway credential is missing from secure storage."
+        case .invalidServerMessage:
+            "The Gateway returned an invalid protocol message."
+        case let .gatewayError(code, message):
+            "Gateway error \(code): \(message)"
+        case .unexpectedReadyMessage:
+            "The first Gateway protocol message was not session.ready."
+        }
+    }
+}
+
+public struct GatewayInvitation: Codable, Equatable, Sendable {
+    public let version: Int
+    public let gatewayURL: URL
+    public let pairingCode: String
+    public let expiresAt: Int64
+
+    public init(
+        version: Int = gatewayRemoteAccessModelVersion,
+        gatewayURL: URL,
+        pairingCode: String,
+        expiresAt: Int64
+    ) throws {
+        guard version == gatewayRemoteAccessModelVersion,
+              !pairingCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              pairingCode.count <= 256,
+              expiresAt > 0 else {
+            throw GatewayMobileError.invalidInvitation
+        }
+        self.version = version
+        self.gatewayURL = try GatewayURLPolicy.normalizedOrigin(gatewayURL)
+        self.pairingCode = pairingCode
+        self.expiresAt = expiresAt
+    }
+
+    public func requireActive(now: Date = Date()) throws {
+        guard expiresAt > Int64(now.timeIntervalSince1970 * 1_000) else {
+            throw GatewayMobileError.invitationExpired
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            version: values.decode(Int.self, forKey: .version),
+            gatewayURL: values.decode(URL.self, forKey: .gatewayURL),
+            pairingCode: values.decode(String.self, forKey: .pairingCode),
+            expiresAt: values.decode(Int64.self, forKey: .expiresAt)
+        )
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case gatewayURL = "gateway_url"
+        case pairingCode = "pairing_code"
+        case expiresAt = "expires_at"
+    }
+}
+
+public struct GatewayConnectionProfile: Codable, Equatable, Sendable {
+    public let version: Int
+    public let id: String
+    public let gatewayURL: URL
+    public let deviceID: String
+    public let credentialReference: String
+    public let clientInstanceID: String
+    public let label: String?
+
+    public init(
+        version: Int = gatewayRemoteAccessModelVersion,
+        id: String,
+        gatewayURL: URL,
+        deviceID: String,
+        credentialReference: String,
+        clientInstanceID: String,
+        label: String? = nil
+    ) throws {
+        let identifiers = [id, deviceID, credentialReference, clientInstanceID]
+        guard version == gatewayRemoteAccessModelVersion,
+              identifiers.allSatisfy({
+                  !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && $0.count <= 128
+              }),
+              label.map({
+                  !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && $0.count <= 128
+              }) ?? true else {
+            throw GatewayMobileError.invalidPairingResponse
+        }
+        self.version = version
+        self.id = id
+        self.gatewayURL = try GatewayURLPolicy.normalizedOrigin(gatewayURL)
+        self.deviceID = deviceID
+        self.credentialReference = credentialReference
+        self.clientInstanceID = clientInstanceID
+        self.label = label
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            version: values.decode(Int.self, forKey: .version),
+            id: values.decode(String.self, forKey: .id),
+            gatewayURL: values.decode(URL.self, forKey: .gatewayURL),
+            deviceID: values.decode(String.self, forKey: .deviceID),
+            credentialReference: values.decode(String.self, forKey: .credentialReference),
+            clientInstanceID: values.decode(String.self, forKey: .clientInstanceID),
+            label: values.decodeIfPresent(String.self, forKey: .label)
+        )
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case id
+        case gatewayURL = "gateway_url"
+        case deviceID = "device_id"
+        case credentialReference = "credential_ref"
+        case clientInstanceID = "client_instance_id"
+        case label
+    }
+}
+
+public struct GatewayDevice: Codable, Equatable, Sendable {
+    public let id: String
+    public let type: String
+    public let label: String?
+
+    public init(id: String, type: String = "mobile", label: String? = nil) {
+        self.id = id
+        self.type = type
+        self.label = label
+    }
+}
+
+public enum GatewayURLPolicy {
+    public static func normalizedOrigin(_ value: URL) throws -> URL {
+        guard var components = URLComponents(url: value, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              components.host != nil,
+              components.user == nil,
+              components.password == nil,
+              (components.path.isEmpty || components.path == "/"),
+              components.query == nil,
+              components.fragment == nil else {
+            throw GatewayMobileError.invalidGatewayURL
+        }
+        components.scheme = scheme
+        components.path = ""
+        guard let normalized = components.url else {
+            throw GatewayMobileError.invalidGatewayURL
+        }
+        return normalized
+    }
+
+    public static func requireSecureRemote(_ value: URL) throws {
+        let normalized = try normalizedOrigin(value)
+        guard normalized.scheme == "https" || isLiteralLoopback(normalized.host) else {
+            throw GatewayMobileError.insecureRemoteGateway
+        }
+    }
+
+    private static func isLiteralLoopback(_ host: String?) -> Bool {
+        guard let host = host?.lowercased() else { return false }
+        return ["127.0.0.1", "::1", "[::1]", "localhost"].contains(host)
+    }
+}

--- a/mobile/ios/Sources/QwenAudioAgentMobile/GatewayPairingClient.swift
+++ b/mobile/ios/Sources/QwenAudioAgentMobile/GatewayPairingClient.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+public struct GatewayPairingOutcome: Equatable, Sendable {
+    public let profile: GatewayConnectionProfile
+    public let ownerID: String
+
+    public init(profile: GatewayConnectionProfile, ownerID: String) {
+        self.profile = profile
+        self.ownerID = ownerID
+    }
+}
+
+public struct GatewayPairingClient: Sendable {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func pair(
+        invitation: GatewayInvitation,
+        device: GatewayDevice,
+        clientInstanceID: String,
+        profileID: String? = nil,
+        credentialStore: any GatewayCredentialStoring,
+        profileStore: any GatewayProfileStoring,
+        now: Date = Date()
+    ) async throws -> GatewayPairingOutcome {
+        try invitation.requireActive(now: now)
+        try GatewayURLPolicy.requireSecureRemote(invitation.gatewayURL)
+
+        let endpoint = invitation.gatewayURL.appending(path: "api/access/pair")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = try JSONEncoder.gateway.encode(PairingRequest(
+            code: invitation.pairingCode,
+            device: device
+        ))
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw GatewayMobileError.invalidPairingResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let failure = try? JSONDecoder().decode(GatewayFailure.self, from: data)
+            throw GatewayMobileError.pairingFailed(
+                status: http.statusCode,
+                code: failure?.code,
+                message: failure?.error ?? HTTPURLResponse.localizedString(forStatusCode: http.statusCode)
+            )
+        }
+        guard let paired = try? JSONDecoder().decode(PairingResponse.self, from: data),
+              !paired.accessToken.isEmpty,
+              !paired.ownerID.isEmpty,
+              !paired.device.id.isEmpty else {
+            throw GatewayMobileError.invalidPairingResponse
+        }
+
+        let credentialReference = "gateway/\(paired.device.id)"
+        let profile = try GatewayConnectionProfile(
+            id: profileID ?? device.id,
+            gatewayURL: invitation.gatewayURL,
+            deviceID: paired.device.id,
+            credentialReference: credentialReference,
+            clientInstanceID: clientInstanceID,
+            label: device.label
+        )
+
+        try await credentialStore.setCredential(paired.accessToken, for: credentialReference)
+        do {
+            try await profileStore.saveProfile(profile)
+        } catch {
+            try? await credentialStore.removeCredential(for: credentialReference)
+            throw error
+        }
+        return GatewayPairingOutcome(profile: profile, ownerID: paired.ownerID)
+    }
+}
+
+private struct PairingRequest: Encodable {
+    let code: String
+    let device: GatewayDevice
+}
+
+private struct PairingResponse: Decodable {
+    let accessToken: String
+    let ownerID: String
+    let device: GatewayDevice
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case ownerID = "owner_id"
+        case device
+    }
+}
+
+private struct GatewayFailure: Decodable {
+    let error: String?
+    let code: String?
+}

--- a/mobile/ios/Sources/QwenAudioAgentMobile/GatewaySessionClient.swift
+++ b/mobile/ios/Sources/QwenAudioAgentMobile/GatewaySessionClient.swift
@@ -1,0 +1,281 @@
+import Foundation
+
+public struct GatewaySessionConfiguration: Sendable {
+    public var sessionID: String
+    public var clientVersion: String?
+    public var clientInstanceID: String
+    public var clientLabel: String?
+    public var capabilities: [String]
+    public var locale: String?
+    public var timeZone: String?
+    public var voiceEnabled: Bool
+    public var inputEnabled: Bool
+    public var outputEnabled: Bool
+    public var textOnly: Bool
+    public var wakeWordOnly: Bool
+    public var takeover: Bool
+
+    public init(
+        sessionID: String = "main",
+        clientVersion: String? = nil,
+        clientInstanceID: String,
+        clientLabel: String? = nil,
+        capabilities: [String] = GatewayMobileCapabilities.reference,
+        locale: String? = Locale.current.identifier,
+        timeZone: String? = TimeZone.current.identifier,
+        voiceEnabled: Bool = true,
+        inputEnabled: Bool = true,
+        outputEnabled: Bool = true,
+        textOnly: Bool = false,
+        wakeWordOnly: Bool = false,
+        takeover: Bool = false
+    ) {
+        self.sessionID = sessionID
+        self.clientVersion = clientVersion
+        self.clientInstanceID = clientInstanceID
+        self.clientLabel = clientLabel
+        self.capabilities = capabilities
+        self.locale = locale
+        self.timeZone = timeZone
+        self.voiceEnabled = voiceEnabled
+        self.inputEnabled = inputEnabled
+        self.outputEnabled = outputEnabled
+        self.textOnly = textOnly
+        self.wakeWordOnly = wakeWordOnly
+        self.takeover = takeover
+    }
+}
+
+public enum GatewayMobileCapabilities {
+    public static let inputAudio = "input.audio"
+    public static let inputText = "input.text"
+    public static let inputImage = "input.image"
+    public static let inputFile = "input.file"
+    public static let playbackReceipts = "playback.receipts"
+    public static let taskCommands = "tasks.commands"
+    public static let permissionRespond = "permissions.respond"
+    public static let inputRespond = "tasks.input.respond"
+    public static let conversationHistory = "conversation.history"
+    public static let clientEvents = "client.events"
+    public static let outputVoice = "session.output_voice"
+    public static let replay = "session.replay"
+    public static let takeover = "session.takeover"
+
+    public static let reference = [
+        inputAudio,
+        inputText,
+        inputImage,
+        inputFile,
+        playbackReceipts,
+        taskCommands,
+        permissionRespond,
+        inputRespond,
+        conversationHistory,
+        clientEvents,
+        outputVoice,
+        replay,
+    ]
+}
+
+public struct GatewaySessionReady: Decodable, Equatable, Sendable {
+    public let type: String
+    public let eventID: String
+    public let requestEventID: String
+    public let protocolVersion: String
+    public let sessionID: String
+    public let capabilities: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case eventID = "event_id"
+        case requestEventID = "request_event_id"
+        case protocolVersion = "protocol_version"
+        case sessionID = "session_id"
+        case capabilities
+    }
+}
+
+public actor GatewaySessionClient {
+    private let session: URLSession
+    private var task: URLSessionWebSocketTask?
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func connect(
+        profile: GatewayConnectionProfile,
+        credentialStore: any GatewayCredentialStoring,
+        configuration: GatewaySessionConfiguration
+    ) async throws -> GatewaySessionReady {
+        guard let credential = try await credentialStore.credential(for: profile.credentialReference),
+              !credential.isEmpty else {
+            throw GatewayMobileError.missingCredential
+        }
+        try GatewayURLPolicy.requireSecureRemote(profile.gatewayURL)
+        let url = try websocketURL(baseURL: profile.gatewayURL, sessionID: configuration.sessionID)
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(credential)", forHTTPHeaderField: "Authorization")
+        let socket = session.webSocketTask(with: request)
+        task = socket
+        socket.resume()
+
+        let hello = GatewaySessionHello(configuration: configuration)
+        let helloData = try JSONEncoder.gateway.encode(hello)
+        guard let helloText = String(data: helloData, encoding: .utf8) else {
+            throw GatewayMobileError.invalidServerMessage
+        }
+        try await socket.send(.string(helloText))
+        let message = try await socket.receive()
+        let data: Data
+        switch message {
+        case let .string(value):
+            guard let value = value.data(using: .utf8) else {
+                throw GatewayMobileError.invalidServerMessage
+            }
+            data = value
+        case let .data(value):
+            data = value
+        @unknown default:
+            throw GatewayMobileError.invalidServerMessage
+        }
+        let envelope = try JSONDecoder().decode(GatewayServerEnvelope.self, from: data)
+        if envelope.type == "error" {
+            throw GatewayMobileError.gatewayError(
+                code: envelope.error?.code ?? "unknown",
+                message: envelope.error?.message ?? "Gateway rejected the session"
+            )
+        }
+        guard envelope.type == "session.ready",
+              let ready = try? JSONDecoder().decode(GatewaySessionReady.self, from: data),
+              ready.requestEventID == hello.eventID else {
+            throw GatewayMobileError.unexpectedReadyMessage
+        }
+        return ready
+    }
+
+    public func sendJSON(_ data: Data) async throws {
+        guard let task else { throw GatewayMobileError.invalidServerMessage }
+        try await task.send(.data(data))
+    }
+
+    public func receive() async throws -> URLSessionWebSocketTask.Message {
+        guard let task else { throw GatewayMobileError.invalidServerMessage }
+        return try await task.receive()
+    }
+
+    public func disconnect() {
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+    }
+
+    private func websocketURL(baseURL: URL, sessionID: String) throws -> URL {
+        guard var components = URLComponents(
+            url: baseURL.appending(path: "api/realtime"),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw GatewayMobileError.invalidGatewayURL
+        }
+        components.scheme = components.scheme == "https" ? "wss" : "ws"
+        components.queryItems = [URLQueryItem(name: "sessionId", value: sessionID)]
+        guard let url = components.url else { throw GatewayMobileError.invalidGatewayURL }
+        return url
+    }
+}
+
+struct GatewaySessionHello: Encodable {
+    let type = "session.hello"
+    let eventID: String
+    let protocolRange = ProtocolRange()
+    let client: Client
+    let capabilities: [String]
+    let locale: String?
+    let timeZone: String?
+    let connection: Connection
+
+    init(configuration: GatewaySessionConfiguration, eventID: String? = nil) {
+        self.eventID = eventID
+            ?? "evt_mobile_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
+        client = Client(
+            type: "mobile",
+            version: configuration.clientVersion,
+            instanceID: configuration.clientInstanceID,
+            label: configuration.clientLabel
+        )
+        var requested = Array(Set(configuration.capabilities)).sorted()
+        if configuration.takeover && !requested.contains(GatewayMobileCapabilities.takeover) {
+            requested.append(GatewayMobileCapabilities.takeover)
+        }
+        capabilities = requested
+        locale = configuration.locale
+        timeZone = configuration.timeZone
+        connection = Connection(configuration: configuration)
+    }
+
+    struct ProtocolRange: Encodable {
+        let min = gatewayClientProtocolVersion
+        let max = gatewayClientProtocolVersion
+    }
+
+    struct Client: Encodable {
+        let type: String
+        let version: String?
+        let instanceID: String
+        let label: String?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case version
+            case instanceID = "instance_id"
+            case label
+        }
+    }
+
+    struct Connection: Encodable {
+        let voiceEnabled: Bool
+        let inputEnabled: Bool
+        let outputEnabled: Bool
+        let textOnly: Bool
+        let wakeWordOnly: Bool
+        let takeover: Bool
+
+        init(configuration: GatewaySessionConfiguration) {
+            voiceEnabled = configuration.voiceEnabled
+            inputEnabled = configuration.inputEnabled
+            outputEnabled = configuration.outputEnabled
+            textOnly = configuration.textOnly
+            wakeWordOnly = configuration.wakeWordOnly
+            takeover = configuration.takeover
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case voiceEnabled = "voice_enabled"
+            case inputEnabled = "input_enabled"
+            case outputEnabled = "output_enabled"
+            case textOnly = "text_only"
+            case wakeWordOnly = "wake_word_only"
+            case takeover
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case eventID = "event_id"
+        case protocolRange = "protocol"
+        case client
+        case capabilities
+        case locale
+        case timeZone = "time_zone"
+        case connection
+    }
+}
+
+private struct GatewayServerEnvelope: Decodable {
+    let type: String
+    let error: GatewayProtocolFailure?
+}
+
+private struct GatewayProtocolFailure: Decodable {
+    let code: String
+    let message: String
+}

--- a/mobile/ios/Sources/QwenAudioAgentMobile/GatewayStores.swift
+++ b/mobile/ios/Sources/QwenAudioAgentMobile/GatewayStores.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Security
+
+public protocol GatewayCredentialStoring: Sendable {
+    func credential(for reference: String) async throws -> String?
+    func setCredential(_ credential: String, for reference: String) async throws
+    func removeCredential(for reference: String) async throws
+}
+
+public protocol GatewayProfileStoring: Sendable {
+    func profile(id: String) async throws -> GatewayConnectionProfile?
+    func saveProfile(_ profile: GatewayConnectionProfile) async throws
+    func removeProfile(id: String) async throws
+}
+
+public actor KeychainGatewayCredentialStore: GatewayCredentialStoring {
+    private let service: String
+
+    public init(service: String = "org.qwen.audio-agent.gateway") {
+        self.service = service
+    }
+
+    public func credential(for reference: String) throws -> String? {
+        var query = baseQuery(reference: reference)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            throw KeychainError(status: status)
+        }
+        return value
+    }
+
+    public func setCredential(_ credential: String, for reference: String) throws {
+        guard !credential.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let data = credential.data(using: .utf8) else {
+            throw GatewayMobileError.missingCredential
+        }
+        let query = baseQuery(reference: reference)
+        let updates: [String: Any] = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, updates as CFDictionary)
+        if updateStatus == errSecSuccess { return }
+        guard updateStatus == errSecItemNotFound else {
+            throw KeychainError(status: updateStatus)
+        }
+        var item = query
+        item[kSecValueData as String] = data
+        item[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let addStatus = SecItemAdd(item as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw KeychainError(status: addStatus)
+        }
+    }
+
+    public func removeCredential(for reference: String) throws {
+        let status = SecItemDelete(baseQuery(reference: reference) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError(status: status)
+        }
+    }
+
+    private func baseQuery(reference: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: reference,
+        ]
+    }
+}
+
+public struct KeychainError: Error, LocalizedError, Sendable {
+    public let status: OSStatus
+
+    public var errorDescription: String? {
+        SecCopyErrorMessageString(status, nil) as String? ?? "Keychain error \(status)"
+    }
+}
+
+public actor UserDefaultsGatewayProfileStore: GatewayProfileStoring {
+    private let defaults: UserDefaults
+    private let key: String
+
+    public init(
+        defaults: UserDefaults = .standard,
+        key: String = "qwenAudioAgent.gatewayConnectionProfiles"
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    public func profile(id: String) throws -> GatewayConnectionProfile? {
+        try profiles().first(where: { $0.id == id })
+    }
+
+    public func saveProfile(_ profile: GatewayConnectionProfile) throws {
+        var values = try profiles()
+        if let index = values.firstIndex(where: { $0.id == profile.id }) {
+            values[index] = profile
+        } else {
+            values.append(profile)
+        }
+        defaults.set(try JSONEncoder.gateway.encode(values), forKey: key)
+    }
+
+    public func removeProfile(id: String) throws {
+        let values = try profiles().filter { $0.id != id }
+        defaults.set(try JSONEncoder.gateway.encode(values), forKey: key)
+    }
+
+    private func profiles() throws -> [GatewayConnectionProfile] {
+        guard let data = defaults.data(forKey: key) else { return [] }
+        return try JSONDecoder().decode([GatewayConnectionProfile].self, from: data)
+    }
+}

--- a/mobile/ios/Tests/QwenAudioAgentMobileTests/GatewayInvitationCodecTests.swift
+++ b/mobile/ios/Tests/QwenAudioAgentMobileTests/GatewayInvitationCodecTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import QwenAudioAgentMobile
+
+@Suite("Gateway invitation codec")
+struct GatewayInvitationCodecTests {
+    private let future = Date(timeIntervalSince1970: 1_799_999_000)
+
+    @Test("round trips the canonical deep link")
+    func roundTrip() throws {
+        let invitation = try GatewayInvitation(
+            gatewayURL: #require(URL(string: "https://phone.example.ts.net")),
+            pairingCode: "one-time-code",
+            expiresAt: 1_800_000_000_000
+        )
+        let encoded = try GatewayInvitationCodec.encode(invitation)
+        #expect(try GatewayInvitationCodec.decode(encoded, now: future) == invitation)
+        #expect(encoded.absoluteString.hasPrefix("qwaudio://connect#"))
+    }
+
+    @Test("rejects expired invitations")
+    func rejectsExpired() throws {
+        let invitation = try GatewayInvitation(
+            gatewayURL: #require(URL(string: "https://phone.example.ts.net")),
+            pairingCode: "expired-code",
+            expiresAt: 1_700_000_000_000
+        )
+        let encoded = try GatewayInvitationCodec.encode(invitation)
+        #expect(throws: GatewayMobileError.invitationExpired) {
+            try GatewayInvitationCodec.decode(encoded, now: future)
+        }
+    }
+
+    @Test("rejects public plaintext and contaminated origins")
+    func rejectsUnsafeOrigins() throws {
+        let plaintext = try GatewayInvitation(
+            gatewayURL: #require(URL(string: "http://gateway.example.test")),
+            pairingCode: "temporary",
+            expiresAt: 1_800_000_000_000
+        )
+        #expect(throws: GatewayMobileError.insecureRemoteGateway) {
+            try GatewayURLPolicy.requireSecureRemote(plaintext.gatewayURL)
+        }
+        for value in [
+            "https://user:secret@gateway.example.test",
+            "https://gateway.example.test/path",
+            "https://gateway.example.test?token=secret",
+        ] {
+            #expect(throws: GatewayMobileError.invalidGatewayURL) {
+                _ = try GatewayInvitation(
+                    gatewayURL: #require(URL(string: value)),
+                    pairingCode: "temporary",
+                    expiresAt: 1_800_000_000_000
+                )
+            }
+        }
+    }
+
+    @Test("rejects unknown invitation fields")
+    func rejectsUnknownFields() throws {
+        let payload = """
+        {"version":1,"gateway_url":"https://gateway.example.test","pairing_code":"temporary","expires_at":1800000000000,"access_token":"must-not-enter-a-qr-code"}
+        """
+        let encoded = try #require(
+            payload.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)
+        )
+        let url = try #require(URL(string: "qwaudio://connect#\(encoded)"))
+        #expect(throws: GatewayMobileError.invalidInvitation) {
+            try GatewayInvitationCodec.decode(url, now: future)
+        }
+    }
+}

--- a/mobile/ios/Tests/QwenAudioAgentMobileTests/GatewayPairingClientTests.swift
+++ b/mobile/ios/Tests/QwenAudioAgentMobileTests/GatewayPairingClientTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+@testable import QwenAudioAgentMobile
+
+@Suite("Gateway pairing client", .serialized)
+struct GatewayPairingClientTests {
+    @Test("redeems once and separates the token from the profile")
+    func pairsAndPersistsSecurely() async throws {
+        let credentials = MemoryCredentialStore()
+        let profiles = MemoryProfileStore()
+        let session = URLSession(configuration: MockURLProtocol.configuration { request in
+            #expect(request.url?.absoluteString == "https://gateway.example.test/api/access/pair")
+            #expect(request.httpMethod == "POST")
+            let requestBody = try request.bodyData()
+            let object = try #require(
+                JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+            )
+            #expect(object["code"] as? String == "one-time-code")
+            let device = try #require(object["device"] as? [String: Any])
+            #expect(device["type"] as? String == "mobile")
+            let body = Data(#"{"access_token":"qwa_device_secret","owner_id":"user_personal","device":{"id":"device_phone","type":"mobile","label":"My iPhone"}}"#.utf8)
+            return (
+                HTTPURLResponse(
+                    url: try #require(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["content-type": "application/json"]
+                )!,
+                body
+            )
+        })
+        let invitation = try GatewayInvitation(
+            gatewayURL: #require(URL(string: "https://gateway.example.test")),
+            pairingCode: "one-time-code",
+            expiresAt: 1_800_000_000_000
+        )
+
+        let outcome = try await GatewayPairingClient(session: session).pair(
+            invitation: invitation,
+            device: GatewayDevice(id: "phone", label: "My iPhone"),
+            clientInstanceID: "mobile-instance",
+            credentialStore: credentials,
+            profileStore: profiles,
+            now: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        #expect(outcome.ownerID == "user_personal")
+        #expect(outcome.profile.deviceID == "device_phone")
+        #expect(outcome.profile.credentialReference == "gateway/device_phone")
+        #expect(await credentials.credential(for: "gateway/device_phone") == "qwa_device_secret")
+        #expect(await profiles.profile(id: "phone") == outcome.profile)
+        let serialized = String(data: try JSONEncoder.gateway.encode(outcome.profile), encoding: .utf8)
+        #expect(serialized?.contains("qwa_device_secret") == false)
+    }
+
+    @Test("rolls back the credential when profile persistence fails")
+    func rollsBackCredential() async throws {
+        let credentials = MemoryCredentialStore()
+        let profiles = MemoryProfileStore(shouldFail: true)
+        let session = URLSession(configuration: MockURLProtocol.configuration { request in
+            let body = Data(#"{"access_token":"qwa_device_secret","owner_id":"user_personal","device":{"id":"device_phone","type":"mobile"}}"#.utf8)
+            return (
+                HTTPURLResponse(
+                    url: try #require(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!,
+                body
+            )
+        })
+        let invitation = try GatewayInvitation(
+            gatewayURL: #require(URL(string: "https://gateway.example.test")),
+            pairingCode: "one-time-code",
+            expiresAt: 1_800_000_000_000
+        )
+
+        await #expect(throws: TestFailure.self) {
+            _ = try await GatewayPairingClient(session: session).pair(
+                invitation: invitation,
+                device: GatewayDevice(id: "phone"),
+                clientInstanceID: "mobile-instance",
+                credentialStore: credentials,
+                profileStore: profiles,
+                now: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+        }
+        #expect(await credentials.credential(for: "gateway/device_phone") == nil)
+    }
+}
+
+private actor MemoryCredentialStore: GatewayCredentialStoring {
+    private var values: [String: String] = [:]
+
+    func credential(for reference: String) -> String? { values[reference] }
+    func setCredential(_ credential: String, for reference: String) { values[reference] = credential }
+    func removeCredential(for reference: String) { values.removeValue(forKey: reference) }
+}
+
+private actor MemoryProfileStore: GatewayProfileStoring {
+    private var values: [String: GatewayConnectionProfile] = [:]
+    private let shouldFail: Bool
+
+    init(shouldFail: Bool = false) { self.shouldFail = shouldFail }
+
+    func profile(id: String) -> GatewayConnectionProfile? { values[id] }
+    func saveProfile(_ profile: GatewayConnectionProfile) throws {
+        if shouldFail { throw TestFailure() }
+        values[profile.id] = profile
+    }
+    func removeProfile(id: String) { values.removeValue(forKey: id) }
+}
+
+private struct TestFailure: Error {}
+
+private extension URLRequest {
+    func bodyData() throws -> Data {
+        if let httpBody { return httpBody }
+        guard let stream = httpBodyStream else { throw TestFailure() }
+        stream.open()
+        defer { stream.close() }
+        var result = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count < 0 { throw stream.streamError ?? TestFailure() }
+            if count == 0 { break }
+            result.append(buffer, count: count)
+        }
+        return result
+    }
+}
+
+private final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+    typealias Handler = @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+    private nonisolated(unsafe) static var handler: Handler?
+
+    static func configuration(handler: @escaping Handler) -> URLSessionConfiguration {
+        self.handler = handler
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return configuration
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            guard let handler = Self.handler else { throw TestFailure() }
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/mobile/ios/Tests/QwenAudioAgentMobileTests/GatewaySessionModelsTests.swift
+++ b/mobile/ios/Tests/QwenAudioAgentMobileTests/GatewaySessionModelsTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import QwenAudioAgentMobile
+
+@Suite("Gateway session models")
+struct GatewaySessionModelsTests {
+    @Test("encodes a mobile GCP 6.0 hello")
+    func encodesHello() throws {
+        let configuration = GatewaySessionConfiguration(
+            clientVersion: "0.1.0",
+            clientInstanceID: "mobile_phone",
+            clientLabel: "My iPhone",
+            capabilities: [GatewayMobileCapabilities.inputAudio],
+            takeover: true
+        )
+        let hello = GatewaySessionHello(configuration: configuration, eventID: "evt_mobile")
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder.gateway.encode(hello)) as? [String: Any]
+        )
+        #expect(object["type"] as? String == "session.hello")
+        #expect(object["event_id"] as? String == "evt_mobile")
+        let client = try #require(object["client"] as? [String: Any])
+        #expect(client["type"] as? String == "mobile")
+        let capabilities = try #require(object["capabilities"] as? [String])
+        #expect(capabilities.contains(GatewayMobileCapabilities.takeover))
+    }
+
+    @Test("decodes the GCP 6.0 ready envelope")
+    func decodesReady() throws {
+        let data = Data(#"{"type":"session.ready","event_id":"evt_server","request_event_id":"evt_mobile","protocol_version":"6.0.0","session_id":"main","capabilities":["input.audio","session.replay"]}"#.utf8)
+        let ready = try JSONDecoder().decode(GatewaySessionReady.self, from: data)
+        #expect(ready.type == "session.ready")
+        #expect(ready.protocolVersion == gatewayClientProtocolVersion)
+        #expect(ready.capabilities == ["input.audio", "session.replay"])
+    }
+
+    @Test("connection profiles never serialize credentials")
+    func profileContainsOnlyReference() throws {
+        let profile = try GatewayConnectionProfile(
+            id: "phone",
+            gatewayURL: #require(URL(string: "https://gateway.example.test")),
+            deviceID: "device_phone",
+            credentialReference: "keychain/device_phone",
+            clientInstanceID: "mobile_phone",
+            label: "My iPhone"
+        )
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder.gateway.encode(profile)) as? [String: Any]
+        )
+        #expect(object["credential_ref"] as? String == "keychain/device_phone")
+        #expect(object["access_token"] == nil)
+    }
+
+    @Test("rejects invalid persisted connection profiles")
+    func rejectsInvalidPersistedProfile() {
+        let data = Data(#"{"version":2,"id":"phone","gateway_url":"https://gateway.example.test","device_id":"device_phone","credential_ref":"keychain/device_phone","client_instance_id":"mobile_phone"}"#.utf8)
+        #expect(throws: (any Error).self) {
+            _ = try JSONDecoder().decode(GatewayConnectionProfile.self, from: data)
+        }
+    }
+}


### PR DESCRIPTION
## 变更说明

这是 RA4 Mobile Client 的第一个原生 iOS 基础切片，为后续麦克风、音频播放和任务 UI 提供安全的 Gateway 接入边界：

- 新增独立的 Swift Package（iOS 17+），严格解析版本化的 `qwaudio://connect#...` 邀请；
- 校验邀请有效期、字段和 Gateway origin，远程连接仅允许 HTTPS，明文 HTTP 仅允许 loopback；
- 通过 `/api/access/pair` 兑换一次性 pairing code，将可撤销 token 存入 iOS Keychain；
- 持久化 profile 只保存 credential reference，不序列化 token；
- 通过带 Bearer 认证的 `/api/realtime` WebSocket 完成 GCP 6.0 `session.hello` / `session.ready` 握手；
- 补充中英文集成文档、RA4 roadmap checkpoint、CHANGELOG 和 macOS CI 中的 Swift/iOS 构建检查。

本 PR 刻意不包含 Realtime provider API Key、Backend Agent 配置、公共中继或厂商设备协议。完整 iOS App 的扫码、麦克风、播放、任务与权限 UI 将拆分为后续可审查的 PR。

## 验证

- [ ] `npm test`
  - root、server（1045/1045）和 web（106/106）通过；
  - TUI 为 54/56，两个失败来自非交互终端下的 composer/paste 测试，与本次不涉及 TUI 的 diff 无关。
- [x] `npm run lint`
- [x] `npm run build`
- [x] 行为变化已补充测试或说明无法自动测试的原因
- [x] `cd mobile/ios && swift test`（10 tests / 3 suites）
- [x] unsigned generic iOS build（iOS 17, arm64）
- [x] `npm run docs:build`

## 兼容性与安全

- [x] 未提交密钥、用户数据、日志或内部地址
- [x] 配置、用户可见行为和依赖变化已同步更新文档
- [x] 已说明网络、权限、隐私、持久化或发布流程影响；不适用时请注明

安全边界：

- 邀请凭据保留在 URL fragment，本地解析，不发送给服务器；
- 设备 token 使用 `AfterFirstUnlockThisDeviceOnly` Keychain 可访问性；
- profile 持久化失败时回滚已写入的 credential；
- 不开放公网裸 Gateway，文档要求使用 Tailscale 或等价的已认证私有部署；
- 回滚方式为移除 `mobile/ios` package 及对应 CI job，不影响现有 Web/Desktop/TUI 客户端。
