### PR TITLE
docs(lightrag): stop implying the workspace selector isolates data

### DIFF
--- a/examples/lightrag/README.md
+++ b/examples/lightrag/README.md
@@ -138,7 +138,7 @@ after a real terminal state. Deletion likewise waits for remote completion inste
 |---|---|---|
 | `LIGHTRAG_URL` | `http://127.0.0.1:9621` | LightRAG Server endpoint |
 | `LIGHTRAG_API_KEY` | empty | LightRAG access key sent as `X-API-Key` |
-| `LIGHTRAG_WORKSPACE` | empty | Fixed workspace; never derived from model input or owner data |
+| `LIGHTRAG_WORKSPACE` | empty | Optional workspace selector sent as `LIGHTRAG-WORKSPACE`; leave empty unless the operator provisioned one |
 | `LIGHTRAG_QUERY_MODE` | `mix` | `local`, `global`, `hybrid`, `naive`, or `mix` |
 | `LIGHTRAG_RETRIEVAL_TIMEOUT_MS` | `60000` | Maximum time the Gateway waits for retrieval |
 | `LIGHTRAG_REQUEST_TIMEOUT_MS` | `30000` | Timeout for one HTTP request |
@@ -150,11 +150,18 @@ Cancelling a Gateway ingestion task stops the provider's local wait. It delibera
 call LightRAG's global `cancel_pipeline`, which could cancel unrelated documents in the same
 instance.
 
+Leave `LIGHTRAG_WORKSPACE` empty unless a LightRAG operator has provisioned a workspace for this
+key. Today LightRAG reads the `LIGHTRAG-WORKSPACE` header only on its status route; the retrieval
+and document endpoints ignore it, so a value here does not isolate data — everything lands in the
+server's configured workspace. Once server-side multi-workspace support lands, a selector without
+a catalog record whose member table includes this key is rejected rather than silently falling
+back, so an unset selector is the correct configuration before and after that change.
+
 ## Replace and extend
 
 | Goal | Change |
 |---|---|
-| Use an existing LightRAG service | Set `LIGHTRAG_URL`, `LIGHTRAG_API_KEY`, and `LIGHTRAG_WORKSPACE`. |
+| Use an existing LightRAG service | Set `LIGHTRAG_URL` and `LIGHTRAG_API_KEY`. |
 | Tune retrieval | Set `LIGHTRAG_QUERY_MODE` and the retrieval timeout. |
 | Embed in another host | Create the provider and inject it through `knowledgeProvider` in `createGatewayApplication`. |
 | Replace LightRAG | Implement the same versioned `KnowledgeProvider` contract. |

--- a/examples/lightrag/README_ZH.md
+++ b/examples/lightrag/README_ZH.md
@@ -130,7 +130,7 @@ node --env-file=examples/lightrag/.env.local examples/lightrag/gateway.mjs
 |---|---|---|
 | `LIGHTRAG_URL` | `http://127.0.0.1:9621` | LightRAG Server 地址 |
 | `LIGHTRAG_API_KEY` | 空 | 通过 `X-API-Key` 发送的 LightRAG 访问密钥 |
-| `LIGHTRAG_WORKSPACE` | 空 | 固定 workspace；不会从模型输入或 owner 动态生成 |
+| `LIGHTRAG_WORKSPACE` | 空 | 可选的 workspace 选择器，通过 `LIGHTRAG-WORKSPACE` 发送；除运维已开通外请留空 |
 | `LIGHTRAG_QUERY_MODE` | `mix` | `local`、`global`、`hybrid`、`naive` 或 `mix` |
 | `LIGHTRAG_RETRIEVAL_TIMEOUT_MS` | `60000` | Gateway 等待一次检索的最长时间 |
 | `LIGHTRAG_REQUEST_TIMEOUT_MS` | `30000` | 单次 HTTP 请求超时 |
@@ -141,11 +141,16 @@ node --env-file=examples/lightrag/.env.local examples/lightrag/gateway.mjs
 Gateway 取消入库任务时，Provider 会停止本地等待，但不会调用 LightRAG 的全局
 `cancel_pipeline`，以免取消同一实例中的其他文档。
 
+除 LightRAG 运维已为该密钥开通 workspace 外，`LIGHTRAG_WORKSPACE` 请留空。当前 LightRAG 只在
+状态路由读取 `LIGHTRAG-WORKSPACE`，检索与文档端点并不读取，因此在此填值不会带来数据隔离，数据
+仍会落到服务端配置的那个 workspace。等服务端多 workspace 支持落地后，未登记 catalog 记录、或
+成员表中不含该密钥的选择器会被直接拒绝而非静默回退，所以留空在改动前后都是正确配置。
+
 ## 替换和扩展
 
 | 需求 | 修改位置 |
 |---|---|
-| 使用已有 LightRAG 服务 | 设置 `LIGHTRAG_URL`、`LIGHTRAG_API_KEY` 和 `LIGHTRAG_WORKSPACE`。 |
+| 使用已有 LightRAG 服务 | 设置 `LIGHTRAG_URL` 和 `LIGHTRAG_API_KEY`。 |
 | 调整检索策略 | 设置 `LIGHTRAG_QUERY_MODE` 和检索超时。 |
 | 在其他宿主中接入 | 创建 Provider 后，通过 `knowledgeProvider` 注入 `createGatewayApplication`。 |
 | 替换为其他知识系统 | 实现同一版本的 `KnowledgeProvider` 接口。 |


### PR DESCRIPTION
## 变更说明

`examples/lightrag` 的文档此前指引用户在接入已有服务时设置 `LIGHTRAG_WORKSPACE`，并把它描述为「固定 workspace」，容易被读成按 workspace 的数据隔离。

上游源码核实结论：LightRAG 目前只在状态路由读取 `LIGHTRAG-WORKSPACE`（`get_workspace_from_request` 定义于 `lightrag/api/lightrag_server.py:1811`，唯一调用点在 `:2861` 的 `get_status`），`/query/*` 与 `/documents/*` 完全不读取；`document_routes.py:6725-6731` 的 `Vary: LIGHTRAG-WORKSPACE` 是为将来设计预先声明的，注释明确写着按工作区解析尚未落地。

因此按原文档设置该变量的用户实际上没有隔离，数据仍落到服务端配置的那个 workspace。上游多 workspace 设计（HKUDS/LightRAG#3631）进一步规定：语法合法但未登记 catalog 记录的选择器返回 404 而非静默回退。维护者在该讨论中确认，正确的下游指引是在运维显式创建 catalog 记录并把密钥加入成员表之前留空该项——这在改动前后都成立。

本 PR 只改文档：说明选择器为可选且默认留空、补充当前行为与将来要求，并把「使用已有 LightRAG 服务」一行改为只设置 `LIGHTRAG_URL` 与 `LIGHTRAG_API_KEY`。`.env.example` 原本就是空值，无需改动；代码行为不变。

## 验证

- [x] `npm run lint`
- [x] `npm run docs:build`（含 `check-docs-site` 链接与锚点检查，105 页通过）
- [x] 行为变化已补充测试或说明无法自动测试的原因（纯文档修正，无行为变化）

## 兼容性与安全

- [x] 未提交密钥、用户数据、日志或内部地址
- [x] 配置、用户可见行为和依赖变化已同步更新文档（中英文 README 同步）
- [x] 已说明网络、权限、隐私、持久化或发布流程影响：修正了一处会让用户高估隔离强度的表述，属于隐私/多租户预期的纠偏；无代码或依赖变化