### PR TITLE
ci(smart-cockpit): validate the client build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+      # Smart Cockpit has its own Vite/ESLint toolchain outside the root
+      # workspace graph. Exercise it once on the baseline Linux job instead of
+      # duplicating the same frontend build across the full OS/Node matrix.
+      - if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
+        run: npm ci --prefix examples/smart-cockpit/client --ignore-scripts
+      - if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
+        run: npm run example:smart-cockpit:lint
+      - if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
+        run: npm run example:smart-cockpit:build
       - if: ${{ matrix.os == 'macos-latest' && matrix.node == '22.22.2' }}
         run: npm run test:desktop-smoke
       # 真实消费者验收：打包 → 装进只含已声明依赖的裸消费者 → CLI 与

--- a/examples/smart-cockpit/client/src/components/CarModel3D.jsx
+++ b/examples/smart-cockpit/client/src/components/CarModel3D.jsx
@@ -81,6 +81,9 @@ function TeslaModel({ carState }) {
     }
   }, [scene])
 
+  // Three.js scene nodes are mutable runtime objects. Updating their transforms
+  // is the rendering API here, not mutation of React state or hook inputs.
+  /* eslint-disable react-hooks/immutability */
   useEffect(() => {
     Object.entries(model.windows).forEach(([key, node]) => {
       const ratio = openRatio(carState[key])
@@ -113,6 +116,7 @@ function TeslaModel({ carState }) {
       model.rearTrunk.position.z += 0.04
     }
   }, [carState, model])
+  /* eslint-enable react-hooks/immutability */
 
   useFrame(({ clock }) => {
     if (carState.flashLightsCount !== flashCount.current) {


### PR DESCRIPTION
## Summary

- install and validate the standalone Smart Cockpit client on the baseline Linux CI job
- run the client-specific ESLint and Vite build without multiplying work across the full matrix
- document the narrow Three.js mutability exception required by the client lint rules

## Verification

- `npm test`
- `npm run lint`
- `npm run example:smart-cockpit:lint`
- `npm run example:smart-cockpit:build`
