### PR TITLE
fix(web): apply backpressure to realtime microphone audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- WebUI 实时麦克风发送现在遵循 WebSocket 缓冲高水位；网络拥塞时丢弃过期音频块，
+  并在缓冲恢复后继续发送，避免旧音频无限积压。
+
 - 移除 `backend-adapter` 与 `custom-conversation-client` 示例目录及文档入口，保留后台 SDK 与客户端协议能力。
 
 - 新增 AI Passport 语音客户端示例：音频小包拆分、有界发送缓冲、心跳与关闭原因透传，

--- a/shared/gateway/client-sdk.mjs
+++ b/shared/gateway/client-sdk.mjs
@@ -153,6 +153,12 @@ export class GatewayClient {
     return this.socket?.readyState ?? 3
   }
 
+  // Expose the browser WebSocket send buffer so live audio clients can apply
+  // backpressure without reaching through the SDK's socket abstraction.
+  get bufferedAmount() {
+    return this.socket?.bufferedAmount ?? 0
+  }
+
   close() {
     this.stop()
   }

--- a/test/gateway-client-sdk.test.mjs
+++ b/test/gateway-client-sdk.test.mjs
@@ -103,6 +103,21 @@ test('passes remote credentials below GCP and requests takeover explicitly', () 
   client.stop()
 })
 
+test('exposes the underlying transport buffered amount for flow control', () => {
+  const socket = new FakeSocket()
+  const client = new GatewayClient({
+    url: 'ws://gateway.test/api/realtime',
+    createSocket: () => socket,
+    reconnect: false,
+  }).start()
+
+  socket.open()
+  socket.bufferedAmount = 4096
+  assert.equal(client.bufferedAmount, 4096)
+  client.stop()
+  assert.equal(client.bufferedAmount, 0)
+})
+
 test('reference Client negotiates once and correlates runtime commands', async () => {
   const socket = new FakeSocket()
   const client = new GatewayClient({

--- a/web/src/realtime/audio.js
+++ b/web/src/realtime/audio.js
@@ -13,6 +13,8 @@ function appendSamples(previous, input) {
   return samples
 }
 
+const textEncoder = new TextEncoder()
+
 /**
  * Resamples one continuous PCM stream while retaining the interpolation phase
  * between input chunks. The stream can be reset when a capture or target rate
@@ -136,6 +138,97 @@ export function decodePcm(base64) {
     output[index] = view.getInt16(index * 2, true) / 0x8000
   }
   return output
+}
+
+export const REALTIME_AUDIO_SEND_HIGH_WATER_BYTES = 64 * 1024
+export const REALTIME_AUDIO_SEND_LOW_WATER_BYTES = 16 * 1024
+
+function serializedByteLength(value) {
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value)
+  return typeof serialized === 'string'
+    ? textEncoder.encode(serialized).byteLength
+    : 0
+}
+
+/**
+ * Limits realtime microphone sends to the transport buffer's high-water mark.
+ * Audio is a live stream, so dropping a chunk while the socket is congested is
+ * preferable to retaining seconds of stale audio and increasing turn latency.
+ * Control messages continue to use GatewayClient.send directly.
+ */
+export function createRealtimeAudioSendController({
+  send,
+  getBufferedAmount = () => 0,
+  highWaterMarkBytes = REALTIME_AUDIO_SEND_HIGH_WATER_BYTES,
+  lowWaterMarkBytes = REALTIME_AUDIO_SEND_LOW_WATER_BYTES,
+  onDrop,
+} = {}) {
+  if (typeof send !== 'function') throw new TypeError('send is required')
+
+  const highWater = Math.max(1, Number(highWaterMarkBytes) || 0)
+  const lowWater = Math.max(
+    0,
+    Math.min(highWater, Number(lowWaterMarkBytes) || 0),
+  )
+  let congested = false
+  let droppedCount = 0
+
+  const bufferedAmount = () => {
+    try {
+      const value = Number(getBufferedAmount())
+      return Number.isFinite(value) && value > 0 ? value : 0
+    } catch {
+      return 0
+    }
+  }
+
+  const drop = (buffered, payloadBytes) => {
+    droppedCount += 1
+    try {
+      onDrop?.({
+        bufferedAmount: buffered,
+        payloadBytes,
+        droppedCount,
+      })
+    } catch {
+      // A telemetry callback must never interrupt microphone processing.
+    }
+  }
+
+  return {
+    send(event) {
+      const buffered = bufferedAmount()
+      const payloadBytes = serializedByteLength(event)
+      if (congested && buffered > lowWater) {
+        drop(buffered, payloadBytes)
+        return false
+      }
+      congested = false
+
+      if (buffered + payloadBytes > highWater) {
+        congested = true
+        drop(buffered, payloadBytes)
+        return false
+      }
+
+      if (!send(event)) return false
+      if (bufferedAmount() >= highWater) congested = true
+      return true
+    },
+
+    reset() {
+      congested = false
+      droppedCount = 0
+    },
+
+    get congested() {
+      return congested
+    },
+
+    get droppedCount() {
+      return droppedCount
+    },
+  }
 }
 
 // Leaves enough Web Audio timeline headroom for a source to be scheduled. The

--- a/web/src/realtime/useRealtimeVoice.js
+++ b/web/src/realtime/useRealtimeVoice.js
@@ -19,6 +19,7 @@ import { gatewayReferenceClientCapabilities } from '../../../shared/gateway/clie
 import {
   audioSchedulingLeadSeconds,
   createPcmPlaybackQueue,
+  createRealtimeAudioSendController,
   createStreamingResampler,
   decodePcm,
   pcmBase64,
@@ -875,6 +876,7 @@ export default function useRealtimeVoice({
         const wakeWordResampler = createStreamingResampler()
         const inputResampler = createStreamingResampler()
         let inputResamplerSocket = null
+        let inputAudioSender = null
         let source
         let processor
         try {
@@ -888,6 +890,8 @@ export default function useRealtimeVoice({
             if (wakeWordOnlyRef.current) {
               inputResampler.reset()
               inputResamplerSocket = null
+              inputAudioSender?.reset()
+              inputAudioSender = null
               const wakeAudio = wakeWordResampler.process(samples, context.sampleRate, 16_000)
               if (wakeAudio.length) wakeWordAudioRef.current?.(pcmBase64(wakeAudio), 16_000)
               return
@@ -897,11 +901,17 @@ export default function useRealtimeVoice({
             if (socket?.readyState !== WebSocket.OPEN) {
               inputResampler.reset()
               inputResamplerSocket = null
+              inputAudioSender?.reset()
+              inputAudioSender = null
               return
             }
             if (socket !== inputResamplerSocket) {
               inputResampler.reset()
               inputResamplerSocket = socket
+              inputAudioSender = createRealtimeAudioSendController({
+                send: event => socket.send(event),
+                getBufferedAmount: () => socket.bufferedAmount,
+              })
             }
             const audio = inputResampler.process(
               samples,
@@ -909,7 +919,7 @@ export default function useRealtimeVoice({
               inputSampleRate.current,
             )
             if (audio.length) {
-              socket.send({
+              inputAudioSender.send({
                 type: GatewayClientEvent.AUDIO_APPEND,
                 audio: pcmBase64(audio),
               })
@@ -925,6 +935,8 @@ export default function useRealtimeVoice({
               wakeWordResampler.reset()
               inputResampler.reset()
               inputResamplerSocket = null
+              inputAudioSender?.reset()
+              inputAudioSender = null
               processor?.disconnect()
               source?.disconnect()
             },

--- a/web/test/audio.test.mjs
+++ b/web/test/audio.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   audioSchedulingLeadSeconds,
   createPcmPlaybackQueue,
+  createRealtimeAudioSendController,
   createStreamingResampler,
   mergePcmPlaybackItems,
   resample,
@@ -12,6 +13,51 @@ test('resamples audio to the requested approximate length', () => {
   const input = new Float32Array(480)
   const output = resample(input, 48000, 16000)
   assert.equal(output.length, 160)
+})
+
+test('drops live audio while the transport buffer is congested', () => {
+  let bufferedAmount = 0
+  const sent = []
+  const drops = []
+  const controller = createRealtimeAudioSendController({
+    highWaterMarkBytes: 100,
+    lowWaterMarkBytes: 20,
+    getBufferedAmount: () => bufferedAmount,
+    send: event => {
+      sent.push(event)
+      bufferedAmount = 100
+      return true
+    },
+    onDrop: details => drops.push(details),
+  })
+
+  assert.equal(controller.send({ type: 'audio.append', audio: 'pcm' }), true)
+  assert.equal(controller.congested, true)
+  assert.equal(controller.send({ type: 'audio.append', audio: 'stale' }), false)
+  assert.equal(sent.length, 1)
+  assert.equal(controller.droppedCount, 1)
+  assert.equal(drops[0].bufferedAmount, 100)
+
+  bufferedAmount = 10
+  assert.equal(controller.send({ type: 'audio.append', audio: 'fresh' }), true)
+  assert.equal(sent.length, 2)
+})
+
+test('resets audio send congestion and drop accounting', () => {
+  let bufferedAmount = 90
+  const controller = createRealtimeAudioSendController({
+    highWaterMarkBytes: 100,
+    lowWaterMarkBytes: 20,
+    getBufferedAmount: () => bufferedAmount,
+    send: () => true,
+  })
+
+  assert.equal(controller.send({ type: 'audio.append', audio: 'pcm' }), false)
+  assert.equal(controller.congested, true)
+  assert.equal(controller.droppedCount, 1)
+  controller.reset()
+  assert.equal(controller.congested, false)
+  assert.equal(controller.droppedCount, 0)
 })
 
 test('returns an empty result for empty input instead of NaN', () => {


### PR DESCRIPTION
## Summary

- Expose the WebSocket buffered amount through GatewayClient.
- Apply high/low-water backpressure to live microphone PCM sends.
- Drop stale audio while the transport is congested so latency does not grow without bound.
- Reset congestion state when the socket, capture mode, or microphone lifecycle changes.

## Verification

- node --test test/gateway-client-sdk.test.mjs web/test/audio.test.mjs — 41 passed, 0 failed.

## Compatibility and safety

- Only live microphone audio chunks are subject to dropping; control messages keep using the existing GatewayClient send path.
- No protocol or persisted-data format changes.
- Drop telemetry is optional and cannot interrupt microphone processing.