### PR TITLE
ci: validate the advertised Node 26 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node: [22.22.2, 24.15.0]
+        # The package advertises Node 26 support. Validate the new major on
+        # Linux without multiplying the full cross-platform matrix.
+        include:
+          - os: ubuntu-latest
+            node: 26.0.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

- Add one `ubuntu-latest / Node 26.0.0` entry to the existing CI matrix.
- Keep the full Node 22 and Node 24 cross-platform matrix unchanged.
- Let the existing `required` aggregate cover the new matrix entry automatically.

## Motivation

`package.json` advertises `^22.22.2 || ^24.15.0 || >=26.0.0`, but CI only exercised Node 22.22.2 and 24.15.0. This change verifies the newly advertised major version without multiplying the macOS and Windows jobs.

## Validation

- Parsed `.github/workflows/ci.yml` with the repository's existing `yaml` dependency and confirmed the include entry and required dependencies.
- Node 26.0.0 full workspace test: 1962 total, 1943 passed, 19 skipped, 0 failed.
- Node 26.0.0 `npm run build`: passed.
- Node 26.0.0 `node scripts/verify-package.mjs`: passed.
- Node 26.0.0 `npm run lint`: passed.
- `git diff --check`: passed.

## Compatibility

No runtime or package changes. Node 22.22.2 remains the documented baseline for `.nvmrc`; this PR only verifies the additional advertised Node 26 range.
