### PR TITLE
docs: align architecture articles with runtime

### DIFF
--- a/docs/promo/articles/acp-decoupling.md
+++ b/docs/promo/articles/acp-decoupling.md
@@ -1,8 +1,8 @@
 # ACP：让语音层与 Agent 彻底解耦的架构实践
 
-> 一个月内接入 9 个后台 Agent（OpenCode、OpenClaw、Qoder、Kimi Code、
-> Hermes、CodeBuddy、Codex、Claude Code、通用 ACP），语音层零改动。
-> 本文讲 qwen-audio-agent 是怎么做到的。
+> OpenCode、OpenClaw、Qoder、Qwen Code、MiniMax Code、Kimi Code、Hermes、
+> CodeBuddy、Codex、Claude Code、DeepSeek、Pi，以及用户自带的通用 ACP Agent，
+> 都通过同一边界接入。本文讲 qwen-audio-agent 是怎么做到的。
 
 ## 背景：Agent 生态快得离谱
 
@@ -19,24 +19,24 @@
 ```
 语音运行时（voice/）
       │  只认识"任务"和"事件"，不认识任何 Agent
-协调层（coordinator / session registry）
-      │  统一的 ACP 会话抽象
-ACP 进程客户端（acp/process-client）
+协议中立层（backend/ + task/）
+      │  BackendPort、Task 生命周期
+ACP 接入层（acp/backend-adapter + session-registry + process-client）
       │  JSON-RPC over stdio
 后台 Agent 进程（opencode / claude / codex / …）
 ```
 
-### 第一层：进程客户端
+### 组件一：进程客户端
 
 `AcpProcessClient`（`server/src/agent/acp/process-client.mjs`）负责
 把任意 ACP Agent 当作子进程管理：spawn 进程、用 stdio 建立 JSON-RPC
 双向通道、管理请求/响应/通知的生命周期。对上层来说，所有 Agent
 都长一个样：一个可以收发消息的会话。
 
-### 第二层：Backend Driver——一个 Agent 一个"驱动"
+### 组件二：Backend Driver——一个 Agent 一个"驱动"
 
-接入一个新 Agent，只需要写一个 driver 对象（`server/src/agent/acp/drivers/`），
-描述它的"身份信息"：
+每个产品的连接方式和能力差异由 driver 对象
+（`server/src/agent/acp/drivers/`）描述：
 
 ```js
 export const openCodeBackendDriver = {
@@ -54,6 +54,7 @@ export const openCodeBackendDriver = {
   },
   createProfile({ root, directory }) {
     return {
+      label: this.label,
       acpConnection: processAcpConnection({
         command: process.execPath,
         args: [resolve(root, 'scripts/runtime/opencode.mjs'), 'acp'],
@@ -73,36 +74,47 @@ export const openCodeBackendDriver = {
 
 ```js
 const drivers = new Map([
-  openCodeBackendDriver, openClawBackendDriver, qoderBackendDriver,
-  kimiBackendDriver, hermesBackendDriver, codeBuddyBackendDriver,
-  codexBackendDriver, claudeBackendDriver, genericAcpBackendDriver,
-].map(driver => [driver.id, driver]))
+  openCodeBackendDriver,
+  openClawBackendDriver,
+  ...localAcpBackendDrivers,
+  codeBuddyBackendDriver,
+  codexBackendDriver,
+  claudeBackendDriver,
+  deepSeekHarnessBackendDriver,
+  piBackendDriver,
+  genericAcpBackendDriver,
+].map(validateBackendDriver).map(driver => [driver.id, driver]))
 ```
 
-**新增一个 Agent = 新增一个文件 + 注册一行。** 语音层、会话管理、
-任务系统全都不用动。
+新增 Agent 时扩展对应 driver，并在 registry 与 `shared/backend/catalog.mjs`
+登记身份、安装和配置元数据；语音层、BackendPort 和 Task 生命周期不用改。
 
-### 第三层：适配器统一事件流
+### 组件三：适配器统一事件流
 
-不同 Agent 的行为差异（会话恢复规则、权限请求方式、工具调用格式）
-收敛在 `AcpBackendAdapter`（约 1500 行）里。例如 ACP 的会话更新事件：
+通用 ACP 会话与事件处理收敛在 `AcpBackendAdapter`，产品的连接和能力差异留在
+drivers；OpenClaw 的原生委托则封装在 `drivers/openclaw-delegation.mjs`。
+协议事件进入 Task 系统前会依次归一化：
 
-- `agent_message_chunk` → 转成前台的增量文本/语音流；
-- `tool_call` / `tool_call_update` → 转成任务进度事件，
-  驱动"正在查资料……"这类自然语言播报；
-- 权限请求 → 转成语音确认（"它想修改 xx 文件，同意吗？"）。
+- `agent_message_chunk` → `backend.message` → `task.updated`；
+- `tool_call` / `tool_call_update` → `backend.activity` →
+  `task.progress` / `task.updated`；
+- ACP 权限请求经 permission broker 转成 `backend.permission.requested`，再进入
+  `task.permission.requested`，由前台自然询问用户。
 
-## 两类接入方式
+## 四类接入方式
 
-实践中 Agent 分两种情况：
+共享 catalog 用四个 integration 类型描述安装和连接方式：
 
-1. **原生 ACP**（OpenCode、Qoder、Kimi Code 等）：Agent 自己说 ACP，
-   直接连。我们提供一键安装脚本，`npm install -g` 之后开箱即用。
-2. **外部适配**（Claude Code、Codex）：Agent 本身不说 ACP，
-   通过社区适配器（如 claude-code-acp）桥接。driver 里把"适配器本体
-   + 桥接进程"一起管理，对用户透明。
+1. **native**：OpenCode、Qoder、Qwen Code、MiniMax Code、Kimi Code、Hermes、
+   CodeBuddy、DeepSeek；
+2. **bridge**：OpenClaw 通过项目维护的桥接层对接 ACP；
+3. **adapter**：Codex、Claude Code、Pi 通过独立 ACP 适配器接入；
+4. **generic**：用户通过 `ACP_COMMAND` 连接任意兼容 Agent。
 
-对语音层来说，这两种没有任何区别——这就是协议边界的价值。
+桌面端和 CLI 读取同一 catalog，提供统一的按需安装与配置流程；具体认证仍由
+对应 Agent 自己完成。
+
+对语音层来说，这些接入方式没有任何区别——这就是协议边界的价值。
 
 ## 解耦带来的实际收益
 
@@ -110,7 +122,7 @@ const drivers = new Map([
   语音习惯、记忆、任务历史都不受影响；
 - **跟进生态**：新 Agent 发布后，接入工作通常在一天内完成；
 - **可测试**：协议层可以完全用 mock 进程做集成测试，
-  不需要真实 Agent 环境（仓库里有完整的 acp-process-client 测试）。
+  不需要真实 Agent 环境（见 `server/test/acp-process-client.test.mjs`）。
 
 ## 给同行的建议
 

--- a/docs/promo/articles/acp-decoupling.md
+++ b/docs/promo/articles/acp-decoupling.md
@@ -42,12 +42,25 @@ ACP 进程客户端（acp/process-client）
 export const openCodeBackendDriver = {
   id: 'opencode',
   label: 'OpenCode',
+  capabilities: {
+    delegation: true,
+    permissions: true,
+    backendUi: true,
+    nativeSessionHistory: true,
+    externalMcp: true,
+    nativeDelegation: false,
+    sessionMcp: true,
+    coordinatorMcpInstructions: true,
+  },
   createProfile({ root, directory }) {
     return {
-      command: resolve(root, 'scripts/opencode-acp'),  // 启动命令
-      args: [],
-      env: baseEnvironment(),
-      externalMcp: true,        // 能力差异标记
+      acpConnection: processAcpConnection({
+        command: process.execPath,
+        args: [resolve(root, 'scripts/runtime/opencode.mjs'), 'acp'],
+        cwd: directory,
+        env: { ...baseEnvironment('opencode'), ELECTRON_RUN_AS_NODE: '1' },
+      }),
+      externalMcp: true,
       nativeDelegation: false,
       backendUi: true,
       uiUrl({ baseUrl, sessionId }) { /* ... */ },

--- a/docs/promo/articles/full-duplex-voice-frontend.md
+++ b/docs/promo/articles/full-duplex-voice-frontend.md
@@ -21,7 +21,7 @@ qwen-audio-agent 把系统切成两层：
 ```
 ┌────────────────────────────────────────────┐
 │  语音前台（Realtime Voice Runtime）          │
-│  · 全双工语音流（WebRTC/WebSocket）          │
+│  · 全双工语音流（WebSocket）                 │
 │  · 打断检测与播放队列管理                    │
 │  · 前台模型：能直接回答的立即回答            │
 └───────────────┬────────────────────────────┘
@@ -34,10 +34,11 @@ qwen-audio-agent 把系统切成两层：
 └────────────────────────────────────────────┘
 ```
 
-前台是一个实时语音运行时（核心实现在 `server/src/voice/realtime-gateway.mjs`，
-约 1900 行），后台复用用户已有的 Agent，通过统一的 ACP 协议接入
-（`server/src/agent/`）。两层之间没有强耦合：换任何一个后台 Agent，
-语音层完全不用动。
+前台的核心编排入口是 `server/src/voice/realtime-gateway.mjs`；输入、展示和连接
+生命周期分别由 `realtime-input-runtime.mjs`、`realtime-presentation-runtime.mjs`
+和 `realtime-provider-session.mjs` 管理。后台复用用户已有的 Agent，通过
+`server/src/agent/acp/` 中统一的 ACP 边界接入。两层没有产品级强耦合：
+换后台 Agent 时，语音层不用跟着改。
 
 ## 关键设计一：能答的立即答，要干活的交出去
 
@@ -69,14 +70,19 @@ qwen-audio-agent 把系统切成两层：
 全双工最难的点是打断（barge-in）。用户随时可能开口，此时系统里可能同时存在：
 正在合成的回复、排队中的播放片段、后台任务的进度播报。
 
-我们把打断处理做成一条明确的状态链（`realtime-gateway.mjs`）：
+我们把打断处理做成一条明确的状态链：
 
-1. 检测到用户语音输入 → 标记 `user_interruption`；
-2. `cancelQueuedPlayback()` 清空播放队列，已播完的保留、未播的丢弃；
-3. 对已开始播放的回复发 `response.interrupted`，被取消的回复保留为
-   短生命周期的"墓碑"（tombstone），防止迟到的异步事件把它复活；
-4. 前台 `cancelResponses()` 通知语音提供商停止生成，节省 token 和延迟；
+1. Provider 报告 `speech_started`，输入运行时确认这是一次用户打断；
+2. Gateway 发出 `playback.clear`（`reason=user_interruption`），WebUI、TUI 或桌面端
+   清空尚未播放的音频，并回传 `playback.cancelled`；
+3. `RealtimePresentationRuntime.cancelPlayback()` 把对应响应标记为 `suppressed`；
+   只有确实开始播放过的响应才产生 `response.interrupted`；
+4. `RealtimeProviderSession.cancelResponse()` 调用前台 Provider 的 `cancel()`，
+   向上游发送 `response.cancel`，停止继续生成；
 5. 打断后立刻进入新一轮对话——用户感知不到"系统在善后"。
+
+这条链分别落在 `realtime-input-runtime.mjs`、`realtime-presentation-runtime.mjs`
+和 `realtime-provider-session.mjs`，客户端只负责真实的音频播放状态。
 
 其中"墓碑"是个容易被忽略的细节：实时系统里到处是异步回调，
 一个被取消的响应如果在几百毫秒后被迟到的 `response.done` 事件触发，
@@ -87,7 +93,7 @@ qwen-audio-agent 把系统切成两层：
 
 后台任务完成后，不是弹一个通知，而是**回到当前对话里**：
 
-- 任务状态（`task.cancelling` / `task.cancelled` / 完成 / 失败）
+- 任务状态（`task.cancelling` / `task.cancelled` / `task.completed` / `task.failed`）
   作为事件流进入前台；
 - 完成时由 Gateway 把结果交回前台模型，生成自然的口语播报
   （"刚才那个任务好了，结果是……"）；
@@ -98,9 +104,10 @@ qwen-audio-agent 把系统切成两层：
 
 ## 关键设计四：连接是语音系统的生命线
 
-WebRTC/WebSocket 长连接在真实网络下一定会断。前台实现了
-带退避的重连机制（`reconnect-backoff.mjs`），并且重连与会话状态解耦：
-连接恢复后，会话上下文、任务状态从服务端恢复，用户几乎无感。
+WebSocket 长连接在真实网络下一定会断。Client → Gateway 的恢复由
+`shared/gateway/client-sdk.mjs` 管理，Gateway → Realtime Provider 的退避策略位于
+`server/src/voice/reconnect-backoff.mjs`。连接生命周期与持久化的对话、Task 状态
+相互解耦；连接恢复后再从服务端重放和校准，用户几乎无感。
 
 ## 经验总结
 

--- a/docs/promo/articles/full-duplex-voice-frontend.md
+++ b/docs/promo/articles/full-duplex-voice-frontend.md
@@ -47,27 +47,22 @@ qwen-audio-agent 把系统切成两层：
 - **需要工具或长时间处理** → 打包成任务委派给后台 Agent，前台先用一句话
   确认（"我去查一下，你先忙别的"），对话不断线。
 
-这个"路由"决策由一个轻量的协调器完成（`server/src/agent/coordinator.mjs`），
-它的输出是一个强 schema 约束的决策对象：
+这个路由由前台模型基于系统规则和工具描述完成。需要后台执行时，模型调用
+`spawn_thinking`；Gateway 中的 `AgentTaskRuntime`
+（`server/src/voice/tools/agent-task-runtime.mjs`）立即创建 Task，并返回一张受理回执：
 
 ```js
-// 两种决策：respond（前台直接回答）/ delegate（委派后台）
 {
-  work_id: '…',
-  state: 'delegated',
-  mode: 'delegate',
-  delegation_id: '…',
-  target_session_id: '…',
-  presentation: {
-    speech: '我让后台去跑这个任务，你可以继续问我别的。',
-    inline: { title: '任务详情', format: 'markdown', content: '…' }
-  }
+  status: 'accepted',
+  task_id: '…',
+  message: '工作已受理，请自然确认一次，不要再次调用工具。'
 }
 ```
 
-注意 `presentation` 被拆成 **speech（说出来）** 和 **inline（展示出来）**
-两部分。语音通道信息密度低，长内容不该念出来；同一份结果，
-耳朵收摘要，眼睛收全文。这是语音前台和聊天窗口最大的交互差异。
+这张回执只确认任务已进入 Gateway，不等待后台往返。Task 的事实状态和结果由
+`TaskManager` 管理，客户端接收结构化 Task 事件；任务完成后，
+`AnnouncementManager` 再把结果转换成统一的 `AgentDelivery`，交给前台模型生成自然、
+简短的口语回复。后台不能自行注入一套面向 UI 的展示结构，执行与表达保持分离。
 
 ## 关键设计二：打断是状态机，不是一个事件
 
@@ -94,7 +89,8 @@ qwen-audio-agent 把系统切成两层：
 
 - 任务状态（`task.cancelling` / `task.cancelled` / 完成 / 失败）
   作为事件流进入前台；
-- 完成时由协调器生成一段自然的口语播报（"刚才那个任务好了，结果是……"）；
+- 完成时由 Gateway 把结果交回前台模型，生成自然的口语播报
+  （"刚才那个任务好了，结果是……"）；
 - 用户可以立刻追问、修改或再派一个新任务，上下文不丢失。
 
 这就是"Agent 始终在场"的具体含义：它不是一问一答的机器，
@@ -115,8 +111,9 @@ WebRTC/WebSocket 长连接在真实网络下一定会断。前台实现了
    协议层（我们用 ACP）是唯一可持续的边界。
 2. **打断的工程质量决定产品口碑**。用户对"打断没反应""打断后又冒出半句话"
    的容忍度是零。异步事件的生命周期管理要做成显式状态机。
-3. **speech 和 inline 分离**。所有"把聊天窗口的回答直接念出来"的设计
-   都会失败。语音输出要重写，不是截断。
+3. **结构化状态和口语表达分离**。客户端消费 Task 事件，前台模型负责把结果
+   说得自然。所有"把聊天窗口的回答直接念出来"的设计都会失败；语音输出要重写，
+   不是截断。
 
 ---
 


### PR DESCRIPTION
## Summary

- replace removed coordinator/schema examples with the current `spawn_thinking` → Task → `AgentDelivery` flow
- align ACP paths, driver registration, integration categories, and event mapping with the current runtime
- document the actual WebSocket interruption and reconnect lifecycles
- keep structured Task state and spoken presentation as separate boundaries

## Verification

- `npm run lint`
- `npm run docs:build`
- `git diff --check`
