### PR TITLE
refactor(providers): isolate shared text model client

### DIFF
--- a/scripts/test/memory-extractor-e2e.mjs
+++ b/scripts/test/memory-extractor-e2e.mjs
@@ -15,10 +15,10 @@ import { ConversationSync } from '../../server/src/conversation/conversation-syn
 import { FrontendMemoryService } from '../../server/src/conversation/frontend-memory-service.mjs'
 import { MarkdownContextStore } from '../../server/src/conversation/markdown-context-store.mjs'
 import { MemoryAudit } from '../../server/src/conversation/memory-audit.mjs'
+import { MemoryExtractor } from '../../server/src/conversation/memory-extractor.mjs'
 import {
-  MemoryExtractor,
-  createExtractorLlmCall,
-} from '../../server/src/conversation/memory-extractor.mjs'
+  createOpenAiCompatibleTextCall,
+} from '../../server/src/providers/llm/openai-compatible-chat.mjs'
 
 function resolveApiKey() {
   if (process.env.QWEN_AUDIO_MEMORY_API_KEY) return process.env.QWEN_AUDIO_MEMORY_API_KEY
@@ -166,7 +166,7 @@ for (const scenario of SCENARIOS) {
     memoryService,
     conversationSync: session(scenario.turns),
     audit: new MemoryAudit({ filePath: auditPath }),
-    llmCall: createExtractorLlmCall({
+    llmCall: createOpenAiCompatibleTextCall({
       baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
       apiKey,
       model,

--- a/server/src/app/gateway-application.mjs
+++ b/server/src/app/gateway-application.mjs
@@ -12,10 +12,7 @@ import { InputAssetRegistry } from '../voice/input-asset-registry.mjs'
 import { IdentityManager } from '../core/identity.mjs'
 import { FrontendNotesStore } from '../conversation/frontend-notes.mjs'
 import { MemoryAudit } from '../conversation/memory-audit.mjs'
-import {
-  MemoryExtractor,
-  createExtractorLlmCall,
-} from '../conversation/memory-extractor.mjs'
+import { MemoryExtractor } from '../conversation/memory-extractor.mjs'
 import { FrontendMemoryRuntime } from '../conversation/memory-runtime.mjs'
 import { createConfiguredMemoryProvider } from './memory-provider-factory.mjs'
 import { SessionConversationHistory } from './session-conversation-history.mjs'
@@ -25,6 +22,9 @@ import { PreferencePromoter } from '../conversation/preference-promoter.mjs'
 import { ProfileObserver } from '../conversation/profile-observer.mjs'
 import { SessionDigestPool } from '../conversation/session-digest.mjs'
 import { SessionSummariser } from '../conversation/session-summariser.mjs'
+import {
+  createOpenAiCompatibleTextCall,
+} from '../providers/llm/openai-compatible-chat.mjs'
 import {
   KnowledgeLibrary,
 } from '../knowledge/local-library.mjs'
@@ -300,17 +300,17 @@ const notesStore = new FrontendNotesStore({
 // lightweight text model after a voice session closes. Providers advertising
 // sessionObservation own that lifecycle themselves, so two independent
 // learners can never write conflicting memories from the same conversation.
-// Without an API key createExtractorLlmCall returns null
+// Without an API key createOpenAiCompatibleTextCall returns null
 // and the extractor stays silently disabled; explicit memories are
 // unaffected. ASSISTANT.md is never exposed as a writable document.
 const memoryAudit = new MemoryAudit({
   filePath: config.memoryAuditPath,
   onWarning: warning => logger.warn('memory.audit_warning', { warning }),
 })
-// 记忆类模型调用共用一套凭据与轻量文本模型；没有 API key 时为 null，
-// 依赖它的模块各自静默禁用，本地纯语音链路不受影响。
-const memoryLlmCall = config.memoryAutoEnabled
-  ? createExtractorLlmCall({
+// 后台轻量分析共用一套文本模型调用；没有 API key 时为 null，依赖它的
+// 记忆学习、会话摘要和资料摘要模块各自静默禁用，本地纯语音链路不受影响。
+const textModelCall = config.memoryAutoEnabled
+  ? createOpenAiCompatibleTextCall({
       baseUrl: config.memoryBaseUrl,
       apiKey: config.memoryApiKey,
       model: config.memoryModel,
@@ -326,7 +326,7 @@ const memoryExtractor = providerOwnsSessionObservation
       memoryService: frontendMemoryRuntime,
       conversationSync,
       audit: memoryAudit,
-      llmCall: memoryLlmCall,
+      llmCall: textModelCall,
       logger,
     })
 // 偏好自更新：观察器从刚结束的会话里推断画像信号 → 槽位池积累跨会话确认 →
@@ -352,12 +352,12 @@ if (config.preferenceLearningEnabled && !providerOwnsSessionObservation) {
     audit: memoryAudit,
     logger,
   })
-  profileObserver = memoryLlmCall
+  profileObserver = textModelCall
     ? new ProfileObserver({
         candidatePool: preferenceCandidates,
         conversationSync,
         audit: memoryAudit,
-        llmCall: memoryLlmCall,
+        llmCall: textModelCall,
         logger,
       })
     : null
@@ -373,12 +373,12 @@ if (config.sessionDigestEnabled) {
     filePath: config.sessionDigestPath,
     onWarning: warning => logger.warn('session_digest.persistence_warning', { warning }),
   })
-  sessionSummariser = memoryLlmCall
+  sessionSummariser = textModelCall
     ? new SessionSummariser({
         digestPool: sessionDigests,
         conversationSync,
         audit: memoryAudit,
-        llmCall: memoryLlmCall,
+        llmCall: textModelCall,
         logger,
         // 把本场派过的活沉淀进摘要。排除 control（「查一下那个任务的进展」这个
         // 动作本身）与 reminder（未来要做的事，不属于「做过什么」）。
@@ -401,11 +401,11 @@ if (config.domainLibraryEnabled) {
     indexPath: config.domainIndexPath,
     onWarning: warning => logger.warn('domain.persistence_warning', { warning }),
   })
-  domainSummariser = memoryLlmCall
+  domainSummariser = textModelCall
     ? new KnowledgeSummariser({
         library: domainLibrary,
         audit: memoryAudit,
-        llmCall: memoryLlmCall,
+        llmCall: textModelCall,
         logger,
       })
     : null

--- a/server/src/conversation/memory-extractor.mjs
+++ b/server/src/conversation/memory-extractor.mjs
@@ -199,66 +199,6 @@ function transcriptLines(messages, maxChars) {
   return lines
 }
 
-// Production llmCall factory: one stateless chat-completions request against
-// any OpenAI-compatible endpoint (DashScope by default, local Ollama works
-// too). Returns null without an API key so the extractor silently disables —
-// the voice-only product must degrade without a sound.
-export function createExtractorLlmCall({
-  baseUrl,
-  apiKey,
-  model,
-  timeoutMs = 10_000,
-  fetchImpl = globalThis.fetch,
-} = {}) {
-  if (!apiKey || !baseUrl || !model) return null
-  return async ({ system, user }) => {
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), timeoutMs)
-    try {
-      const request = async (includeTemperature) => fetchImpl(
-        `${baseUrl}/chat/completions`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${apiKey}`,
-          },
-          body: JSON.stringify({
-            model,
-            messages: [
-              { role: 'system', content: system },
-              { role: 'user', content: user },
-            ],
-            ...(includeTemperature ? { temperature: 0 } : {}),
-          }),
-          signal: controller.signal,
-        },
-      )
-      // Some OpenAI-compatible models reject optional sampling parameters.
-      // Retry once with the smallest common request shape; the timeout remains
-      // shared so a compatibility retry cannot double the caller's deadline.
-      let response = await request(true)
-      if (response.status === 400) {
-        await response.body?.cancel?.()
-        response = await request(false)
-      }
-      if (!response.ok) {
-        const detail = String(await response.text().catch(() => ''))
-          .replace(/\s+/g, ' ')
-          .trim()
-          .slice(0, 300)
-        throw new Error(
-          `memory extractor request failed: ${response.status}${detail ? ` ${detail}` : ''}`,
-        )
-      }
-      const payload = await response.json()
-      return String(payload?.choices?.[0]?.message?.content || '')
-    } finally {
-      clearTimeout(timer)
-    }
-  }
-}
-
 export class MemoryExtractor {
   constructor({
     memoryService,

--- a/server/src/providers/llm/openai-compatible-chat.mjs
+++ b/server/src/providers/llm/openai-compatible-chat.mjs
@@ -1,0 +1,58 @@
+// One stateless chat-completions request against any OpenAI-compatible
+// endpoint. Returning null for incomplete configuration lets optional
+// background analysis disable itself without affecting the voice runtime.
+export function createOpenAiCompatibleTextCall({
+  baseUrl,
+  apiKey,
+  model,
+  timeoutMs = 10_000,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (!apiKey || !baseUrl || !model) return null
+  return async ({ system, user }) => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const request = async (includeTemperature) => fetchImpl(
+        `${baseUrl}/chat/completions`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model,
+            messages: [
+              { role: 'system', content: system },
+              { role: 'user', content: user },
+            ],
+            ...(includeTemperature ? { temperature: 0 } : {}),
+          }),
+          signal: controller.signal,
+        },
+      )
+      // Some OpenAI-compatible models reject optional sampling parameters.
+      // Retry once with the smallest common request shape; the timeout remains
+      // shared so a compatibility retry cannot double the caller's deadline.
+      let response = await request(true)
+      if (response.status === 400) {
+        await response.body?.cancel?.()
+        response = await request(false)
+      }
+      if (!response.ok) {
+        const detail = String(await response.text().catch(() => ''))
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, 300)
+        throw new Error(
+          `text model request failed: ${response.status}${detail ? ` ${detail}` : ''}`,
+        )
+      }
+      const payload = await response.json()
+      return String(payload?.choices?.[0]?.message?.content || '')
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/server/test/memory-extractor.test.mjs
+++ b/server/test/memory-extractor.test.mjs
@@ -6,10 +6,7 @@ import test from 'node:test'
 import { ConversationSync } from '../src/conversation/conversation-sync.mjs'
 import { FrontendMemoryService } from '../src/conversation/frontend-memory-service.mjs'
 import { MarkdownContextStore } from '../src/conversation/markdown-context-store.mjs'
-import {
-  MemoryExtractor,
-  createExtractorLlmCall,
-} from '../src/conversation/memory-extractor.mjs'
+import { MemoryExtractor } from '../src/conversation/memory-extractor.mjs'
 
 const OWNER = 'owner'
 const SESSION = 'main'
@@ -318,46 +315,4 @@ test('survives provider and malformed-output failures without throwing', async (
     await instance.maybeRun({ ownerId: OWNER, sessionId: SESSION })
     assert.equal(events.at(-1).op, 'error')
   }
-})
-
-test('createExtractorLlmCall posts to chat completions and surfaces errors', async () => {
-  assert.equal(createExtractorLlmCall({ baseUrl: 'https://example.com/v1', apiKey: '' }), null)
-  const requests = []
-  const llmCall = createExtractorLlmCall({
-    baseUrl: 'https://example.com/v1',
-    apiKey: 'test-key',
-    model: 'qwen-flash',
-    fetchImpl: async (url, options) => {
-      requests.push({ url, options })
-      return { ok: true, json: async () => ({ choices: [{ message: { content: '{}' } }] }) }
-    },
-  })
-  assert.equal(await llmCall({ system: 's', user: 'u' }), '{}')
-  assert.equal(requests[0].url, 'https://example.com/v1/chat/completions')
-  assert.equal(requests[0].options.headers.Authorization, 'Bearer test-key')
-  assert.equal(JSON.parse(requests[0].options.body).temperature, 0)
-
-  const retriedRequests = []
-  const compatible = createExtractorLlmCall({
-    baseUrl: 'https://example.com/v1',
-    apiKey: 'test-key',
-    model: 'strict-compatible-model',
-    fetchImpl: async (url, options) => {
-      retriedRequests.push({ url, options })
-      return retriedRequests.length === 1
-        ? { ok: false, status: 400, text: async () => 'unsupported temperature' }
-        : { ok: true, json: async () => ({ choices: [{ message: { content: '[]' } }] }) }
-    },
-  })
-  assert.equal(await compatible({ system: 's', user: 'u' }), '[]')
-  assert.equal(retriedRequests.length, 2)
-  assert.equal('temperature' in JSON.parse(retriedRequests[1].options.body), false)
-
-  const failing = createExtractorLlmCall({
-    baseUrl: 'https://example.com/v1',
-    apiKey: 'test-key',
-    model: 'qwen-flash',
-    fetchImpl: async () => ({ ok: false, status: 429, text: async () => 'rate limited' }),
-  })
-  await assert.rejects(() => failing({ system: 's', user: 'u' }), /request failed: 429 rate limited/)
 })

--- a/server/test/openai-compatible-chat.test.mjs
+++ b/server/test/openai-compatible-chat.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  createOpenAiCompatibleTextCall,
+} from '../src/providers/llm/openai-compatible-chat.mjs'
+
+test('posts to OpenAI-compatible chat completions and surfaces errors', async () => {
+  assert.equal(createOpenAiCompatibleTextCall({
+    baseUrl: 'https://example.com/v1',
+    apiKey: '',
+  }), null)
+  const requests = []
+  const llmCall = createOpenAiCompatibleTextCall({
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'test-key',
+    model: 'qwen-flash',
+    fetchImpl: async (url, options) => {
+      requests.push({ url, options })
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: '{}' } }] }),
+      }
+    },
+  })
+  assert.equal(await llmCall({ system: 's', user: 'u' }), '{}')
+  assert.equal(requests[0].url, 'https://example.com/v1/chat/completions')
+  assert.equal(requests[0].options.headers.Authorization, 'Bearer test-key')
+  assert.equal(JSON.parse(requests[0].options.body).temperature, 0)
+
+  const retriedRequests = []
+  const compatible = createOpenAiCompatibleTextCall({
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'test-key',
+    model: 'strict-compatible-model',
+    fetchImpl: async (url, options) => {
+      retriedRequests.push({ url, options })
+      return retriedRequests.length === 1
+        ? { ok: false, status: 400, text: async () => 'unsupported temperature' }
+        : {
+            ok: true,
+            json: async () => ({ choices: [{ message: { content: '[]' } }] }),
+          }
+    },
+  })
+  assert.equal(await compatible({ system: 's', user: 'u' }), '[]')
+  assert.equal(retriedRequests.length, 2)
+  assert.equal(
+    'temperature' in JSON.parse(retriedRequests[1].options.body),
+    false,
+  )
+
+  const failing = createOpenAiCompatibleTextCall({
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'test-key',
+    model: 'qwen-flash',
+    fetchImpl: async () => ({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited',
+    }),
+  })
+  await assert.rejects(
+    () => failing({ system: 's', user: 'u' }),
+    /text model request failed: 429 rate limited/,
+  )
+})


### PR DESCRIPTION
## Summary

- move the reusable OpenAI-compatible chat-completions client out of the memory extractor
- give the shared client a provider-level name and reuse it for memory learning, session summaries, and knowledge summaries
- keep request, retry, timeout, and optional-disable behavior unchanged
- move the transport-specific tests alongside the new provider module boundary

## Verification

- `npm run lint`
- `node --test server/test/openai-compatible-chat.test.mjs server/test/memory-extractor.test.mjs server/test/session-summariser.test.mjs server/test/knowledge-summariser.test.mjs server/test/dependency-boundaries.test.mjs`
- `git diff --check`

The local aggregate Gateway test encountered the existing macOS keychain `SecItemCopyMatching` process crash; all tests covering this change pass, and CI remains the authoritative full-suite check.
