### PR TITLE
refactor(examples): use public framework entries

### DIFF
--- a/examples/backend-adapter/README.md
+++ b/examples/backend-adapter/README.md
@@ -4,7 +4,8 @@
 shows lifecycle, Task submission, status, cancellation, events, bounded public
 results, and idempotent cleanup without exposing a private task graph.
 
-Run the same public conformance suite used by built-in adapters:
+From a source checkout, run the same public conformance suite used by built-in
+adapters:
 
 ```bash
 node --test server/test/backend-adapter-sdk.test.mjs

--- a/examples/backend-adapter/in-memory-backend.mjs
+++ b/examples/backend-adapter/in-memory-backend.mjs
@@ -1,6 +1,6 @@
 import {
   defineBackendAdapter,
-} from '../../server/src/backend/backend-adapter-sdk.mjs'
+} from 'qwen-audio-agent/backend-adapter-sdk'
 
 function clean(value) {
   return String(value || '').trim()

--- a/examples/smart-cockpit/bench/runner/run-voice.mjs
+++ b/examples/smart-cockpit/bench/runner/run-voice.mjs
@@ -15,16 +15,16 @@ import { CockpitStateStore } from '../../service/state-store.mjs'
 import { COCKPIT_SURFACE_ROUTING } from '../../service/tools/registry.mjs'
 import {
   GatewayClient,
-} from '../../../../shared/gateway/client-sdk.mjs'
+} from 'qwen-audio-agent/gateway-client-sdk'
 import {
   GatewayClientCapability,
   GatewayClientProtocolEvent,
-} from '../../../../shared/protocol/gateway-client-protocol.mjs'
+} from 'qwen-audio-agent/gateway-client-protocol'
 import {
   GatewayClientEvent,
   GatewayServerEvent,
   GatewayTaskEvent,
-} from '../../../../shared/protocol/realtime-events.mjs'
+} from 'qwen-audio-agent/realtime-events'
 import { loadNavigationCases, routeCasesExpectedPaths } from '../evaluator/cases.mjs'
 import { scoreTrace, summarizeScores } from '../evaluator/score.mjs'
 

--- a/test/public-example-boundaries.test.mjs
+++ b/test/public-example-boundaries.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const examples = [
+  '../examples/backend-adapter/in-memory-backend.mjs',
+  '../examples/smart-cockpit/bench/runner/run-voice.mjs',
+]
+
+test('public examples depend only on exported framework entry points', async () => {
+  const manifest = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+  )
+  for (const path of examples) {
+    const source = await readFile(new URL(path, import.meta.url), 'utf8')
+    const imports = [...source.matchAll(
+      /from ['"]qwen-audio-agent\/([^'"]+)['"]/g,
+    )]
+    assert.ok(imports.length, `${path} does not use a public framework entry`)
+    for (const [, subpath] of imports) {
+      assert.ok(
+        manifest.exports[`./${subpath}`],
+        `${path} imports an unexported framework entry: ${subpath}`,
+      )
+    }
+    assert.doesNotMatch(
+      source,
+      /from ['"](?:\.\.\/)+(?:server\/src|shared)\//,
+      `${path} imports a private framework module`,
+    )
+  }
+})


### PR DESCRIPTION
## Summary

- make runnable examples consume stable package exports instead of private source paths
- document that the adapter conformance test is run from a source checkout
- guard public example imports with a focused boundary test

## Verification

- `npm test`
- `npm run build`
- `npm run lint`
- `node scripts/verify-package.mjs`
- `node --test test/public-example-boundaries.test.mjs`
