### PR TITLE
ci: maintain GitLab synchronization on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
           registry-url: https://registry.npmjs.org/
+      # Test the GitLab-only synchronizer against disposable local repositories.
+      # GitHub Actions never runs the real synchronization job or needs its token.
+      - if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
+        run: node --test .gitlab/sync-github.test.mjs
       - run: npm ci
       - run: npm test
       - run: npm run build

--- a/.gitlab/README.md
+++ b/.gitlab/README.md
@@ -1,0 +1,59 @@
+# GitHub → GitLab hourly snapshot
+
+This directory is maintained on GitHub `main` and mirrored to GitLab `main`
+with the rest of the repository. No dedicated automation branch is needed.
+GitHub Actions runs isolated integration tests only; the scheduled synchronization
+runs exclusively in Aone CI for the GitLab repository.
+
+The hosted task checks at the start of every hour, even when GitLab `main`
+has not changed. Configure `dry_run=false`, serial execution and failure-only
+notifications after validation.
+
+The Aone CI task references `.gitlab/github-sync.yml` on GitLab `main`, checks
+out `main`, and runs `.gitlab/sync-github.sh`. Both the task's default branch
+and scheduled trigger branch must be `main`, with always-run enabled.
+Aone's default CI Token is read-only. Configure the following under repository
+Settings → Continuous Integration → Variable Management. Deployment-specific
+values belong in CI configuration, not in this directory.
+
+| Name | Type | Value |
+| --- | --- | --- |
+| `SYNC_SOURCE_URL` | Variables | GitHub source repository URL, without credentials. |
+| `SYNC_TARGET_URL` | Variables | GitLab HTTPS repository URL, without credentials. |
+| `SYNC_GITLAB_USERNAME` | Variables | Account used to authenticate GitLab writes. |
+| `SYNC_COMMIT_NAME` | Variables | Snapshot author and committer name. |
+| `SYNC_COMMIT_EMAIL` | Variables | Snapshot author and committer email accepted by the destination. |
+| `SYNC_BOOTSTRAP_TARGET` | Variables | Verified initial GitLab main commit SHA. |
+| `SYNC_BOOTSTRAP_SOURCE` | Variables | GitHub commit SHA with the same tree as that initial GitLab commit. |
+| `GITLAB_SYNC_TOKEN` | Secrets | Token authorized to write this GitLab repository. |
+
+The baseline pair is required only until the first snapshot records its source.
+Use the narrowest available token scope and an appropriate expiry.
+Checkout uses Aone's read-only CI credential. The write token is supplied only
+to the sync step through its environment and a repository-scoped Git credential
+helper. Remote URLs and Git config never contain the write token; the GitHub
+fetch does not inherit it. Never commit a token or paste one into chat. Keep
+the schedule disabled until a real write succeeds.
+GitHub source files are never checked out or executed by the job.
+The official `setup-github-proxy` component supplies Aone's supported GitHub
+transport. Network operations have bounded timeouts and never prompt for login.
+
+Register one repository-YAML template task with an hourly schedule, always-run
+enabled, and failure-only notifications. Start with `dry_run=true`; switch it to
+false only after a successful hosted-runner dry run and write-permission check.
+
+The synchronizer creates at most one ordinary commit when code differs, using
+the configured author and committer identity. The commit tree exactly
+matches GitHub main; the commit message records the source SHA and previous SHA.
+No changes means no commit. The existing GitLab main history is preserved.
+
+Only the verified initial baseline or a matching previous snapshot is accepted.
+Independent GitLab edits, source-history divergence, unavailable baselines and
+concurrent pushes fail closed. Never force-push or change a baseline simply to
+silence a failure; review it first.
+
+Commit metadata still contains the configured identity and source URL. Moving
+configuration out of source files does not anonymize or rewrite Git history.
+
+Run isolated integration tests with `node --test .gitlab/sync-github.test.mjs`.
+No personal access token is stored in this directory.

--- a/.gitlab/git-credential.sh
+++ b/.gitlab/git-credential.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Git consumes stdout as its credential protocol; never invoke this for logging.
+# Do not persist credentials on Git's store/erase callbacks.
+[ "${1:-}" = get ] || exit 0
+protocol= host= path=
+while IFS='=' read -r key value && [ -n "$key" ]; do
+  case "$key" in
+    protocol) protocol=$value ;;
+    host) host=$value ;;
+    path) path=$value ;;
+  esac
+done
+[ "$protocol" = https ] || exit 0
+[ -n "$host" ] && [ -n "$path" ] || exit 0
+[ "https://$host/$path" = "${SYNC_TARGET_URL:-}" ] || exit 0
+[ -n "${SYNC_GITLAB_USERNAME:-}" ] || exit 0
+[ -n "${SYNC_GITLAB_TOKEN:-}" ] || exit 0
+case "$SYNC_GITLAB_USERNAME$SYNC_GITLAB_TOKEN" in *$'\n'*|*$'\r'*) exit 0 ;; esac
+printf 'username=%s\npassword=%s\n' "$SYNC_GITLAB_USERNAME" "$SYNC_GITLAB_TOKEN"

--- a/.gitlab/github-sync.yml
+++ b/.gitlab/github-sync.yml
@@ -1,0 +1,44 @@
+name: GitHub main hourly snapshot
+
+# Registered as a repository-YAML template in Aone CI, using GitLab main.
+# Scheduling and failure notifications are configured on the Aone task.
+# This file is not a GitHub Actions workflow.
+params:
+  dry_run:
+    type: boolean
+    default: true
+    description: Validate the snapshot and push permission without updating main.
+
+strategy:
+  concurrency:
+    group: github-main-snapshot
+    parallelism: 1
+
+jobs:
+  sync:
+    name: Sync GitHub main to GitLab main
+    timeout: 10m
+    steps:
+      - uses: checkout
+        inputs:
+          ref: main
+          # Keep checkout read-only. Its token option embeds credentials in
+          # remote URLs, which Git LFS can print in diagnostic messages.
+          lfs: false
+      # Aone's supported GitHub transport. The initial checkout is GitLab, so
+      # its automatic GitHub acceleration does not cover our subsequent fetch.
+      - uses: setup-github-proxy
+      - name: Validate baseline and synchronize snapshot
+        envs:
+          SYNC_DRY_RUN: '${{params.dry_run}}'
+          SYNC_SOURCE_URL: '${{vars.SYNC_SOURCE_URL}}'
+          SYNC_TARGET_URL: '${{vars.SYNC_TARGET_URL}}'
+          SYNC_GITLAB_USERNAME: '${{vars.SYNC_GITLAB_USERNAME}}'
+          SYNC_COMMIT_NAME: '${{vars.SYNC_COMMIT_NAME}}'
+          SYNC_COMMIT_EMAIL: '${{vars.SYNC_COMMIT_EMAIL}}'
+          SYNC_BOOTSTRAP_TARGET: '${{vars.SYNC_BOOTSTRAP_TARGET}}'
+          SYNC_BOOTSTRAP_SOURCE: '${{vars.SYNC_BOOTSTRAP_SOURCE}}'
+          SYNC_GITLAB_TOKEN: '${{secrets.GITLAB_SYNC_TOKEN}}'
+        run: |
+          test -n "$SYNC_GITLAB_TOKEN" || { echo 'GITLAB_SYNC_TOKEN is required' >&2; exit 1; }
+          bash .gitlab/sync-github.sh

--- a/.gitlab/sync-github.sh
+++ b/.gitlab/sync-github.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script runs from the CI GitLab checkout. It imports GitHub objects,
+# never executes the fetched tree, and creates a normal child of GitLab main.
+source_url=${SYNC_SOURCE_URL:-}
+target_remote=${SYNC_TARGET_REMOTE:-origin}
+bootstrap_target=${SYNC_BOOTSTRAP_TARGET:-}
+bootstrap_source=${SYNC_BOOTSTRAP_SOURCE:-}
+dry_run=${SYNC_DRY_RUN:-true}
+export GIT_TERMINAL_PROMPT=0
+export GCM_INTERACTIVE=never
+
+# CI provides GNU timeout; local macOS tests may not. HTTP low-speed limits
+# remain active on either platform. Do not let unattended auth wait for input.
+network_git() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --kill-after=10s 180s git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 "$@"
+  else
+    git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 "$@"
+  fi
+}
+
+fail() { printf 'Sync stopped: %s\n' "$1" >&2; exit 1; }
+for variable in SYNC_SOURCE_URL SYNC_COMMIT_NAME SYNC_COMMIT_EMAIL; do
+  [ -n "${!variable:-}" ] || fail "$variable is required"
+done
+case "$dry_run" in true|false) ;; *) fail 'SYNC_DRY_RUN must be true or false' ;; esac
+git rev-parse --git-dir >/dev/null
+
+# Keep credentials out of remote URLs, command arguments and Git config.
+# Only the exact GitLab repository can obtain the step-scoped environment token.
+credential_helper=
+if [ -n "${SYNC_GITLAB_TOKEN:-}" ]; then
+  [ "$target_remote" = origin ] || fail 'Authenticated CI sync requires the origin remote'
+  for variable in SYNC_TARGET_URL SYNC_GITLAB_USERNAME; do
+    [ -n "${!variable:-}" ] || fail "$variable is required for authenticated sync"
+  done
+  target_url_pattern='^https://[[:alnum:].-]+(:[0-9]+)?/[[:alnum:]._~%/-]+$'
+  [[ "$SYNC_TARGET_URL" =~ $target_url_pattern ]] \
+    || fail 'SYNC_TARGET_URL must be an HTTPS repository URL without credentials, query or fragment'
+  case "$SYNC_GITLAB_USERNAME$SYNC_GITLAB_TOKEN" in
+    *$'\n'*|*$'\r'*) fail 'Credentials must not contain line breaks' ;;
+  esac
+  git remote set-url origin "$SYNC_TARGET_URL"
+  git config --unset-all remote.origin.pushurl || [ "$?" = 5 ]
+  credential_script=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/git-credential.sh
+  printf -v credential_helper '!bash %q' "$credential_script"
+fi
+target_git() {
+  if [ -n "$credential_helper" ]; then
+    network_git -c credential.helper= -c credential.useHttpPath=true \
+      -c "credential.helper=$credential_helper" "$@"
+  else
+    network_git "$@"
+  fi
+}
+
+# Do not send destination credentials to the public GitHub source.
+printf '[1/4] Fetch GitHub main\n'
+(
+  unset SYNC_GITLAB_TOKEN
+  network_git -c credential.helper= -c http.extraHeader= \
+    -c http.https://github.com/.extraHeader= \
+    fetch --quiet --no-tags "$source_url" main
+)
+source_commit=$(git rev-parse 'FETCH_HEAD^{commit}')
+source_tree=$(git rev-parse "$source_commit^{tree}")
+printf '[2/4] Fetch GitLab main\n'
+target_git fetch --quiet --no-tags "$target_remote" main
+target_commit=$(git rev-parse 'FETCH_HEAD^{commit}')
+target_tree=$(git rev-parse "$target_commit^{tree}")
+
+printf '[3/4] Verify snapshot baseline\n'
+previous_source=$(git show -s --format='%(trailers:key=GitHub-Commit,valueonly)' "$target_commit")
+if [ -z "$previous_source" ]; then
+  [ -n "$bootstrap_target" ] && [ -n "$bootstrap_source" ] \
+    || fail 'Initial sync requires SYNC_BOOTSTRAP_TARGET and SYNC_BOOTSTRAP_SOURCE'
+  [ "$target_commit" = "$bootstrap_target" ] || fail 'GitLab main has an unrecognized commit; manual review is required'
+  previous_source=$bootstrap_source
+else
+  previous_repository=$(git show -s --format='%(trailers:key=GitHub-Repository,valueonly)' "$target_commit")
+  [ "$previous_repository" = "$source_url" ] || fail 'The previous snapshot belongs to a different source repository'
+fi
+[[ "$previous_source" =~ ^[0-9a-f]{40}$ ]] || fail 'Invalid GitHub baseline commit'
+git cat-file -e "$previous_source^{commit}" || fail 'GitHub baseline is unavailable'
+[ "$target_tree" = "$(git rev-parse "$previous_source^{tree}")" ] \
+  || fail 'GitLab main contains changes outside the recorded GitHub snapshot'
+git merge-base --is-ancestor "$previous_source" "$source_commit" \
+  || fail 'GitHub main history diverged from the previous snapshot'
+
+if [ "$target_tree" = "$source_tree" ]; then
+  printf 'No code changes. GitHub main: %s; GitLab main: %s\n' "$source_commit" "$target_commit"
+  exit 0
+fi
+
+message=$(printf 'sync: GitHub main %s..%s\n\nGitHub-Repository: %s\nGitHub-Commit: %s\nGitHub-Previous: %s\n' \
+  "${previous_source:0:12}" "${source_commit:0:12}" "$source_url" "$source_commit" "$previous_source")
+snapshot=$(printf '%s\n' "$message" | \
+  GIT_AUTHOR_NAME="$SYNC_COMMIT_NAME" GIT_AUTHOR_EMAIL="$SYNC_COMMIT_EMAIL" \
+  GIT_COMMITTER_NAME="$SYNC_COMMIT_NAME" GIT_COMMITTER_EMAIL="$SYNC_COMMIT_EMAIL" \
+  git commit-tree "$source_tree" -p "$target_commit")
+
+# A regular push also acts as a concurrency guard: another writer moving main
+# causes rejection. Never force-push, merge, or silently replace their changes.
+if [ "$dry_run" = true ]; then
+  printf '[4/4] Validate GitLab push permission (dry run)\n'
+  target_git push --dry-run "$target_remote" "$snapshot:refs/heads/main"
+  printf 'Dry run passed. Would sync %s..%s; no remote changes made.\n' "$previous_source" "$source_commit"
+else
+  printf '[4/4] Push GitLab snapshot\n'
+  target_git push "$target_remote" "$snapshot:refs/heads/main"
+  printf 'Synced GitHub %s to GitLab %s.\n' "$source_commit" "$snapshot"
+fi

--- a/.gitlab/sync-github.test.mjs
+++ b/.gitlab/sync-github.test.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const script = fileURLToPath(new URL('./sync-github.sh', import.meta.url))
+const credentialScript = fileURLToPath(new URL('./git-credential.sh', import.meta.url))
+const targetUrl = 'https://gitlab.example.test/example/project.git'
+const syncIdentity = { SYNC_COMMIT_NAME: 'Sync Bot', SYNC_COMMIT_EMAIL: 'sync-bot@example.test' }
+const identity = { GIT_AUTHOR_NAME: 'Fixture', GIT_AUTHOR_EMAIL: 'fixture@example.test',
+  GIT_COMMITTER_NAME: 'Fixture', GIT_COMMITTER_EMAIL: 'fixture@example.test' }
+function git(cwd, args, input) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', input,
+    env: { ...process.env, ...identity } })
+  assert.equal(result.status, 0, result.stderr)
+  return result.stdout.trim()
+}
+function commit(cwd, files, message = 'fixture') {
+  for (const [name, content] of Object.entries(files)) writeFileSync(join(cwd, name), content)
+  git(cwd, ['add', '.'])
+  const tree = git(cwd, ['write-tree'])
+  const head = spawnSync('git', ['rev-parse', '--verify', 'HEAD'], { cwd, encoding: 'utf8' })
+  const parents = head.status === 0 ? ['-p', head.stdout.trim()] : []
+  const sha = git(cwd, ['commit-tree', tree, ...parents], message)
+  git(cwd, ['update-ref', 'refs/heads/main', sha])
+  return sha
+}
+function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), 'snapshot-sync-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  const source = join(root, 'source')
+  const target = join(root, 'target.git')
+  const worker = join(root, 'worker')
+  mkdirSync(source)
+  git(source, ['init', '-b', 'main'])
+  const baseline = commit(source, { 'file.txt': 'initial\n' })
+  git(root, ['clone', '--bare', source, target])
+  git(root, ['clone', target, worker])
+  return { root, source, target, worker, baseline,
+    run(extra = {}) {
+      return spawnSync('bash', [script], { cwd: worker, encoding: 'utf8', env: {
+        ...process.env, ...syncIdentity, SYNC_TARGET_URL: targetUrl,
+        SYNC_GITLAB_USERNAME: 'sync-bot', SYNC_TARGET_REMOTE: 'origin',
+        SYNC_SOURCE_URL: source, SYNC_BOOTSTRAP_SOURCE: baseline,
+        SYNC_BOOTSTRAP_TARGET: baseline, SYNC_DRY_RUN: 'false', SYNC_GITLAB_TOKEN: '', ...extra,
+      } })
+    },
+    head() { return git(root, ['--git-dir', target, 'rev-parse', 'main']) },
+  }
+}
+
+test('no-op creates no commit; several source commits become one ordinary snapshot', t => {
+  const f = fixture(t)
+  assert.equal(f.run().status, 0)
+  assert.equal(f.head(), f.baseline)
+  commit(f.source, { 'file.txt': 'second\n' })
+  const latest = commit(f.source, { 'file.txt': 'third\n', 'new.txt': 'added' })
+  const result = f.run()
+  assert.equal(result.status, 0, result.stderr)
+  const target = f.head()
+  assert.equal(git(f.root, ['--git-dir', f.target, 'rev-parse', `${target}^`]), f.baseline)
+  assert.equal(git(f.root, ['--git-dir', f.target, 'rev-parse', `${target}^{tree}`]),
+    git(f.source, ['rev-parse', `${latest}^{tree}`]))
+  assert.equal(git(f.root, ['--git-dir', f.target, 'show', '-s', '--format=%an|%ae|%cn|%ce', target]),
+    'Sync Bot|sync-bot@example.test|Sync Bot|sync-bot@example.test')
+  assert.equal(f.run({ SYNC_BOOTSTRAP_SOURCE: '', SYNC_BOOTSTRAP_TARGET: '' }).status, 0)
+  assert.equal(f.head(), target)
+  commit(f.source, { 'file.txt': 'fourth\n' })
+  assert.equal(f.run().status, 0)
+  assert.equal(git(f.root, ['--git-dir', f.target, 'rev-parse', 'main^']), target)
+})
+
+test('dry run validates without pushing', t => {
+  const f = fixture(t)
+  commit(f.source, { 'file.txt': 'updated\n' })
+  const result = f.run({ SYNC_DRY_RUN: 'true' })
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /Dry run passed/)
+  assert.match(result.stdout, /\[1\/4\] Fetch GitHub main/)
+  assert.match(result.stdout, /\[4\/4\] Validate GitLab push permission/)
+  assert.equal(f.head(), f.baseline)
+})
+
+test('independent destination edits stop synchronization', t => {
+  const f = fixture(t)
+  const local = commit(f.worker, { 'local.txt': 'must survive' })
+  git(f.worker, ['push', 'origin', 'main'])
+  commit(f.source, { 'file.txt': 'updated\n' })
+  const result = f.run()
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /unrecognized commit/)
+  assert.equal(f.head(), local)
+})
+
+test('copied snapshot metadata cannot hide independent edits', t => {
+  const f = fixture(t)
+  const message = `manual edit\n\nGitHub-Repository: ${f.source}\nGitHub-Commit: ${f.baseline}\n`
+  const local = commit(f.worker, { 'local.txt': 'must survive' }, message)
+  git(f.worker, ['push', 'origin', 'main'])
+  commit(f.source, { 'file.txt': 'updated\n' })
+  const result = f.run()
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /changes outside/)
+  assert.equal(f.head(), local)
+})
+
+test('rewritten source history is rejected', t => {
+  const f = fixture(t)
+  const orphan = git(f.source, ['commit-tree', git(f.source, ['rev-parse', 'HEAD^{tree}'])], 'new root')
+  git(f.source, ['update-ref', 'refs/heads/main', orphan])
+  const result = f.run()
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /history diverged/)
+  assert.equal(f.head(), f.baseline)
+})
+
+test('credential helper only serves the exact HTTPS destination and never stores credentials', () => {
+  const token = 'test-only-write-token'
+  const invoke = (operation, host, path, protocol = 'https', secret = token) =>
+    spawnSync('bash', [credentialScript, operation], { encoding: 'utf8',
+      input: `protocol=${protocol}\nhost=${host}\npath=${path}\n\n`,
+      env: { ...process.env, SYNC_TARGET_URL: targetUrl,
+        SYNC_GITLAB_USERNAME: 'sync-bot', SYNC_GITLAB_TOKEN: secret } })
+  const allowed = invoke('get', 'gitlab.example.test', 'example/project.git')
+  assert.equal(allowed.status, 0)
+  assert.equal(allowed.stderr, '')
+  assert.equal(allowed.stdout, `username=sync-bot\npassword=${token}\n`)
+  for (const args of [
+    ['get', 'github.example.test', 'example/project.git'],
+    ['get', 'gitlab.example.test', 'another/repository.git'],
+    ['get', 'gitlab.example.test', 'example/project.git', 'http'],
+    ['get', 'gitlab.example.test', 'example/project.git', 'https', ''],
+    ['get', 'gitlab.example.test', 'example/project.git', 'https', 'token\nextra=value'],
+    ['store', 'gitlab.example.test', 'example/project.git'],
+    ['erase', 'gitlab.example.test', 'example/project.git'],
+  ]) {
+    const denied = invoke(...args)
+    assert.equal(denied.status, 0)
+    assert.equal(denied.stdout, '')
+    assert.equal(denied.stderr, '')
+  }
+})
+
+test('CI strips credentials from both remote URLs before network operations', t => {
+  const f = fixture(t)
+  const secret = 'test-only-old-credential'
+  const credentialUrl = `https://sync-bot:${secret}@gitlab.example.test/example/project.git`
+  git(f.worker, ['remote', 'set-url', 'origin', credentialUrl])
+  git(f.worker, ['remote', 'set-url', '--push', 'origin', credentialUrl])
+  const result = f.run({ SYNC_GITLAB_TOKEN: 'test-only-new-credential',
+    SYNC_SOURCE_URL: join(f.root, 'missing-source.git') })
+  assert.notEqual(result.status, 0) // Stop locally before any real network access.
+  assert.match(result.stdout, /\[1\/4\] Fetch GitHub main/)
+  for (const args of [['remote', 'get-url', 'origin'], ['remote', 'get-url', '--push', 'origin']]) {
+    assert.equal(git(f.worker, args), targetUrl)
+  }
+  assert.doesNotMatch(readFileSync(join(f.worker, '.git/config'), 'utf8'), /test-only-/)
+  assert.doesNotMatch(result.stdout + result.stderr, /test-only-/)
+  assert.equal(f.head(), f.baseline)
+})
+
+test('missing deployment configuration fails before fetching', t => {
+  const f = fixture(t)
+  for (const key of ['SYNC_SOURCE_URL', 'SYNC_COMMIT_NAME', 'SYNC_COMMIT_EMAIL',
+    'SYNC_TARGET_URL', 'SYNC_GITLAB_USERNAME']) {
+    const result = f.run({ SYNC_GITLAB_TOKEN: 'test-only-token', [key]: '' })
+    assert.notEqual(result.status, 0, key)
+    assert.match(result.stderr, new RegExp(`${key} is required`))
+    assert.doesNotMatch(result.stdout, /Fetch/)
+  }
+  assert.equal(f.head(), f.baseline)
+})
+
+test('credential-bearing or malformed target URLs are rejected without logging their value', t => {
+  const f = fixture(t)
+  for (const url of [
+    'http://gitlab.example.test/example/project.git',
+    'https://user:test-only-token@gitlab.example.test/example/project.git',
+    `${targetUrl}?token=test-only-token`, `${targetUrl}#fragment`,
+    `${targetUrl}\nextra=value`, 'https://gitlab.example.test',
+  ]) {
+    const result = f.run({ SYNC_GITLAB_TOKEN: 'test-only-token', SYNC_TARGET_URL: url })
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /SYNC_TARGET_URL must be an HTTPS repository URL/)
+    assert.doesNotMatch(result.stdout + result.stderr, /test-only-token|Fetch/)
+  }
+  assert.equal(f.head(), f.baseline)
+})
+
+test('initial sync requires an explicitly configured baseline pair', t => {
+  const f = fixture(t)
+  for (const key of ['SYNC_BOOTSTRAP_TARGET', 'SYNC_BOOTSTRAP_SOURCE']) {
+    const result = f.run({ [key]: '' })
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Initial sync requires/)
+  }
+  assert.equal(f.head(), f.baseline)
+})


### PR DESCRIPTION
## Summary

- Maintain the GitLab-only hourly GitHub snapshot synchronizer under `.gitlab/` on `main` in both repositories, removing the need for a dedicated automation branch.
- Keep repository URLs, commit identity and bootstrap baselines in CI variables; the write token remains a CI Secret scoped to the destination repository.
- Run isolated local-repository integration tests in GitHub CI. GitHub Actions does not run the actual synchronization or receive its token.

## Validation

- `node --test .gitlab/sync-github.test.mjs` — 10 tests passed.
- `bash -n .gitlab/sync-github.sh .gitlab/git-credential.sh`
- `git diff --check`

## Deployment

After merge, use the existing synchronizer once to update GitLab `main`, point the Aone task to `.gitlab/github-sync.yml` on `main`, verify a hosted run, then retire the old automation branch. Preserve hourly always-run scheduling, serial execution and failure-only notifications.
