### PR TITLE
docs(cockpit): highlight benchmark results

### DIFF
--- a/examples/smart-cockpit/README.md
+++ b/examples/smart-cockpit/README.md
@@ -18,6 +18,49 @@ work together.
 
 https://github.com/user-attachments/assets/0136b6ec-2ff8-49ba-8f07-55e7006d2e7d
 
+## Architecture
+
+![Smart cockpit framework architecture](docs/framework-architecture.svg)
+
+The base qwen-audio-agent boundary is foreground conversation plus backend
+execution. The cockpit client and Gateway form the foreground, the cockpit
+Agent handles backend tasks, and the Service supplies scenario state, business
+rules, and the tool execution environment.
+
+See the [architecture document](docs/architecture.md) for complete boundaries
+and data flows.
+
+## Benchmark Results
+
+The benchmark evaluates cockpit tool calling with the same tools, prompt,
+deterministic state, and scorer for Text and Realtime models.
+
+### Short Suite
+
+86 canonical cases across vehicle control, music, navigation, and weather.
+
+| Domain | Cases | Expected calls | Text pass rate | Text actual calls | Realtime pass rate | Realtime actual calls |
+|---|---:|---:|---:|---:|---:|---:|
+| Vehicle | 24 | 23 | 100.00% | 23 | 100.00% | 23 |
+| Music | 18 | 17 | 100.00% | 17 | 100.00% | 17 |
+| Navigation | 36 | 44 | 100.00% | 44 | 97.22% | 44 |
+| Weather | 8 | 8 | 100.00% | 8 | 100.00% | 8 |
+| Overall | 86 | 92 | 100.00% | 92 | 98.84% | 92 |
+
+### Long-Context Suite
+
+10 mixed-domain conversations, 500 total turns, 250 expected tool calls, and
+250 no-tool chitchat/background turns. Long-context results focus on call-level,
+state, and no-tool behavior instead of task pass rate.
+
+| Model | Calls exp/act | Tool acc | Aligned tool | Arg acc | Aligned arg | Missing/extra | Final state | Checkpoints | Silent turns |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Text `qwen3.8-flash` | 250 / 252 | 88.80% | 100.00% | 91.20% | 100.00% | 0 / 2 | 100.00% | 100.00% | 90.00% |
+| Realtime `qwen-audio-3.0-realtime-plus` | 250 / 246 | 71.20% | 98.40% | 76.00% | 98.40% | 4 / 0 | 100.00% | 80.00% | 100.00% |
+
+See the [Benchmark guide](bench/README.md) for datasets, commands, alignment
+metrics, timeout retry behavior, and scoring rules.
+
 ## Core features
 
 - **Realtime voice conversation:** continuous dialogue, natural interruption,
@@ -32,26 +75,6 @@ https://github.com/user-attachments/assets/0136b6ec-2ff8-49ba-8f07-55e7006d2e7d
   and order state through scenario-owned HTTP/SSE channels.
 - **Replaceable components:** the client, backend Agent, and scenario service can
   each be replaced without changing the framework core.
-
-## Architecture
-
-![Smart cockpit framework architecture](docs/framework-architecture.svg)
-
-The base qwen-audio-agent boundary is foreground conversation plus backend
-execution. The cockpit client and Gateway form the foreground, the cockpit Agent
-handles backend tasks, and the Service supplies scenario state, business rules,
-and the tool execution environment.
-
-| Directory / process | Default address | Responsibility |
-|---|---|---|
-| [`client/`](client/) / cockpit-client | `http://127.0.0.1:5173` | Replaceable cockpit client responsible for audio I/O, conversation interaction, and business panels. |
-| [`gateway/`](gateway/) / cockpit-gateway | `http://127.0.0.1:18888` | Foreground Agent and Gateway composition for realtime conversation, foreground tools, and backend task submission. |
-| [`agent/`](agent/) / cockpit-agent | `http://127.0.0.1:3020` | Replaceable A2A backend Agent; Qwen3.8-Flash interprets and orchestrates tasks. |
-| [`service/`](service/) / cockpit-service | `http://127.0.0.1:3010` | Cockpit environment and infrastructure for state, rules, external integrations, and MCP tools. |
-| [`bootstrap/`](bootstrap/) | — | Shared environment loading and startup preflight for all four processes. |
-
-See the [architecture document](docs/architecture.md) for complete boundaries
-and data flows.
 
 ## Quick start
 
@@ -108,28 +131,6 @@ Realtime fast path, while `flashbuy` and `custom-skills` run through the backend
 Agent. Change the scenario routing in
 [`surface-routing.json`](service/tools/surface-routing.json); see the
 [tool directory guide](service/tools/README.md) for extension details.
-
-## Benchmark
-
-The example includes a reproducible cockpit tool-calling benchmark. It uses the
-same tools, prompt, deterministic state, and scorer to evaluate tool selection,
-argument generation, and no-tool decisions in both single-turn and long-context
-conversations:
-
-- Short suite: 86 cockpit instructions.
-- Long-context suite: 10 conversations and 500 turns, including 250 expected
-  tool calls and 250 no-tool turns.
-- Four runners: Gold, text model, controlled Realtime, and full voice pipeline.
-
-```bash
-node examples/smart-cockpit/bench/runner/run-gold.mjs
-node examples/smart-cockpit/bench/runner/run-text.mjs
-node examples/smart-cockpit/bench/runner/run-realtime.mjs
-node examples/smart-cockpit/bench/runner/run-voice.mjs
-```
-
-See the [Benchmark guide](bench/README.md) for datasets, runtime options, and
-scoring rules.
 
 ## Replace and extend
 

--- a/examples/smart-cockpit/README_ZH.md
+++ b/examples/smart-cockpit/README_ZH.md
@@ -14,6 +14,44 @@
 
 https://github.com/user-attachments/assets/0136b6ec-2ff8-49ba-8f07-55e7006d2e7d
 
+## 架构
+
+![智能座舱框架架构图](docs/framework-architecture.svg)
+
+qwen-audio-agent 的基础边界是“前台对话 + 后台执行”。座舱客户端与 Gateway 组成前台，
+座舱 Agent 负责后台任务，Service 提供场景状态、业务规则和工具执行环境。
+
+完整的边界与数据流见[架构文档](docs/architecture.md)。
+
+## 评测结果
+
+评测使用同一套工具、Prompt、确定性状态和评分器，对比 Text 与 Realtime 模型的座舱
+工具调用能力。
+
+### 短用例集
+
+86 个标准用例，覆盖车控、音乐、导航和天气。
+
+| 领域 | 用例数 | 预期调用数 | Text 通过率 | Text 实际调用 | Realtime 通过率 | Realtime 实际调用 |
+|---|---:|---:|---:|---:|---:|---:|
+| Vehicle | 24 | 23 | 100.00% | 23 | 100.00% | 23 |
+| Music | 18 | 17 | 100.00% | 17 | 100.00% | 17 |
+| Navigation | 36 | 44 | 100.00% | 44 | 97.22% | 44 |
+| Weather | 8 | 8 | 100.00% | 8 | 100.00% | 8 |
+| Overall | 86 | 92 | 100.00% | 92 | 98.84% | 92 |
+
+### 长上下文集
+
+10 段混合领域对话，共 500 轮、250 次预期工具调用和 250 个无工具闲聊/背景轮次。
+长上下文评测关注工具调用、状态和无工具判断，不使用端到端任务通过率。
+
+| 模型 | 调用 预期/实际 | Tool acc | Aligned tool | Arg acc | Aligned arg | Missing/extra | Final state | Checkpoints | Silent turns |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Text `qwen3.8-flash` | 250 / 252 | 88.80% | 100.00% | 91.20% | 100.00% | 0 / 2 | 100.00% | 100.00% | 90.00% |
+| Realtime `qwen-audio-3.0-realtime-plus` | 250 / 246 | 71.20% | 98.40% | 76.00% | 98.40% | 4 / 0 | 100.00% | 80.00% | 100.00% |
+
+数据集、运行命令、alignment 指标、超时重试和评分规则见 [Benchmark 说明](bench/README.md)。
+
 ## 核心特点
 
 - **实时语音对话：**支持连续交流、自然打断、多轮上下文、音色和人设切换。
@@ -22,23 +60,6 @@ https://github.com/user-attachments/assets/0136b6ec-2ff8-49ba-8f07-55e7006d2e7d
 - **标准后台接入：**示例 Agent 通过 A2A 1.0 连接 Gateway，可替换为客户自己的 A2A、ACP 或定制后台。
 - **场景状态联动：**座舱 UI 通过场景 HTTP/SSE 通道展示车辆、路线、音乐和订单状态。
 - **组件可替换：**客户可以独立替换座舱客户端、后台 Agent 或场景 Service，无需修改框架核心。
-
-## 架构
-
-![智能座舱框架架构图](docs/framework-architecture.svg)
-
-qwen-audio-agent 的基础边界是“前台对话 + 后台执行”。座舱客户端与 Gateway 组成前台，
-座舱 Agent 负责后台任务，Service 提供场景状态、业务规则和工具执行环境。
-
-| 目录 / 进程 | 默认地址 | 职责 |
-|---|---|---|
-| [`client/`](client/) / cockpit-client | `http://127.0.0.1:5173` | 可替换的座舱客户端；负责音频 I/O、对话交互和业务面板。 |
-| [`gateway/`](gateway/) / cockpit-gateway | `http://127.0.0.1:18888` | 前台 Agent 与 Gateway 场景装配；处理实时对话、前台工具和后台任务提交。 |
-| [`agent/`](agent/) / cockpit-agent | `http://127.0.0.1:3020` | 可替换的 A2A 后台 Agent；Qwen3.8-Flash 负责理解和编排任务。 |
-| [`service/`](service/) / cockpit-service | `http://127.0.0.1:3010` | 座舱环境与基础设施；管理状态、规则、外部服务适配和 MCP 工具。 |
-| [`bootstrap/`](bootstrap/) | — | 四个进程共用的环境加载和启动预检。 |
-
-完整的边界与数据流见[架构文档](docs/architecture.md)。
 
 ## 快速开始
 
@@ -92,24 +113,6 @@ MCP 工具，还包含 Gateway 内置工具和按能力动态启用的工具。
 `flashbuy` 和 `custom-skills` 由后台 Agent 执行。通过
 [`surface-routing.json`](service/tools/surface-routing.json) 即可调整场景分流；扩展方式见
 [工具目录说明](service/tools/README.md)。
-
-## Benchmark
-
-示例内置可复现的座舱工具调用评测，使用同一套工具、Prompt、确定性状态和评分器，
-验证模型在单轮及长上下文对话中的工具选择、参数生成与无工具判断：
-
-- 短用例集：86 个座舱指令。
-- 长上下文集：10 段对话、500 轮，其中包含 250 次预期工具调用和 250 个无工具轮次。
-- 支持 Gold、文本模型、受控 Realtime 和完整语音链路四种运行方式。
-
-```bash
-node examples/smart-cockpit/bench/runner/run-gold.mjs
-node examples/smart-cockpit/bench/runner/run-text.mjs
-node examples/smart-cockpit/bench/runner/run-realtime.mjs
-node examples/smart-cockpit/bench/runner/run-voice.mjs
-```
-
-数据集、运行参数和评分规则见 [Benchmark 说明](bench/README.md)。
 
 ## 替换和扩展
 

--- a/examples/smart-cockpit/bench/README.md
+++ b/examples/smart-cockpit/bench/README.md
@@ -38,10 +38,10 @@ conversation turns, 250 expected tool calls, and 250 no-tool chitchat or
 background turns. Because every case is mixed-domain, the table only shows core
 overall metrics.
 
-| Model | Calls exp/act | Pass | Tool acc | Aligned tool | Arg acc | Aligned arg | Missing/extra | Final state | Checkpoints | Silent turns |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Text `qwen3.8-flash` | 250 / 252 | 80.00% | 88.80% | 100.00% | 91.20% | 100.00% | 0 / 2 | 100.00% | 100.00% | 90.00% |
-| Realtime `qwen-audio-3.0-realtime-plus` | 250 / 246 | 60.00% | 71.20% | 98.40% | 76.00% | 98.40% | 4 / 0 | 100.00% | 80.00% | 100.00% |
+| Model | Calls exp/act | Tool acc | Aligned tool | Arg acc | Aligned arg | Missing/extra | Final state | Checkpoints | Silent turns |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Text `qwen3.8-flash` | 250 / 252 | 88.80% | 100.00% | 91.20% | 100.00% | 0 / 2 | 100.00% | 100.00% | 90.00% |
+| Realtime `qwen-audio-3.0-realtime-plus` | 250 / 246 | 71.20% | 98.40% | 76.00% | 98.40% | 4 / 0 | 100.00% | 80.00% | 100.00% |
 
 Gold replay passes the long suite with 10/10 cases and 250/250 tool calls. The
 combined `--suite all` gold replay passes 96/96 cases with 342/342 tool calls.
@@ -65,8 +65,9 @@ The two remaining text failures are genuine model errors: one spurious
 
 Because earlier Realtime runs aborted whole cases on the first turn timeout,
 their scores are not directly comparable to these numbers. Aborted runs never
-reached the later checkpoints, so the 60% long-suite pass rate here reflects
-complete 50-turn transcripts rather than a regression.
+reached the later checkpoints, while the current long-context numbers are based
+on complete 50-turn transcripts and should be read through call-level,
+state-checkpoint, and silent-turn metrics instead of a task-completion rate.
 
 ## Quick Run
 
@@ -191,7 +192,7 @@ Each case records:
 
 `evaluator/score.mjs` scores a collected trace on:
 
-- full case pass rate for tool/state behavior
+- optional full-case pass rate for short-suite sanity checks
 - total expected and actual tool calls
 - expected and actual tool calls by tool domain
 - per-case-domain summaries for vehicle, music, navigation, and weather


### PR DESCRIPTION
## Summary

- Move smart-cockpit README flow to Demo, Architecture, then Benchmark Results.
- Add short-suite and long-context benchmark result tables to English and Chinese smart-cockpit READMEs.
- Remove the long-context pass-rate column from the detailed benchmark README and clarify that long-context evaluation should use call-level, state, checkpoint, and silent-turn metrics.

## Validation

- `git diff --check -- examples/smart-cockpit/README.md examples/smart-cockpit/README_ZH.md examples/smart-cockpit/bench/README.md`

Docs-only change; benchmark was not rerun.