### PR TITLE
refactor(remote): keep private tailnet access only

### DIFF
--- a/cli/src/arguments.mjs
+++ b/cli/src/arguments.mjs
@@ -29,7 +29,6 @@ const GATEWAY_ACTIONS = new Set([
   'uninstall',
 ])
 const REMOTE_ACTIONS = new Set(['status', 'enable', 'disable', 'invite', 'devices', 'revoke'])
-const REMOTE_ACCESS_MODES = new Set(['private', 'funnel'])
 const BACKEND_PERMISSION_MODES = new Set(['native', 'full'])
 const TUI_AUDIO_MODES = new Set(['half', 'full'])
 const SKILL_ACTIONS = new Set(['install', 'list', 'remove', 'update'])
@@ -124,8 +123,6 @@ export function parseArguments(argv, env = process.env) {
     realtimeModel: '',
     gatewayAction,
     remoteAction,
-    remoteMode: 'private',
-    remoteModeSpecified: false,
     remoteDeviceId,
     url: env.QWEN_AUDIO_AGENT_URL || 'http://127.0.0.1:3101',
     accessToken: String(
@@ -192,9 +189,6 @@ export function parseArguments(argv, env = process.env) {
       options.gatewayConfigurationSpecified = true
     } else if (argument === '--realtime-model') {
       options.realtimeModel = nextValue(args, index++, '--realtime-model')
-    } else if (argument === '--mode') {
-      options.remoteMode = nextValue(args, index++, '--mode').toLowerCase()
-      options.remoteModeSpecified = true
     } else if (argument === '--session') {
       options.sessionId = nextValue(args, index++, '--session')
     } else if (argument === '--audio-mode') {
@@ -275,18 +269,6 @@ export function parseArguments(argv, env = process.env) {
   if (command !== 'setup' && gatewayAction !== 'remote' && options.json) {
     throw new Error('--json 只适用于 setup 或 gateway remote')
   }
-  if (
-    options.remoteModeSpecified
-    && (
-      gatewayAction !== 'remote'
-      || !['enable', 'invite'].includes(remoteAction)
-    )
-  ) {
-    throw new Error('--mode 只适用于 gateway remote enable 或 invite')
-  }
-  if (!REMOTE_ACCESS_MODES.has(options.remoteMode)) {
-    throw new Error(`不支持的远程访问模式：${options.remoteMode}（可选 private、funnel）`)
-  }
   if (command !== 'tui' && audioModeSpecified) {
     throw new Error('--audio-mode 只适用于 tui')
   }
@@ -339,7 +321,7 @@ export function helpText() {
     '  qwenaudio gateway start           启动后台服务',
     '  qwenaudio gateway status          查看 Gateway 状态',
     '  qwenaudio gateway pair            创建远程客户端一次性配对码',
-    '  qwenaudio gateway remote enable   开启 Tailnet 私有远程访问（默认）',
+    '  qwenaudio gateway remote enable   开启私有 Tailnet 远程访问',
     '  qwenaudio gateway remote status   查看远程访问状态',
     '  qwenaudio gateway remote invite   创建可导入的远程客户端邀请',
     '  qwenaudio gateway remote disable  关闭远程访问',
@@ -370,7 +352,6 @@ export function helpText() {
     '  --backend-permission-mode MODE  native（默认）或 full（最高权限）',
     '  --backend-url URL      后台 Server 地址',
     '  --backend-agent ID     指定协调 Agent',
-    '  --mode private|funnel  远程访问模式；默认 private，funnel 为显式公网入口',
     '',
     'Setup 选项：',
     '  --backend NAME         只检查指定后台；默认检查全部后台',

--- a/cli/src/launcher.mjs
+++ b/cli/src/launcher.mjs
@@ -213,7 +213,7 @@ export async function main(argv, {
   listPairedDevices = url => listGatewayDevices(url),
   revokePairedDevice = (url, id) => revokeGatewayDevice(url, id),
   readRemoteAccess = url => readGatewayRemoteAccess(url),
-  enableRemoteAccess = (url, mode) => enableGatewayRemoteAccess(url, { mode }),
+  enableRemoteAccess = url => enableGatewayRemoteAccess(url),
   disableRemoteAccess = url => disableGatewayRemoteAccess(url),
   openExternal = url => openBrowser(url),
   manageService = (action, options) => manageGatewayService(action, options),
@@ -432,8 +432,7 @@ export async function main(argv, {
         stdout.write(`请完成一次远程访问授权：${status.authUrl}\n`)
       }
       else if (status.published) {
-        const label = status.mode === 'funnel' ? 'Funnel 公网入口' : 'Tailnet 私有通道'
-        stdout.write(`远程访问已开启（${label}）：${status.endpoint.url}\n`)
+        stdout.write(`远程访问已开启（Tailnet 私有通道）：${status.endpoint.url}\n`)
       }
       else if (status.state === 'error') {
         stdout.write(`远程访问异常：${status.error?.message || '未知错误'}\n`)
@@ -445,7 +444,7 @@ export async function main(argv, {
     }
     const health = await inspectGateway(options.url)
     if (!health) throw new Error(`Gateway 未运行：${options.url}`)
-    const status = await enableRemoteAccess(options.url, options.remoteMode)
+    const status = await enableRemoteAccess(options.url)
     if (status.state === 'auth_required') {
       await openExternal(status.authUrl).catch(() => {})
       stdout.write(
@@ -470,8 +469,7 @@ export async function main(argv, {
     }
     const endpoint = status.endpoint
     if (options.remoteAction === 'enable') {
-      const label = status.mode === 'funnel' ? 'Funnel 公网入口' : 'Tailnet 私有通道'
-      stdout.write(`远程访问已开启（${label}）：${endpoint.url}\n`)
+      stdout.write(`远程访问已开启（Tailnet 私有通道）：${endpoint.url}\n`)
       return 0
     }
     const ticket = await createPairingTicket(options.url)
@@ -491,11 +489,8 @@ export async function main(argv, {
     }
     else {
       const qrCode = await renderInvitationQr(browserUrl)
-      const prerequisite = status.mode === 'funnel'
-        ? '当前使用 Funnel 公网入口。\n'
-        : '请先在手机安装并连接官方 Tailscale App，加入与 Gateway 相同的 Tailnet。\n'
       stdout.write(
-        prerequisite
+        '请先在手机安装并连接官方 Tailscale App，加入与 Gateway 相同的 Tailnet。\n'
         + '移动端扫码接入：\n'
         + `${qrCode}\n`
         + `接入链接（移动端 / 桌面端）：\n${appUrl}\n`

--- a/cli/test/arguments.test.mjs
+++ b/cli/test/arguments.test.mjs
@@ -318,27 +318,16 @@ test('documents the service and client commands', () => {
   assert.doesNotMatch(text, /--attach-openclaw/)
   assert.doesNotMatch(text, /--backend-mode/)
   assert.match(text, /--backend-permission-mode MODE/)
-  assert.match(text, /--mode private\|funnel/)
+  assert.doesNotMatch(text, /--mode private/)
   assert.match(text, /--audio-mode MODE/)
   assert.match(text, /x\s+半双工模式下手动打断当前回复/)
 })
 
-test('uses private remote access by default and accepts explicit Funnel mode', () => {
-  assert.equal(
-    parseArguments(['gateway', 'remote', 'invite'], {}).remoteMode,
-    'private',
-  )
-  assert.equal(
-    parseArguments(['gateway', 'remote', 'invite', '--mode', 'funnel'], {}).remoteMode,
-    'funnel',
-  )
+test('keeps Gateway remote access private and exposes no mode selector', () => {
+  assert.equal('remoteMode' in parseArguments(['gateway', 'remote', 'invite'], {}), false)
   assert.throws(
-    () => parseArguments(['gateway', 'remote', 'status', '--mode', 'funnel'], {}),
-    /--mode 只适用于/,
-  )
-  assert.throws(
-    () => parseArguments(['gateway', '--mode', 'funnel'], {}),
-    /--mode 只适用于/,
+    () => parseArguments(['gateway', 'remote', 'invite', '--mode', 'public'], {}),
+    /未知参数：--mode/,
   )
 })
 

--- a/cli/test/launcher.test.mjs
+++ b/cli/test/launcher.test.mjs
@@ -81,7 +81,6 @@ function harness({ ownsProcesses = false } = {}) {
         connected: true,
         published: true,
         state: 'connected',
-        mode: 'private',
         endpoint: { url: 'https://voice.example.ts.net:8443' },
       }),
       enableRemoteAccess: async () => ({
@@ -90,7 +89,6 @@ function harness({ ownsProcesses = false } = {}) {
         connected: true,
         published: true,
         state: 'connected',
-        mode: 'private',
         endpoint: {
           url: 'https://voice.example.ts.net:8443',
           secure: true,
@@ -417,26 +415,6 @@ test('manages a Gateway remote endpoint and creates a portable invitation', asyn
   assert.match(json.app_url, /^qwaudio:\/\/connect\?v=1&gateway=/)
   assert.match(json.browser_url, /^https:\/\/voice\.example\.ts\.net:8443\/c\?e=[a-z0-9]+#/)
 
-  const funnel = harness()
-  funnel.dependencies.enableRemoteAccess = async (_url, mode) => {
-    assert.equal(mode, 'funnel')
-    return {
-      available: true,
-      enabled: true,
-      connected: true,
-      published: true,
-      state: 'connected',
-      mode: 'funnel',
-      endpoint: { url: 'https://voice.example.ts.net:8443', secure: true },
-    }
-  }
-  funnel.dependencies.renderInvitationQr = async () => '[compact QR]'
-  assert.equal(
-    await main(['gateway', 'remote', 'invite', '--mode', 'funnel'], funnel.dependencies),
-    0,
-  )
-  assert.match(funnel.calls.at(-1)[1], /^当前使用 Funnel 公网入口。/)
-
   const devices = harness()
   assert.equal(await main(['gateway', 'remote', 'devices'], devices.dependencies), 0)
   assert.match(devices.calls.at(-1)[1], /phone-one/)
@@ -460,7 +438,7 @@ test('opens the one-time remote network setup page when required', async () => {
     published: false,
     state: 'error',
     actionUrl: 'https://tailscale.com/s/https',
-    error: { code: 'funnel_start_failed', message: 'HTTPS is required' },
+    error: { code: 'private_listener_start_failed', message: 'HTTPS is required' },
   })
 
   assert.equal(await main(['gateway', 'remote', 'enable'], target.dependencies), 0)

--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -23,17 +23,8 @@ prevents it. Use `gateway remote status`, `devices`, `revoke ID`, and `disable` 
 Remote-access state and invitation issuance belong exclusively to the Gateway CLI; Desktop,
 Mobile, and other Clients only import connection links.
 
-For a temporary public endpoint that does not require the Tailscale app on the remote device,
-explicitly use:
-
-```bash
-qwenaudio gateway remote enable --mode funnel
-qwenaudio gateway remote invite --mode funnel
-```
-
-Funnel requires MagicDNS, HTTPS, and Funnel permission in the tailnet and is subject to Tailscale's
-bandwidth limits. Neither private access nor Funnel bypasses Gateway authentication: every remote
-business request except the one-time pairing shell requires a paired-device credential.
+Remote access does not bypass Gateway authentication: every remote business request except the
+one-time pairing shell requires a paired-device credential.
 
 For one personal access key:
 

--- a/docs/configuration/advanced.zh.md
+++ b/docs/configuration/advanced.zh.md
@@ -22,15 +22,7 @@ Client 使用的短时邀请。Tailscale 会优先建立点对点直连；受 NA
 `disable` 管理。远程设置和邀请签发统一归 Gateway CLI 所有；Desktop、Mobile 等客户端
 只负责导入接入链接。
 
-需要不安装 Tailscale App 也能访问的临时公网入口时，显式使用：
-
-```bash
-qwenaudio gateway remote enable --mode funnel
-qwenaudio gateway remote invite --mode funnel
-```
-
-Funnel 需要 Tailnet 开启 MagicDNS、HTTPS 和 Funnel 权限，且存在官方带宽限制。无论私有
-通道还是 Funnel 都不会绕过 Gateway 认证：除一次性配对页外，远程业务请求必须携带已
+远程访问不会绕过 Gateway 认证：除一次性配对页外，远程业务请求必须携带已
 配对设备凭据。
 
 配置一个个人访问密钥：

--- a/docs/getting-started/mobile.md
+++ b/docs/getting-started/mobile.md
@@ -44,9 +44,8 @@ one.
 
 By default, the remote HTTPS/WSS endpoint is reachable only inside the private
 tailnet and Tailscale prefers a direct device-to-device path. It may use a DERP
-relay on restrictive networks. For a temporary public endpoint, explicitly run
-`qwenaudio gateway remote invite --mode funnel`. Gateway business APIs remain
-protected by paired-device credentials in either mode. See
+relay on restrictive networks. Gateway business APIs remain protected by
+paired-device credentials. See
 [Remote Access Security](../configuration/advanced.md#remote-access-security)
 for implementation details, authorization requirements, and troubleshooting.
 

--- a/docs/getting-started/mobile.zh.md
+++ b/docs/getting-started/mobile.zh.md
@@ -34,9 +34,8 @@ Client Protocol，不直接接触 Realtime Provider 或后台协议。
 `qwenaudio gateway remote revoke <设备 ID>` 撤销。
 
 默认远程地址只在私有 Tailnet 内可达，并优先建立设备间直连；在受限网络下，Tailscale
-可能自动使用 DERP 中继。需要临时公网入口时，可显式使用
-`qwenaudio gateway remote invite --mode funnel`。两种模式下 Gateway 业务接口都受配对
-凭据保护。底层机制、授权要求和高级排障见
+可能自动使用 DERP 中继。Gateway 业务接口始终受配对凭据保护。底层机制、
+授权要求和高级排障见
 [远程访问安全](../configuration/advanced.zh.md#远程访问安全)。
 
 ## 开发构建

--- a/docs/roadmap/gateway-remote-access.md
+++ b/docs/roadmap/gateway-remote-access.md
@@ -21,7 +21,7 @@ Desktop ─┐
 WebUI ───┤
 TUI ─────┼── GCP over WebSocket ── Gateway ── BackendPort
 Mobile ──┘               ▲
-                         └── local endpoint or Gateway-owned private tailnet / Funnel
+                         └── local endpoint or Gateway-owned private tailnet
 ```
 
 ## Architectural boundaries
@@ -47,8 +47,8 @@ Clients see only an ordinary Gateway endpoint.
 - Local Clients continue to connect to `http://127.0.0.1:3101` without setup.
 - The Gateway CLI enables and manages remote access, opens the one-time browser
   authorization flow, and emits a QR code, native-client connection link, and
-  browser access link. Private-tailnet access is the default and remote devices
-  use the official Tailscale app; Funnel remains an explicit public option.
+  browser access link. Remote devices join the same private tailnet through the
+  official Tailscale app.
   Desktop, Mobile, and other Clients only consume invitations and do not
   integrate the underlying implementation.
 - A remote Desktop, TUI, WebUI, or Mobile Client consumes the same invitation,
@@ -132,8 +132,7 @@ profile contract.
   Desktop and CLI lifecycles.
 - [x] Download and verify the platform component on first use, provide browser
   authorization, and restore persisted state on later Gateway starts.
-- [x] Publish a private-tailnet HTTPS/WSS endpoint by default, retain an explicit
-  Funnel mode, and keep Gateway on loopback.
+- [x] Publish a private-tailnet HTTPS/WSS endpoint and keep Gateway on loopback.
 - [x] Add CLI status, enable, disable, invite, device-list, and revoke commands.
 - [ ] Validate persistent GCP WebSocket and long-running audio on a physical phone.
 
@@ -170,8 +169,7 @@ and remotely.
 - [x] Produce reproducible iOS and Android development builds.
 
 Exit criteria: a phone pairs through the private-tailnet HTTPS endpoint, reconnects
-later, and completes the same core conversation and Task flows as WebUI; explicit
-Funnel mode remains available.
+later, and completes the same core conversation and Task flows as WebUI.
 
 ## RA5 — Hardening and release readiness
 
@@ -179,7 +177,7 @@ Funnel mode remains available.
   expired/replayed invitations, revoked devices, and stale leases.
 - [x] Reuse the paired, persisted Client instance identity after a Mobile app
   restart so it is not mistaken for a different client.
-- [ ] Test direct-tailnet/DERP fallback, Funnel, Wi-Fi/cellular transitions,
+- [ ] Test direct-tailnet/DERP fallback, Wi-Fi/cellular transitions,
   computer sleep/wake, Gateway restart, and one-hour WebSocket/audio sessions.
 - [x] Run protocol conformance against Desktop, WebUI, TUI, and Mobile.
 - [x] Add macOS, Windows, Linux, iOS, and Android build checks; real-device

--- a/docs/roadmap/gateway-remote-access.zh.md
+++ b/docs/roadmap/gateway-remote-access.zh.md
@@ -19,7 +19,7 @@ Desktop ─┐
 WebUI ───┤
 TUI ─────┼── GCP over WebSocket ── Gateway ── BackendPort
 Mobile ──┘               ▲
-                         └── 本机 Endpoint 或 Gateway 托管的私有 Tailnet / Funnel
+                         └── 本机 Endpoint 或 Gateway 托管的私有 Tailnet
 ```
 
 ## 架构边界
@@ -40,8 +40,8 @@ Task 状态或 BackendPort。Client 最终只看到普通 Gateway Endpoint。
 
 - 本机 Client 继续零配置连接 `http://127.0.0.1:3101`。
 - Gateway CLI 开启和管理远程访问；首次打开网页完成授权，并统一输出二维码、客户端
-  接入链接和浏览器访问链接。默认通过私有 Tailnet 连接，远程设备使用官方 Tailscale
-  App；Funnel 作为显式可选的公网入口保留。Desktop、Mobile 等 Client 只消费邀请，
+  接入链接和浏览器访问链接。远程设备通过官方 Tailscale App 加入同一私有 Tailnet。
+  Desktop、Mobile 等 Client 只消费邀请，
   不集成底层远程访问实现。
 - 远程 Desktop、TUI、WebUI 或 Mobile 消费同一种邀请，换取可撤销设备凭据，并保存到
   平台安全存储。
@@ -115,8 +115,7 @@ WebSocket subprotocol 值承载可撤销设备凭据，服务端只选择并回�
 
 - [x] 将 tsnet 作为 Gateway 远程访问模块的可选进程，独立于 Desktop 与 CLI 生命周期。
 - [x] 首次开启时按平台下载并校验组件，通过网页完成一次授权，状态持久化后自动恢复。
-- [x] 默认发布 Tailnet 私有 HTTPS/WSS Endpoint，同时保留显式 Funnel 模式，并保持
-  Gateway Listener 只监听 loopback。
+- [x] 发布 Tailnet 私有 HTTPS/WSS Endpoint，并保持 Gateway Listener 只监听 loopback。
 - [x] 增加 CLI status、enable、disable、invite、设备列表与撤销命令。
 - [ ] 在真实手机上验证 GCP WebSocket 与长时间音频连接。
 
@@ -146,13 +145,13 @@ Tailnet。
 - [x] 产出可复现的 iOS、Android 开发构建。
 
 完成条件：手机通过私有 Tailnet HTTPS Endpoint 完成一次配对后，后续可自动重连，并
-完成与 WebUI 相同的核心对话和 Task 流程；显式 Funnel 模式保持可用。
+完成与 WebUI 相同的核心对话和 Task 流程。
 
 ## RA5 — 加固与发版准备
 
 - [x] 增加远程未认证、Origin 绕过、邀请过期/重放、设备撤销和旧租约的反例测试。
 - [x] 移动端在 App 重启后复用配对时持久化的 Client 实例身份，避免被误判为新客户端。
-- [ ] 测试 Tailnet 直连/DERP 回退、Funnel、Wi-Fi/蜂窝切换、电脑休眠/唤醒、Gateway 重启，以及
+- [ ] 测试 Tailnet 直连/DERP 回退、Wi-Fi/蜂窝切换、电脑休眠/唤醒、Gateway 重启，以及
   一小时 WebSocket/音频会话。
 - [x] 对 Desktop、WebUI、TUI 与 Mobile 执行统一协议 Conformance。
 - [x] 增加 macOS、Windows、Linux、iOS 与 Android 构建检查；真实设备场景仍按上一项

--- a/server/src/access/gateway-remote-access-service.mjs
+++ b/server/src/access/gateway-remote-access-service.mjs
@@ -18,7 +18,6 @@ import { GatewayUrlSchema } from '../../../shared/gateway-remote-access.mjs'
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const PACKAGE_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).version
 const SUPPORTED_PORTS = new Set([443, 8443, 10000])
-const REMOTE_ACCESS_MODES = new Set(['private', 'funnel'])
 const AUTH_URL = /^https:\/\/login\.tailscale\.com\//
 const ACTION_URL = /^https:\/\/tailscale\.com\//
 
@@ -160,32 +159,21 @@ export async function ensureTsnetComponent({
   return { path: destination, source: 'downloaded' }
 }
 
-export function normalizeRemoteAccessMode(value, fallback = 'private') {
-  const mode = String(value || fallback).trim().toLowerCase()
-  if (!REMOTE_ACCESS_MODES.has(mode)) {
-    const error = new TypeError(`Unsupported remote access mode: ${mode}`)
-    error.code = 'remote_access_mode_invalid'
-    throw error
-  }
-  return mode
-}
-
-function readSettings(path, defaultMode) {
+function readSettings(path) {
   try {
     const stored = JSON.parse(readFileSync(path, 'utf8'))
     return {
       enabled: stored?.enabled === true,
-      mode: normalizeRemoteAccessMode(stored?.mode, defaultMode),
     }
   } catch {
-    return { enabled: false, mode: defaultMode }
+    return { enabled: false }
   }
 }
 
-function writeSettings(path, { enabled, mode }) {
+function writeSettings(path, { enabled }) {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
   const temporary = `${path}.${process.pid}.tmp`
-  writeFileSync(temporary, `${JSON.stringify({ version: 2, enabled, mode }, null, 2)}\n`, {
+  writeFileSync(temporary, `${JSON.stringify({ version: 3, enabled }, null, 2)}\n`, {
     mode: 0o600,
   })
   renameSync(temporary, path)
@@ -205,13 +193,8 @@ export class GatewayRemoteAccessService {
     if (!SUPPORTED_PORTS.has(port)) {
       throw new TypeError('Remote access port must be 443, 8443, or 10000')
     }
-    const defaultMode = normalizeRemoteAccessMode(
-      env.QWEN_AUDIO_REMOTE_ACCESS_MODE,
-      'private',
-    )
     const settings = readSettings(
       join(resolve(configDirectory), 'state', 'remote-access.json'),
-      defaultMode,
     )
     this.configDirectory = resolve(configDirectory)
     this.settingsPath = join(this.configDirectory, 'state', 'remote-access.json')
@@ -223,7 +206,6 @@ export class GatewayRemoteAccessService {
     this.spawnImpl = spawnImpl
     this.ensureComponent = ensureComponent
     this.enabled = settings.enabled
-    this.mode = settings.mode
     this.gatewayUrl = ''
     this.child = null
     this.startPromise = null
@@ -241,7 +223,6 @@ export class GatewayRemoteAccessService {
     return {
       available: true,
       enabled: this.enabled,
-      mode: this.mode,
       connected: this.state === 'connected',
       published: Boolean(this.endpoint),
       state: this.state,
@@ -255,13 +236,9 @@ export class GatewayRemoteAccessService {
     }
   }
 
-  async enable(gatewayUrl, { mode = 'private' } = {}) {
-    const nextMode = normalizeRemoteAccessMode(mode)
-    const modeChanged = nextMode !== this.mode
+  async enable(gatewayUrl) {
     this.enabled = true
-    this.mode = nextMode
-    writeSettings(this.settingsPath, { enabled: true, mode: this.mode })
-    if (modeChanged && (this.child || this.startPromise)) await this.stop()
+    writeSettings(this.settingsPath, { enabled: true })
     return this.start(gatewayUrl)
   }
 
@@ -297,7 +274,6 @@ export class GatewayRemoteAccessService {
         '--state-dir', this.stateDirectory,
         '--hostname', this.hostname,
         '--port', String(this.port),
-        '--mode', this.mode,
       ], {
         env: { ...this.env },
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -346,7 +322,7 @@ export class GatewayRemoteAccessService {
 
   async disable() {
     this.enabled = false
-    writeSettings(this.settingsPath, { enabled: false, mode: this.mode })
+    writeSettings(this.settingsPath, { enabled: false })
     await this.stop()
     this.state = 'disabled'
     return { ...this.status(), changed: true }
@@ -421,7 +397,7 @@ export class GatewayRemoteAccessService {
       this.authUrl = null
       this.actionUrl = null
       this.error = null
-      this.logger?.info?.('remote_access.ready', { endpoint, mode: this.mode })
+      this.logger?.info?.('remote_access.ready', { endpoint })
       this.#resolveWaiters()
     } else if (event.type === 'error') {
       this.actionUrl = ACTION_URL.test(event.action_url || '')

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -36,10 +36,7 @@ import {
   parseGatewayAccessKeys,
 } from '../access/gateway-access.mjs'
 import { gatewayBrowserPairingPage } from '../access/browser-pairing-page.mjs'
-import {
-  GatewayRemoteAccessService,
-  normalizeRemoteAccessMode,
-} from '../access/gateway-remote-access-service.mjs'
+import { GatewayRemoteAccessService } from '../access/gateway-remote-access-service.mjs'
 import {
   GATEWAY_CAPABILITIES,
   GATEWAY_PROTOCOL_VERSION,
@@ -634,13 +631,7 @@ app.post('/api/access/remote', (req, res) => {
       code: 'gateway_not_ready',
     })
   }
-  let mode
-  try {
-    mode = normalizeRemoteAccessMode(req.body?.mode, 'private')
-  } catch (error) {
-    return res.status(400).json({ error: error.message, code: error.code })
-  }
-  Promise.resolve(remoteAccessRuntime.enable(localGatewayOrigin(address), { mode }))
+  Promise.resolve(remoteAccessRuntime.enable(localGatewayOrigin(address)))
     .then(status => res.status(status.state === 'auth_required' ? 202 : 200).json(status))
     .catch(error => respondRemoteAccessError(res, error))
 })

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -140,8 +140,8 @@ test('protects remote HTTP access and completes one-time device pairing', async 
         : null,
     }),
     resume: async url => remoteAccessCalls.push(['resume', url]),
-    enable: async (url, options) => {
-      remoteAccessCalls.push(['enable', url, options])
+    enable: async url => {
+      remoteAccessCalls.push(['enable', url])
       remoteAccessEnabled = true
       return remoteAccess.status()
     },
@@ -195,7 +195,7 @@ test('protects remote HTTP access and completes one-time device pairing', async 
   assert.equal(enabledRemoteAccess.status, 200)
   assert.equal(enabledRemoteAccess.body.endpoint.url, 'https://voice.example.ts.net')
   assert.equal(remoteAccessCalls.at(-1)[1], `http://127.0.0.1:${port}`)
-  assert.deepEqual(remoteAccessCalls.at(-1)[2], { mode: 'private' })
+  assert.equal(remoteAccessCalls.at(-1).length, 2)
 
   const denied = await requestJson({
     port,

--- a/server/test/gateway-remote-access-service.test.mjs
+++ b/server/test/gateway-remote-access-service.test.mjs
@@ -112,16 +112,12 @@ test('Gateway owns tsnet authorization, endpoint state, persistence, and shutdow
   const awaitingAuth = await enabling
   assert.equal(awaitingAuth.state, 'auth_required')
   assert.equal(awaitingAuth.published, false)
-  assert.equal(awaitingAuth.mode, 'private')
   assert.match(spawnCall.args.join(' '), /127\.0\.0\.1:3101/)
-  assert.deepEqual(spawnCall.args.slice(-2), ['--mode', 'private'])
+  assert.deepEqual(spawnCall.args.slice(-2), ['--port', '443'])
+  assert.equal(spawnCall.args.includes('--mode'), false)
   assert.equal(
     JSON.parse(readFileSync(join(directory, 'state', 'remote-access.json'))).enabled,
     true,
-  )
-  assert.equal(
-    JSON.parse(readFileSync(join(directory, 'state', 'remote-access.json'))).mode,
-    'private',
   )
 
   child.stdout.write(`${JSON.stringify({
@@ -142,7 +138,7 @@ test('Gateway owns tsnet authorization, endpoint state, persistence, and shutdow
   assert.equal(existsSync(join(directory, 'state', 'tsnet')), false)
 })
 
-test('preserves actionable Funnel setup errors after the component exits', async () => {
+test('preserves actionable private Tailnet setup errors after the component exits', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'qwa-tsnet-action-'))
   const child = fakeChild()
   const service = new GatewayRemoteAccessService({
@@ -150,32 +146,18 @@ test('preserves actionable Funnel setup errors after the component exits', async
     spawnImpl: () => child,
     ensureComponent: async () => ({ path: '/tmp/qwaudio-tsnet', source: 'test' }),
   })
-  const enabling = service.enable('http://127.0.0.1:3101', { mode: 'funnel' })
+  const enabling = service.enable('http://127.0.0.1:3101')
   await new Promise(resolve => setImmediate(resolve))
   child.stdout.write(`${JSON.stringify({
     type: 'error',
-    code: 'funnel_start_failed',
-    message: 'Funnel requires HTTPS',
+    code: 'private_listener_start_failed',
+    message: 'Tailnet HTTPS is not ready',
     action_url: 'https://tailscale.com/s/https',
   })}\n`)
   child.emit('exit', 1, null)
 
   const failed = await enabling
-  assert.equal(failed.mode, 'funnel')
   assert.equal(failed.state, 'error')
-  assert.equal(failed.error.code, 'funnel_start_failed')
+  assert.equal(failed.error.code, 'private_listener_start_failed')
   assert.equal(failed.actionUrl, 'https://tailscale.com/s/https')
-})
-
-test('rejects unsupported remote access modes before starting the component', async () => {
-  const directory = mkdtempSync(join(tmpdir(), 'qwa-tsnet-mode-'))
-  const service = new GatewayRemoteAccessService({
-    configDirectory: directory,
-    spawnImpl: () => { throw new Error('must not spawn') },
-    ensureComponent: async () => ({ path: '/tmp/qwaudio-tsnet', source: 'test' }),
-  })
-  await assert.rejects(
-    service.enable('http://127.0.0.1:3101', { mode: 'public' }),
-    error => error.code === 'remote_access_mode_invalid',
-  )
 })

--- a/shared/gateway-client.mjs
+++ b/shared/gateway-client.mjs
@@ -106,7 +106,6 @@ export function readGatewayRemoteAccess(baseUrl, fetchImpl = fetch) {
 
 export function enableGatewayRemoteAccess(
   baseUrl,
-  { mode = 'private' } = {},
   fetchImpl = fetch,
 ) {
   return gatewayManagementRequest(
@@ -114,8 +113,6 @@ export function enableGatewayRemoteAccess(
     '/api/access/remote',
     {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ mode }),
     },
     fetchImpl,
     { timeoutMs: 180_000 },

--- a/sidecars/tsnet/main.go
+++ b/sidecars/tsnet/main.go
@@ -1,7 +1,6 @@
 // qwaudio-tsnet publishes a loopback Qwen Audio Agent Gateway through a
-// private tailnet by default, with Funnel available as an explicit option. It
-// is an implementation detail of Gateway remote access, not a second Gateway
-// and not a client-facing protocol endpoint.
+// private tailnet. It is an implementation detail of Gateway remote access,
+// not a second Gateway and not a client-facing protocol endpoint.
 package main
 
 import (
@@ -11,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -52,17 +50,15 @@ func main() {
 	var gatewayURL string
 	var stateDir string
 	var hostname string
-	var mode string
 	var port int
 	flag.StringVar(&gatewayURL, "gateway", "http://127.0.0.1:3101", "loopback Gateway URL")
 	flag.StringVar(&stateDir, "state-dir", "", "persistent tsnet state directory")
 	flag.StringVar(&hostname, "hostname", "qwen-audio-agent", "Tailscale node hostname")
-	flag.StringVar(&mode, "mode", "private", "remote access mode: private or funnel")
 	flag.IntVar(&port, "port", 443, "remote HTTPS port")
 	flag.Parse()
 
 	events := new(eventWriter)
-	if err := run(gatewayURL, stateDir, hostname, mode, port, events); err != nil {
+	if err := run(gatewayURL, stateDir, hostname, port, events); err != nil {
 		fields := map[string]any{
 			"code":    errorCode(err),
 			"message": err.Error(),
@@ -75,16 +71,13 @@ func main() {
 	}
 }
 
-func run(gatewayURL, stateDir, hostname, mode string, port int, events *eventWriter) error {
+func run(gatewayURL, stateDir, hostname string, port int, events *eventWriter) error {
 	target, err := url.Parse(gatewayURL)
 	if err != nil || target.Scheme != "http" || !isLoopback(target.Hostname()) {
 		return fmt.Errorf("invalid_gateway: gateway must be a loopback HTTP URL")
 	}
 	if stateDir == "" {
 		return fmt.Errorf("invalid_state_dir: state directory is required")
-	}
-	if mode != "private" && mode != "funnel" {
-		return fmt.Errorf("invalid_mode: mode must be private or funnel")
 	}
 	if port != 443 && port != 8443 && port != 10000 {
 		return fmt.Errorf("invalid_port: HTTPS port must be 443, 8443, or 10000")
@@ -120,16 +113,8 @@ func run(gatewayURL, stateDir, hostname, mode string, port int, events *eventWri
 		return fmt.Errorf("tailscale_start_failed: %w", err)
 	}
 
-	var listener net.Listener
-	if mode == "funnel" {
-		listener, err = server.ListenFunnel("tcp", fmt.Sprintf(":%d", port))
-	} else {
-		listener, err = server.ListenTLS("tcp", fmt.Sprintf(":%d", port))
-	}
+	listener, err := server.ListenTLS("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
-		if mode == "funnel" {
-			return fmt.Errorf("funnel_start_failed: %w", err)
-		}
 		return fmt.Errorf("private_listener_start_failed: %w", err)
 	}
 	defer listener.Close()
@@ -153,7 +138,7 @@ func run(gatewayURL, stateDir, hostname, mode string, port int, events *eventWri
 		Handler:           proxy,
 		ReadHeaderTimeout: 15 * time.Second,
 	}
-	events.emit("endpoint_ready", map[string]any{"url": endpoint, "mode": mode})
+	events.emit("endpoint_ready", map[string]any{"url": endpoint})
 
 	serveError := make(chan error, 1)
 	go func() { serveError <- httpServer.Serve(listener) }()

--- a/test/gateway-access-client.test.mjs
+++ b/test/gateway-access-client.test.mjs
@@ -118,7 +118,6 @@ test('remote access lifecycle helpers call only the local Gateway management pla
   await readGatewayRemoteAccess('http://127.0.0.1:3101', fetchImpl)
   await enableGatewayRemoteAccess(
     'http://127.0.0.1:3101',
-    { mode: 'funnel' },
     fetchImpl,
   )
   await disableGatewayRemoteAccess('http://127.0.0.1:3101', fetchImpl)
@@ -127,5 +126,5 @@ test('remote access lifecycle helpers call only the local Gateway management pla
     ['http://127.0.0.1:3101/api/access/remote', 'POST'],
     ['http://127.0.0.1:3101/api/access/remote', 'DELETE'],
   ])
-  assert.deepEqual(JSON.parse(requests[1].options.body), { mode: 'funnel' })
+  assert.equal(requests[1].options.body, undefined)
 })

--- a/test/remote-access-client-boundary.test.mjs
+++ b/test/remote-access-client-boundary.test.mjs
@@ -11,7 +11,7 @@ const clientSourceDirectories = [
   'mobile/src',
 ]
 const sourceExtensions = new Set(['.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx'])
-const implementationTerms = /\b(?:tailscale|tailnet|tsnet|funnel)\b/i
+const implementationTerms = /\b(?:tailscale|tailnet|tsnet)\b/i
 
 function sourceFiles(directory) {
   return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {


### PR DESCRIPTION
## Summary

- remove the public remote-access mode and its configuration surface
- keep Gateway remote access on a single private Tailnet path
- simplify the tsnet sidecar, API, CLI, tests, and bilingual documentation

Closes no issue; follows #320.

## Validation

- npm test
- npm run lint
- npm run build
- git diff --check