### PR TITLE
feat: add LightRAG knowledge provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ chat naturally and get real work done.
 | Desktop | Voice chat, progress follow-up, tools, and background tasks. | [Docs][desktop-docs] | Available |
 | Smart cockpit | Vehicle control, navigation, music, weather, and services. | [Example][smart-cockpit-example] | Available |
 | VoiceMem | Optional semantic memory with transcript or native-audio input. | [Setup example][voicemem-example] | Available |
+| LightRAG | Replaceable knowledge base with semantic retrieval, document indexing, and management. | [Integration example][lightrag-example] | Available |
 | Customer support | Issue clarification, order lookup, tickets, and human handoff. | TBD | Planned |
 | Embodied intelligence | Voice commands, action execution, inspection, and exception feedback. | TBD | Planned |
 | Livestream assistant | Audience interaction, product explanation, coupons, and risk reminders. | TBD | Exploratory |
@@ -196,9 +197,15 @@ shows how to install VoiceMem outside the framework, configure the connector, an
 Realtime transcripts and VoiceMem-native audio. Lightweight Markdown memory remains the default;
 the core npm package contains no VoiceMem Python code or dependencies.
 
+The [LightRAG integration example](https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/lightrag)
+connects an independently deployed knowledge base through the generic `KnowledgeProvider`.
+LightRAG keeps control of its LLM, embeddings, documents, and indexes; the core npm package does
+not include LightRAG or Python dependencies.
+
 [desktop-docs]: docs/desktop/overview.md
 [smart-cockpit-example]: examples/smart-cockpit
 [voicemem-example]: https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/voicemem
+[lightrag-example]: https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/lightrag
 
 ## Community
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -161,6 +161,7 @@ npm run desktop:build:linux      # Linux（AppImage + deb，无需签名）
 | 桌面办公 | 实时语音交流、进度追问、工具调用和后台任务执行。 | [文档][desktop-docs-zh] | 已提供 |
 | 智能座舱 | 车控、导航、音乐、天气和生活服务。 | [示例][smart-cockpit-example] | 已提供 |
 | VoiceMem | 可选语义记忆，支持转写文本或原生音频输入。 | [配置示例][voicemem-example] | 已提供 |
+| LightRAG | 可替换知识库，支持语义检索、文档索引和管理。 | [接入示例][lightrag-example] | 已提供 |
 | 客服助手 | 问题澄清、订单查询、工单处理和人工转接。 | 待补充 | 规划中 |
 | 具身智能 | 语音指令、动作执行、巡检和异常反馈。 | 待补充 | 规划中 |
 | 直播助手 | 弹幕互动、商品讲解、优惠发放和风险提醒。 | 待补充 | 探索中 |
@@ -181,9 +182,14 @@ npm run example:smart-cockpit          # 同时启动 service、agent、gateway 
 原生音频处理之间切换。默认仍使用轻量 Markdown 记忆；核心 npm 包不包含 VoiceMem
 Python 代码或依赖。
 
+[LightRAG 接入示例](https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/lightrag)
+展示了如何通过通用 `KnowledgeProvider` 连接用户独立部署的知识库。LightRAG 继续管理
+自己的 LLM、Embedding、文档和索引，核心 npm 包不包含 LightRAG 或 Python 依赖。
+
 [desktop-docs-zh]: docs/desktop/overview.zh.md
 [smart-cockpit-example]: examples/smart-cockpit
 [voicemem-example]: https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/voicemem
+[lightrag-example]: https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/lightrag
 
 ## 交流与分享
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -104,6 +104,7 @@ function sidebar(prefix = '') {
       items: [
         { text: t('智能座舱', 'Smart Cockpit'), link: `${prefix}/scenarios/smart-cockpit` },
         { text: 'VoiceMem', link: `${prefix}/scenarios/voicemem` },
+        { text: 'LightRAG', link: `${prefix}/scenarios/lightrag` },
       ],
     },
     {

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -29,6 +29,10 @@ stack — connect the knowledge system you already operate.
 
 → [Knowledge Retrieval Provider](reference/knowledge.md)
 
+The [LightRAG integration example](scenarios/lightrag.md) shows how to connect a complete,
+independently deployed knowledge system while leaving its models, indexes, and data under
+LightRAG's control.
+
 ## Backend: Connect a New Agent
 
 Four paths put a backend behind the protocol-neutral `BackendPort`: the

--- a/docs/extensions.zh.md
+++ b/docs/extensions.zh.md
@@ -27,6 +27,9 @@ Provider 注册表。
 
 → [知识检索 Provider](reference/knowledge.zh.md)
 
+[LightRAG 接入示例](scenarios/lightrag.zh.md)展示了如何连接用户独立部署的完整知识库，
+同时让模型配置、索引和数据继续由 LightRAG 自己管理。
+
 ## 后台：接入新 Agent
 
 四条路径把后台接到协议中立的 `BackendPort` 之后：零代码的通用 ACP

--- a/docs/reference/knowledge.md
+++ b/docs/reference/knowledge.md
@@ -144,10 +144,32 @@ await provider.list({}, { ownerId })
 await provider.remove({ documentId: 'doc-42' }, { ownerId })
 ```
 
+The three management methods use stable minimal response shapes:
+
+```js
+ingest() // { document: { id, title, ... } }
+list()   // { documents: [{ id, title, ... }] }
+remove() // { removed: true, document: { id, title, ... } }
+```
+
+The Gateway normalizes `id`, `title`, `filename`, `status`, timestamps, summaries, and bounded
+metadata. Clients never need to understand provider-native objects. Remote job IDs, graph
+objects, and raw responses must not enter these values.
+
 `ingest()` returns a Promise. The Gateway uses its own TaskManager for queueing,
 cancellation, and status, so a Provider does not need another ingestion-job
 protocol. If a remote service indexes asynchronously, its Adapter can wait or
 poll inside `ingest()` and stop when `signal` is aborted.
+
+A remote Provider that needs a longer retrieval window can configure the generic runtime at
+the composition root:
+
+```js
+createGatewayApplication({
+  knowledgeProvider: provider,
+  knowledgeRuntimeOptions: { timeoutMs: 60_000 },
+})
+```
 
 ## Built-in basic implementation
 
@@ -194,6 +216,11 @@ An Adapter only translates fields and calls:
 
 Vendor clients, remote job IDs, vector-store collection IDs, and raw responses
 stay inside the Adapter and never cross into the Gateway, Realtime, or clients.
+
+The repository's
+[`examples/lightrag`](https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/lightrag)
+is a complete external Provider example. It uses the LightRAG REST API for retrieval, upload,
+listing, and deletion, and collapses asynchronous indexing into this interface.
 
 For the matching concepts in established frameworks, see the
 [LlamaIndex Ingestion Pipeline](https://developers.llamaindex.ai/python/framework/module_guides/loading/ingestion_pipeline/)

--- a/docs/reference/knowledge.zh.md
+++ b/docs/reference/knowledge.zh.md
@@ -137,9 +137,30 @@ await provider.list({}, { ownerId })
 await provider.remove({ documentId: 'doc-42' }, { ownerId })
 ```
 
+三种管理方法使用稳定的最小返回结构：
+
+```js
+ingest() // { document: { id, title, ... } }
+list()   // { documents: [{ id, title, ... }] }
+remove() // { removed: true, document: { id, title, ... } }
+```
+
+Gateway 会统一规范化 `id`、`title`、`filename`、`status`、时间、摘要和有界元数据，
+客户端不需要理解供应商对象。Provider 的远程 Job ID、图谱对象和原始响应不能放进
+这些返回值。
+
 `ingest()` 返回 Promise。Gateway 使用自己的 TaskManager 提供排队、取消和状态，不要求
 Provider 再实现一套入库 Job 协议。远程知识服务自身若异步建索引，其 Adapter 在
 `ingest()` 内等待或轮询，收到 `signal` 后停止即可。
+
+远程 Provider 需要更长检索时间时，可在组合根设置通用运行时选项：
+
+```js
+createGatewayApplication({
+  knowledgeProvider: provider,
+  knowledgeRuntimeOptions: { timeoutMs: 60_000 },
+})
+```
 
 ## 内置基础实现
 
@@ -182,6 +203,10 @@ Adapter 只做字段和调用方式转换：
 
 供应商 Client、远程 Job ID、向量库 Collection ID 和原始响应对象都留在 Adapter 内，
 不能泄漏到 Gateway、Realtime 或客户端。
+
+仓库中的 [`examples/lightrag`](https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/lightrag)
+是完整的外部 Provider 示例：它使用 LightRAG REST API 完成检索、上传、列表和删除，
+并把异步索引状态收敛到上述接口。
 
 主流框架的对应概念可参考 [LlamaIndex Ingestion Pipeline](https://developers.llamaindex.ai/python/framework/module_guides/loading/ingestion_pipeline/)
 与 [Haystack DocumentWriter](https://docs.haystack.deepset.ai/docs/documentwriter)。

--- a/docs/scenarios/lightrag.md
+++ b/docs/scenarios/lightrag.md
@@ -1,0 +1,97 @@
+# LightRAG Knowledge Base
+
+qwen-audio-agent can use an independently operated
+[LightRAG](https://github.com/HKUDS/LightRAG) instance as frontend knowledge. LightRAG owns
+document parsing, embeddings, indexing, and retrieval; the Gateway calls it only through the
+`KnowledgeProvider` boundary.
+
+## When to use it
+
+- You want richer semantic and graph retrieval than the built-in keyword library.
+- You already use LightRAG and want the voice frontend to reuse its documents and model setup.
+- You want the knowledge system to evolve or be replaced independently of Realtime and clients.
+
+## Prepare LightRAG
+
+LightRAG requires an independently configured LLM and embedding model. Either can run locally or
+through an OpenAI-compatible service. Install the Server with `uv`:
+
+```bash
+uv tool install "lightrag-hku[api]"
+```
+
+Create `.env` in the LightRAG working directory with this general shape:
+
+```dotenv
+LLM_BINDING=openai
+LLM_BINDING_HOST=https://your-openai-compatible-service.example/v1
+LLM_BINDING_API_KEY=your_llm_key
+LLM_MODEL=your_llm_model
+
+EMBEDDING_BINDING=openai
+EMBEDDING_BINDING_HOST=https://your-openai-compatible-service.example/v1
+EMBEDDING_BINDING_API_KEY=your_embedding_key
+EMBEDDING_MODEL=your_embedding_model
+EMBEDDING_DIM=1024
+
+LIGHTRAG_API_KEY=your_lightrag_api_key
+```
+
+The embedding dimension must match the model. Follow the
+[official LightRAG documentation](https://github.com/HKUDS/LightRAG/blob/main/docs/LightRAG-API-Server.md)
+for the complete configuration. Start a localhost-only service:
+
+```bash
+lightrag-server --host 127.0.0.1 --port 9621
+```
+
+## Run the integration example
+
+From a qwen-audio-agent source checkout:
+
+```bash
+cp examples/lightrag/.env.example examples/lightrag/.env.local
+```
+
+Set the voice frontend and LightRAG connection values:
+
+```dotenv
+DASHSCOPE_API_KEY=your_dashscope_api_key
+LIGHTRAG_URL=http://127.0.0.1:9621
+LIGHTRAG_API_KEY=your_lightrag_api_key
+LIGHTRAG_WORKSPACE=
+LIGHTRAG_QUERY_MODE=mix
+```
+
+Start the example:
+
+```bash
+node --env-file=examples/lightrag/.env.local examples/lightrag/gateway.mjs
+```
+
+Open `http://127.0.0.1:3101`, import a file from the Knowledge Library panel, wait for indexing,
+then query it by voice or text. This isolated example uses frontend-only mode and does not start
+a backend Agent.
+
+`DASHSCOPE_API_KEY` belongs only to the voice frontend. LightRAG keeps its LLM and embedding
+configuration in its own process. qwen-audio-agent does not install, start, or modify LightRAG.
+
+## Data and task boundaries
+
+- The Gateway obtains raw chunks from `/query/data`; the voice frontend generates the answer.
+- LightRAG `track_id` values, graph objects, and HTTP responses do not reach the client or model.
+- Upload and deletion are asynchronous inside LightRAG, but the Gateway reports success only
+  after real completion.
+- Cancelling a Gateway ingestion task stops waiting without invoking a global pipeline cancel
+  that could affect other documents.
+- Users remain responsible for LightRAG documents, indexes, credentials, and workspace storage.
+
+See [`examples/lightrag`](https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/lightrag)
+for the full code and configuration reference.
+
+## Authors and acknowledgements
+
+- Thanks to [the LightRAG project and its contributors](https://github.com/HKUDS/LightRAG) for
+  open-sourcing the document processing, knowledge graph, and retrieval capabilities.
+- [Li Xu](https://github.com/x-lixu) designed the replaceable `KnowledgeProvider` boundary and
+  implemented this integration example.

--- a/docs/scenarios/lightrag.zh.md
+++ b/docs/scenarios/lightrag.zh.md
@@ -1,0 +1,92 @@
+# LightRAG 知识库
+
+qwen-audio-agent 可以把用户独立运行的
+[LightRAG](https://github.com/HKUDS/LightRAG) 作为前台知识库。LightRAG 负责文档解析、
+Embedding、索引和检索，Gateway 只通过 `KnowledgeProvider` 调用它。
+
+## 适合什么场景
+
+- 希望获得比内置关键词资料库更完整的语义与图谱检索。
+- 已经在使用 LightRAG，希望语音前台复用现有文档和模型配置。
+- 希望知识库可以独立升级或替换，不修改 Realtime 和客户端。
+
+## 准备 LightRAG
+
+LightRAG 必须独立配置一个 LLM 和一个 Embedding 模型。模型可以部署在本地，也可以使用
+OpenAI 兼容服务。推荐通过 `uv` 安装 Server：
+
+```bash
+uv tool install "lightrag-hku[api]"
+```
+
+在 LightRAG 的运行目录创建 `.env`，填写以下类型的配置：
+
+```dotenv
+LLM_BINDING=openai
+LLM_BINDING_HOST=https://your-openai-compatible-service.example/v1
+LLM_BINDING_API_KEY=your_llm_key
+LLM_MODEL=your_llm_model
+
+EMBEDDING_BINDING=openai
+EMBEDDING_BINDING_HOST=https://your-openai-compatible-service.example/v1
+EMBEDDING_BINDING_API_KEY=your_embedding_key
+EMBEDDING_MODEL=your_embedding_model
+EMBEDDING_DIM=1024
+
+LIGHTRAG_API_KEY=your_lightrag_api_key
+```
+
+Embedding 维度必须与模型一致。完整配置以
+[LightRAG 官方文档](https://github.com/HKUDS/LightRAG/blob/main/docs/LightRAG-API-Server.md)
+为准。启动本机服务：
+
+```bash
+lightrag-server --host 127.0.0.1 --port 9621
+```
+
+## 运行接入示例
+
+在 qwen-audio-agent 源码目录执行：
+
+```bash
+cp examples/lightrag/.env.example examples/lightrag/.env.local
+```
+
+填写语音前台和 LightRAG 连接信息：
+
+```dotenv
+DASHSCOPE_API_KEY=your_dashscope_api_key
+LIGHTRAG_URL=http://127.0.0.1:9621
+LIGHTRAG_API_KEY=your_lightrag_api_key
+LIGHTRAG_WORKSPACE=
+LIGHTRAG_QUERY_MODE=mix
+```
+
+启动：
+
+```bash
+node --env-file=examples/lightrag/.env.local examples/lightrag/gateway.mjs
+```
+
+打开 `http://127.0.0.1:3101`，在资料库面板中导入文件，等待索引完成后即可通过语音或
+文字查询。这个示例使用仅前台模式，不会启动后台 Agent。
+
+`DASHSCOPE_API_KEY` 只用于语音前台；LightRAG 的 LLM 和 Embedding 配置保留在它自己的
+进程中。qwen-audio-agent 不会安装、启动或修改 LightRAG。
+
+## 数据与任务边界
+
+- Gateway 使用 `/query/data` 获取原始检索片段，最终回答由语音前台生成。
+- LightRAG 的 `track_id`、图谱对象和 HTTP 响应不暴露给客户端或模型。
+- 上传和删除虽然在 LightRAG 内部异步执行，但 Gateway 只在真实完成后报告成功。
+- 取消 Gateway 入库任务会停止等待，不会调用可能影响其他文档的全局索引取消操作。
+- LightRAG 的文档、索引、模型凭据和 workspace 均由用户自行保存和管理。
+
+完整代码与全部配置项见
+[`examples/lightrag`](https://github.com/QwenAudio/qwen-audio-agent/tree/main/examples/lightrag)。
+
+## 作者与致谢
+
+- 感谢 [LightRAG 项目及其贡献者](https://github.com/HKUDS/LightRAG)创建并开源文档处理、
+  知识图谱和检索能力。
+- [Li Xu](https://github.com/x-lixu) 设计可替换的 `KnowledgeProvider` 边界并实现本接入示例。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ export default [
       '**/coverage/**',
       'docs/.vitepress/cache/**',
       'docs/.vitepress/.site/**',
-      'examples/**',
+      'examples/!(lightrag)/**',
       'tui/native/**',
       'mobile/android/app/src/main/assets/public/**',
       'mobile/ios/App/App/public/**',

--- a/examples/lightrag/.env.example
+++ b/examples/lightrag/.env.example
@@ -1,0 +1,15 @@
+# qwen-audio-agent voice frontend. The LightRAG process has its own model and
+# embedding configuration; do not duplicate those settings here.
+DASHSCOPE_API_KEY=your_dashscope_api_key
+AGENT_PROTOCOL=none
+
+LIGHTRAG_URL=http://127.0.0.1:9621
+LIGHTRAG_API_KEY=
+LIGHTRAG_WORKSPACE=
+# local | global | hybrid | naive | mix
+LIGHTRAG_QUERY_MODE=mix
+LIGHTRAG_RETRIEVAL_TIMEOUT_MS=60000
+LIGHTRAG_REQUEST_TIMEOUT_MS=30000
+LIGHTRAG_INGESTION_TIMEOUT_MS=900000
+LIGHTRAG_DELETION_TIMEOUT_MS=120000
+LIGHTRAG_POLL_INTERVAL_MS=1000

--- a/examples/lightrag/.gitignore
+++ b/examples/lightrag/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/examples/lightrag/README.md
+++ b/examples/lightrag/README.md
@@ -1,0 +1,172 @@
+# Qwen Audio Agent LightRAG Integration Example
+
+English | [中文](README_ZH.md)
+
+This example connects an independently deployed
+[LightRAG](https://github.com/HKUDS/LightRAG) instance to qwen-audio-agent. LightRAG owns
+document parsing, chunking, embeddings, indexing, and retrieval. The Gateway only consumes it
+through the generic `KnowledgeProvider` boundary; it does not install, start, or reconfigure
+LightRAG.
+
+## Core features
+
+- **Replaceable knowledge base:** the generic runtime depends only on the versioned
+  `KnowledgeProvider` contract; all LightRAG-specific code stays in this example.
+- **Raw-context retrieval:** `/query/data` supplies source chunks while the voice frontend
+  remains responsible for the final answer.
+- **Complete library management:** file upload, asynchronous indexing, paginated listing,
+  and asynchronous deletion are supported.
+- **Independent model configuration:** LightRAG owns its LLM, embedding model, indexes,
+  and storage without implicit configuration sharing with the voice frontend.
+- **Provider object isolation:** graph objects, remote `track_id` values, and raw HTTP
+  responses never cross the provider boundary.
+
+## Architecture
+
+| Component | Responsibility |
+|---|---|
+| qwen-audio-agent Gateway | Realtime voice conversation, knowledge tools, and ingestion task lifecycle. |
+| [`LightRagKnowledgeProvider`](lightrag-provider.mjs) | Maps LightRAG APIs to the generic `KnowledgeProvider`. |
+| [`LightRagClient`](lightrag-client.mjs) | LightRAG URL, authentication, workspace, timeouts, and HTTP errors. |
+| User-managed LightRAG Server | Document parsing, chunking, embeddings, graph, indexing, and retrieval. |
+
+The provider calls LightRAG `/query/data` for raw retrieval chunks, leaving final answer
+generation to the voice frontend. Graph objects, remote `track_id` values, and raw HTTP
+responses never cross the provider boundary.
+
+## Quick start
+
+Use the Node.js version required by the repository and install `uv` first. From the
+qwen-audio-agent repository root:
+
+```bash
+npm ci
+```
+
+### Install and configure LightRAG
+
+Install LightRAG independently with `uv`:
+
+```bash
+uv tool install "lightrag-hku[api]"
+mkdir -p ~/lightrag-runtime
+cd ~/lightrag-runtime
+```
+
+LightRAG requires both an LLM and an embedding model. They may run through local Ollama or an
+OpenAI-compatible service; the user owns the model, dimensions, and endpoint choices. The
+following is only the minimal shape of the `.env` file in the current directory:
+
+```dotenv
+LLM_BINDING=openai
+LLM_BINDING_HOST=https://your-openai-compatible-service.example/v1
+LLM_BINDING_API_KEY=your_llm_key
+LLM_MODEL=your_llm_model
+
+EMBEDDING_BINDING=openai
+EMBEDDING_BINDING_HOST=https://your-openai-compatible-service.example/v1
+EMBEDDING_BINDING_API_KEY=your_embedding_key
+EMBEDDING_MODEL=your_embedding_model
+EMBEDDING_DIM=1024
+
+# Recommended even for a local API
+LIGHTRAG_API_KEY=your_lightrag_api_key
+```
+
+`EMBEDDING_DIM` must match the selected embedding model. Do not change the model or dimension
+after indexing data without clearing and rebuilding the LightRAG index as documented upstream.
+
+Start a server bound only to localhost:
+
+```bash
+cd ~/lightrag-runtime
+lightrag-server --host 127.0.0.1 --port 9621
+```
+
+Open `http://127.0.0.1:9621/webui` to verify it. See the
+[official LightRAG Server documentation](https://github.com/HKUDS/LightRAG/blob/main/docs/LightRAG-API-Server.md)
+for complete model, parser, and storage configuration.
+
+### Start the example Gateway
+
+From the qwen-audio-agent repository root:
+
+```bash
+cp examples/lightrag/.env.example examples/lightrag/.env.local
+```
+
+Edit `.env.local`:
+
+```dotenv
+DASHSCOPE_API_KEY=your_dashscope_api_key
+AGENT_PROTOCOL=none
+
+LIGHTRAG_URL=http://127.0.0.1:9621
+LIGHTRAG_API_KEY=your_lightrag_api_key
+LIGHTRAG_WORKSPACE=
+LIGHTRAG_QUERY_MODE=mix
+```
+
+`DASHSCOPE_API_KEY` belongs only to the qwen-audio-agent voice frontend. LightRAG uses the model
+configuration of its own process. The two processes do not automatically share configuration,
+even when they call the same model provider.
+
+Start the example:
+
+```bash
+node --env-file=examples/lightrag/.env.local examples/lightrag/gateway.mjs
+```
+
+Open `http://127.0.0.1:3101`. This isolated example uses frontend-only mode to test the
+knowledge provider without starting a backend Agent.
+
+## Try it
+
+1. Open **Knowledge Library** in the WebUI.
+2. Paste an absolute path to a local file and import it.
+3. Wait for LightRAG to finish parsing and indexing.
+4. Ask: “According to my knowledge library, summarize the release approval rules.”
+
+Upload is asynchronous: LightRAG keeps indexing after returning a `track_id`. The provider
+polls internally until `PROCESSED` or `FAILED`, so the Gateway updates its ingestion task only
+after a real terminal state. Deletion likewise waits for remote completion instead of treating
+`deletion_started` as “deleted.”
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `LIGHTRAG_URL` | `http://127.0.0.1:9621` | LightRAG Server endpoint |
+| `LIGHTRAG_API_KEY` | empty | LightRAG access key sent as `X-API-Key` |
+| `LIGHTRAG_WORKSPACE` | empty | Fixed workspace; never derived from model input or owner data |
+| `LIGHTRAG_QUERY_MODE` | `mix` | `local`, `global`, `hybrid`, `naive`, or `mix` |
+| `LIGHTRAG_RETRIEVAL_TIMEOUT_MS` | `60000` | Maximum time the Gateway waits for retrieval |
+| `LIGHTRAG_REQUEST_TIMEOUT_MS` | `30000` | Timeout for one HTTP request |
+| `LIGHTRAG_INGESTION_TIMEOUT_MS` | `900000` | Maximum wait for indexing |
+| `LIGHTRAG_DELETION_TIMEOUT_MS` | `120000` | Maximum wait for deletion |
+| `LIGHTRAG_POLL_INTERVAL_MS` | `1000` | Remote job polling interval |
+
+Cancelling a Gateway ingestion task stops the provider's local wait. It deliberately does not
+call LightRAG's global `cancel_pipeline`, which could cancel unrelated documents in the same
+instance.
+
+## Replace and extend
+
+| Goal | Change |
+|---|---|
+| Use an existing LightRAG service | Set `LIGHTRAG_URL`, `LIGHTRAG_API_KEY`, and `LIGHTRAG_WORKSPACE`. |
+| Tune retrieval | Set `LIGHTRAG_QUERY_MODE` and the retrieval timeout. |
+| Embed in another host | Create the provider and inject it through `knowledgeProvider` in `createGatewayApplication`. |
+| Replace LightRAG | Implement the same versioned `KnowledgeProvider` contract. |
+
+To integrate another knowledge system, replace only the provider. Realtime tools, Gateway
+tasks, and clients require no vendor-specific code. See
+[Knowledge Provider](../../docs/reference/knowledge.md) for the complete contract.
+
+## Authors and acknowledgements
+
+- [The LightRAG project and its contributors](https://github.com/HKUDS/LightRAG): created and
+  open-sourced LightRAG, which provides the document processing, knowledge graph, and retrieval
+  capabilities used by this example.
+- [Li Xu](https://github.com/x-lixu): designed the replaceable `KnowledgeProvider` boundary and
+  implemented the LightRAG integration example.

--- a/examples/lightrag/README_ZH.md
+++ b/examples/lightrag/README_ZH.md
@@ -1,0 +1,161 @@
+# Qwen Audio Agent LightRAG 接入示例
+
+[English](README.md) | 中文
+
+这个示例展示如何把用户独立部署的
+[LightRAG](https://github.com/HKUDS/LightRAG) 接入 qwen-audio-agent。LightRAG
+拥有文档解析、切分、Embedding、索引和检索；Gateway 只通过通用
+`KnowledgeProvider` 接口使用它，不安装、不启动，也不修改 LightRAG。
+
+## 核心特点
+
+- **知识库可替换：**通用知识运行时只依赖带版本的 `KnowledgeProvider` 接口，
+  LightRAG 专用逻辑全部留在本示例中。
+- **原始材料检索：**使用 `/query/data` 获取检索片段，最终回答仍由语音前台生成。
+- **完整资料管理：**支持文件上传、异步索引、分页列表和异步删除。
+- **独立模型配置：**LightRAG 自行管理 LLM、Embedding 模型、索引和存储，
+  不与语音前台共享隐式配置。
+- **供应商对象隔离：**图谱对象、远程 `track_id` 和原始 HTTP 响应不会穿过
+  Provider 边界。
+
+## 架构
+
+| 组件 | 职责 |
+|---|---|
+| qwen-audio-agent Gateway | 实时语音对话、知识工具和入库任务生命周期。 |
+| [`LightRagKnowledgeProvider`](lightrag-provider.mjs) | 把 LightRAG API 映射为通用 `KnowledgeProvider`。 |
+| [`LightRagClient`](lightrag-client.mjs) | LightRAG URL、认证、workspace、超时和 HTTP 错误。 |
+| 用户运行的 LightRAG Server | 文档解析、切分、Embedding、图谱、索引和检索。 |
+
+Provider 使用 LightRAG 的 `/query/data` 获取原始检索片段，最终回答仍由语音前台组织。
+LightRAG 的图谱对象、远程 `track_id` 和原始 HTTP 响应不会穿过 Provider 边界。
+
+## 快速开始
+
+需要使用仓库要求的 Node.js 版本，并提前安装 `uv`。在 qwen-audio-agent 仓库根目录执行：
+
+```bash
+npm ci
+```
+
+### 安装并配置 LightRAG
+
+推荐使用 `uv` 独立安装：
+
+```bash
+uv tool install "lightrag-hku[api]"
+mkdir -p ~/lightrag-runtime
+cd ~/lightrag-runtime
+```
+
+LightRAG 必须配置一个 LLM 和一个 Embedding 模型。它们可以来自本地 Ollama，也可以来自
+OpenAI 兼容服务；具体模型、维度和服务地址由用户决定。下面只展示必要字段，保存为当前
+目录的 `.env`：
+
+```dotenv
+LLM_BINDING=openai
+LLM_BINDING_HOST=https://your-openai-compatible-service.example/v1
+LLM_BINDING_API_KEY=your_llm_key
+LLM_MODEL=your_llm_model
+
+EMBEDDING_BINDING=openai
+EMBEDDING_BINDING_HOST=https://your-openai-compatible-service.example/v1
+EMBEDDING_BINDING_API_KEY=your_embedding_key
+EMBEDDING_MODEL=your_embedding_model
+EMBEDDING_DIM=1024
+
+# 推荐为本机 API 设置独立访问密钥
+LIGHTRAG_API_KEY=your_lightrag_api_key
+```
+
+Embedding 维度必须与所选模型一致。首次索引后不要直接更换 Embedding 模型或维度；需要
+更换时，请按照 LightRAG 文档清理并重新建立索引。
+
+启动仅监听本机的服务：
+
+```bash
+cd ~/lightrag-runtime
+lightrag-server --host 127.0.0.1 --port 9621
+```
+
+打开 `http://127.0.0.1:9621/webui`，确认服务正常。完整模型、解析器和存储配置见
+[LightRAG Server 官方文档](https://github.com/HKUDS/LightRAG/blob/main/docs/LightRAG-API-Server.md)。
+
+### 启动示例 Gateway
+
+在 qwen-audio-agent 仓库根目录执行：
+
+```bash
+cp examples/lightrag/.env.example examples/lightrag/.env.local
+```
+
+编辑 `.env.local`：
+
+```dotenv
+DASHSCOPE_API_KEY=your_dashscope_api_key
+AGENT_PROTOCOL=none
+
+LIGHTRAG_URL=http://127.0.0.1:9621
+LIGHTRAG_API_KEY=your_lightrag_api_key
+LIGHTRAG_WORKSPACE=
+LIGHTRAG_QUERY_MODE=mix
+```
+
+这里的 `DASHSCOPE_API_KEY` 只供 qwen-audio-agent 语音前台使用；LightRAG 使用它自己
+进程中的模型配置。两者即使连接同一家模型服务，也不会自动共享配置。
+
+启动示例：
+
+```bash
+node --env-file=examples/lightrag/.env.local examples/lightrag/gateway.mjs
+```
+
+打开 `http://127.0.0.1:3101`。示例使用仅前台模式，目的是单独验证知识库 Provider，
+不会启动后台 Agent。
+
+## 体验方法
+
+1. 在 WebUI 打开“资料库”。
+2. 粘贴一个本机文件的绝对路径并导入。
+3. 等待 LightRAG 完成解析和索引。
+4. 询问：“根据资料库，概括这份文档的发布审批规则。”
+
+上传是异步的：LightRAG 返回 `track_id` 后仍会继续索引。Provider 会在内部轮询到
+`PROCESSED` 或 `FAILED`，Gateway 只在真实终态后更新入库任务。删除也会等待远端实际
+完成，不会把 `deletion_started` 提前显示成“已删除”。
+
+## 配置
+
+| 变量 | 默认值 | 说明 |
+|---|---|---|
+| `LIGHTRAG_URL` | `http://127.0.0.1:9621` | LightRAG Server 地址 |
+| `LIGHTRAG_API_KEY` | 空 | 通过 `X-API-Key` 发送的 LightRAG 访问密钥 |
+| `LIGHTRAG_WORKSPACE` | 空 | 固定 workspace；不会从模型输入或 owner 动态生成 |
+| `LIGHTRAG_QUERY_MODE` | `mix` | `local`、`global`、`hybrid`、`naive` 或 `mix` |
+| `LIGHTRAG_RETRIEVAL_TIMEOUT_MS` | `60000` | Gateway 等待一次检索的最长时间 |
+| `LIGHTRAG_REQUEST_TIMEOUT_MS` | `30000` | 单次 HTTP 请求超时 |
+| `LIGHTRAG_INGESTION_TIMEOUT_MS` | `900000` | 等待索引完成的最长时间 |
+| `LIGHTRAG_DELETION_TIMEOUT_MS` | `120000` | 等待删除完成的最长时间 |
+| `LIGHTRAG_POLL_INTERVAL_MS` | `1000` | 远端作业轮询间隔 |
+
+Gateway 取消入库任务时，Provider 会停止本地等待，但不会调用 LightRAG 的全局
+`cancel_pipeline`，以免取消同一实例中的其他文档。
+
+## 替换和扩展
+
+| 需求 | 修改位置 |
+|---|---|
+| 使用已有 LightRAG 服务 | 设置 `LIGHTRAG_URL`、`LIGHTRAG_API_KEY` 和 `LIGHTRAG_WORKSPACE`。 |
+| 调整检索策略 | 设置 `LIGHTRAG_QUERY_MODE` 和检索超时。 |
+| 在其他宿主中接入 | 创建 Provider 后，通过 `knowledgeProvider` 注入 `createGatewayApplication`。 |
+| 替换为其他知识系统 | 实现同一版本的 `KnowledgeProvider` 接口。 |
+
+要接入其他知识系统，只替换 Provider；Realtime 工具、Gateway Task 和客户端不需要加入
+供应商专属代码。完整接口见[知识库 Provider](../../docs/reference/knowledge.zh.md)。
+
+## 作者与致谢
+
+- [LightRAG 项目及其贡献者](https://github.com/HKUDS/LightRAG)：创建并开源 LightRAG，
+  为本示例提供文档处理、知识图谱和检索能力。
+- [Li Xu](https://github.com/x-lixu)：设计可替换的 `KnowledgeProvider` 边界，并实现
+  LightRAG 接入示例。

--- a/examples/lightrag/gateway.mjs
+++ b/examples/lightrag/gateway.mjs
@@ -1,0 +1,23 @@
+// This example embeds the normal Gateway and replaces only its knowledge
+// provider. LightRAG remains an independently installed and managed service.
+process.env.AGENT_PROTOCOL ||= 'none'
+
+const [{ createGatewayApplication }, { createLightRagKnowledgeProviderFromEnv }] = await Promise.all([
+  import('qwen-audio-agent/gateway-application'),
+  import('./lightrag-provider.mjs'),
+])
+
+const provider = createLightRagKnowledgeProviderFromEnv()
+const gateway = createGatewayApplication({
+  knowledgeProvider: provider,
+  knowledgeRuntimeOptions: {
+    timeoutMs: Number(process.env.LIGHTRAG_RETRIEVAL_TIMEOUT_MS) || 60_000,
+  },
+})
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, async () => {
+    await gateway.close()
+    process.exit(0)
+  })
+}

--- a/examples/lightrag/lightrag-client.mjs
+++ b/examples/lightrag/lightrag-client.mjs
@@ -1,0 +1,125 @@
+import { openAsBlob } from 'node:fs'
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+
+function positiveInteger(value, fallback) {
+  const number = Math.trunc(Number(value))
+  return Number.isFinite(number) && number > 0 ? number : fallback
+}
+
+function endpoint(value) {
+  const url = new URL(String(value || '').trim())
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new TypeError('LIGHTRAG_URL must use HTTP or HTTPS')
+  }
+  url.username = ''
+  url.password = ''
+  url.pathname = `${url.pathname.replace(/\/+$/u, '')}/`
+  return url
+}
+
+function errorMessage(payload, fallback) {
+  return String(payload?.detail ?? payload?.message ?? fallback ?? '').trim()
+}
+
+export class LightRagHttpError extends Error {
+  constructor(message, { status = 0, retryable = false, code = 'lightrag_error' } = {}) {
+    super(message)
+    this.name = 'LightRagHttpError'
+    this.status = status
+    this.retryable = retryable
+    this.code = code
+  }
+}
+
+export class LightRagClient {
+  constructor({
+    baseUrl,
+    apiKey = '',
+    workspace = '',
+    fetchImpl = globalThis.fetch,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  } = {}) {
+    if (typeof fetchImpl !== 'function') {
+      throw new TypeError('LightRagClient requires fetch')
+    }
+    this.baseUrl = endpoint(baseUrl)
+    this.apiKey = String(apiKey || '').trim()
+    this.workspace = String(workspace || '').trim()
+    this.fetch = fetchImpl
+    this.requestTimeoutMs = positiveInteger(
+      requestTimeoutMs,
+      DEFAULT_REQUEST_TIMEOUT_MS,
+    )
+  }
+
+  headers(extra = {}) {
+    return {
+      Accept: 'application/json',
+      ...(this.apiKey ? { 'X-API-Key': this.apiKey } : {}),
+      ...(this.workspace ? { 'LIGHTRAG-WORKSPACE': this.workspace } : {}),
+      ...extra,
+    }
+  }
+
+  async request(path, {
+    method = 'GET',
+    body,
+    signal,
+    timeoutMs = this.requestTimeoutMs,
+  } = {}) {
+    const timeoutSignal = AbortSignal.timeout(positiveInteger(
+      timeoutMs,
+      this.requestTimeoutMs,
+    ))
+    const requestSignal = signal
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
+    const jsonBody = body != null && !(body instanceof FormData)
+    let response
+    try {
+      response = await this.fetch(new URL(path.replace(/^\//u, ''), this.baseUrl), {
+        method,
+        headers: this.headers(jsonBody ? { 'Content-Type': 'application/json' } : {}),
+        ...(body == null ? {} : { body: jsonBody ? JSON.stringify(body) : body }),
+        signal: requestSignal,
+      })
+    } catch (error) {
+      if (requestSignal.aborted) throw requestSignal.reason
+      throw new LightRagHttpError('无法连接 LightRAG 服务。', {
+        retryable: true,
+        code: 'lightrag_unreachable',
+      })
+    }
+    const payload = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      const status = Number(response.status) || 0
+      throw new LightRagHttpError(
+        errorMessage(payload, `LightRAG request failed (${status})`),
+        {
+          status,
+          retryable: status === 408 || status === 409 || status === 429 || status >= 500,
+          code: status === 409
+            ? 'lightrag_conflict'
+            : status === 429 ? 'lightrag_busy' : 'lightrag_request_failed',
+        },
+      )
+    }
+    return payload
+  }
+
+  async uploadFile(path, { name, signal, timeoutMs } = {}) {
+    const form = new FormData()
+    form.append(
+      'file',
+      await openAsBlob(path),
+      String(name || '').trim() || 'document',
+    )
+    return this.request('/documents/upload', {
+      method: 'POST',
+      body: form,
+      signal,
+      timeoutMs,
+    })
+  }
+}

--- a/examples/lightrag/lightrag-provider.mjs
+++ b/examples/lightrag/lightrag-provider.mjs
@@ -1,0 +1,322 @@
+import { basename } from 'node:path'
+import {
+  KNOWLEDGE_PROVIDER_PROTOCOL_VERSION,
+} from 'qwen-audio-agent/knowledge-provider'
+import { LightRagClient, LightRagHttpError } from './lightrag-client.mjs'
+
+const TERMINAL_DOCUMENT_STATUSES = new Set(['PROCESSED', 'FAILED'])
+const DEFAULT_POLL_INTERVAL_MS = 1_000
+const DEFAULT_INGESTION_TIMEOUT_MS = 15 * 60_000
+const DEFAULT_DELETION_TIMEOUT_MS = 2 * 60_000
+const MAX_DOCUMENT_PAGES = 100
+const QUERY_MODES = new Set(['local', 'global', 'hybrid', 'naive', 'mix'])
+
+function clean(value) {
+  return String(value || '').trim()
+}
+
+function positiveInteger(value, fallback) {
+  const number = Math.trunc(Number(value))
+  return Number.isFinite(number) && number > 0 ? number : fallback
+}
+
+function abortableDelay(ms, signal) {
+  if (signal?.aborted) return Promise.reject(signal.reason)
+  return new Promise((resolve, reject) => {
+    const cleanup = () => signal?.removeEventListener('abort', aborted)
+    const timer = setTimeout(() => {
+      cleanup()
+      resolve()
+    }, ms)
+    const aborted = () => {
+      clearTimeout(timer)
+      cleanup()
+      reject(signal.reason)
+    }
+    signal?.addEventListener('abort', aborted, { once: true })
+  })
+}
+
+function publicDocument(value) {
+  const id = clean(value?.id)
+  if (!id) return null
+  const path = clean(value?.file_path)
+  const filename = path ? basename(path) : ''
+  const summary = clean(value?.content_summary)
+  return {
+    id,
+    title: filename || summary || id,
+    ...(filename ? { filename } : {}),
+    ...(summary ? { gist: summary } : {}),
+    ...(value?.status ? { status: clean(value.status).toLowerCase() } : {}),
+    ...(value?.created_at ? { created_at: clean(value.created_at) } : {}),
+    ...(value?.updated_at ? { updated_at: clean(value.updated_at) } : {}),
+    source: 'lightrag',
+    metadata: {
+      ...(Number.isFinite(Number(value?.content_length))
+        ? { content_length: Number(value.content_length) }
+        : {}),
+      ...(Number.isFinite(Number(value?.chunks_count))
+        ? { chunks_count: Number(value.chunks_count) }
+        : {}),
+    },
+  }
+}
+
+function publicUrl(value) {
+  try {
+    const url = new URL(clean(value))
+    return ['http:', 'https:'].includes(url.protocol) ? url.href : ''
+  } catch {
+    return ''
+  }
+}
+
+function ingestionError(documents) {
+  const failed = documents.find(item => clean(item?.status).toUpperCase() === 'FAILED')
+  const message = clean(failed?.error_msg) || 'LightRAG 文档索引失败。'
+  return new LightRagHttpError(message, {
+    code: 'lightrag_ingestion_failed',
+  })
+}
+
+export class LightRagKnowledgeProvider {
+  constructor({
+    baseUrl,
+    apiKey = '',
+    workspace = '',
+    queryMode = 'mix',
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    ingestionTimeoutMs = DEFAULT_INGESTION_TIMEOUT_MS,
+    deletionTimeoutMs = DEFAULT_DELETION_TIMEOUT_MS,
+    requestTimeoutMs,
+    fetchImpl,
+  } = {}) {
+    this.client = new LightRagClient({
+      baseUrl,
+      apiKey,
+      workspace,
+      requestTimeoutMs,
+      fetchImpl,
+    })
+    this.workspace = clean(workspace)
+    this.queryMode = clean(queryMode) || 'mix'
+    if (!QUERY_MODES.has(this.queryMode)) {
+      throw new TypeError(
+        `LIGHTRAG_QUERY_MODE must be one of: ${[...QUERY_MODES].join(', ')}`,
+      )
+    }
+    this.pollIntervalMs = positiveInteger(pollIntervalMs, DEFAULT_POLL_INTERVAL_MS)
+    this.ingestionTimeoutMs = positiveInteger(
+      ingestionTimeoutMs,
+      DEFAULT_INGESTION_TIMEOUT_MS,
+    )
+    this.deletionTimeoutMs = positiveInteger(
+      deletionTimeoutMs,
+      DEFAULT_DELETION_TIMEOUT_MS,
+    )
+  }
+
+  describe() {
+    return {
+      protocolVersion: KNOWLEDGE_PROVIDER_PROTOCOL_VERSION,
+      key: 'lightrag',
+      label: 'LightRAG',
+      capabilities: {
+        filters: false,
+        scores: false,
+        citations: false,
+        ingestion: true,
+        management: true,
+      },
+    }
+  }
+
+  async health({ signal } = {}) {
+    try {
+      await this.client.request('/health', { signal })
+      return { status: 'ready' }
+    } catch (error) {
+      if (signal?.aborted) throw signal.reason
+      return {
+        status: 'unavailable',
+        message: error?.message || 'LightRAG 服务不可用。',
+      }
+    }
+  }
+
+  async retrieve(request, context = {}) {
+    const requestedBases = Array.isArray(request?.knowledgeBaseIds)
+      ? request.knowledgeBaseIds.map(clean).filter(Boolean)
+      : []
+    if (
+      requestedBases.length
+      && (!this.workspace || !requestedBases.includes(this.workspace))
+    ) {
+      return { results: [] }
+    }
+    if (request?.filters && Object.keys(request.filters).length) {
+      throw new LightRagHttpError('当前 LightRAG 示例不支持检索过滤条件。', {
+        code: 'lightrag_filters_unsupported',
+      })
+    }
+    const topK = Math.max(1, Math.min(8, Number(request?.topK) || 5))
+    const response = await this.client.request('/query/data', {
+      method: 'POST',
+      body: {
+        query: clean(request?.query),
+        mode: this.queryMode,
+        top_k: topK,
+        chunk_top_k: topK,
+      },
+      signal: context.signal,
+    })
+    if (clean(response?.status).toLowerCase() === 'failure') {
+      throw new LightRagHttpError(
+        clean(response?.message) || 'LightRAG 检索失败。',
+        { code: 'lightrag_retrieval_failed', retryable: true },
+      )
+    }
+    const references = new Map(
+      (response?.data?.references || []).map(item => [clean(item.reference_id), item]),
+    )
+    return {
+      results: (response?.data?.chunks || []).slice(0, topK).flatMap((chunk, index) => {
+        const content = clean(chunk?.content)
+        const referenceId = clean(chunk?.reference_id)
+        const reference = references.get(referenceId)
+        const path = clean(chunk?.file_path ?? reference?.file_path)
+        const id = clean(chunk?.chunk_id) || `${referenceId || 'chunk'}-${index + 1}`
+        if (!content) return []
+        const uri = publicUrl(path)
+        return [{
+          id,
+          content,
+          source: {
+            ...(referenceId ? { id: referenceId } : {}),
+            ...(path ? { title: basename(path), locator: path } : {}),
+            ...(uri ? { uri } : {}),
+          },
+          metadata: {
+            provider: 'lightrag',
+            ...(referenceId ? { reference_id: referenceId } : {}),
+          },
+        }]
+      }),
+    }
+  }
+
+  async ingest(request, context = {}) {
+    const sourcePath = clean(request?.source?.path ?? request?.path)
+    if (!sourcePath) {
+      throw new TypeError('LightRAG ingestion requires a local file path')
+    }
+    const uploaded = await this.client.uploadFile(sourcePath, {
+      name: clean(request?.source?.name) || basename(sourcePath),
+      signal: context.signal,
+    })
+    const trackId = clean(uploaded?.track_id)
+    if (!trackId) {
+      throw new LightRagHttpError('LightRAG 上传响应缺少 track_id。', {
+        code: 'lightrag_invalid_upload_response',
+      })
+    }
+    const deadline = Date.now() + this.ingestionTimeoutMs
+    while (Date.now() < deadline) {
+      const tracked = await this.client.request(
+        `/documents/track_status/${encodeURIComponent(trackId)}`,
+        { signal: context.signal },
+      )
+      const documents = Array.isArray(tracked?.documents) ? tracked.documents : []
+      if (documents.some(item => clean(item?.status).toUpperCase() === 'FAILED')) {
+        throw ingestionError(documents)
+      }
+      if (
+        documents.length
+        && documents.every(item => TERMINAL_DOCUMENT_STATUSES.has(
+          clean(item?.status).toUpperCase(),
+        ))
+      ) {
+        const document = publicDocument(documents[0])
+        if (document) return { document }
+      }
+      await abortableDelay(this.pollIntervalMs, context.signal)
+    }
+    throw new LightRagHttpError('等待 LightRAG 完成文档索引超时。', {
+      retryable: true,
+      code: 'lightrag_ingestion_timeout',
+    })
+  }
+
+  async list(_request, context = {}) {
+    const documents = []
+    let page = 1
+    while (page <= MAX_DOCUMENT_PAGES) {
+      const response = await this.client.request('/documents/paginated', {
+        method: 'POST',
+        body: {
+          page,
+          page_size: 200,
+          sort_field: 'updated_at',
+          sort_direction: 'desc',
+        },
+        signal: context.signal,
+      })
+      documents.push(...(response?.documents || []).map(publicDocument).filter(Boolean))
+      if (!response?.pagination?.has_next) break
+      page += 1
+    }
+    if (page > MAX_DOCUMENT_PAGES) {
+      throw new LightRagHttpError(
+        `LightRAG 文档列表超过 ${MAX_DOCUMENT_PAGES} 页，已停止继续读取。`,
+        { code: 'lightrag_document_list_limit' },
+      )
+    }
+    return { documents }
+  }
+
+  async remove(request, context = {}) {
+    const documentId = clean(request?.documentId ?? request?.id)
+    if (!documentId) throw new TypeError('LightRAG removal requires documentId')
+    const response = await this.client.request('/documents/delete_document', {
+      method: 'DELETE',
+      body: {
+        doc_ids: [documentId],
+        delete_file: true,
+        delete_llm_cache: false,
+      },
+      signal: context.signal,
+    })
+    if (response?.status !== 'deletion_started') {
+      throw new LightRagHttpError(
+        clean(response?.message) || 'LightRAG 暂时无法删除文档。',
+        { retryable: response?.status === 'busy', code: 'lightrag_delete_rejected' },
+      )
+    }
+    const deadline = Date.now() + this.deletionTimeoutMs
+    while (Date.now() < deadline) {
+      const documents = (await this.list({}, context)).documents
+      if (!documents.some(item => item.id === documentId)) {
+        return { removed: true, document: { id: documentId, title: documentId } }
+      }
+      await abortableDelay(this.pollIntervalMs, context.signal)
+    }
+    throw new LightRagHttpError('等待 LightRAG 完成文档删除超时。', {
+      retryable: true,
+      code: 'lightrag_deletion_timeout',
+    })
+  }
+}
+
+export function createLightRagKnowledgeProviderFromEnv(env = process.env) {
+  return new LightRagKnowledgeProvider({
+    baseUrl: env.LIGHTRAG_URL || 'http://127.0.0.1:9621',
+    apiKey: env.LIGHTRAG_API_KEY,
+    workspace: env.LIGHTRAG_WORKSPACE,
+    queryMode: env.LIGHTRAG_QUERY_MODE,
+    pollIntervalMs: env.LIGHTRAG_POLL_INTERVAL_MS,
+    ingestionTimeoutMs: env.LIGHTRAG_INGESTION_TIMEOUT_MS,
+    deletionTimeoutMs: env.LIGHTRAG_DELETION_TIMEOUT_MS,
+    requestTimeoutMs: env.LIGHTRAG_REQUEST_TIMEOUT_MS,
+  })
+}

--- a/package.json
+++ b/package.json
@@ -157,6 +157,8 @@
     "docs/voice-frontends/qwen-omni-realtime.zh.md",
     "docs/scenarios/smart-cockpit.md",
     "docs/scenarios/smart-cockpit.zh.md",
+    "docs/scenarios/lightrag.md",
+    "docs/scenarios/lightrag.zh.md",
     "docs/scenarios/voicemem.md",
     "docs/scenarios/voicemem.zh.md",
     "docs/resources/papers.md",

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -113,6 +113,7 @@ export function createGatewayApplication({
   // Compatibility alias for embedders that adopted the original injection name.
   knowledgeRetrievalProvider = null,
   frontendKnowledge = null,
+  knowledgeRuntimeOptions = {},
   frontendMcp = undefined,
   frontendOpenApi = undefined,
   sessionJournal = null,
@@ -429,7 +430,12 @@ const knowledgeProviderRuntime = knowledgeProvider
         : null,
     }) : null)
 const frontendKnowledgeRuntime = frontendKnowledge || (knowledgeProviderRuntime
-  ? new FrontendKnowledgeRuntime({ provider: knowledgeProviderRuntime })
+  ? new FrontendKnowledgeRuntime({
+      ...(knowledgeRuntimeOptions && typeof knowledgeRuntimeOptions === 'object'
+        ? knowledgeRuntimeOptions
+        : {}),
+      provider: knowledgeProviderRuntime,
+    })
   : null)
 const knowledgeLibrary = knowledgeProviderRuntime
   && supportsKnowledgeManagement(knowledgeProviderRuntime)

--- a/server/src/app/knowledge/knowledge-library-service.mjs
+++ b/server/src/app/knowledge/knowledge-library-service.mjs
@@ -2,6 +2,9 @@ import { basename } from 'node:path'
 import { TaskNotificationPolicy } from '../../task/task-state.mjs'
 import {
   assertKnowledgeProvider,
+  normalizeKnowledgeIngestionResponse,
+  normalizeKnowledgeListResponse,
+  normalizeKnowledgeRemovalResponse,
   supportsKnowledgeManagement,
 } from '../../frontend/knowledge/retrieval-provider.mjs'
 
@@ -49,7 +52,10 @@ export class KnowledgeLibraryService {
           signal,
           onEvent,
         })
-        const document = result?.document || result
+        const { document } = normalizeKnowledgeIngestionResponse(result)
+        if (!document) {
+          throw new TypeError('KnowledgeProvider ingest() returned no document')
+        }
         return {
           content: document?.title
             ? `已把《${document.title}》收进资料库。`
@@ -63,12 +69,13 @@ export class KnowledgeLibraryService {
 
   async list({ ownerId } = {}) {
     const result = await this.provider.list({}, { ownerId: clean(ownerId) })
-    return Array.isArray(result) ? result : result?.documents || []
+    return normalizeKnowledgeListResponse(result).documents
   }
 
   async remove({ ownerId, documentId } = {}) {
-    return this.provider.remove({ documentId: clean(documentId) }, {
+    const result = await this.provider.remove({ documentId: clean(documentId) }, {
       ownerId: clean(ownerId),
     })
+    return normalizeKnowledgeRemovalResponse(result)
   }
 }

--- a/server/src/frontend/knowledge/retrieval-provider.mjs
+++ b/server/src/frontend/knowledge/retrieval-provider.mjs
@@ -33,6 +33,81 @@ function boundedMetadata(value) {
   return entries.length ? Object.fromEntries(entries) : undefined
 }
 
+function cleanStringList(value, { maxItems = 32, maxChars = 300 } = {}) {
+  if (!Array.isArray(value)) return undefined
+  const items = value
+    .map(item => clean(item, maxChars))
+    .filter(Boolean)
+    .slice(0, maxItems)
+  return items.length ? items : undefined
+}
+
+/**
+ * Normalize the small document projection shared by built-in and external
+ * knowledge providers. Provider-specific jobs, graph objects, and transport
+ * responses deliberately stay behind the provider boundary.
+ */
+export function normalizeKnowledgeDocument(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const id = clean(value.id ?? value.documentId ?? value.document_id, 160)
+  if (!id) return null
+  const filename = clean(value.filename ?? value.fileName ?? value.file_path, 500)
+  const title = clean(value.title ?? value.name ?? value.content_summary, 300)
+    || filename
+    || id
+  const status = clean(value.status, 40).toLowerCase()
+  const gist = clean(value.gist ?? value.summary ?? value.content_summary, 1_000)
+  const path = clean(value.path ?? value.file_path, 1_000)
+  const source = clean(value.source, 500)
+  const sections = cleanStringList(value.sections)
+  const bytes = Number(value.bytes ?? value.size)
+  const importedAt = clean(value.imported_at ?? value.importedAt, 80)
+  const createdAt = clean(value.created_at ?? value.createdAt, 80)
+  const updatedAt = clean(value.updated_at ?? value.updatedAt, 80)
+  const metadata = boundedMetadata(value.metadata)
+  return {
+    id,
+    title,
+    ...(filename ? { filename } : {}),
+    ...(status ? { status } : {}),
+    ...(gist ? { gist } : {}),
+    ...(sections ? { sections } : {}),
+    ...(path ? { path } : {}),
+    ...(source ? { source } : {}),
+    ...(Number.isFinite(bytes) && bytes >= 0 ? { bytes } : {}),
+    ...(importedAt ? { imported_at: importedAt } : {}),
+    ...(createdAt ? { created_at: createdAt } : {}),
+    ...(updatedAt ? { updated_at: updatedAt } : {}),
+    ...(typeof value.summarised === 'boolean'
+      ? { summarised: value.summarised }
+      : {}),
+    ...(metadata ? { metadata } : {}),
+  }
+}
+
+export function normalizeKnowledgeIngestionResponse(value) {
+  return {
+    document: normalizeKnowledgeDocument(value?.document ?? value),
+  }
+}
+
+export function normalizeKnowledgeListResponse(value) {
+  const candidates = Array.isArray(value)
+    ? value
+    : Array.isArray(value?.documents) ? value.documents : []
+  return {
+    documents: candidates.map(normalizeKnowledgeDocument).filter(Boolean),
+  }
+}
+
+export function normalizeKnowledgeRemovalResponse(value) {
+  const document = normalizeKnowledgeDocument(value?.document)
+  return {
+    removed: Boolean(value?.removed),
+    ...(document ? { document } : {}),
+  }
+}
+
 function normalizeCapabilities(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
   return Object.fromEntries(

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -543,12 +543,14 @@ test('enables knowledge only when an external provider is injected', async () =>
     autoStart: false,
     agent: disabledBackend(),
     knowledgeProvider,
+    knowledgeRuntimeOptions: { timeoutMs: 45_000 },
     frontendMcp: null,
     frontendOpenApi: null,
   })
 
   assert.equal(application.services.knowledgeProvider, knowledgeProvider)
   assert.equal(application.services.knowledgeLibrary, null)
+  assert.equal(application.services.frontendKnowledge.timeoutMs, 45_000)
   assert.deepEqual(application.services.frontendKnowledge.describe(), {
     configured: true,
     capabilities: ['knowledge'],

--- a/server/test/knowledge-retrieval-provider.test.mjs
+++ b/server/test/knowledge-retrieval-provider.test.mjs
@@ -6,6 +6,10 @@ import {
   assertKnowledgeRetrievalProvider,
   describeKnowledgeRetrievalProvider,
   knowledgeProviderHealth,
+  normalizeKnowledgeDocument,
+  normalizeKnowledgeIngestionResponse,
+  normalizeKnowledgeListResponse,
+  normalizeKnowledgeRemovalResponse,
   normalizeKnowledgeProviderHealth,
   normalizeKnowledgeRetrievalResponse,
   supportsKnowledgeManagement,
@@ -54,6 +58,47 @@ test('validates the minimal versioned retrieval provider contract', () => {
     key: 'custom-rag',
     label: 'Custom RAG',
     capabilities: { filters: true, scores: false },
+  })
+})
+
+test('normalizes provider-neutral knowledge management projections', () => {
+  assert.deepEqual(normalizeKnowledgeDocument({
+    document_id: ' doc-one ',
+    file_path: '/inputs/manual.pdf',
+    content_summary: ' Release guide ',
+    status: 'PROCESSED',
+    created_at: '2026-09-06T00:00:00Z',
+    size: 42,
+    sections: [' Intro ', '', 'Approvals'],
+    metadata: { category: 'guide', nested: { ignored: true } },
+  }), {
+    id: 'doc-one',
+    title: 'Release guide',
+    filename: '/inputs/manual.pdf',
+    status: 'processed',
+    gist: 'Release guide',
+    sections: ['Intro', 'Approvals'],
+    path: '/inputs/manual.pdf',
+    bytes: 42,
+    created_at: '2026-09-06T00:00:00Z',
+    metadata: { category: 'guide' },
+  })
+  assert.deepEqual(normalizeKnowledgeIngestionResponse({
+    document: { id: 'doc-one', title: 'Manual' },
+  }), {
+    document: { id: 'doc-one', title: 'Manual' },
+  })
+  assert.deepEqual(normalizeKnowledgeListResponse({
+    documents: [{ id: 'doc-one', title: 'Manual' }, { title: 'invalid' }],
+  }), {
+    documents: [{ id: 'doc-one', title: 'Manual' }],
+  })
+  assert.deepEqual(normalizeKnowledgeRemovalResponse({
+    removed: true,
+    document: { id: 'doc-one', title: 'Manual' },
+  }), {
+    removed: true,
+    document: { id: 'doc-one', title: 'Manual' },
   })
 })
 

--- a/test/lightrag-knowledge-provider.test.mjs
+++ b/test/lightrag-knowledge-provider.test.mjs
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import {
+  LightRagKnowledgeProvider,
+} from '../examples/lightrag/lightrag-provider.mjs'
+
+function json(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function queuedFetch(responses) {
+  const calls = []
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url: String(url), options })
+    const next = responses.shift()
+    if (!next) throw new Error(`Unexpected request: ${url}`)
+    return typeof next === 'function' ? next(url, options) : next
+  }
+  return { calls, fetchImpl }
+}
+
+test('maps LightRAG raw chunks without leaking graph or transport objects', async () => {
+  const transport = queuedFetch([json({
+    status: 'success',
+    data: {
+      entities: [{ entity_name: 'private graph object' }],
+      relationships: [{ description: 'private edge' }],
+      chunks: [{
+        chunk_id: 'chunk-1',
+        content: 'Release requires two reviewers.',
+        file_path: '/inputs/release-guide.pdf',
+        reference_id: 'ref-1',
+      }],
+      references: [{ reference_id: 'ref-1', file_path: '/inputs/release-guide.pdf' }],
+    },
+    metadata: { private_provider_data: true },
+  })])
+  const provider = new LightRagKnowledgeProvider({
+    baseUrl: 'http://127.0.0.1:9621',
+    apiKey: 'secret',
+    workspace: 'personal',
+    fetchImpl: transport.fetchImpl,
+  })
+
+  const result = await provider.retrieve({ query: 'release rules', topK: 3 })
+
+  assert.deepEqual(result, {
+    results: [{
+      id: 'chunk-1',
+      content: 'Release requires two reviewers.',
+      source: {
+        id: 'ref-1',
+        title: 'release-guide.pdf',
+        locator: '/inputs/release-guide.pdf',
+      },
+      metadata: { provider: 'lightrag', reference_id: 'ref-1' },
+    }],
+  })
+  assert.equal(transport.calls[0].url, 'http://127.0.0.1:9621/query/data')
+  assert.equal(transport.calls[0].options.headers['X-API-Key'], 'secret')
+  assert.equal(transport.calls[0].options.headers['LIGHTRAG-WORKSPACE'], 'personal')
+  assert.deepEqual(JSON.parse(transport.calls[0].options.body), {
+    query: 'release rules',
+    mode: 'mix',
+    top_k: 3,
+    chunk_top_k: 3,
+  })
+  assert.equal(JSON.stringify(result).includes('private graph object'), false)
+})
+
+test('waits for asynchronous LightRAG ingestion and keeps track_id private', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'qwaudio-lightrag-'))
+  const filePath = join(directory, 'manual.md')
+  writeFileSync(filePath, '# Manual')
+  const transport = queuedFetch([
+    (_url, options) => {
+      assert.equal(options.body instanceof FormData, true)
+      return json({ status: 'success', track_id: 'track-private' })
+    },
+    json({
+      track_id: 'track-private',
+      documents: [{ id: 'doc-1', status: 'PROCESSING' }],
+    }),
+    json({
+      track_id: 'track-private',
+      documents: [{
+        id: 'doc-1',
+        status: 'PROCESSED',
+        file_path: 'manual.md',
+        content_summary: 'A manual',
+        content_length: 8,
+        chunks_count: 1,
+      }],
+    }),
+  ])
+  const provider = new LightRagKnowledgeProvider({
+    baseUrl: 'http://127.0.0.1:9621',
+    fetchImpl: transport.fetchImpl,
+    pollIntervalMs: 1,
+  })
+  try {
+    const result = await provider.ingest({
+      source: { type: 'file', path: filePath, name: 'manual.md' },
+    })
+    assert.deepEqual(result, {
+      document: {
+        id: 'doc-1',
+        title: 'manual.md',
+        filename: 'manual.md',
+        gist: 'A manual',
+        status: 'processed',
+        source: 'lightrag',
+        metadata: { content_length: 8, chunks_count: 1 },
+      },
+    })
+    assert.equal(JSON.stringify(result).includes('track-private'), false)
+    assert.match(transport.calls[2].url, /track_status\/track-private$/u)
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('normalizes paginated documents and waits for asynchronous deletion', async () => {
+  const document = {
+    id: 'doc-1',
+    status: 'PROCESSED',
+    file_path: 'manual.pdf',
+    content_summary: 'Manual',
+  }
+  const transport = queuedFetch([
+    json({ documents: [document], pagination: { has_next: false } }),
+    json({ status: 'deletion_started', doc_id: 'doc-1' }),
+    json({ documents: [document], pagination: { has_next: false } }),
+    json({ documents: [], pagination: { has_next: false } }),
+  ])
+  const provider = new LightRagKnowledgeProvider({
+    baseUrl: 'http://127.0.0.1:9621',
+    fetchImpl: transport.fetchImpl,
+    pollIntervalMs: 1,
+  })
+
+  assert.deepEqual(await provider.list(), {
+    documents: [{
+      id: 'doc-1',
+      title: 'manual.pdf',
+      filename: 'manual.pdf',
+      gist: 'Manual',
+      status: 'processed',
+      source: 'lightrag',
+      metadata: {},
+    }],
+  })
+  assert.deepEqual(await provider.remove({ documentId: 'doc-1' }), {
+    removed: true,
+    document: { id: 'doc-1', title: 'doc-1' },
+  })
+  assert.deepEqual(JSON.parse(transport.calls[1].options.body), {
+    doc_ids: ['doc-1'],
+    delete_file: true,
+    delete_llm_cache: false,
+  })
+})
+
+test('reports unavailable health and stops ingestion polling when aborted', async () => {
+  const unavailable = new LightRagKnowledgeProvider({
+    baseUrl: 'http://127.0.0.1:9621',
+    fetchImpl: async () => { throw new Error('offline') },
+  })
+  assert.deepEqual(await unavailable.health(), {
+    status: 'unavailable',
+    message: '无法连接 LightRAG 服务。',
+  })
+
+  const directory = mkdtempSync(join(tmpdir(), 'qwaudio-lightrag-abort-'))
+  const filePath = join(directory, 'manual.md')
+  writeFileSync(filePath, '# Manual')
+  const transport = queuedFetch([
+    json({ status: 'success', track_id: 'track-1' }),
+    json({ documents: [{ id: 'doc-1', status: 'PROCESSING' }] }),
+  ])
+  const provider = new LightRagKnowledgeProvider({
+    baseUrl: 'http://127.0.0.1:9621',
+    fetchImpl: transport.fetchImpl,
+    pollIntervalMs: 100,
+  })
+  const controller = new AbortController()
+  const pending = provider.ingest({ source: { path: filePath } }, {
+    signal: controller.signal,
+  })
+  setTimeout(() => controller.abort(new DOMException('cancelled', 'AbortError')), 5)
+  try {
+    await assert.rejects(pending, error => error?.name === 'AbortError')
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects unsupported query modes before opening a connection', () => {
+  assert.throws(
+    () => new LightRagKnowledgeProvider({
+      baseUrl: 'http://127.0.0.1:9621',
+      queryMode: 'bypass',
+    }),
+    /LIGHTRAG_QUERY_MODE must be one of/u,
+  )
+})
+
+test('does not turn caller cancellation into an unavailable health status', async () => {
+  const controller = new AbortController()
+  controller.abort(new DOMException('cancelled', 'AbortError'))
+  const provider = new LightRagKnowledgeProvider({
+    baseUrl: 'http://127.0.0.1:9621',
+    fetchImpl: async (_url, { signal }) => {
+      throw signal.reason
+    },
+  })
+  await assert.rejects(
+    provider.health({ signal: controller.signal }),
+    error => error?.name === 'AbortError',
+  )
+})


### PR DESCRIPTION
## Summary

- add a replaceable LightRAG KnowledgeProvider example for retrieval and document management
- normalize provider-neutral knowledge management projections and configurable retrieval timeout
- document the integration in the bilingual README and user manual

## Validation

- npm run lint
- npm test
- npm run docs:build
- npm pack --dry-run