### PR TITLE
test(web): add browser voice lifecycle smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+      - if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
+        run: npx playwright install --with-deps chromium
+      - if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
+        run: npm run test:web-browser
       # Smart Cockpit has its own Vite/ESLint toolchain outside the root
       # workspace graph. Exercise it once on the baseline Linux job instead of
       # duplicating the same frontend build across the full OS/Node matrix.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
         run: npx playwright install --with-deps chromium
       - if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
         run: npm run test:web-browser
+      - if: ${{ failure() && matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: browser-voice-diagnostics
+          path: output/playwright/browser-webui-smoke/
+          if-no-files-found: ignore
+          retention-days: 7
       # Smart Cockpit has its own Vite/ESLint toolchain outside the root
       # workspace graph. Exercise it once on the baseline Linux job instead of
       # duplicating the same frontend build across the full OS/Node matrix.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+output/playwright/browser-webui-smoke/
 web/dist/
 dist/
 .venv/

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint": "10.9.1",
         "eslint-plugin-react-hooks": "7.1.1",
         "globals": "17.12.0",
+        "playwright": "^1.63.0",
         "vitepress": "^1.6.4"
       },
       "engines": {
@@ -8640,6 +8641,35 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "gateway": "npm run start --workspace server",
     "desktop": "npm run start --workspace desktop",
     "test:desktop-smoke": "node scripts/electron-smoke.mjs",
+    "test:web-browser": "node scripts/test/browser-webui-smoke.mjs",
     "desktop:build": "node scripts/check-desktop-release-env.mjs && npm run build && electron-builder --config desktop/electron-builder.yml --mac dmg zip",
     "desktop:build:local": "npm run build && electron-builder --config desktop/electron-builder.yml --config.mac.identity=- --config.mac.hardenedRuntime=false --config.mac.notarize=false --mac dmg",
     "desktop:build:linux": "npm run build && electron-builder --config desktop/electron-builder.yml --linux AppImage deb",
@@ -302,6 +303,7 @@
     "eslint": "10.9.1",
     "eslint-plugin-react-hooks": "7.1.1",
     "globals": "17.12.0",
+    "playwright": "^1.63.0",
     "vitepress": "^1.6.4"
   },
   "overrides": {

--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -1,0 +1,30 @@
+# WebUI browser smoke
+
+Install dependencies with `npm ci`, install Chromium with
+`npx playwright install chromium`, then run `npm run test:web-browser`.
+The script starts its own Vite server on loopback port 4174. Set
+`QWEN_BROWSER_SMOKE_PORT` if that port is occupied.
+
+Chromium loads the real React page. Gateway, microphone, and AudioContext are
+test doubles: this suite checks client wiring and lifecycle, not physical audio
+devices or native Web Audio rendering. No cloud API key is needed.
+
+The reconnect scenario closes the established connection during playback,
+requires a new connection's negotiated heartbeat response, then sends another
+PCM frame and checks its connection ID and visible reply. It also delivers a
+late reply through the closed socket to verify the SDK ignores it. Microphone
+acquisition counts must remain unchanged during reconnect.
+
+Unexpected page exceptions and console errors fail the run before the page is
+closed. On failure, each run saves screenshots, `trace.zip`, `errors.log`, and
+`vite.log` in a timestamped directory under
+`output/playwright/browser-webui-smoke/`. Open the trace with
+`npx playwright show-trace <path-to-trace.zip>`. The Ubuntu baseline CI uploads
+that directory as `browser-voice-diagnostics` and retains it for seven days.
+Successful runs produce no new saved diagnostics; prior failure directories
+remain available locally and are ignored by Git.
+
+To verify the diagnostic failure path, run with
+`QWEN_BROWSER_SMOKE_INJECT_ERROR=1`. This deliberately injects a page exception;
+the command must exit nonzero and save the diagnostic artifacts. Unset the
+variable for normal validation.

--- a/scripts/test/browser-webui-smoke.mjs
+++ b/scripts/test/browser-webui-smoke.mjs
@@ -27,8 +27,10 @@ const MOCK_BROWSER_APIS = String.raw`
     playbackStarts: 0,
     playbackStops: 0,
     socketMessages: 0,
+    socketConnections: 0,
+    socketCloses: 0,
     nextEvent: 1,
-    lastSocket: null,
+    serverDisconnected: false,
     processor: null,
   }
 
@@ -76,7 +78,7 @@ const MOCK_BROWSER_APIS = String.raw`
       this.url = url
       this.readyState = MockWebSocket.CONNECTING
       eventListeners(this)
-      state.lastSocket = this
+      increment('socketConnections')
       setTimeout(() => {
         this.readyState = MockWebSocket.OPEN
         this.emit('open')
@@ -118,6 +120,10 @@ const MOCK_BROWSER_APIS = String.raw`
             type: 'audio.done',
             responseId: 'response-browser-smoke',
           })
+          if (location.search.includes('browser-smoke=reconnect') && !state.serverDisconnected) {
+            state.serverDisconnected = true
+            setTimeout(() => this.close(), 5)
+          }
         }, 0)
       }
     }
@@ -125,6 +131,7 @@ const MOCK_BROWSER_APIS = String.raw`
     close() {
       if (this.readyState === MockWebSocket.CLOSED) return
       this.readyState = MockWebSocket.CLOSED
+      increment('socketCloses')
       this.emit('close', { code: 1000 })
     }
   }
@@ -191,7 +198,7 @@ const MOCK_BROWSER_APIS = String.raw`
         connect() {},
         start() {
           increment('playbackStarts')
-          setTimeout(() => source.onended?.(), 0)
+          setTimeout(() => source.onended?.(), 40)
         },
         stop() {
           increment('playbackStops')
@@ -201,10 +208,7 @@ const MOCK_BROWSER_APIS = String.raw`
     }
   }
 
-  const track = eventListeners({
-    muted: false,
-    stop() { increment('trackStops') },
-  })
+  let trackNumber = 0
   const mediaDevices = eventListeners({
     async getUserMedia() {
       increment('mediaRequests')
@@ -212,6 +216,14 @@ const MOCK_BROWSER_APIS = String.raw`
         const error = new Error('Permission denied')
         error.name = 'NotAllowedError'
         throw error
+      }
+      trackNumber += 1
+      const track = eventListeners({
+        muted: false,
+        stop() { increment('trackStops') },
+      })
+      if (location.search.includes('browser-smoke=track-ended') && trackNumber === 1) {
+        setTimeout(() => track.emit('ended'), 10)
       }
       return {
         getAudioTracks: () => [track],
@@ -313,6 +325,38 @@ async function testHappyPath(context) {
   await page.close()
 }
 
+async function testReconnectInterruptsPlayback(context) {
+  const page = await preparePage(context, '?browser-smoke=reconnect')
+  await page.getByRole('button', { name: '开启麦克风', exact: true }).click()
+  await page.getByRole('button', { name: '麦克风静音', exact: true })
+    .waitFor({ state: 'visible' })
+  await waitForAttribute(page, 'data-media-requests', value => value === '1')
+  await waitForAttribute(page, 'data-playback-starts', value => Number(value) >= 1)
+  await waitForAttribute(page, 'data-socket-connections', value => Number(value) >= 2)
+  await waitForAttribute(page, 'data-playback-stops', value => Number(value) >= 1)
+
+  assert.equal(await page.locator('html').getAttribute('data-media-requests'), '1')
+  assert.equal(await page.locator('html').getAttribute('data-processor-connects'), '1')
+  assert.equal(await page.locator('html').getAttribute('data-track-stops') || '0', '0')
+
+  await page.getByRole('button', { name: '麦克风静音', exact: true }).click()
+  await waitForAttribute(page, 'data-track-stops', value => value === '1')
+  await page.close()
+}
+
+async function testEndedTrackIsReacquired(context) {
+  const page = await preparePage(context, '?browser-smoke=track-ended')
+  await page.getByRole('button', { name: '开启麦克风', exact: true }).click()
+  await page.getByRole('button', { name: '麦克风静音', exact: true })
+    .waitFor({ state: 'visible' })
+  await waitForAttribute(page, 'data-media-requests', value => Number(value) >= 2)
+  await waitForAttribute(page, 'data-track-stops', value => Number(value) >= 1)
+  await waitForAttribute(page, 'data-processor-connects', value => Number(value) >= 2)
+
+  assert.equal(await page.locator('html').getAttribute('data-media-requests'), '2')
+  await page.close()
+}
+
 async function testPermissionDenied(context) {
   const page = await preparePage(context, '?browser-smoke=deny-microphone')
   await page.getByRole('button', { name: '开启麦克风', exact: true }).click()
@@ -330,9 +374,11 @@ try {
   browser = await chromium.launch({ headless: true })
   const context = await browser.newContext({ locale: 'zh-CN' })
   await testHappyPath(context)
+  await testReconnectInterruptsPlayback(context)
+  await testEndedTrackIsReacquired(context)
   await testPermissionDenied(context)
   await context.close()
-  console.log('Browser WebUI voice smoke passed: happy path and permission denial.')
+  console.log('Browser WebUI voice smoke passed: happy path, reconnect, track recovery, and permission denial.')
 } finally {
   await browser?.close()
   if (server.vite.exitCode === null) server.vite.kill()

--- a/scripts/test/browser-webui-smoke.mjs
+++ b/scripts/test/browser-webui-smoke.mjs
@@ -1,0 +1,339 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { resolve } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { chromium } from 'playwright'
+
+const projectRoot = resolve(import.meta.dirname, '../..')
+const webRoot = resolve(projectRoot, 'web')
+const port = Number(process.env.QWEN_BROWSER_SMOKE_PORT || 4174)
+const baseUrl = `http://127.0.0.1:${port}`
+
+// Keep the browser test deterministic and offline: the page gets a local
+// protocol/media double, while Chromium still exercises the real React page,
+// permission branch, Web Audio wiring, and cleanup lifecycle.
+const MOCK_BROWSER_APIS = String.raw`
+(() => {
+  const state = {
+    mediaRequests: 0,
+    trackStops: 0,
+    audioContexts: 0,
+    audioCloses: 0,
+    sourceConnects: 0,
+    sourceDisconnects: 0,
+    processorConnects: 0,
+    processorDisconnects: 0,
+    audioAppends: 0,
+    playbackStarts: 0,
+    playbackStops: 0,
+    socketMessages: 0,
+    nextEvent: 1,
+    lastSocket: null,
+    processor: null,
+  }
+
+  const update = (name, value) => {
+    state[name] = value
+    document.documentElement.dataset[name] = String(value)
+  }
+  const increment = name => update(name, state[name] + 1)
+  const eventListeners = target => {
+    target.listeners = new Map()
+    target.addEventListener = (name, listener) => {
+      const listeners = target.listeners.get(name) || []
+      listeners.push(listener)
+      target.listeners.set(name, listeners)
+    }
+    target.removeEventListener = (name, listener) => {
+      target.listeners.set(
+        name,
+        (target.listeners.get(name) || []).filter(item => item !== listener),
+      )
+    }
+    target.emit = (name, value) => {
+      for (const listener of target.listeners.get(name) || []) listener(value)
+    }
+    return target
+  }
+
+  const serverEvent = (socket, event) => {
+    if (socket.readyState !== MockWebSocket.OPEN) return
+    socket.emit('message', {
+      data: JSON.stringify({
+        event_id: 'mock-server-' + state.nextEvent++,
+        ...event,
+      }),
+    })
+  }
+
+  class MockWebSocket {
+    static CONNECTING = 0
+    static OPEN = 1
+    static CLOSING = 2
+    static CLOSED = 3
+
+    constructor(url) {
+      this.url = url
+      this.readyState = MockWebSocket.CONNECTING
+      eventListeners(this)
+      state.lastSocket = this
+      setTimeout(() => {
+        this.readyState = MockWebSocket.OPEN
+        this.emit('open')
+      }, 0)
+    }
+
+    send(raw) {
+      const message = JSON.parse(raw)
+      state.socketMessages += 1
+      document.documentElement.dataset.lastSocketMessage = message.type
+      if (message.type === 'session.hello') {
+        setTimeout(() => serverEvent(this, {
+          type: 'session.ready',
+          request_event_id: message.event_id,
+          protocol_version: '6.0.0',
+          session_id: 'browser-smoke',
+          capabilities: [],
+        }), 0)
+        setTimeout(() => serverEvent(this, {
+          type: 'voice.ready',
+          inputSampleRate: 16_000,
+          provider: 'browser-smoke',
+        }), 0)
+      }
+      if (message.type === 'audio.append') {
+        increment('audioAppends')
+        setTimeout(() => {
+          serverEvent(this, {
+            type: 'response.started',
+            responseId: 'response-browser-smoke',
+          })
+          serverEvent(this, {
+            type: 'audio.delta',
+            audio: 'AAAAAA==',
+            sampleRate: 24_000,
+            responseId: 'response-browser-smoke',
+          })
+          serverEvent(this, {
+            type: 'audio.done',
+            responseId: 'response-browser-smoke',
+          })
+        }, 0)
+      }
+    }
+
+    close() {
+      if (this.readyState === MockWebSocket.CLOSED) return
+      this.readyState = MockWebSocket.CLOSED
+      this.emit('close', { code: 1000 })
+    }
+  }
+
+  class MockAudioContext {
+    constructor() {
+      increment('audioContexts')
+      this.state = 'suspended'
+      this.currentTime = 0
+      this.sampleRate = 48_000
+      this.destination = {}
+    }
+
+    resume() {
+      this.state = 'running'
+      return Promise.resolve()
+    }
+
+    close() {
+      increment('audioCloses')
+      this.state = 'closed'
+      return Promise.resolve()
+    }
+
+    createMediaStreamSource() {
+      return {
+        connect() { increment('sourceConnects') },
+        disconnect() { increment('sourceDisconnects') },
+      }
+    }
+
+    createScriptProcessor() {
+      const processor = {
+        onaudioprocess: null,
+        connected: false,
+        connect() {
+          if (processor.connected) return
+          processor.connected = true
+          increment('processorConnects')
+          state.processor = processor
+          setTimeout(() => processor.onaudioprocess?.({
+            inputBuffer: {
+              getChannelData: () => Float32Array.from([0.1, 0.2, 0.3, 0.4]),
+            },
+          }), 0)
+        },
+        disconnect() {
+          increment('processorDisconnects')
+        },
+      }
+      return processor
+    }
+
+    createBuffer(_channels, length, sampleRate) {
+      return {
+        duration: length / sampleRate,
+        copyToChannel() {},
+      }
+    }
+
+    createBufferSource() {
+      const source = {
+        onended: null,
+        connect() {},
+        start() {
+          increment('playbackStarts')
+          setTimeout(() => source.onended?.(), 0)
+        },
+        stop() {
+          increment('playbackStops')
+        },
+      }
+      return source
+    }
+  }
+
+  const track = eventListeners({
+    muted: false,
+    stop() { increment('trackStops') },
+  })
+  const mediaDevices = eventListeners({
+    async getUserMedia() {
+      increment('mediaRequests')
+      if (location.search.includes('deny-microphone')) {
+        const error = new Error('Permission denied')
+        error.name = 'NotAllowedError'
+        throw error
+      }
+      return {
+        getAudioTracks: () => [track],
+        getTracks: () => [track],
+      }
+    },
+  })
+
+  try {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: mediaDevices,
+    })
+  } catch {
+    navigator.mediaDevices.getUserMedia = mediaDevices.getUserMedia
+  }
+  window.WebSocket = MockWebSocket
+  window.AudioContext = MockAudioContext
+  window.webkitAudioContext = MockAudioContext
+})()
+`
+
+function startVite() {
+  const vite = spawn(
+    process.execPath,
+    [resolve(projectRoot, 'node_modules/vite/bin/vite.js'), '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
+    { cwd: webRoot, stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+  let output = ''
+  vite.stdout.on('data', chunk => { output += chunk.toString() })
+  vite.stderr.on('data', chunk => { output += chunk.toString() })
+  return { vite, getOutput: () => output }
+}
+
+async function waitForServer(vite, getOutput) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (vite.exitCode !== null) {
+      throw new Error(`Vite exited before startup: ${getOutput()}`)
+    }
+    try {
+      const response = await fetch(baseUrl)
+      if (response.ok) return
+    } catch {
+      // The dev server is still binding its port.
+    }
+    await delay(100)
+  }
+  throw new Error(`Timed out waiting for Vite: ${getOutput()}`)
+}
+
+async function waitForAttribute(page, name, predicate, timeoutMs = 5_000) {
+  const html = page.locator('html')
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const value = await html.getAttribute(name)
+    if (predicate(value)) return value
+    await delay(50)
+  }
+  throw new Error(`Timed out waiting for ${name}`)
+}
+
+async function preparePage(context, path) {
+  const page = await context.newPage()
+  await page.route('**/api/health', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      ok: true,
+      realtimeProvider: 'browser-smoke',
+      realtimeLabel: 'Browser Smoke',
+      backend: { enabled: false, status: 'not_configured' },
+    }),
+  }))
+  await page.addInitScript({ content: MOCK_BROWSER_APIS })
+  await page.goto(`${baseUrl}/${path}`, { waitUntil: 'domcontentloaded' })
+  return page
+}
+
+async function testHappyPath(context) {
+  const page = await preparePage(context, '?browser-smoke=happy')
+  const enable = page.getByRole('button', { name: '开启麦克风', exact: true })
+  await enable.waitFor({ state: 'visible' })
+  await enable.click()
+  await page.getByRole('button', { name: '麦克风静音', exact: true })
+    .waitFor({ state: 'visible' })
+  await waitForAttribute(page, 'data-media-requests', value => value === '1')
+  await waitForAttribute(page, 'data-audio-appends', value => Number(value) >= 1)
+  await waitForAttribute(page, 'data-playback-starts', value => Number(value) >= 1)
+
+  assert.equal(await page.locator('html').getAttribute('data-audio-contexts'), '1')
+  assert.equal(await page.locator('html').getAttribute('data-track-stops') || '0', '0')
+
+  await page.getByRole('button', { name: '麦克风静音', exact: true }).click()
+  await page.getByRole('button', { name: '开启麦克风', exact: true })
+    .waitFor({ state: 'visible' })
+  await waitForAttribute(page, 'data-track-stops', value => value === '1')
+  await waitForAttribute(page, 'data-source-disconnects', value => value === '1')
+  await waitForAttribute(page, 'data-processor-disconnects', value => value === '1')
+  await page.close()
+}
+
+async function testPermissionDenied(context) {
+  const page = await preparePage(context, '?browser-smoke=deny-microphone')
+  await page.getByRole('button', { name: '开启麦克风', exact: true }).click()
+  await page.getByText('麦克风权限未开启，请在系统设置中允许后重试', { exact: true })
+    .waitFor({ state: 'visible' })
+  assert.equal(await page.locator('html').getAttribute('data-media-requests'), '1')
+  assert.equal(await page.locator('html').getAttribute('data-track-stops') || '0', '0')
+  await page.close()
+}
+
+const server = startVite()
+let browser
+try {
+  await waitForServer(server.vite, server.getOutput)
+  browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({ locale: 'zh-CN' })
+  await testHappyPath(context)
+  await testPermissionDenied(context)
+  await context.close()
+  console.log('Browser WebUI voice smoke passed: happy path and permission denial.')
+} finally {
+  await browser?.close()
+  if (server.vite.exitCode === null) server.vite.kill()
+}

--- a/scripts/test/browser-webui-smoke.mjs
+++ b/scripts/test/browser-webui-smoke.mjs
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { chromium } from 'playwright'
 
@@ -33,8 +32,9 @@ const MOCK_BROWSER_APIS = String.raw`
     socketCloses: 0,
     sessionReadyEvents: 0,
     nextEvent: 1,
-    serverDisconnected: false,
     processor: null,
+    activeSocket: null,
+    oldSocket: null,
   }
 
   const update = (name, value) => {
@@ -82,8 +82,11 @@ const MOCK_BROWSER_APIS = String.raw`
       this.readyState = MockWebSocket.CONNECTING
       eventListeners(this)
       increment('socketConnections')
+      this.id = state.socketConnections
       setTimeout(() => {
+        if (this.readyState !== MockWebSocket.CONNECTING) return
         this.readyState = MockWebSocket.OPEN
+        state.activeSocket = this
         this.emit('open')
       }, 0)
     }
@@ -94,21 +97,17 @@ const MOCK_BROWSER_APIS = String.raw`
       document.documentElement.dataset.lastSocketMessage = message.type
       if (message.type === 'session.hello') {
         setTimeout(() => {
+          if (this.readyState !== MockWebSocket.OPEN) return
           increment('sessionReadyEvents')
           serverEvent(this, {
             type: 'session.ready',
             request_event_id: message.event_id,
             protocol_version: '6.0.0',
             session_id: 'browser-smoke',
-            capabilities: [],
+            capabilities: ['session.heartbeat'],
           })
-          if (state.sessionReadyEvents > 1) {
-            setTimeout(() => state.processor?.onaudioprocess?.({
-              inputBuffer: {
-                getChannelData: () => Float32Array.from([0.4, 0.3, 0.2, 0.1]),
-              },
-            }), 0)
-          }
+          this.handshakeReady = true
+          serverEvent(this, { type: 'session.ping', event_id: 'ping-' + this.id })
         }, 0)
         setTimeout(() => serverEvent(this, {
           type: 'voice.ready',
@@ -118,26 +117,32 @@ const MOCK_BROWSER_APIS = String.raw`
       }
       if (message.type === 'audio.append') {
         increment('audioAppends')
+        document.documentElement.dataset.audioSocket = String(this.id)
         setTimeout(() => {
+          const responseId = 'response-browser-smoke-' + this.id
           serverEvent(this, {
             type: 'response.started',
-            responseId: 'response-browser-smoke',
+            responseId,
           })
           serverEvent(this, {
             type: 'audio.delta',
             audio: 'AAAAAA==',
             sampleRate: 24_000,
-            responseId: 'response-browser-smoke',
+            responseId,
           })
           serverEvent(this, {
             type: 'audio.done',
-            responseId: 'response-browser-smoke',
+            responseId,
           })
-          if (location.search.includes('browser-smoke=reconnect') && !state.serverDisconnected) {
-            state.serverDisconnected = true
-            setTimeout(() => this.close(), 5)
-          }
+          serverEvent(this, { type: 'transcript.final', role: 'assistant',
+            responseId, content: 'Reply from connection ' + this.id })
         }, 0)
+      }
+      if (message.type === 'playback.started') {
+        document.documentElement.dataset.playbackResponse = message.responseId
+      }
+      if (message.type === 'session.pong' && message.request_event_id === 'ping-' + this.id) {
+        document.documentElement.dataset.negotiatedSocket = String(this.id)
       }
     }
 
@@ -192,6 +197,7 @@ const MOCK_BROWSER_APIS = String.raw`
           }), 0)
         },
         disconnect() {
+          processor.connected = false
           increment('processorDisconnects')
         },
       }
@@ -211,7 +217,9 @@ const MOCK_BROWSER_APIS = String.raw`
         connect() {},
         start() {
           increment('playbackStarts')
-          setTimeout(() => source.onended?.(), 40)
+          if (!location.search.includes('browser-smoke=reconnect')) {
+            setTimeout(() => source.onended?.(), 40)
+          }
         },
         stop() {
           increment('playbackStops')
@@ -256,6 +264,22 @@ const MOCK_BROWSER_APIS = String.raw`
   window.WebSocket = MockWebSocket
   window.AudioContext = MockAudioContext
   window.webkitAudioContext = MockAudioContext
+  window.browserSmoke = {
+    connection: () => ({ id: state.activeSocket?.id, ready: state.activeSocket?.handshakeReady }),
+    disconnect() { state.oldSocket = state.activeSocket; state.oldSocket.close() },
+    input() {
+      if (state.processor?.connected) state.processor.onaudioprocess?.({
+        inputBuffer: { getChannelData: () => Float32Array.from([0.4, 0.3, 0.2, 0.1]) },
+      })
+    },
+    stale() {
+      // Deliberately bypass the mock transport guard to exercise the SDK's guard.
+      state.oldSocket.emit('message', { data: JSON.stringify({
+        type: 'transcript.final', event_id: 'stale-event', role: 'assistant',
+        responseId: 'stale-response', content: 'STALE CONNECTION REPLY',
+      }) })
+    },
+  }
 })()
 `
 
@@ -320,7 +344,16 @@ async function preparePage(context, path, diagnostics) {
   }))
   await page.addInitScript({ content: MOCK_BROWSER_APIS })
   await page.goto(`${baseUrl}/${path}`, { waitUntil: 'domcontentloaded' })
+  if (process.env.QWEN_BROWSER_SMOKE_INJECT_ERROR === '1') {
+    await page.evaluate(() => { setTimeout(() => { throw new Error('smoke diagnostic probe') }, 0) })
+  }
   return page
+}
+
+async function finishPage(page, diagnostics) {
+  assert.deepEqual(diagnostics.filter(item => item.type === 'pageerror' || item.type === 'console:error'), [],
+    'Browser reported an unexpected error')
+  await page.close()
 }
 
 async function testHappyPath(context, diagnostics) {
@@ -343,7 +376,7 @@ async function testHappyPath(context, diagnostics) {
   await waitForAttribute(page, 'data-track-stops', value => value === '1')
   await waitForAttribute(page, 'data-source-disconnects', value => value === '1')
   await waitForAttribute(page, 'data-processor-disconnects', value => value === '1')
-  await page.close()
+  await finishPage(page, diagnostics)
 }
 
 async function testReconnectInterruptsPlayback(context, diagnostics) {
@@ -353,10 +386,22 @@ async function testReconnectInterruptsPlayback(context, diagnostics) {
     .waitFor({ state: 'visible' })
   await waitForAttribute(page, 'data-media-requests', value => value === '1')
   await waitForAttribute(page, 'data-playback-starts', value => Number(value) >= 1)
-  await waitForAttribute(page, 'data-session-ready-events', value => Number(value) >= 2)
-  await waitForAttribute(page, 'data-audio-appends', value => Number(value) >= 2)
-  await waitForAttribute(page, 'data-playback-starts', value => Number(value) >= 2)
+  const first = await page.evaluate(() => window.browserSmoke.connection())
+  assert.equal(first.ready, true)
+  const previousStarts = Number(await page.locator('html').getAttribute('data-playback-starts'))
+  await page.evaluate(() => window.browserSmoke.disconnect())
   await waitForAttribute(page, 'data-playback-stops', value => Number(value) >= 1)
+  await page.waitForFunction(id => {
+    const connection = window.browserSmoke.connection()
+    return connection.ready && connection.id !== id
+  }, first.id)
+  const second = await page.evaluate(() => window.browserSmoke.connection())
+  await waitForAttribute(page, 'data-negotiated-socket', value => value === String(second.id))
+  await page.evaluate(() => { window.browserSmoke.stale(); window.browserSmoke.input() })
+  await waitForAttribute(page, 'data-audio-socket', value => value === String(second.id))
+  await waitForAttribute(page, 'data-playback-starts', value => Number(value) === previousStarts + 1)
+  await page.getByText('Reply from connection ' + second.id, { exact: true }).waitFor()
+  assert.equal(await page.getByText('STALE CONNECTION REPLY', { exact: true }).count(), 0)
 
   assert.equal(await page.locator('html').getAttribute('data-media-requests'), '1')
   assert.equal(await page.locator('html').getAttribute('data-processor-connects'), '1')
@@ -365,7 +410,7 @@ async function testReconnectInterruptsPlayback(context, diagnostics) {
 
   await page.getByRole('button', { name: '麦克风静音', exact: true }).click()
   await waitForAttribute(page, 'data-track-stops', value => value === '1')
-  await page.close()
+  await finishPage(page, diagnostics)
 }
 
 async function testEndedTrackIsReacquired(context, diagnostics) {
@@ -378,7 +423,7 @@ async function testEndedTrackIsReacquired(context, diagnostics) {
   await waitForAttribute(page, 'data-processor-connects', value => Number(value) >= 2)
 
   assert.equal(await page.locator('html').getAttribute('data-media-requests'), '2')
-  await page.close()
+  await finishPage(page, diagnostics)
 }
 
 async function testPermissionDenied(context, diagnostics) {
@@ -388,7 +433,7 @@ async function testPermissionDenied(context, diagnostics) {
     .waitFor({ state: 'visible' })
   assert.equal(await page.locator('html').getAttribute('data-media-requests'), '1')
   assert.equal(await page.locator('html').getAttribute('data-track-stops') || '0', '0')
-  await page.close()
+  await finishPage(page, diagnostics)
 }
 
 const server = startVite()
@@ -396,7 +441,7 @@ let browser
 let context
 let tracingActive = false
 const diagnostics = []
-const diagnosticsDirectory = resolve(projectRoot, 'output/playwright/browser-webui-smoke')
+const diagnosticsDirectory = resolve(projectRoot, 'output/playwright/browser-webui-smoke', String(Date.now()))
 try {
   await waitForServer(server.vite, server.getOutput)
   browser = await chromium.launch({ headless: true })

--- a/scripts/test/browser-webui-smoke.mjs
+++ b/scripts/test/browser-webui-smoke.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import { resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { chromium } from 'playwright'
@@ -29,6 +31,7 @@ const MOCK_BROWSER_APIS = String.raw`
     socketMessages: 0,
     socketConnections: 0,
     socketCloses: 0,
+    sessionReadyEvents: 0,
     nextEvent: 1,
     serverDisconnected: false,
     processor: null,
@@ -90,13 +93,23 @@ const MOCK_BROWSER_APIS = String.raw`
       state.socketMessages += 1
       document.documentElement.dataset.lastSocketMessage = message.type
       if (message.type === 'session.hello') {
-        setTimeout(() => serverEvent(this, {
-          type: 'session.ready',
-          request_event_id: message.event_id,
-          protocol_version: '6.0.0',
-          session_id: 'browser-smoke',
-          capabilities: [],
-        }), 0)
+        setTimeout(() => {
+          increment('sessionReadyEvents')
+          serverEvent(this, {
+            type: 'session.ready',
+            request_event_id: message.event_id,
+            protocol_version: '6.0.0',
+            session_id: 'browser-smoke',
+            capabilities: [],
+          })
+          if (state.sessionReadyEvents > 1) {
+            setTimeout(() => state.processor?.onaudioprocess?.({
+              inputBuffer: {
+                getChannelData: () => Float32Array.from([0.4, 0.3, 0.2, 0.1]),
+              },
+            }), 0)
+          }
+        }, 0)
         setTimeout(() => serverEvent(this, {
           type: 'voice.ready',
           inputSampleRate: 16_000,
@@ -285,8 +298,16 @@ async function waitForAttribute(page, name, predicate, timeoutMs = 5_000) {
   throw new Error(`Timed out waiting for ${name}`)
 }
 
-async function preparePage(context, path) {
+async function preparePage(context, path, diagnostics) {
   const page = await context.newPage()
+  page.on('pageerror', error => diagnostics.push({
+    type: 'pageerror',
+    message: error.stack || String(error),
+  }))
+  page.on('console', message => diagnostics.push({
+    type: `console:${message.type()}`,
+    message: message.text(),
+  }))
   await page.route('**/api/health', route => route.fulfill({
     status: 200,
     contentType: 'application/json',
@@ -302,8 +323,8 @@ async function preparePage(context, path) {
   return page
 }
 
-async function testHappyPath(context) {
-  const page = await preparePage(context, '?browser-smoke=happy')
+async function testHappyPath(context, diagnostics) {
+  const page = await preparePage(context, '?browser-smoke=happy', diagnostics)
   const enable = page.getByRole('button', { name: '开启麦克风', exact: true })
   await enable.waitFor({ state: 'visible' })
   await enable.click()
@@ -325,18 +346,21 @@ async function testHappyPath(context) {
   await page.close()
 }
 
-async function testReconnectInterruptsPlayback(context) {
-  const page = await preparePage(context, '?browser-smoke=reconnect')
+async function testReconnectInterruptsPlayback(context, diagnostics) {
+  const page = await preparePage(context, '?browser-smoke=reconnect', diagnostics)
   await page.getByRole('button', { name: '开启麦克风', exact: true }).click()
   await page.getByRole('button', { name: '麦克风静音', exact: true })
     .waitFor({ state: 'visible' })
   await waitForAttribute(page, 'data-media-requests', value => value === '1')
   await waitForAttribute(page, 'data-playback-starts', value => Number(value) >= 1)
-  await waitForAttribute(page, 'data-socket-connections', value => Number(value) >= 2)
+  await waitForAttribute(page, 'data-session-ready-events', value => Number(value) >= 2)
+  await waitForAttribute(page, 'data-audio-appends', value => Number(value) >= 2)
+  await waitForAttribute(page, 'data-playback-starts', value => Number(value) >= 2)
   await waitForAttribute(page, 'data-playback-stops', value => Number(value) >= 1)
 
   assert.equal(await page.locator('html').getAttribute('data-media-requests'), '1')
   assert.equal(await page.locator('html').getAttribute('data-processor-connects'), '1')
+  assert.ok(Number(await page.locator('html').getAttribute('data-socket-connections')) >= 2)
   assert.equal(await page.locator('html').getAttribute('data-track-stops') || '0', '0')
 
   await page.getByRole('button', { name: '麦克风静音', exact: true }).click()
@@ -344,8 +368,8 @@ async function testReconnectInterruptsPlayback(context) {
   await page.close()
 }
 
-async function testEndedTrackIsReacquired(context) {
-  const page = await preparePage(context, '?browser-smoke=track-ended')
+async function testEndedTrackIsReacquired(context, diagnostics) {
+  const page = await preparePage(context, '?browser-smoke=track-ended', diagnostics)
   await page.getByRole('button', { name: '开启麦克风', exact: true }).click()
   await page.getByRole('button', { name: '麦克风静音', exact: true })
     .waitFor({ state: 'visible' })
@@ -357,8 +381,8 @@ async function testEndedTrackIsReacquired(context) {
   await page.close()
 }
 
-async function testPermissionDenied(context) {
-  const page = await preparePage(context, '?browser-smoke=deny-microphone')
+async function testPermissionDenied(context, diagnostics) {
+  const page = await preparePage(context, '?browser-smoke=deny-microphone', diagnostics)
   await page.getByRole('button', { name: '开启麦克风', exact: true }).click()
   await page.getByText('麦克风权限未开启，请在系统设置中允许后重试', { exact: true })
     .waitFor({ state: 'visible' })
@@ -369,17 +393,59 @@ async function testPermissionDenied(context) {
 
 const server = startVite()
 let browser
+let context
+let tracingActive = false
+const diagnostics = []
+const diagnosticsDirectory = resolve(projectRoot, 'output/playwright/browser-webui-smoke')
 try {
   await waitForServer(server.vite, server.getOutput)
   browser = await chromium.launch({ headless: true })
-  const context = await browser.newContext({ locale: 'zh-CN' })
-  await testHappyPath(context)
-  await testReconnectInterruptsPlayback(context)
-  await testEndedTrackIsReacquired(context)
-  await testPermissionDenied(context)
+  context = await browser.newContext({ locale: 'zh-CN' })
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true })
+  tracingActive = true
+  await testHappyPath(context, diagnostics)
+  await testReconnectInterruptsPlayback(context, diagnostics)
+  await testEndedTrackIsReacquired(context, diagnostics)
+  await testPermissionDenied(context, diagnostics)
+  await context.tracing.stop()
+  tracingActive = false
   await context.close()
-  console.log('Browser WebUI voice smoke passed: happy path, reconnect, track recovery, and permission denial.')
+  context = null
+  console.log('Browser WebUI voice smoke passed: happy path, reconnect continuation, track recovery, and permission denial.')
+} catch (error) {
+  await mkdir(diagnosticsDirectory, { recursive: true })
+  const pages = context?.pages?.() || []
+  await Promise.all(pages.map((page, index) => page.screenshot({
+    path: join(diagnosticsDirectory, `failure-page-${index + 1}.png`),
+    fullPage: true,
+  }).catch(reason => diagnostics.push({
+    type: 'screenshot-error',
+    message: String(reason),
+  }))))
+  if (tracingActive) {
+    await context.tracing.stop({
+      path: join(diagnosticsDirectory, 'trace.zip'),
+    }).catch(reason => diagnostics.push({
+      type: 'trace-error',
+      message: String(reason),
+    }))
+    tracingActive = false
+  }
+  await writeFile(
+    join(diagnosticsDirectory, 'errors.log'),
+    [
+      `failure: ${error?.stack || error}`,
+      ...diagnostics.map(item => `[${item.type}] ${item.message}`),
+    ].join('\n'),
+    'utf8',
+  )
+  await writeFile(join(diagnosticsDirectory, 'vite.log'), server.getOutput(), 'utf8')
+  if (error instanceof Error) {
+    error.message = `${error.message} (diagnostics: ${diagnosticsDirectory})`
+  }
+  throw error
 } finally {
+  await context?.close()
   await browser?.close()
   if (server.vite.exitCode === null) server.vite.kill()
 }


### PR DESCRIPTION
The WebUI has unit coverage for media helpers but lacked browser-level checks of the React voice lifecycle. This PR adds a Chromium smoke suite with deterministic Gateway, microphone and AudioContext doubles. It does not validate physical devices or native audio rendering.

Coverage includes microphone enable/disable and resource release, permission denial, ended-track recovery, and disconnect during playback. Reconnect checks identify the replacement socket, require its negotiated heartbeat reply, send another PCM frame, and assert a visible response from that connection. A deliberately late old-socket reply must not appear in the page. The mock cannot reopen a socket after it has been closed.

Unexpected page exceptions and console errors fail the suite before page cleanup. Failures save screenshots, a Playwright trace, browser errors, and Vite output to a timestamped directory; Ubuntu CI uploads these as `browser-voice-diagnostics` with seven-day retention. Successful runs create no new saved diagnostic files. See `scripts/test/README.md` for usage and fault injection.

Validation for the latest changes:

- Local Chromium smoke: passed all four scenarios.
- Targeted ESLint: passed.
- Injected page exception: correctly exited nonzero and produced screenshot, trace, browser errors and Vite log.
- Earlier clean dependency installation and Web unit suite: passed (129 tests on the local base).

Browser dependencies and CI steps are development-only; production client code and protocol are unchanged. Browser tests run on the Ubuntu Node 22 baseline matrix entry, which is included in the existing required aggregate.
