### PR TITLE
fix(session): restore journals with sequence gaps

### DIFF
--- a/server/src/session/session-journal.mjs
+++ b/server/src/session/session-journal.mjs
@@ -69,7 +69,7 @@ export class SessionJournal {
       }
       const normalized = normalizeSessionEvent(event, {
         sessionId: this.sessionId,
-        seq: this.events.length + 1,
+        seq: (this.events.at(-1)?.seq || 0) + 1,
         time: this.now(),
       })
       await appendFile(this.filePath, line(normalized), { encoding: 'utf8', mode: 0o600 })

--- a/server/test/session-journal.test.mjs
+++ b/server/test/session-journal.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { appendFile, mkdtemp, readFile } from 'node:fs/promises'
+import { appendFile, mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -20,6 +20,23 @@ test('writes a DSH-shaped append-only session log and restores sequence', async 
   await restored.open()
   assert.deepEqual(restored.eventsSince().map(event => event.seq), [1, 2])
   assert.equal(JSON.parse((await readFile(journal.filePath, 'utf8')).split('\n')[0]).type, 'session')
+})
+
+test('restores historical journals with monotonic sequence gaps and appends after the last sequence', async () => {
+  const journal = await journalFixture()
+  await journal.append({ type: SessionEventType.USER_MESSAGE, payload: { text: 'hello' } })
+  await journal.append({ type: SessionEventType.TURN_END, payload: { reason: 'completed' } })
+  const records = (await readFile(journal.filePath, 'utf8')).trim().split('\n').map(JSON.parse)
+  records[1].seq = 127
+  records[2].seq = 136
+  await writeFile(journal.filePath, `${records.map(record => JSON.stringify(record)).join('\n')}\n`, 'utf8')
+
+  const restored = new SessionJournal({ filePath: journal.filePath, sessionId: 'session-1' })
+  await restored.open()
+  const appended = await restored.append({ type: SessionEventType.USER_MESSAGE, payload: { text: 'again' } })
+
+  assert.deepEqual(restored.eventsSince().map(event => event.seq), [127, 136, 137])
+  assert.equal(appended.seq, 137)
 })
 
 test('deduplicates retried writes by eventId', async () => {

--- a/shared/session-events.mjs
+++ b/shared/session-events.mjs
@@ -61,10 +61,18 @@ export function validateSessionLog(records, { sessionId } = {}) {
     throw new TypeError('invalid session log header')
   }
   if (sessionId && header.sessionId !== sessionId) throw new TypeError('session id mismatch')
+  let previousSeq = 0
   events.forEach((event, index) => {
-    if (event.schema !== SESSION_LOG_SCHEMA || event.sessionId !== header.sessionId || event.seq !== index + 1) {
-      throw new TypeError(`invalid session event at sequence ${index + 1}`)
+    if (
+      event.schema !== SESSION_LOG_SCHEMA
+      || event.sessionId !== header.sessionId
+      || !Number.isInteger(event.seq)
+      || event.seq < 1
+      || event.seq <= previousSeq
+    ) {
+      throw new TypeError(`invalid session event at index ${index + 1}`)
     }
+    previousSeq = event.seq
   })
   return { header, events }
 }


### PR DESCRIPTION
## Summary

- accept positive, strictly increasing historical journal sequences even when gaps exist
- continue appending from the last durable sequence instead of the event count
- cover recovery and append behavior with a regression test

## Verification

- `node --test server/test/session-journal.test.mjs`
- replayed the two reported local journals successfully
- started Gateway and restored conversation history without warnings