### PR TITLE
docs: add DeepSeek and Windows local debugging setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ DASHSCOPE_API_KEY=
 # 可选：选择后台 Agent；留空时仅使用前台实时语音聊天。
 # OpenCode/OpenClaw 支持自动安装和百炼配置。
 # 可选 openclaw、opencode、qoder、qwen、kimi、hermes、
-# codebuddy、codex、claude、pi、通用 acp 或 none。
+# codebuddy、codex、claude、deepseek、pi、通用 acp 或 none。
 AGENT_PROTOCOL=openclaw
 
 # 配置后台后，Gateway 默认启动并管理所选 Agent 的 ACP 进程。
@@ -87,6 +87,14 @@ AGENT_PROTOCOL=openclaw
 # CLAUDE_CODE_ACP_RUNTIME=auto
 # CLAUDE_CODE_EXECUTABLE=
 # CLAUDE_WORKSPACE=
+
+# DeepSeek Harness 使用独立的官方 API Key，不可替代语音前台的 DashScope Key。
+# 先运行 qwenaudio install deepseek，再运行 dsh web 配置凭据；
+# 也可在不提交 Git 的 .env.local 中设置 DEEPSEEK_API_KEY。
+# AGENT_PROTOCOL=deepseek
+# DEEPSEEK_API_KEY=
+# DEEPSEEK_HARNESS_MODEL=deepseek-v4-pro
+# DEEPSEEK_HARNESS_WORKSPACE=
 
 # Pi 通过社区适配器 pi-acp 接入，复用已安装 Pi 的认证与配置；
 # 认证请在终端运行 pi 后通过 /login 完成，或配置 ANTHROPIC_API_KEY 等官方模型变量。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- 补充 DeepSeek API 与 Windows 本地调试配置说明，区分后台模型密钥和实时语音密钥。
+- 更新间接依赖 `fast-uri` 至 3.1.7、`@xmldom/xmldom` 至 0.8.15，并将
+  `qs` 覆盖为 6.16.0，修复 URI、XML 和查询字符串解析相关安全问题。
 - 后台 Session 模型覆盖统一使用 ACP `configOptions` 与
   `session/set_config_option`，不再调用私有模型接口或生成后台配置文件；未声明标准
   模型选项的 Agent 将沿用自身配置。OpenCode/OpenClaw 一键托管初始化保持不变。

--- a/docs/configuration/backend.md
+++ b/docs/configuration/backend.md
@@ -75,6 +75,68 @@ DEEPSEEK_HARNESS_MODEL=deepseek-v4-pro
 
 `DEEPSEEK_API_KEY` may still be set as an explicit per-run override.
 
+### Windows source debugging with DeepSeek
+
+Run in PowerShell at the repository root with Node.js and npm installed:
+
+```powershell
+npm ci
+# Keep local configuration, logs and task data in the ignored runtime/ directory.
+$env:QWAUDIO_CONFIG_DIR = Join-Path $PWD 'runtime/local'
+$env:QWAUDIO_DATA_DIR = $env:QWAUDIO_CONFIG_DIR
+node cli/bin/qwenaudio.mjs install deepseek
+```
+
+For the first setup, copy `.env.example` to `.env.local`. Edit an existing file
+instead of overwriting it. Change `AGENT_PROTOCOL` to `deepseek` and configure
+the following values, keeping only one assignment for each variable:
+
+```dotenv
+AGENT_PROTOCOL=deepseek
+DEEPSEEK_API_KEY=
+DEEPSEEK_HARNESS_MODEL=deepseek-v4-pro
+QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
+DASHSCOPE_API_KEY=
+```
+
+Enter a complete DeepSeek key in `DEEPSEEK_API_KEY`, or run `dsh web` to use the
+Harness credential store. A masked key or Tracking ID cannot authenticate.
+`DASHSCOPE_API_KEY` is a separate credential for the default realtime voice
+frontend; a DeepSeek key cannot replace it. Select the DeepSeek model through
+`DEEPSEEK_HARNESS_MODEL`; no generic backend model override is needed.
+
+```powershell
+node cli/bin/qwenaudio.mjs setup --backend deepseek
+node server/src/index.mjs
+```
+
+Open <http://127.0.0.1:3101>. The `setup` command checks installation and
+configuration without making model requests. A successful real task is still
+needed to verify authentication, available balance and model access.
+
+Without a voice key, explicitly opt into the existing UI debugging mode in
+the same PowerShell session:
+
+```powershell
+$env:QWEN_AUDIO_ALLOW_UNCONFIGURED = '1'
+$env:AGENT_PROTOCOL = 'none'
+node server/src/index.mjs
+```
+
+This mode supports UI and Gateway debugging only, without voice conversations
+or backend tasks. Stop the process and remove the temporary overrides before
+restarting with the real configuration from `.env.local`:
+
+```powershell
+Remove-Item Env:QWEN_AUDIO_ALLOW_UNCONFIGURED -ErrorAction SilentlyContinue
+Remove-Item Env:AGENT_PROTOCOL -ErrorAction SilentlyContinue
+node server/src/index.mjs
+```
+
+The Gateway listens on loopback by default. Git ignores `.env.local` and
+`runtime/`; inspect `git diff --cached` before submitting a PR to ensure no
+credentials or runtime data were staged.
+
 ## Skill Management
 
 Backend agents execute the actual tasks, so standard Agent Skills

--- a/docs/configuration/backend.zh.md
+++ b/docs/configuration/backend.zh.md
@@ -62,6 +62,62 @@ DEEPSEEK_HARNESS_MODEL=deepseek-v4-pro
 
 仍可通过 `DEEPSEEK_API_KEY` 为单次运行显式覆盖凭据。
 
+### Windows 源码调试：DeepSeek 后台
+
+在仓库根目录的 PowerShell 中执行（需要 Node.js 和 npm）：
+
+```powershell
+npm ci
+# 将本次调试的配置、日志和任务数据留在已被 Git 忽略的 runtime/ 下。
+$env:QWAUDIO_CONFIG_DIR = Join-Path $PWD 'runtime/local'
+$env:QWAUDIO_DATA_DIR = $env:QWAUDIO_CONFIG_DIR
+node cli/bin/qwenaudio.mjs install deepseek
+```
+
+首次配置时复制 `.env.example` 为 `.env.local`；已有该文件时直接编辑，避免覆盖。
+将 `AGENT_PROTOCOL` 改为 `deepseek`，并填写以下配置，不要保留重复的同名变量：
+
+```dotenv
+AGENT_PROTOCOL=deepseek
+DEEPSEEK_API_KEY=
+DEEPSEEK_HARNESS_MODEL=deepseek-v4-pro
+QWEN_AUDIO_AGENT_BACKEND_PERMISSION_MODE=native
+DASHSCOPE_API_KEY=
+```
+
+把完整的 DeepSeek Key 填入 `DEEPSEEK_API_KEY`，或运行 `dsh web` 使用
+Harness 自己的凭据存储。带星号的掩码 Key 和 Tracking ID 都不能用于认证。
+`DASHSCOPE_API_KEY` 是默认实时语音前台的独立凭据，不能填 DeepSeek Key。
+DeepSeek 模型由 `DEEPSEEK_HARNESS_MODEL` 选择，不需要设置通用后台模型覆盖。
+
+```powershell
+node cli/bin/qwenaudio.mjs setup --backend deepseek
+node server/src/index.mjs
+```
+
+然后打开 <http://127.0.0.1:3101>。`setup` 检查安装和配置状态，不会发送模型请求；
+只有真实任务执行成功，才能确认 API 的认证、余额和模型可用性。
+
+尚无语音 Key 时，可以在同一个 PowerShell 中显式启用项目已有的界面调试模式：
+
+```powershell
+$env:QWEN_AUDIO_ALLOW_UNCONFIGURED = '1'
+$env:AGENT_PROTOCOL = 'none'
+node server/src/index.mjs
+```
+
+此模式仅用于界面及 Gateway 调试，不能进行语音对话或后台任务。
+停止进程后，清除临时覆盖再启动，即可使用 `.env.local` 中的真实配置：
+
+```powershell
+Remove-Item Env:QWEN_AUDIO_ALLOW_UNCONFIGURED -ErrorAction SilentlyContinue
+Remove-Item Env:AGENT_PROTOCOL -ErrorAction SilentlyContinue
+node server/src/index.mjs
+```
+
+Gateway 默认仅监听本机。`.env.local` 和 `runtime/` 已被 Git 忽略，提交 PR 前
+仍需检查 `git diff --cached`，确保没有凭据或运行数据。
+
 ## 技能管理
 
 后台 Agent 负责执行实际任务，因此标准 Agent Skills（开放格式的

--- a/package-lock.json
+++ b/package-lock.json
@@ -5717,6 +5717,22 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
     "@hono/node-server": "2.0.12",
     "@electron/asar": "4.2.1",
     "@electron/universal": "3.0.6",
-    "fast-uri": "3.1.6",
+    "fast-uri": "3.1.7",
     "qs": "6.16.0",
     "uuid": "11.1.1"
   }

--- a/web/src/useRealtimeVoice.js
+++ b/web/src/useRealtimeVoice.js
@@ -692,6 +692,13 @@ export default function useRealtimeVoice({
           eventRef.current?.(connectedEvent)
         } else if (status.state === 'ready') {
           takeoverRef.current = false
+          // The Gateway protocol can be ready even when the optional realtime
+          // provider is not configured. Text input should be allowed to reach
+          // the Gateway in that state so the UI can report the provider error
+          // (for example, a missing DASHSCOPE_API_KEY) instead of claiming the
+          // Gateway itself is disconnected.
+          hasConnectedRef.current = true
+          flushPendingManualInputs()
         } else if (status.state === 'unavailable') {
           dispatchClientState({
             type: GatewayServerEvent.VOICE_CONNECTION,


### PR DESCRIPTION
## What changed
- Document DeepSeek API configuration and Windows local debugging.
- Add a local DashScope configuration helper and startup guidance.
- Fix frontend readiness handling so manual messages are released after the gateway is ready.
- Update dependency overrides for vulnerable URI/XML/query parsers.

## Validation
- git diff --check`n- package.json and package-lock.json parse successfully.
- Local gateway health verified as ready with DeepSeek backend and DashScope realtime provider.