### PR TITLE
test: close package boundary coverage gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "eval:frontend": "node server/eval/run-frontend-evaluations.mjs",
     "test": "node --test test/*.test.mjs && npm run test --workspace server && npm run test --workspace web && npm run test --workspace tui && npm run test --workspace desktop && npm run test --workspace @qwen-audio-agent/cli && npm run test --workspace @qwen-audio-agent/mobile && npm run test:smart-cockpit",
     "pretest:smart-cockpit": "npm ci --prefix examples/smart-cockpit/service --ignore-scripts && npm ci --prefix examples/smart-cockpit/agent --ignore-scripts",
-    "test:smart-cockpit": "npm test --prefix examples/smart-cockpit/service && npm test --prefix examples/smart-cockpit/agent && node --test examples/smart-cockpit/bootstrap/test/*.test.mjs examples/smart-cockpit/client/test/*.test.mjs examples/smart-cockpit/gateway/test/*.test.mjs examples/smart-cockpit/test/*.test.mjs",
+    "test:smart-cockpit": "npm test --prefix examples/smart-cockpit/service && npm test --prefix examples/smart-cockpit/agent && node --test examples/smart-cockpit/bench/test/*.test.mjs examples/smart-cockpit/bootstrap/test/*.test.mjs examples/smart-cockpit/client/test/*.test.mjs examples/smart-cockpit/gateway/test/*.test.mjs examples/smart-cockpit/test/*.test.mjs",
     "audit:release": "node scripts/audit-dependencies.mjs",
     "version:set": "node scripts/set-version.mjs",
     "version:patch": "node scripts/set-version.mjs patch",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -37,6 +37,45 @@ export function parsePackOutput(stdout) {
   return entries.filter(Boolean)
 }
 
+/**
+ * Return exported package targets that are absent from an npm pack file list.
+ * Exact exports must name one packaged file; pattern exports must match at
+ * least one packaged file.
+ *
+ * @param {object} exportsMap The package.json exports map.
+ * @param {Set<string>} files Paths emitted by npm pack.
+ * @returns {string[]} Missing export targets.
+ */
+export function findMissingExportTargets(exportsMap, files) {
+  const targets = new Set()
+  const collect = (value) => {
+    if (typeof value === 'string') {
+      targets.add(value.replace(/^\.\//, ''))
+      return
+    }
+    if (Array.isArray(value)) {
+      value.forEach(collect)
+      return
+    }
+    if (value && typeof value === 'object') {
+      Object.values(value).forEach(collect)
+    }
+  }
+  collect(exportsMap)
+
+  return [...targets].filter((target) => {
+    const wildcard = target.indexOf('*')
+    if (wildcard === -1) return !files.has(target)
+    const prefix = target.slice(0, wildcard)
+    const suffix = target.slice(wildcard + 1)
+    return ![...files].some(file => (
+      file.startsWith(prefix)
+      && file.endsWith(suffix)
+      && file.length >= prefix.length + suffix.length
+    ))
+  })
+}
+
 // npm 10 在 `npm pack` 时会触发 `prepare` 生命周期脚本,构建工具(vite 等)的
 // 日志会混入 stdout,污染 pack 的 JSON 输出(`--ignore-scripts` 不阻止 prepare)。
 // 这里从 stdout 末尾按括号配对提取最后一个 JSON 块,以兼容前导/尾部噪声,同时
@@ -107,6 +146,11 @@ if (isMain) {
   }
   if (packages.length !== 1) throw new Error('npm pack 返回了意外的包数量')
   const files = new Set(packages[0].files.map(file => file.path))
+  const manifest = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'))
+  const missingExports = findMissingExportTargets(manifest.exports, files)
+  if (missingExports.length) {
+    throw new Error(`npm 成品缺少公开导出目标：${missingExports.join(', ')}`)
+  }
   const required = [
     'cli/bin/qwenaudio.mjs',
     'config/backends/deepseek-harness/cordis.yml',

--- a/test/verify-package.test.mjs
+++ b/test/verify-package.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { parsePackOutput } from '../scripts/verify-package.mjs'
+import {
+  findMissingExportTargets,
+  parsePackOutput,
+} from '../scripts/verify-package.mjs'
 
 // npm <=10 emits `npm pack --json` as an array of package entries.
 const ARRAY_FORMAT = JSON.stringify([
@@ -92,4 +95,29 @@ test('throws on empty output', () => {
 
 test('throws on non-JSON output', () => {
   assert.throws(() => parsePackOutput('this is not json'), /JSON/)
+})
+
+test('finds missing exact and wildcard package export targets', () => {
+  const exportsMap = {
+    './exact': './shared/exact.mjs',
+    './conditional': {
+      import: './shared/import.mjs',
+      require: './shared/require.cjs',
+    },
+    './assets/*': './dist/*',
+  }
+  const complete = new Set([
+    'shared/exact.mjs',
+    'shared/import.mjs',
+    'shared/require.cjs',
+    'dist/index.js',
+  ])
+  assert.deepEqual(findMissingExportTargets(exportsMap, complete), [])
+
+  const incomplete = new Set(['shared/exact.mjs'])
+  assert.deepEqual(findMissingExportTargets(exportsMap, incomplete), [
+    'shared/import.mjs',
+    'shared/require.cjs',
+    'dist/*',
+  ])
 })


### PR DESCRIPTION
## Summary

- include the Smart Cockpit benchmark contract tests in the normal test entry point
- verify every exact and wildcard `package.json` export against the real npm pack file list
- cover conditional and wildcard export validation with unit tests

## Verification

- `npm test`
- `npm run lint`
- `npm run test:smart-cockpit`
- `node --test test/verify-package.test.mjs`
- `node scripts/verify-package.mjs`
