### PR TITLE
fix(mobile): preserve remote client identity

### DIFF
--- a/docs/roadmap/gateway-remote-access.md
+++ b/docs/roadmap/gateway-remote-access.md
@@ -170,6 +170,8 @@ completes the same core conversation and Task flows as WebUI.
 
 - [x] Add negative tests for unauthenticated remote requests, origin bypass,
   expired/replayed invitations, revoked devices, and stale leases.
+- [x] Reuse the paired, persisted Client instance identity after a Mobile app
+  restart so it is not mistaken for a different client.
 - [ ] Test Funnel, Wi-Fi/cellular transitions,
   computer sleep/wake, Gateway restart, and one-hour WebSocket/audio sessions.
 - [x] Run protocol conformance against Desktop, WebUI, TUI, and Mobile.

--- a/docs/roadmap/gateway-remote-access.zh.md
+++ b/docs/roadmap/gateway-remote-access.zh.md
@@ -145,6 +145,7 @@ WebSocket subprotocol 值承载可撤销设备凭据，服务端只选择并回�
 ## RA5 — 加固与发版准备
 
 - [x] 增加远程未认证、Origin 绕过、邀请过期/重放、设备撤销和旧租约的反例测试。
+- [x] 移动端在 App 重启后复用配对时持久化的 Client 实例身份，避免被误判为新客户端。
 - [ ] 测试 Funnel、Wi-Fi/蜂窝切换、电脑休眠/唤醒、Gateway 重启，以及
   一小时 WebSocket/音频会话。
 - [x] 对 Desktop、WebUI、TUI 与 Mobile 执行统一协议 Conformance。

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { configureGatewayTransport } from '../../web/src/gateway-transport.js'
 import '../../web/src/styles.css'
 import './mobile.css'
-import { pairMobileGateway } from './mobile-profile.js'
+import { mobileGatewayTransport, pairMobileGateway } from './mobile-profile.js'
 import {
   loadMobileGatewayProfile,
   mobileDeviceId,
@@ -24,12 +24,7 @@ function MobileApp() {
   const pairing = useRef(false)
 
   const activateProfile = useCallback(async next => {
-    configureGatewayTransport({
-      gatewayUrl: next.gatewayUrl,
-      accessToken: next.accessToken,
-      clientType: 'mobile',
-      clientLabel: next.label || '移动端',
-    })
+    configureGatewayTransport(mobileGatewayTransport(next))
     const module = await import('../../web/src/App.jsx')
     setProfile(next)
     setWebApp(() => module.default)

--- a/mobile/src/mobile-profile.js
+++ b/mobile/src/mobile-profile.js
@@ -29,6 +29,18 @@ export function parseMobileGatewayProfile(value) {
   }
 }
 
+export function mobileGatewayTransport(profile) {
+  const parsed = parseMobileGatewayProfile(profile)
+  if (!parsed) throw new TypeError('complete mobile Gateway profile is required')
+  return {
+    gatewayUrl: parsed.gatewayUrl,
+    accessToken: parsed.accessToken,
+    clientType: 'mobile',
+    clientLabel: parsed.label,
+    clientInstanceId: parsed.clientInstanceId,
+  }
+}
+
 export async function pairMobileGateway(invitationUrl, {
   request,
   deviceId,

--- a/mobile/test/mobile-profile.test.mjs
+++ b/mobile/test/mobile-profile.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { encodeGatewayInvitation } from '../../shared/gateway-remote-access.mjs'
-import { pairMobileGateway, parseMobileGatewayProfile } from '../src/mobile-profile.js'
+import {
+  mobileGatewayTransport,
+  pairMobileGateway,
+  parseMobileGatewayProfile,
+} from '../src/mobile-profile.js'
 
 const invitation = encodeGatewayInvitation({
   version: 1,
@@ -34,6 +38,25 @@ test('pairs a mobile profile without exposing backend configuration', async () =
     deviceId: 'phone-one',
     clientInstanceId: 'mobile-client-one',
     label: 'Mobile',
+  })
+})
+
+test('keeps the paired client instance stable across native app restarts', () => {
+  const stored = {
+    gatewayUrl: 'https://voice.example.test',
+    accessToken: 'qwa_revocable-mobile-token',
+    deviceId: 'mobile-device-one',
+    clientInstanceId: 'mobile-client-one',
+    label: 'Mobile',
+  }
+  assert.equal(parseMobileGatewayProfile(stored)?.clientInstanceId, 'mobile-client-one')
+  assert.equal(parseMobileGatewayProfile({ ...stored })?.clientInstanceId, 'mobile-client-one')
+  assert.deepEqual(mobileGatewayTransport(stored), {
+    gatewayUrl: 'https://voice.example.test',
+    accessToken: 'qwa_revocable-mobile-token',
+    clientType: 'mobile',
+    clientLabel: 'Mobile',
+    clientInstanceId: 'mobile-client-one',
   })
 })
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -70,6 +70,7 @@ import {
   initialDesktopClientSettings,
 } from './desktop-client-settings.js'
 import {
+  gatewayClientInstanceId,
   gatewayClientLabel,
   gatewayClientType,
   gatewayFetch,
@@ -84,6 +85,7 @@ const initialDesktopSurfaceMode = (
     : 'orb'
 )
 const activeClientType = gatewayClientType(desktopOrbMode ? 'desktop' : 'web')
+const activeClientInstanceId = gatewayClientInstanceId()
 const composerEnabled = supportsComposerInput(activeClientType)
 
 function getSessionId() {
@@ -782,6 +784,7 @@ export default function App() {
     wakeWordOnly: voiceEnabledForWakeWord,
     clientType: activeClientType,
     clientLabel: gatewayClientLabel(desktopOrbMode ? t('桌面端') : 'WebUI'),
+    clientInstanceId: activeClientInstanceId,
     clientStates: desktopOrbMode ? ['sleeping'] : [],
     realtimeProvider: realtimeProviderForConnection(
       realtimeProvider,

--- a/web/src/gateway-transport.js
+++ b/web/src/gateway-transport.js
@@ -5,6 +5,7 @@ let runtime = Object.freeze({
   accessToken: '',
   clientType: '',
   clientLabel: '',
+  clientInstanceId: '',
 })
 
 function cleanGatewayUrl(value = '') {
@@ -25,6 +26,7 @@ export function configureGatewayTransport(options = {}) {
     accessToken: String(options.accessToken || '').trim(),
     clientType: String(options.clientType || '').trim(),
     clientLabel: String(options.clientLabel || '').trim(),
+    clientInstanceId: String(options.clientInstanceId || '').trim(),
   })
   return runtime
 }
@@ -39,6 +41,10 @@ export function gatewayClientType(fallback = 'web') {
 
 export function gatewayClientLabel(fallback = 'WebUI') {
   return runtime.clientLabel || fallback
+}
+
+export function gatewayClientInstanceId(fallback = '') {
+  return runtime.clientInstanceId || fallback
 }
 
 export function gatewayHttpUrl(path) {

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -213,6 +213,7 @@ export default function useRealtimeVoice({
   wakeWordOnly = false,
   clientType = 'web',
   clientLabel = 'WebUI',
+  clientInstanceId: configuredClientInstanceId = '',
   clientStates = [],
   realtimeProvider = '',
   onEvent,
@@ -246,7 +247,9 @@ export default function useRealtimeVoice({
   const pendingManualInputsRef = useRef([])
   const audioRef = useRef(null)
   const currentTurnId = useRef('')
-  const clientInstanceId = useRef(crypto.randomUUID())
+  const clientInstanceId = useRef(
+    String(configuredClientInstanceId || '').trim() || crypto.randomUUID(),
+  )
   const inputSampleRate = useRef(DEFAULT_INPUT_RATE)
   const clientStatesSignature = [...new Set(
     (Array.isArray(clientStates) ? clientStates : [])

--- a/web/test/gateway-transport.test.mjs
+++ b/web/test/gateway-transport.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   configureGatewayTransport,
   createGatewayWebSocket,
+  gatewayClientInstanceId,
   gatewayFetch,
   gatewayHttpUrl,
   gatewayRealtimeUrl,
@@ -23,7 +24,9 @@ test('routes mobile HTTP and WebSocket traffic through a secure remote profile',
     gatewayUrl: 'https://voice.example.test',
     accessToken: 'qwa_example-device-token_1234567890',
     clientType: 'mobile',
+    clientInstanceId: 'mobile-stable-instance',
   })
+  assert.equal(gatewayClientInstanceId(), 'mobile-stable-instance')
   const requests = []
   await gatewayFetch('api/health', { cache: 'no-store' }, async (url, init) => {
     requests.push({ url, init })
@@ -47,6 +50,11 @@ test('routes mobile HTTP and WebSocket traffic through a secure remote profile',
   createGatewayWebSocket(gatewayRealtimeUrl('mobile-session'), {}, FakeWebSocket)
   assert.equal(sockets[0].protocols[0], 'qwaudio.gcp.v6')
   assert.match(sockets[0].protocols[1], /^qwaudio\.bearer\.qwa_/)
+})
+
+test('leaves browser client identity ephemeral unless a native host supplies one', () => {
+  assert.equal(gatewayClientInstanceId(), '')
+  assert.equal(gatewayClientInstanceId('browser-generated-instance'), 'browser-generated-instance')
 })
 
 test('never sends browser credentials over an insecure remote socket', () => {


### PR DESCRIPTION
## Summary

- pass the paired Mobile client instance identity through the shared Web transport into the GCP handshake
- keep browser and Desktop identities ephemeral unless a native host explicitly supplies one
- add regression coverage and update the bilingual RA5 roadmap

This prevents a restarted Mobile app from being mistaken for a different active client, avoiding unnecessary takeover and replay behavior.

## Verification

- `npm run release:check`
- `npm run mobile:build`
- `npm run docs:build`

Refs #320 (RA5)