### PR TITLE
feat(web): move microphone capture to AudioWorklet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   现在与写入共用跨进程锁，避免读取撞上 Windows 文件替换过程。
 - WebUI 麦克风重采样现在会跨 PCM 分块保留插值相位，并对空输入安全返回空数据，
   减少非整数采样率转换时的累计偏差。
+- WebUI 麦克风采集改用 AudioWorklet 在音频线程处理采样块，主线程继续负责流式重采样
+  和发送；不支持 AudioWorklet 的浏览器会明确报告不支持，而不是静默退回旧处理器。
 - Gateway Client 为 Socket 连接和 Session 握手增加超时与恢复；连接只有在收到
   `session.ready` 后才会重置重连退避。
 - Gateway Client 不再把旧连接中尚未完成的桌面 Action 结果发送到重连后的新连接。

--- a/web/src/realtime/microphone-audio-worklet-constants.js
+++ b/web/src/realtime/microphone-audio-worklet-constants.js
@@ -1,0 +1,1 @@
+export const MICROPHONE_AUDIO_WORKLET_PROCESSOR_NAME = 'qwen-audio-microphone'

--- a/web/src/realtime/microphone-audio-worklet-processor.js
+++ b/web/src/realtime/microphone-audio-worklet-processor.js
@@ -1,0 +1,23 @@
+import { MICROPHONE_AUDIO_WORKLET_PROCESSOR_NAME } from './microphone-audio-worklet-constants.js'
+
+class MicrophoneAudioWorkletProcessor extends AudioWorkletProcessor {
+  process(inputs, outputs) {
+    const input = inputs[0]?.[0]
+    if (input?.length) {
+      const samples = new Float32Array(input)
+      this.port.postMessage({
+        type: 'samples',
+        samples: samples.buffer,
+      }, [samples.buffer])
+    }
+
+    // Keep the graph alive without routing microphone audio back to speakers.
+    for (const channel of outputs[0] || []) channel.fill(0)
+    return true
+  }
+}
+
+registerProcessor(
+  MICROPHONE_AUDIO_WORKLET_PROCESSOR_NAME,
+  MicrophoneAudioWorkletProcessor,
+)

--- a/web/src/realtime/microphone-audio-worklet.js
+++ b/web/src/realtime/microphone-audio-worklet.js
@@ -1,0 +1,72 @@
+import { MICROPHONE_AUDIO_WORKLET_PROCESSOR_NAME } from './microphone-audio-worklet-constants.js'
+
+const modulePromises = new WeakMap()
+
+function modulePromise(context, moduleUrl) {
+  let modules = modulePromises.get(context)
+  if (!modules) {
+    modules = new Map()
+    modulePromises.set(context, modules)
+  }
+  let promise = modules.get(moduleUrl)
+  if (!promise) {
+    promise = context.audioWorklet.addModule(moduleUrl).catch(error => {
+      modules.delete(moduleUrl)
+      throw error
+    })
+    modules.set(moduleUrl, promise)
+  }
+  return promise
+}
+
+function toSamples(value) {
+  if (value instanceof Float32Array) return value
+  if (value instanceof ArrayBuffer) return new Float32Array(value)
+  if (ArrayBuffer.isView(value)) {
+    return new Float32Array(value.buffer, value.byteOffset, value.byteLength / Float32Array.BYTES_PER_ELEMENT)
+  }
+  return null
+}
+
+export async function createMicrophoneAudioWorkletNode({
+  context,
+  moduleUrl,
+  onSamples,
+  nodeConstructor = globalThis.AudioWorkletNode,
+} = {}) {
+  if (!context?.audioWorklet || typeof context.audioWorklet.addModule !== 'function') {
+    throw Object.assign(new Error('AudioWorklet is not available'), { name: 'NotSupportedError' })
+  }
+  if (!moduleUrl) throw new TypeError('moduleUrl is required')
+  if (typeof nodeConstructor !== 'function') {
+    throw Object.assign(new Error('AudioWorkletNode is not available'), { name: 'NotSupportedError' })
+  }
+  if (typeof onSamples !== 'function') throw new TypeError('onSamples is required')
+
+  await modulePromise(context, moduleUrl)
+  const node = new nodeConstructor(context, MICROPHONE_AUDIO_WORKLET_PROCESSOR_NAME, {
+    numberOfInputs: 1,
+    numberOfOutputs: 1,
+    outputChannelCount: [1],
+  })
+  let closed = false
+  const handleMessage = event => {
+    if (closed || event?.data?.type !== 'samples') return
+    const samples = toSamples(event.data.samples)
+    if (samples?.length) onSamples(samples)
+  }
+  node.port.addEventListener?.('message', handleMessage)
+  if (!node.port.addEventListener) node.port.onmessage = handleMessage
+
+  return {
+    node,
+    close() {
+      if (closed) return
+      closed = true
+      node.port.removeEventListener?.('message', handleMessage)
+      if (!node.port.removeEventListener) node.port.onmessage = null
+      node.port.close?.()
+      node.disconnect?.()
+    },
+  }
+}

--- a/web/src/realtime/useRealtimeVoice.js
+++ b/web/src/realtime/useRealtimeVoice.js
@@ -23,6 +23,7 @@ import {
   decodePcm,
   pcmBase64,
 } from './audio.js'
+import { createMicrophoneAudioWorkletNode } from './microphone-audio-worklet.js'
 import {
   createMicrophoneCaptureLifecycle,
   microphoneErrorKind,
@@ -37,6 +38,10 @@ import {
 
 const DEFAULT_INPUT_RATE = 16000
 const OUTPUT_RATE = 24000
+const microphoneAudioWorkletProcessorUrl = new URL(
+  './microphone-audio-worklet-processor.js',
+  import.meta.url,
+).href
 
 export function acceptsVoiceState(event, currentTurnId) {
   return acceptsGatewayVoiceState(event, currentTurnId)
@@ -877,61 +882,71 @@ export default function useRealtimeVoice({
         let inputResamplerSocket = null
         let source
         let processor
+        let closeProcessor = () => {}
+        let captureClosed = false
         try {
           source = context.createMediaStreamSource(media)
-          processor = context.createScriptProcessor(2048, 1, 1)
-          processor.onaudioprocess = event => {
-            const samples = microphoneSamplesDuringManualInput(
-              event.inputBuffer.getChannelData(0),
-              manualInputPendingRef.current,
-            )
-            if (wakeWordOnlyRef.current) {
-              inputResampler.reset()
-              inputResamplerSocket = null
-              const wakeAudio = wakeWordResampler.process(samples, context.sampleRate, 16_000)
-              if (wakeAudio.length) wakeWordAudioRef.current?.(pcmBase64(wakeAudio), 16_000)
-              return
-            }
-            wakeWordResampler.reset()
-            const socket = socketRef.current
-            if (socket?.readyState !== WebSocket.OPEN) {
-              inputResampler.reset()
-              inputResamplerSocket = null
-              return
-            }
-            if (socket !== inputResamplerSocket) {
-              inputResampler.reset()
-              inputResamplerSocket = socket
-            }
-            const audio = inputResampler.process(
-              samples,
-              context.sampleRate,
-              inputSampleRate.current,
-            )
-            if (audio.length) {
-              socket.send({
-                type: GatewayClientEvent.AUDIO_APPEND,
-                audio: pcmBase64(audio),
-              })
-            }
-          }
+          const worklet = await createMicrophoneAudioWorkletNode({
+            context,
+            moduleUrl: microphoneAudioWorkletProcessorUrl,
+            onSamples: rawSamples => {
+              if (captureClosed) return
+              const samples = microphoneSamplesDuringManualInput(
+                rawSamples,
+                manualInputPendingRef.current,
+              )
+              if (wakeWordOnlyRef.current) {
+                inputResampler.reset()
+                inputResamplerSocket = null
+                const wakeAudio = wakeWordResampler.process(samples, context.sampleRate, 16_000)
+                if (wakeAudio.length) wakeWordAudioRef.current?.(pcmBase64(wakeAudio), 16_000)
+                return
+              }
+              wakeWordResampler.reset()
+              const socket = socketRef.current
+              if (socket?.readyState !== WebSocket.OPEN) {
+                inputResampler.reset()
+                inputResamplerSocket = null
+                return
+              }
+              if (socket !== inputResamplerSocket) {
+                inputResampler.reset()
+                inputResamplerSocket = socket
+              }
+              const audio = inputResampler.process(
+                samples,
+                context.sampleRate,
+                inputSampleRate.current,
+              )
+              if (audio.length) {
+                socket.send({
+                  type: GatewayClientEvent.AUDIO_APPEND,
+                  audio: pcmBase64(audio),
+                })
+              }
+            },
+          })
+          processor = worklet.node
+          closeProcessor = worklet.close
           source.connect(processor)
           processor.connect(context.destination)
           return {
             media,
             track: media.getAudioTracks()[0],
             close() {
+              captureClosed = true
               media.getTracks().forEach(track => track.stop())
               wakeWordResampler.reset()
               inputResampler.reset()
               inputResamplerSocket = null
-              processor?.disconnect()
+              closeProcessor()
               source?.disconnect()
             },
           }
         } catch (error) {
+          captureClosed = true
           media.getTracks().forEach(track => track.stop())
-          processor?.disconnect()
+          closeProcessor()
           source?.disconnect()
           throw error
         }

--- a/web/test/microphone-audio-worklet.test.mjs
+++ b/web/test/microphone-audio-worklet.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createMicrophoneAudioWorkletNode } from '../src/realtime/microphone-audio-worklet.js'
+
+class FakePort {
+  constructor() {
+    this.listeners = new Set()
+    this.closed = false
+  }
+
+  addEventListener(name, listener) {
+    if (name === 'message') this.listeners.add(listener)
+  }
+
+  removeEventListener(name, listener) {
+    if (name === 'message') this.listeners.delete(listener)
+  }
+
+  emit(data) {
+    for (const listener of this.listeners) listener({ data })
+  }
+
+  close() {
+    this.closed = true
+  }
+}
+
+class FakeAudioWorkletNode {
+  constructor(context, name, options) {
+    this.context = context
+    this.name = name
+    this.options = options
+    this.port = new FakePort()
+    this.disconnected = false
+  }
+
+  disconnect() {
+    this.disconnected = true
+  }
+}
+
+function contextFixture() {
+  const modules = []
+  return {
+    context: {
+      audioWorklet: {
+        addModule: async url => { modules.push(url) },
+      },
+    },
+    modules,
+  }
+}
+
+test('loads one processor module per AudioContext and forwards samples', async () => {
+  const { context, modules } = contextFixture()
+  const received = []
+  const first = await createMicrophoneAudioWorkletNode({
+    context,
+    moduleUrl: '/assets/microphone-worklet.js',
+    nodeConstructor: FakeAudioWorkletNode,
+    onSamples: samples => received.push([...samples]),
+  })
+  const second = await createMicrophoneAudioWorkletNode({
+    context,
+    moduleUrl: '/assets/microphone-worklet.js',
+    nodeConstructor: FakeAudioWorkletNode,
+    onSamples: samples => received.push([...samples]),
+  })
+
+  assert.deepEqual(modules, ['/assets/microphone-worklet.js'])
+  assert.equal(first.node.name, 'qwen-audio-microphone')
+  assert.equal(first.node.options.numberOfInputs, 1)
+  first.node.port.emit({ type: 'samples', samples: Float32Array.from([0.1, 0.2]).buffer })
+  second.node.port.emit({ type: 'samples', samples: Float32Array.from([0.3]).buffer })
+  assert.deepEqual(
+    received.map(samples => samples.map(value => Number(value.toFixed(5)))),
+    [[0.1, 0.2], [0.3]],
+  )
+
+  first.close()
+  second.close()
+  assert.equal(first.node.port.closed, true)
+  assert.equal(first.node.disconnected, true)
+})
+
+test('rejects unsupported AudioWorklet contexts', async () => {
+  await assert.rejects(
+    createMicrophoneAudioWorkletNode({
+      context: {},
+      moduleUrl: '/assets/microphone-worklet.js',
+      nodeConstructor: FakeAudioWorkletNode,
+      onSamples() {},
+    }),
+    error => error.name === 'NotSupportedError',
+  )
+})
+
+test('does not forward samples after close', async () => {
+  const { context } = contextFixture()
+  const received = []
+  const capture = await createMicrophoneAudioWorkletNode({
+    context,
+    moduleUrl: '/assets/microphone-worklet.js',
+    nodeConstructor: FakeAudioWorkletNode,
+    onSamples: samples => received.push(samples),
+  })
+  capture.close()
+  capture.node.port.emit({ type: 'samples', samples: Float32Array.from([1]).buffer })
+  assert.equal(received.length, 0)
+})


### PR DESCRIPTION
## Problem

The WebUI currently captures microphone audio with the deprecated `ScriptProcessorNode`, so audio callbacks run on the main thread and can be delayed by rendering or other JavaScript work.

## Changes

- Add a dedicated `AudioWorkletProcessor` that copies microphone samples from the audio rendering thread to the main thread with transferable buffers.
- Load one processor module per `AudioContext` and expose a small lifecycle wrapper for the worklet node.
- Keep the existing wake-word, streaming resampler, and Gateway audio protocol behavior unchanged.
- Route silence to the output so microphone audio is never played back to the user.
- Clean up the worklet port, node, media tracks, and graph connections on stop, reconnect, and acquisition failure.
- Use a `new URL(..., import.meta.url)` asset reference so both Vite builds and Node tests can load the voice hook.
- Add unit coverage for module deduplication, sample transfer, unsupported contexts, and post-close messages.

## Validation

- `npm test --workspace web` — 146 passed, 0 failed
- `npm run lint` — passed
- `npm run build --workspace web` — passed

## Compatibility

- No Gateway protocol or persisted-data format changes.
- Browsers without AudioWorklet support receive the existing microphone unsupported error path.
