### PR TITLE
fix(framework): coordinate tool results and synchronize memory

### DIFF
--- a/docs/reference/frontend-mcp.md
+++ b/docs/reference/frontend-mcp.md
@@ -39,7 +39,7 @@ DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
       "tools": {
         "search": {
           "enabled": true,
-          "timeoutMs": 8000,
+          "timeoutMs": 10000,
           "maxResultBytes": 32768,
           "maxCallsPerTurn": 2,
           "description": "Search the user's configured document source."
@@ -92,6 +92,7 @@ Each exposed tool receives a stable model-visible name:
 - Streamable HTTP and stdio transports are supported. The legacy standalone SSE
   transport is not supported.
 - Discovery and connection have a bounded timeout (8 seconds by default).
+- Each frontend MCP tool execution times out after 10 seconds by default; set the tool's `timeoutMs` to override it.
 - Remote servers require HTTPS. Loopback HTTP is allowed only without headers.
 - A server URL may be one exact environment reference such as `${MCP_URL}`.
 - Header values may reference one exact environment variable with
@@ -106,6 +107,9 @@ Each exposed tool receives a stable model-visible name:
 - `tools` is an explicit allowlist. Enabled tools execute inline in the current
   conversation turn; the Gateway does not insert a generic confirmation turn
   based on whether a tool reads or writes.
+- Calls in one model response can execute concurrently. After all results are
+  returned and that response ends, the Gateway requests one result summary.
+  Later responses may call tools again, within the existing turn limits and deduplication rules.
 - Behavioral metadata such as `readOnlyHint` and `destructiveHint` belongs to
   the MCP server's standard Tool Annotations. It is metadata, not Gateway policy.
 - MCP servers must enforce any required confirmation, authorization, or business

--- a/docs/reference/frontend-mcp.zh.md
+++ b/docs/reference/frontend-mcp.zh.md
@@ -36,7 +36,7 @@ DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
       "tools": {
         "search": {
           "enabled": true,
-          "timeoutMs": 8000,
+          "timeoutMs": 10000,
           "maxResultBytes": 32768,
           "maxCallsPerTurn": 2,
           "description": "检索用户配置的文档来源。"
@@ -88,6 +88,7 @@ DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
 
 - 支持 Streamable HTTP 和 stdio Transport；不支持旧版独立 SSE Transport。
 - 工具发现和连接有超时边界，默认 8 秒。
+- 每次前台 MCP 工具执行默认超时 10 秒，可通过该工具的 `timeoutMs` 调整。
 - 远端服务必须使用 HTTPS；回环地址可以使用 HTTP，但不能携带 Header。
 - Server URL 可以用 `${MCP_URL}` 精确引用一个环境变量。
 - Header 值可以用 `${VARIABLE}` 精确引用一个环境变量；变量缺失即配置错误。
@@ -98,6 +99,8 @@ DOCUMENT_MCP_AUTHORIZATION=Bearer replace-me
   如果填写，必须是绝对路径。子进程只继承 SDK 的安全基础环境和显式配置的 `env`。
 - `tools` 是显式白名单；启用的工具由 Gateway 在当前对话轮次内直接调用，不再根据
   读写类型插入一轮通用确认。
+- 同一模型响应中的工具可并发执行；全部结果回填且该响应结束后，再统一请求一次结果回复。
+  后续响应仍可继续调用工具，既有轮次预算与去重规则不变。
 - `readOnlyHint`、`destructiveHint` 等行为信息由 MCP Server 按标准 Tool Annotations
   提供。它们是元信息，不是 Gateway 的执行策略。
 - 需要确认、鉴权或业务安全校验的操作由 MCP Server 在自己的能力边界内强制执行。

--- a/docs/reference/memory-provider.md
+++ b/docs/reference/memory-provider.md
@@ -45,6 +45,28 @@ This is a document control plane, not a second memory store. It is owner-scoped 
 passes writes through `FrontendMemoryRuntime`, and therefore works unchanged with the default
 Markdown provider or an injected provider. Clients should render only the formats they
 understand and preserve exact source text when issuing a delete or replacement.
+The model-context projection omits Markdown template/editing comments so examples are
+not treated as saved facts. Existing observed-preference priority and truncation notices
+retain their original wording. API/tool reads and revisions retain the original document
+for exact edits. Plain-text provider documents are not interpreted as Markdown.
+
+After a successful edit, the runtime notifies active conversations for the same owner.
+For Realtime providers supporting mutable sessions, client/API edits refresh the memory
+instructions at the next idle point without reconnecting; deleted facts must not remain
+in the model's saved-memory snapshot. Same-session tool writes already return the updated
+documents and retain their cache-only refresh. Notifications belong to the runtime wrapper;
+custom providers do not need a new protocol method.
+
+Connected clients also receive `memory.changed` after a runtime write persists an actual
+change, whether it came from the memory tool, the API, or automatic extraction. The event
+is sent only to clients for the same owner. It contains only `type: "memory.changed"`
+plus the normal protocol envelope, never memory content or an owner identifier. Clients
+should reload `GET /api/memory` on this invalidation and whenever the Gateway session
+becomes ready, including after reconnecting. This is independent of model prompt refresh:
+same-session tool writes still notify the UI. No-op and failed writes do not notify it.
+The existing Gateway Client SDK forwards this event through `onEvent`; no new capability
+or provider method is required. Do not infer persistence from assistant text or depend
+only on `memory` tool completion, which misses automatic and API writes.
 
 ## Replacing the Memory Provider
 

--- a/docs/reference/memory-provider.zh.md
+++ b/docs/reference/memory-provider.zh.md
@@ -38,6 +38,23 @@ Provider 提供。
 这是一层文档控制面，不是第二套记忆存储。Gateway 负责 owner 隔离，写入统一经过
 `FrontendMemoryRuntime`，所以默认 Markdown Provider 与外部注入 Provider 使用同一协议。
 客户端只应展示自己理解的格式，删除或替换时必须保留并提交精确原文。
+模型上下文投影会去掉 Markdown 的模板与编辑注释，避免把示例当成已保存事实；
+原有的推断优先级说明和截断提示保留原文。API、工具读取和 revision 仍保留原文以支持
+精确编辑。Provider 的纯文本格式不按 Markdown 解释。
+
+编辑成功后，Runtime 会通知同一 owner 的活动对话。支持动态会话更新的 Realtime
+Provider 会在下一个空闲点刷新记忆指令，无需重连，避免模型继续把已删除的信息视为
+已保存。当前会话的记忆工具写入已经通过工具结果返回新文档，仍保留仅刷新缓存的路径。
+变更通知属于 Runtime 包装层，不要求自定义 Provider 增加协议方法。
+
+Runtime 写入持久化且实际产生变更后，还会向同一 owner 的已连接客户端发送
+`memory.changed`，涵盖记忆工具、API 和自动提取写入。事件只含
+`type: "memory.changed"` 与正常协议 envelope，不携带记忆正文或 owner 标识。
+客户端收到后重新请求 `GET /api/memory`，并在 Gateway 会话 ready 时（包括重连后）
+重新读取。这与模型指令刷新独立：当前会话工具写入仍会通知界面；无变更或失败的写入
+不通知。现有 Gateway Client SDK 通过 `onEvent` 透传，无需增加 capability 或 Provider
+方法。不要从助手回复推断已保存，也不要只监听 `memory` 工具完成，否则会漏掉自动提取
+和 API 写入。
 
 ## 替换记忆 Provider
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "./backend-adapter-sdk": "./server/src/backend/backend-adapter-sdk.mjs",
     "./a2a-backend-adapter": "./server/src/backend/adapters/a2a/backend-adapter.mjs",
     "./realtime-provider": "./server/src/voice/realtime-provider-extension.mjs",
+    "./web-retrieval": "./server/src/frontend/retrieval/providers/web-retrieval.mjs",
     "./knowledge-provider": "./server/src/knowledge/provider.mjs",
     "./memory-provider": "./server/src/memory/provider.mjs",
     "./voicemem-provider": "./server/src/memory/providers/voicemem/provider.mjs",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -205,6 +205,14 @@ if (isMain) {
       'shared/memory-provider-catalog.mjs',
     )
   }
+  if (manifest.exports?.['./web-retrieval']) {
+    required.push(
+      'shared/web-search-configuration.mjs',
+      'server/src/frontend/retrieval/frontend-retrieval-runtime.mjs',
+      'server/src/frontend/retrieval/safe-url-fetcher.mjs',
+      'server/src/frontend/retrieval/providers/factory.mjs',
+    )
+  }
   const missing = required.filter(file => !files.has(file))
   if (missing.length) {
     throw new Error(`npm 成品缺少必要文件：${missing.join(', ')}`)

--- a/server/src/core/config.mjs
+++ b/server/src/core/config.mjs
@@ -21,6 +21,8 @@ import {
   loadFrontendProfile,
   resolveFrontendProfileConfiguration,
 } from './frontend-profile.mjs'
+import { resolveWebSearchConfiguration } from '../../../shared/web-search-configuration.mjs'
+export { resolveWebSearchConfiguration } from '../../../shared/web-search-configuration.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const sourceRoot = resolve(here, '../../..')
@@ -122,34 +124,6 @@ export function resolveBackendModels(env = process.env) {
     ).trim(),
     pi: common,
     acp: common,
-  }
-}
-
-export function resolveWebSearchConfiguration(env = process.env) {
-  const bailianMcpUrl = 'https://dashscope.aliyuncs.com/api/v1/mcps/WebSearch/mcp'
-  const explicitMcpUrl = String(env.QWEN_AUDIO_WEB_SEARCH_MCP_URL || '').trim()
-  const dashscopeApiKey = String(env.DASHSCOPE_API_KEY || '').trim()
-  const requestedProvider = String(
-    env.QWEN_AUDIO_WEB_SEARCH_PROVIDER || '',
-  ).trim().toLowerCase()
-  const provider = requestedProvider || (explicitMcpUrl ? 'mcp' : 'so360')
-  if (!['bailian', 'bing', 'mcp', 'none', 'so360'].includes(provider)) {
-    throw new Error(
-      '不支持的 Web Search Provider：'
-      + `${provider}（可选 bailian、bing、mcp、none、so360）`,
-    )
-  }
-  const mcpUrl = provider === 'bailian' ? bailianMcpUrl : explicitMcpUrl
-  const usesBailianMcp = provider === 'bailian'
-  return {
-    provider,
-    mcpUrl,
-    mcpToken: String(
-      env.QWEN_AUDIO_WEB_SEARCH_MCP_TOKEN
-      || (usesBailianMcp ? dashscopeApiKey : ''),
-    ).trim(),
-    mcpTool: String(env.QWEN_AUDIO_WEB_SEARCH_MCP_TOOL || '').trim()
-      || (usesBailianMcp ? 'bailian_web_search' : 'web_search'),
   }
 }
 

--- a/server/src/frontend/retrieval/providers/web-retrieval.mjs
+++ b/server/src/frontend/retrieval/providers/web-retrieval.mjs
@@ -1,0 +1,30 @@
+import { FrontendRetrievalRuntime } from '../frontend-retrieval-runtime.mjs'
+import { createWebSearchProvider } from './factory.mjs'
+import { resolveWebSearchConfiguration } from '../../../../../shared/web-search-configuration.mjs'
+
+/**
+ * Public, side-effect-free composition for a Gateway or standalone Agent.
+ * Reuses the same citations, provider timeouts and SSRF-safe URL fetcher as the
+ * foreground. Does not load .env files, initialize Gateway state, or connect
+ * until search()/fetchUrl() is called. The caller owns tool schemas and policy.
+ */
+export function createWebRetrieval({
+  env = process.env,
+  searchProvider,
+  urlFetcher,
+  searchTimeoutMs,
+} = {}) {
+  const config = resolveWebSearchConfiguration(env)
+  return new FrontendRetrievalRuntime({
+    searchProvider: searchProvider === undefined
+      ? createWebSearchProvider({
+          webSearchProvider: config.provider,
+          webSearchMcpUrl: config.mcpUrl,
+          webSearchMcpToken: config.mcpToken,
+          webSearchMcpTool: config.mcpTool,
+        })
+      : searchProvider,
+    ...(urlFetcher === undefined ? {} : { urlFetcher }),
+    ...(searchTimeoutMs === undefined ? {} : { searchTimeoutMs }),
+  })
+}

--- a/server/src/frontend/tools/mcp/frontend-mcp-config.mjs
+++ b/server/src/frontend/tools/mcp/frontend-mcp-config.mjs
@@ -194,7 +194,7 @@ function normalizedPolicy(value = {}) {
   }
   return {
     enabled,
-    timeoutMs: boundedInteger(value.timeoutMs, 8_000, 100, 30_000),
+    timeoutMs: boundedInteger(value.timeoutMs, 10_000, 100, 30_000),
     maxResultBytes: boundedInteger(
       value.maxResultBytes,
       32 * 1024,

--- a/server/src/frontend/tools/tool-call-handler.mjs
+++ b/server/src/frontend/tools/tool-call-handler.mjs
@@ -1,4 +1,6 @@
 import {
+  CANCEL_AGENT_TASK_TOOL_NAME,
+  ENTER_SLEEP_TOOL_NAME,
   RESPOND_PERMISSION_TOOL_NAME,
   SPAWN_THINKING_TOOL_NAME,
   frontendToolRegistry,
@@ -57,6 +59,21 @@ function compactDebugResult(output) {
 
 function debugSurface(toolName) {
   return toolName === SPAWN_THINKING_TOOL_NAME ? 'backend' : 'frontend'
+}
+
+function needsToolResultSummary(toolName, args) {
+  // Memory writes and lifecycle receipts may accompany an already-spoken
+  // answer. Ordinary reads/actions need their actual result even in that case.
+  for (const feature of optionalFrontendFeatures) {
+    const required = feature.requiresToolResultSummary?.(toolName, args)
+    if (typeof required === 'boolean') return required
+  }
+  return ![
+    SPAWN_THINKING_TOOL_NAME,
+    RESPOND_PERMISSION_TOOL_NAME,
+    CANCEL_AGENT_TASK_TOOL_NAME,
+    ENTER_SLEEP_TOOL_NAME,
+  ].includes(toolName)
 }
 
 export class ToolCallHandler {
@@ -256,6 +273,22 @@ export class ToolCallHandler {
     } = options || {}
     const tool = this.activeToolEntries.get(callId)
     const debug = this.activeToolDebugEntries.get(callId)
+    const batch = this.deferredToolResponses.get(debug?.responseId)
+    if (batch && frontendOptions.createResponse !== false) {
+      // Return every result first. One response may contain several concurrent
+      // calls, including a mix of built-in and external tools.
+      batch.responseRequested = true
+      batch.requiresResultSummary = true
+      Object.assign(batch.responseContext, taskId ? { taskId } : {}, responseContext)
+      if (responseContext?.consumesTaskNotification && taskId && !batch.taskIds.includes(taskId)) {
+        batch.taskIds.push(taskId)
+      }
+      this.addDeferredToolResponseInstructions(
+        debug.responseId,
+        frontendOptions.response?.instructions,
+      )
+      frontendOptions.createResponse = false
+    }
     try {
       this.onToolResultReady({
         callId,
@@ -300,6 +333,8 @@ export class ToolCallHandler {
   beginDeferredToolResponse(responseId, {
     turnId,
     turnGeneration,
+    requestResponse = true,
+    requiresResultSummary = false,
   } = {}, response = null) {
     const key = String(responseId || '')
     if (!key) return null
@@ -308,14 +343,21 @@ export class ToolCallHandler {
       sourceDone: false,
       failed: false,
       suppressResponse: false,
+      sourceHasSpeech: false,
+      responseRequested: false,
+      requiresResultSummary: false,
       turnId,
       turnGeneration,
       responseInstructions: [],
+      responseContext: {},
+      taskIds: [],
     }
     if (!this.deferredToolResponses.has(key) && this.deferredToolResponses.size >= 100) {
       this.deferredToolResponses.delete(this.deferredToolResponses.keys().next().value)
     }
     batch.pending += 1
+    batch.responseRequested ||= requestResponse
+    batch.requiresResultSummary ||= requiresResultSummary
     const instructions = String(response?.instructions || '').trim()
     if (instructions && !batch.responseInstructions.includes(instructions)) {
       batch.responseInstructions.push(instructions)
@@ -339,31 +381,54 @@ export class ToolCallHandler {
     await this.flushDeferredToolResponse(responseId, batch)
   }
 
-  async finishToolResponse(responseId, { suppressResponse = false } = {}) {
+  requiresToolResultSummary(responseId) {
+    const batch = this.deferredToolResponses.get(String(responseId || ''))
+    return batch?.requiresResultSummary === true
+  }
+
+  async finishToolResponse(responseId, {
+    suppressResponse = false,
+    sourceHasSpeech = false,
+  } = {}) {
     const key = String(responseId || '')
     const batch = this.deferredToolResponses.get(key)
     if (!batch) return
     batch.sourceDone = true
     batch.suppressResponse ||= suppressResponse
+    batch.sourceHasSpeech ||= sourceHasSpeech
     await this.flushDeferredToolResponse(key, batch)
   }
 
   async flushDeferredToolResponse(responseId, batch) {
     if (!batch.sourceDone || batch.pending > 0) return
     this.deferredToolResponses.delete(responseId)
-    if (batch.failed || batch.suppressResponse) return
+    if (
+      batch.failed || batch.suppressResponse || !batch.responseRequested
+      || (batch.sourceHasSpeech && !batch.requiresResultSummary)
+      || this.isStale(batch.turnId, batch.turnGeneration)
+    ) return
+    const instructions = [...batch.responseInstructions]
+    if (batch.requiresResultSummary && instructions.length) {
+      instructions.push(
+        '以上针对单项工具的回执说明仅约束该工具；请将本次响应中全部工具的实际结果合并回复，不要遗漏其他工具的成功或失败，也不要把后台受理说成任务已完成。',
+      )
+    }
     await this.getFrontend()?.ensureResponse?.(
       {
         turnId: batch.turnId,
         turnGeneration: batch.turnGeneration,
+        ...batch.responseContext,
+        ...(batch.taskIds.length ? {
+          taskId: batch.taskIds[0],
+          taskIds: batch.taskIds,
+        } : {}),
       },
-      batch.responseInstructions.length
-        ? {
-            response: {
-              instructions: batch.responseInstructions.join(' '),
-            },
-          }
-        : undefined,
+      {
+        shouldCreate: () => !this.isStale(batch.turnId, batch.turnGeneration),
+        ...(instructions.length ? {
+          response: { instructions: instructions.join(' ') },
+        } : {}),
+      },
     )
   }
 
@@ -446,6 +511,15 @@ export class ToolCallHandler {
     }
     this.activeToolDebugEntries.set(callId, debug)
     this.emitToolCallDebug(debug)
+    // Register before any asynchronous execution, so response.done cannot
+    // close a batch while another call is still preparing its result.
+    const deferred = this.beginDeferredToolResponse(responseId, {
+      turnId,
+      turnGeneration: generation,
+      requestResponse: false,
+      requiresResultSummary: needsToolResultSummary(toolName, args),
+    })
+    let failed = false
     try {
       if (external) {
         return await this.executeExternalToolCall(external, {
@@ -515,9 +589,13 @@ export class ToolCallHandler {
         )
       }
       return execution
+    } catch (error) {
+      failed = true
+      throw error
     } finally {
       this.activeToolEntries.delete(callId)
       this.activeToolDebugEntries.delete(callId)
+      await this.completeDeferredToolResponse(deferred, { failed })
     }
   }
 

--- a/server/src/memory/context.mjs
+++ b/server/src/memory/context.mjs
@@ -1,20 +1,42 @@
 import { canonicalScope, isDirectiveScope } from './scopes.mjs'
 
+// These existing document notices carry context semantics, not template facts.
+// Preserve their exact legacy wording without adding rules to the system prompt.
+const OBSERVED_NOTICE = '<!-- 以下为系统观察推断，权威低于上方用户明确要求；如与其冲突，以上方为准 -->'
+const TRUNCATED_NOTICE = '<!-- 内容过长，已截断；精确编辑前请缩小文档 -->'
+
 function clean(value) {
   return String(value || '').replace(/\s+/g, ' ').trim()
+}
+
+function visibleContent(document) {
+  const content = String(document?.content || '').trim()
+  if (document?.format === 'text') return content
+
+  // A truncation can end inside an unfinished template comment. Detach the
+  // appended notice first so clearing that comment cannot swallow the warning.
+  const truncated = content.endsWith(TRUNCATED_NOTICE)
+  const body = truncated ? content.slice(0, -TRUNCATED_NOTICE.length) : content
+  // Markdown template comments are editing guidance, not saved user facts.
+  // Keep raw documents/revisions unchanged for the API and exact-edit tools.
+  const visible = body.replace(/<!--[\s\S]*?(?:-->|$)/g, comment => (
+    comment === OBSERVED_NOTICE ? comment : ''
+  )).trim()
+  return [visible, truncated ? TRUNCATED_NOTICE : ''].filter(Boolean).join('\n\n')
 }
 
 function userPreferencesSection(memories = []) {
   const document = memories.find(memory => (
     isDirectiveScope(clean(memory.scope))
   ))
-  if (!document?.content) return ''
+  const content = visibleContent(document)
+  if (!content) return ''
   const opening = document.revision
     ? `<user_preferences revision="${clean(document.revision)}">`
     : '<user_preferences>'
   return [
     opening,
-    String(document.content).trim(),
+    content,
     '</user_preferences>',
   ].join('\n')
 }
@@ -23,13 +45,14 @@ function memorySection(memories = []) {
   const document = memories.find(memory => (
     canonicalScope(clean(memory.scope)) === 'memory'
   ))
-  if (!document?.content) return ''
+  const content = visibleContent(document)
+  if (!content) return ''
   const opening = document.revision
     ? `<user_memory revision="${clean(document.revision)}">`
     : '<user_memory>'
   return [
     opening,
-    String(document.content).trim(),
+    content,
     '</user_memory>',
   ].join('\n')
 }

--- a/server/src/memory/frontend.mjs
+++ b/server/src/memory/frontend.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { buildMemoryContext } from './context.mjs'
-import { memoryToolEntries, memoryToolHandlers } from './tools.mjs'
+import { MEMORY_TOOL_NAME, memoryToolEntries, memoryToolHandlers } from './tools.mjs'
 
 const instructions = readFileSync(new URL('./PROMPT.md', import.meta.url), 'utf8').trim()
 
@@ -10,4 +10,9 @@ export const memoryFrontend = {
   context: buildMemoryContext,
   instructions,
   capabilities: ({ memoryService }) => memoryService ? ['memory'] : [],
+  // Keep read/write presentation semantics inside this optional feature. A
+  // completed automatic write need not repeat an already-spoken response.
+  requiresToolResultSummary: (name, args) => name === MEMORY_TOOL_NAME
+    ? String(args?.action || '').trim().toLowerCase() === 'read'
+    : undefined,
 }

--- a/server/src/memory/runtime.mjs
+++ b/server/src/memory/runtime.mjs
@@ -54,6 +54,7 @@ export class FrontendMemoryRuntime {
   constructor({ provider } = {}) {
     this.provider = assertMemoryProvider(provider)
     this.closePromise = null
+    this.changeListeners = new Set()
   }
 
   describe() {
@@ -85,17 +86,40 @@ export class FrontendMemoryRuntime {
     return normalizeDocuments(documents)
   }
 
+  subscribe(listener) {
+    if (typeof listener !== 'function') throw new TypeError('listener must be a function')
+    if (this.closePromise) return () => {}
+    this.changeListeners.add(listener)
+    return () => this.changeListeners.delete(listener)
+  }
+
   async apply(ownerId, changes = [], context = {}) {
+    const event = Object.freeze({
+      ownerId,
+      source: context?.source || '',
+      sessionId: context?.sessionId || null,
+    })
     const result = await this.provider.apply(ownerId, changes, context)
     if (!result || typeof result !== 'object' || !Array.isArray(result.documents)) {
       throw new TypeError(
         'MemoryProvider apply() must return changed and documents',
       )
     }
-    return {
+    const normalized = {
       changed: Math.max(0, Math.trunc(Number(result.changed) || 0)),
       documents: normalizeDocuments(result.documents),
     }
+    if (normalized.changed > 0) {
+      for (const listener of this.changeListeners) {
+        try {
+          const pending = listener(event)
+          pending?.catch?.(() => {})
+        } catch {
+          // Observers must not turn a successful persisted write into a failure.
+        }
+      }
+    }
+    return normalized
   }
 
   async query(ownerId, query, options = {}, context = {}) {
@@ -154,6 +178,7 @@ export class FrontendMemoryRuntime {
 
   async close() {
     if (!this.closePromise) {
+      this.changeListeners.clear()
       this.closePromise = Promise.resolve().then(() => this.provider.close?.())
     }
     await this.closePromise

--- a/server/src/voice/realtime-gateway.mjs
+++ b/server/src/voice/realtime-gateway.mjs
@@ -744,6 +744,23 @@ export function attachRealtimeGateway(server, {
       }
     }
     const toolCallTimings = new Map()
+    // Client-side edits are not present in the model's conversation. Refresh
+    // the owner's live memory snapshot after persistence, including deletion.
+    // Same-session tool writes already return the new documents to the model;
+    // retain their existing cache-only path to avoid a redundant prompt update.
+    const unsubscribeMemory = typeof memoryService?.subscribe === 'function'
+      ? memoryService.subscribe(event => {
+          if (event.ownerId !== ownerId) return
+          // Persistence changes invalidate the client view regardless of their
+          // source or whether this session needs a model-instruction refresh.
+          send(ws, { type: GatewayServerEvent.MEMORY_CHANGED })
+          realtimeSession.updateAgentContext({
+            memories: memoryService.list(ownerId, { limit: 64 }),
+          }, {
+            refreshSession: event.source !== 'realtime-tool' || event.sessionId !== sessionId,
+          })
+        })
+      : () => {}
     const toolCalls = new ToolCallHandler({
       taskManager,
       ownerId,
@@ -762,9 +779,14 @@ export function attachRealtimeGateway(server, {
       // 记忆写入只刷新缓存，不重发 session.update：改 instructions 等于改 prompt
       // 前缀，会让整场会话的前缀缓存失效，而用户刚说过的内容本来就在上下文里，
       // 不必靠 instructions 再讲一遍。新值在下一个新会话生效。
-      onMemoryChanged: () => realtimeSession.updateAgentContext({
-        memories: memoryService?.list(ownerId, { limit: 64 }) || [],
-      }, { refreshSession: false }),
+      onMemoryChanged: () => {
+        realtimeSession.updateAgentContext({
+          memories: memoryService?.list(ownerId, { limit: 64 }) || [],
+        }, { refreshSession: false })
+        if (typeof memoryService?.subscribe !== 'function') {
+          send(ws, { type: GatewayServerEvent.MEMORY_CHANGED })
+        }
+      },
       backendRuntime,
       backendAvailability,
       respondAuthorization,
@@ -1800,6 +1822,7 @@ export function attachRealtimeGateway(server, {
       connections?.delete(voiceClient)
       if (!connections?.size) voiceConnections.delete(ownerId)
       unsubscribeTasks()
+      unsubscribeMemory()
       clearResponseCandidate()
       turns.close()
       transcripts.close()

--- a/server/src/voice/realtime-presentation-runtime.mjs
+++ b/server/src/voice/realtime-presentation-runtime.mjs
@@ -340,11 +340,12 @@ export class RealtimePresentationRuntime {
     const responseTurnId = context?.turnId || this.turns.turnId
     const responseStatus = event.response?.status
     const failed = ['failed', 'cancelled', 'incomplete'].includes(responseStatus)
-    const suppressToolFollowUp = Boolean(
-      failed
-      || context?.suppressed
-      || context?.hasAudio
-      || context?.assistantTranscript?.trim()
+    const sourceHasSpeech = Boolean(context?.hasAudio || context?.assistantTranscript?.trim())
+    const suppressResponse = Boolean(failed || context?.suppressed)
+    // A spoken task-acceptance receipt needs no second acknowledgement, but
+    // inline tool results still need a summary after execution has finished.
+    const suppressToolFollowUp = suppressResponse || (
+      sourceHasSpeech && !this.toolCalls.requiresToolResultSummary?.(id)
     )
     const toolFollowUpPending = Boolean(
       context?.hasFunctionCall
@@ -353,7 +354,8 @@ export class RealtimePresentationRuntime {
     )
     if (context) context.awaitsToolFollowUp = toolFollowUpPending
     this.toolCalls.finishToolResponse(id, {
-      suppressResponse: suppressToolFollowUp,
+      suppressResponse,
+      sourceHasSpeech,
     }).catch(error => this.send({
       type: GatewayServerEvent.ERROR,
       message: error.message,

--- a/server/src/voice/realtime-provider.mjs
+++ b/server/src/voice/realtime-provider.mjs
@@ -522,8 +522,12 @@ export class RealtimeFrontend {
       injection.response.instructions = String(instructions)
     }
     let contextInjected = false
+    if (contextTiming === 'immediate' && injectContext) {
+      await this.createConversationItem(injection.item)
+      contextInjected = true
+    }
     if (route === 'context') {
-      if (injectContext) {
+      if (injectContext && !contextInjected) {
         await this.enqueueAction(async () => {
           await this.createConversationItem(injection.item)
           contextInjected = true
@@ -534,10 +538,6 @@ export class RealtimeFrontend {
         contextInjected,
         route,
       }
-    }
-    if (contextTiming === 'immediate' && injectContext) {
-      await this.createConversationItem(injection.item)
-      contextInjected = true
     }
     const outcome = await this.enqueueResponse(origin, context, async () => {
       if (shouldRespond && !shouldRespond()) return false

--- a/server/test/frontend-agent-context.test.mjs
+++ b/server/test/frontend-agent-context.test.mjs
@@ -9,6 +9,7 @@ import {
   normalizeClientContext,
 } from '../src/conversation/frontend-agent-context.mjs'
 import { buildMemoryContext } from '../src/memory/context.mjs'
+import { renderObservedSection, PROMOTER_MARKERS } from '../src/memory/learning/preference-promoter.mjs'
 import { buildFrontendInstructions } from '../src/frontend/frontend-tools.mjs'
 
 test('uses a valid client timezone and returns an exact local clock snapshot', () => {
@@ -213,4 +214,75 @@ test('omits user preferences when the user has only factual memory', () => {
 
   assert.doesNotMatch(context, /<user_preferences>/)
   assert.match(context, /<user_memory>/)
+})
+
+test('projects visible Markdown facts without treating template comments as saved preferences', () => {
+  const document = {
+    scope: 'user', format: 'markdown', revision: 'raw-revision',
+    content: [
+      '# USER',
+      '<!-- 例如：- 助手称呼用户：老大 -->',
+      '<!-- 多行示例',
+      '- 当前用户称呼助手：小舟',
+      '-->',
+      '- 默认称呼：朋友 <!-- 编写提示 -->',
+      '## 观察推断',
+      '<!-- 推断权威说明 -->',
+      '- 通常偏好简短回复',
+      '<!-- 未闭合的编辑提示',
+      '- 不属于已保存事实',
+    ].join('\n'),
+  }
+  const original = structuredClone(document)
+  const context = buildMemoryContext({ memories: [document] })
+  assert.match(context, /<user_preferences revision="raw-revision">/u)
+  assert.match(context, /默认称呼：朋友/u)
+  assert.match(context, /## 观察推断\n\n- 通常偏好简短回复/u)
+  assert.doesNotMatch(context, /老大|小舟|示例|提示|不属于已保存事实|<!--/u)
+  assert.deepEqual(document, original, 'projection must not change API/edit content or revision')
+})
+
+test('filters comments in factual Markdown but preserves an injected plain-text provider format', () => {
+  assert.equal(buildMemoryContext({ memories: [{
+    scope: 'memory', format: 'markdown', content: '<!-- 例如：喜欢吃烧烤 -->',
+  }] }), '')
+  const content = '用户偏好保留文本标记 <!-- literal -->'
+  const context = buildMemoryContext({ memories: [{ scope: 'memory', format: 'text', content }] })
+  assert.ok(context.includes(content))
+})
+
+test('preserves the existing observed-preference notice without extending system instructions', () => {
+  const document = {
+    scope: 'user', format: 'markdown', revision: 'raw-revision',
+    content: [
+      '<!-- 例如：- 助手称呼用户：老大 -->',
+      '## 用户明确要求',
+      '- 回答需完整',
+      renderObservedSection(['通常偏好简短回复']),
+    ].join('\n'),
+  }
+  const original = structuredClone(document)
+  const context = buildMemoryContext({ memories: [document] })
+  assert.ok(context.includes(PROMOTER_MARKERS.OBSERVED_NOTICE))
+  assert.ok(context.indexOf('回答需完整') < context.indexOf(PROMOTER_MARKERS.OBSERVED_NOTICE))
+  assert.match(context, /通常偏好简短回复/u)
+  assert.doesNotMatch(context, /老大|例如/u)
+  assert.deepEqual(document, original)
+})
+
+test('retains the existing truncation warning even when a template comment was cut short', () => {
+  const notice = '<!-- 内容过长，已截断；精确编辑前请缩小文档 -->'
+  for (const comment of ['<!-- 示例：未保存的偏好 -->', '<!-- 示例：未保存的偏好']) {
+    const document = {
+      scope: 'memory', format: 'markdown', revision: 'full-document-revision',
+      content: `- 用户喜欢散步\n${comment}\n\n${notice}`,
+    }
+    const original = structuredClone(document)
+    const context = buildMemoryContext({ memories: [document] })
+    assert.match(context, /用户喜欢散步/u)
+    assert.doesNotMatch(context, /示例|未保存的偏好/u)
+    assert.ok(context.includes(notice))
+    assert.match(context, /revision="full-document-revision"/u)
+    assert.deepEqual(document, original)
+  }
 })

--- a/server/test/frontend-mcp-client.test.mjs
+++ b/server/test/frontend-mcp-client.test.mjs
@@ -104,7 +104,7 @@ test('discovers only explicitly enabled tools under stable namespaced names', as
     parameters: { type: 'object', properties: {} },
   })
   assert.deepEqual(tools[0].policy, {
-    timeoutMs: 8_000,
+    timeoutMs: 10_000,
     maxResultBytes: 32 * 1024,
     maxCallsPerTurn: 1,
   })
@@ -152,7 +152,7 @@ test('preserves standard MCP annotations without turning them into execution pol
     destructiveHint: false,
   })
   assert.deepEqual(tool.policy, {
-    timeoutMs: 8_000,
+    timeoutMs: 10_000,
     maxResultBytes: 32 * 1024,
     maxCallsPerTurn: 2,
   })

--- a/server/test/frontend-mcp-config.test.mjs
+++ b/server/test/frontend-mcp-config.test.mjs
@@ -52,7 +52,7 @@ test('normalizes explicit server and tool policies', () => {
       tools: {
         search: {
           enabled: true,
-          timeoutMs: 8_000,
+          timeoutMs: 10_000,
           maxResultBytes: 32 * 1024,
           maxCallsPerTurn: 2,
         },
@@ -258,7 +258,7 @@ test('enables selected tools without classifying reads and writes', () => {
   }))
   assert.deepEqual(normalized.servers[0].tools.create_issue, {
     enabled: true,
-    timeoutMs: 8_000,
+    timeoutMs: 10_000,
     maxResultBytes: 32 * 1024,
     maxCallsPerTurn: 2,
   })

--- a/server/test/gateway-application.test.mjs
+++ b/server/test/gateway-application.test.mjs
@@ -1,13 +1,14 @@
 import assert from 'node:assert/strict'
-import { once } from 'node:events'
+import { EventEmitter, once } from 'node:events'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { request as httpRequest } from 'node:http'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import test from 'node:test'
-import WebSocket from 'ws'
+import WebSocket, { WebSocketServer } from 'ws'
 import { createGatewayApplication } from '../src/app/gateway-application.mjs'
 import { GATEWAY_CLIENT_REVOKED_CLOSE_CODE } from '../../shared/protocol/gateway-client-protocol.mjs'
+import { GatewayClient } from '../../shared/gateway/client-sdk.mjs'
 import { decodeGatewayDirectConnection } from '../../shared/gateway/remote-access.mjs'
 import { config } from '../src/core/config.mjs'
 import { createRealtimeProviderRegistry } from '../src/voice/providers/provider-registry.mjs'
@@ -16,6 +17,10 @@ import { ConversationSync } from '../src/conversation/conversation-sync.mjs'
 import { SessionJournalRegistry } from '../src/session/session-journal-registry.mjs'
 import { TaskManager } from '../src/task/task-manager.mjs'
 import { TaskStore } from '../src/task/task-store.mjs'
+import { FrontendMemoryRuntime } from '../src/memory/runtime.mjs'
+import { MarkdownMemoryProvider } from '../src/memory/providers/markdown/provider.mjs'
+import { MarkdownContextStore } from '../src/memory/providers/markdown/context-store.mjs'
+import { buildMemoryContext } from '../src/memory/context.mjs'
 
 function createTestGatewayApplication(options = {}) {
   // Application tests must never inherit the process-wide production task
@@ -1039,6 +1044,228 @@ test('serves and edits frontend memory through the generic client control plane'
   } finally {
     await application.close()
   }
+})
+
+test('API memory edits refresh only the owning live Realtime session without reconnecting', { timeout: 10_000 }, async t => {
+  const directory = mkdtempSync(join(tmpdir(), 'qwaudio-live-memory-'))
+  const ownerId = 'live-memory-owner'
+  const sessionId = 'live-memory-session'
+  const preference = '- 用户找餐厅时优先推荐川菜'
+  const userStore = new MarkdownContextStore({
+    filePath: join(directory, 'USER.md'), scope: 'user', personalOwnerId: ownerId,
+  })
+  userStore.persist(ownerId, `# USER\n\n${preference}\n`)
+  const frontendMemory = new FrontendMemoryRuntime({
+    provider: new MarkdownMemoryProvider({ userStore }),
+  })
+  let subscriptions = 0
+  const subscribe = frontendMemory.subscribe.bind(frontendMemory)
+  t.mock.method(frontendMemory, 'subscribe', listener => {
+    subscriptions += 1
+    const unsubscribe = subscribe(listener)
+    let active = true
+    return () => {
+      if (active) subscriptions -= 1
+      active = false
+      unsubscribe()
+    }
+  })
+
+  const upstream = new WebSocketServer({ host: '127.0.0.1', port: 0 })
+  const upstreamEvents = new EventEmitter()
+  const updates = []
+  const upstreamConnections = []
+  let socket
+  let memoryPanel
+  let application
+  t.after(async () => {
+    socket?.terminate()
+    memoryPanel?.stop()
+    await application?.close()
+    for (const client of upstream.clients) client.terminate()
+    await new Promise(resolve => upstream.close(resolve))
+    rmSync(directory, { recursive: true, force: true })
+  })
+  await once(upstream, 'listening', { signal: t.signal })
+  upstream.on('connection', client => {
+    upstreamConnections.push(client)
+    client.on('message', raw => {
+      const message = JSON.parse(raw.toString())
+      if (message.type !== 'session.update') return
+      updates.push({ client, message })
+      client.send(JSON.stringify({ type: 'session.updated' }))
+      upstreamEvents.emit('session.update', message)
+    })
+    client.send(JSON.stringify({ type: 'session.created' }))
+  })
+  const provider = {
+    key: 'memory-test', label: 'Memory Test', visibility: 'gateway-only',
+    inputSampleRate: 16000, outputSampleRate: 24000,
+    protocol: openAiCompatibleProtocol,
+    model: () => 'memory-fixture', voice: () => null,
+    isConfigured: () => true,
+    url: () => `ws://127.0.0.1:${upstream.address().port}/realtime`,
+    headers: () => ({}), classifyError: () => 'other',
+    buildSession: ({ agentContext }) => ({ instructions: buildMemoryContext(agentContext) }),
+    buildSpeakResponse: () => ({}), buildResultInjection: () => ({}),
+    buildPermissionInjection: () => ({}),
+  }
+  application = createTestGatewayApplication({
+    config: {
+      ...config, host: '127.0.0.1', port: 0, personalOwnerId: ownerId,
+      dataDirectory: directory, stateDirectory: join(directory, 'state'),
+      gatewayDeviceStatePath: join(directory, 'devices.json'),
+      gatewayAccessToken: '', gatewayAccessKeys: '',
+      memoryAutoEnabled: false, preferenceLearningEnabled: false,
+      sessionDigestEnabled: false, domainLibraryEnabled: false,
+      reminderSchedulerEnabled: false, sleepTimeoutMs: 0,
+      webSearchProvider: 'none', webSearchMcpUrl: '',
+    },
+    parentPort: null, autoStart: false,
+    frontendMemory, frontendMcp: null, frontendOpenApi: null,
+    realtimeProviderRegistry: createRealtimeProviderRegistry({ providers: [provider] }),
+    realtimeProvider: provider.key,
+  })
+  application.start()
+  if (!application.server.listening) await once(application.server, 'listening', { signal: t.signal })
+  const { port } = application.server.address()
+  socket = new WebSocket(`ws://127.0.0.1:${port}/api/realtime?sessionId=${sessionId}`)
+  const clientEvents = new EventEmitter()
+  const memoryNotifications = []
+  socket.on('message', raw => {
+    const event = JSON.parse(raw.toString())
+    if (event.type === 'memory.changed') memoryNotifications.push(event)
+    clientEvents.emit(event.type, event)
+  })
+  await once(socket, 'open', { signal: t.signal })
+  const ready = once(clientEvents, 'voice.ready', { signal: t.signal })
+  socket.send(JSON.stringify({ type: 'connect', inputEnabled: true, outputEnabled: true }))
+  await ready
+  assert.equal(subscriptions, 1)
+  assert.equal(updates.length, 1)
+  assert.match(updates[0].message.session.instructions, /优先推荐川菜/u)
+
+  const listed = await requestJson({ port, path: '/api/memory' })
+  const userDocument = listed.body.documents.find(document => document.scope === 'user')
+  const refreshed = once(upstreamEvents, 'session.update', { signal: t.signal })
+  const memoryDeleted = once(clientEvents, 'memory.changed', { signal: t.signal })
+  const removed = await requestJson({
+    port, path: '/api/memory', method: 'PATCH',
+    body: { changes: [{
+      document: 'user', expectedRevision: userDocument.revision,
+      edits: [{ old_text: preference, new_text: '' }],
+    }] },
+  })
+  assert.equal(removed.status, 200)
+  assert.equal(removed.body.changed, 1)
+  assert.deepEqual((await memoryDeleted)[0], { type: 'memory.changed' })
+  const [updated] = await refreshed
+  assert.doesNotMatch(updated.session.instructions, /优先推荐川菜/u)
+  assert.match(updated.session.instructions, /<user_preferences revision=/u)
+  assert.equal(updates.length, 2)
+  assert.equal(updates[1].client, upstreamConnections[0])
+  assert.equal(upstreamConnections.length, 1)
+
+  // A pong is an ordered transport barrier, avoiding arbitrary sleeps when
+  // checking that these changes did not produce a session.update frame.
+  const flushUpstream = async () => {
+    const pong = once(upstreamConnections[0], 'pong', { signal: t.signal })
+    upstreamConnections[0].ping()
+    await pong
+    const clientPong = once(socket, 'pong', { signal: t.signal })
+    socket.ping()
+    await clientPong
+  }
+  await frontendMemory.apply('another-owner', [{
+    document: 'user', append: '- 另一个用户喜欢粤菜',
+  }], { source: 'gateway-memory-api' })
+  await flushUpstream()
+  assert.equal(updates.length, 2, 'another owner must not refresh this session')
+  assert.equal(memoryNotifications.length, 1, 'another owner must not invalidate this client')
+
+  const noOp = await requestJson({
+    port, path: '/api/memory', method: 'PATCH',
+    body: { changes: [{ document: 'user', edits: [{ old_text: '# USER', new_text: '# USER' }] }] },
+  })
+  assert.equal(noOp.status, 200)
+  assert.equal(noOp.body.changed, 0)
+  await flushUpstream()
+  assert.equal(updates.length, 2, 'a no-op must not refresh the session')
+  assert.equal(memoryNotifications.length, 1, 'a no-op must not invalidate the client')
+
+  const stale = await requestJson({
+    port, path: '/api/memory', method: 'PATCH',
+    body: { changes: [{ document: 'user', expectedRevision: userDocument.revision, append: preference }] },
+  })
+  assert.equal(stale.status, 409)
+  await flushUpstream()
+  assert.equal(memoryNotifications.length, 1, 'a rejected write must not invalidate the client')
+
+  const memoryRestored = once(clientEvents, 'memory.changed', { signal: t.signal })
+  const restored = await frontendMemory.apply(ownerId, [{
+    document: 'user', append: preference,
+  }], { source: 'realtime-tool', sessionId })
+  assert.equal(restored.changed, 1)
+  await memoryRestored
+  await flushUpstream()
+  assert.equal(updates.length, 2, 'same-session tool writes must remain cache-only')
+  assert.equal(memoryNotifications.length, 2, 'cache-only tool writes must still invalidate the client')
+
+  const nextRefresh = once(upstreamEvents, 'session.update', { signal: t.signal })
+  const editedAgain = await requestJson({
+    port, path: '/api/memory', method: 'PATCH',
+    body: { changes: [{ document: 'user', append: '- 用户希望回答简短' }] },
+  })
+  assert.equal(editedAgain.status, 200)
+  const [latest] = await nextRefresh
+  assert.match(latest.session.instructions, /优先推荐川菜/u)
+  assert.match(latest.session.instructions, /回答简短/u)
+  assert.equal(upstreamConnections.length, 1, 'memory refresh must not restart the provider connection')
+  assert.equal(socket.readyState, WebSocket.OPEN)
+
+  await flushUpstream()
+  assert.equal(memoryNotifications.length, 3)
+  const automaticWrite = once(clientEvents, 'memory.changed', { signal: t.signal })
+  await frontendMemory.apply(ownerId, [{
+    document: 'user', append: '- 用户通常周末外出就餐',
+  }], { source: 'automatic-extraction' })
+  await automaticWrite
+  const latestMemory = await requestJson({ port, path: '/api/memory' })
+  assert.match(latestMemory.body.documents[0].content, /周末外出就餐/u)
+  assert.equal(memoryNotifications.length, 4, 'automatic extraction must invalidate without a tool.call event')
+  assert.ok(memoryNotifications.every(event => Object.keys(event).join(',') === 'type'),
+    'invalidation notifications must not contain private memory content or owner identifiers')
+  const disconnected = once(socket, 'close', { signal: t.signal })
+  socket.close()
+  await disconnected
+
+  // Reconnect as a muted client through the real GCP/SDK path. The Gateway
+  // leases only one Client per owner, so close the legacy connection first.
+  const panelEvents = new EventEmitter()
+  memoryPanel = new GatewayClient({
+    url: `ws://127.0.0.1:${port}/api/realtime?sessionId=memory-panel-session`,
+    createSocket: url => new WebSocket(url),
+    clientType: 'web', clientInstanceId: 'memory-panel', reconnect: false,
+    configure: () => ({ inputEnabled: false, outputEnabled: false, textOnly: false }),
+    onStatus: status => panelEvents.emit(status.state),
+    onEvent: event => panelEvents.emit(event.type, event),
+  })
+  const panelReady = once(panelEvents, 'ready', { signal: t.signal })
+  memoryPanel.start()
+  await panelReady
+  assert.equal(subscriptions, 1)
+  const panelChanged = once(panelEvents, 'memory.changed', { signal: t.signal })
+  await frontendMemory.apply(ownerId, [{
+    document: 'user', append: '- 用户喜欢步行可达的餐厅',
+  }], { source: 'automatic-extraction' })
+  const [notification] = await panelChanged
+  assert.equal(notification.type, 'memory.changed')
+  assert.ok(notification.event_id)
+  assert.deepEqual(Object.keys(notification).sort(), ['event_id', 'type'])
+  assert.equal(upstreamConnections.length, 1, 'a muted memory panel must not start a model session')
+  memoryPanel.stop()
+  await application.close()
+  assert.equal(subscriptions, 0, 'closing the session must release its memory subscription')
 })
 
 // 接线契约：新增的记忆模块默认关闭，显式开启时才装配。

--- a/server/test/memory-runtime.test.mjs
+++ b/server/test/memory-runtime.test.mjs
@@ -17,6 +17,7 @@ function provider(overrides = {}) {
 
 test('keeps trusted mutation context separate from model changes', async () => {
   let received
+  const events = []
   const runtime = new FrontendMemoryRuntime({
     provider: provider({
       apply: async (ownerId, changes, context) => {
@@ -25,11 +26,129 @@ test('keeps trusted mutation context separate from model changes', async () => {
       },
     }),
   })
-  const changes = [{ document: 'memory', append: '- fact' }]
+  runtime.subscribe(event => events.push(event))
+  const changes = [{
+    document: 'memory', append: '- fact', ownerId: 'forged-owner',
+    source: 'forged-source', sessionId: 'forged-session',
+  }]
   const context = { source: 'realtime-tool', sessionId: 'session-private' }
   const result = await runtime.apply('owner-private', changes, context)
   assert.deepEqual(received, { ownerId: 'owner-private', changes, context })
   assert.equal(result.changed, 1)
+  assert.deepEqual(events, [{
+    ownerId: 'owner-private', source: 'realtime-tool', sessionId: 'session-private',
+  }])
+  assert.equal(Object.isFrozen(events[0]), true)
+})
+
+test('notifies synchronously after a successful normalized write without exposing document contents', async () => {
+  let completeWrite
+  const order = []
+  const events = []
+  const runtime = new FrontendMemoryRuntime({
+    provider: provider({
+      apply: () => new Promise(resolve => { completeWrite = resolve }),
+    }),
+  })
+  runtime.subscribe(event => {
+    order.push('notification')
+    events.push(event)
+  })
+  const pending = runtime.apply('owner-one', [], { source: 'gateway-memory-api' })
+    .then(result => {
+      order.push('resolved')
+      return result
+    })
+  assert.deepEqual(events, [])
+
+  completeWrite({ changed: '2.9', documents: [{ scope: 'memory', content: 'private fact' }] })
+  const result = await pending
+
+  assert.equal(result.changed, 2)
+  assert.equal(result.documents[0].content, 'private fact')
+  assert.deepEqual(events, [{ ownerId: 'owner-one', source: 'gateway-memory-api', sessionId: null }])
+  assert.deepEqual(order, ['notification', 'resolved'])
+})
+
+test('notifications retain each owner identity and default absent mutation context', async () => {
+  const events = []
+  const runtime = new FrontendMemoryRuntime({
+    provider: provider({ apply: async () => ({ changed: 1, documents: [] }) }),
+  })
+  runtime.subscribe(event => events.push(event))
+
+  await runtime.apply('owner-one', [])
+  await runtime.apply('owner-two', [], { source: 'realtime-tool', sessionId: 'session-two' })
+
+  assert.deepEqual(events, [
+    { ownerId: 'owner-one', source: '', sessionId: null },
+    { ownerId: 'owner-two', source: 'realtime-tool', sessionId: 'session-two' },
+  ])
+})
+
+test('does not notify for normalized no-op writes, provider failures, or malformed results', async () => {
+  const events = []
+  const runtime = new FrontendMemoryRuntime({ provider: provider() })
+  runtime.subscribe(event => events.push(event))
+
+  for (const changed of [0, -1, 0.9, undefined, null, 'not-a-number']) {
+    runtime.provider.apply = async () => ({ changed, documents: [] })
+    assert.equal((await runtime.apply('owner', [])).changed, 0)
+  }
+  runtime.provider.apply = async () => { throw new Error('write failed') }
+  await assert.rejects(runtime.apply('owner', []), /write failed/)
+  for (const result of [null, {}, { changed: 1, documents: null }]) {
+    runtime.provider.apply = async () => result
+    await assert.rejects(runtime.apply('owner', []), /changed and documents/)
+  }
+
+  assert.deepEqual(events, [])
+})
+
+test('isolates listener exceptions and immutable notifications while allowing unsubscribe', async () => {
+  const events = []
+  const runtime = new FrontendMemoryRuntime({
+    provider: provider({ apply: async () => ({ changed: 1, documents: [] }) }),
+  })
+  assert.throws(() => runtime.subscribe(null), /listener must be a function/)
+  const unsubscribeThrowing = runtime.subscribe(event => {
+    event.ownerId = 'mutated-owner'
+  })
+  runtime.subscribe(async () => { throw new Error('async observer failed') })
+  const unsubscribe = runtime.subscribe(event => events.push(event))
+
+  assert.deepEqual(await runtime.apply('owner', []), { changed: 1, documents: [] })
+  assert.deepEqual(events, [{ ownerId: 'owner', source: '', sessionId: null }])
+  unsubscribe()
+  unsubscribe()
+  unsubscribeThrowing()
+  await runtime.apply('owner', [])
+  assert.equal(events.length, 1)
+})
+
+test('closing drops listeners and prevents subscriptions or pending writes from notifying', async () => {
+  let completeWrite
+  let closeCount = 0
+  const events = []
+  const runtime = new FrontendMemoryRuntime({
+    provider: provider({
+      apply: () => new Promise(resolve => { completeWrite = resolve }),
+      close: async () => { closeCount += 1 },
+    }),
+  })
+  runtime.subscribe(event => events.push(event))
+  const pending = runtime.apply('owner', [])
+
+  await runtime.close()
+  const unsubscribeAfterClose = runtime.subscribe(event => events.push(event))
+  completeWrite({ changed: 1, documents: [] })
+  assert.deepEqual(await pending, { changed: 1, documents: [] })
+  unsubscribeAfterClose()
+  await runtime.close()
+
+  assert.equal(closeCount, 1)
+  assert.equal(runtime.changeListeners.size, 0)
+  assert.deepEqual(events, [])
 })
 
 test('requires a synchronous Realtime snapshot and closes once', async () => {

--- a/server/test/realtime-presentation-runtime.test.mjs
+++ b/server/test/realtime-presentation-runtime.test.mjs
@@ -7,6 +7,7 @@ function harness({
   nonVoiceClient = false,
   turnCitations = null,
   terminalToolResponses = [],
+  resultSummaryResponses = [],
   perResponseInstructions = false,
 } = {}) {
   const events = []
@@ -40,6 +41,7 @@ function harness({
       flush: () => calls.push(['flush']),
     },
     toolCalls: {
+      requiresToolResultSummary: id => resultSummaryResponses.includes(id),
       consumeTerminalToolResponse: id => {
         calls.push(['consumeTerminalToolResponse', id])
         return terminalResponses.delete(id)
@@ -322,7 +324,10 @@ test('releases a spoken function-call turn when its tool follow-up is suppressed
   assert.equal(events.at(-1).state, 'idle')
   assert.deepEqual(
     calls.find(([name]) => name === 'finishToolResponse'),
-    ['finishToolResponse', 'response-1', { suppressResponse: true }],
+    ['finishToolResponse', 'response-1', {
+      suppressResponse: false,
+      sourceHasSpeech: true,
+    }],
   )
   assert.deepEqual(
     calls.find(([name]) => name === 'responseDone'),
@@ -336,6 +341,43 @@ test('releases a spoken function-call turn when its tool follow-up is suppressed
     }],
   )
 })
+
+test('keeps a spoken inline-tool turn open until its results can be summarized', () => {
+  const { runtime, calls } = harness({ resultSummaryResponses: ['response-1'] })
+  deliver(runtime, {
+    type: 'response.audio.delta',
+    response_id: 'response-1',
+    delta: 'audio',
+    __voiceContext: { turnId: 'turn-1', turnGeneration: 1 },
+  })
+  runtime.markFunctionCall('response-1')
+  deliver(runtime, {
+    type: 'response.done',
+    response: { id: 'response-1', status: 'completed' },
+  })
+
+  assert.deepEqual(calls.find(([name]) => name === 'finishToolResponse'), [
+    'finishToolResponse', 'response-1', { suppressResponse: false, sourceHasSpeech: true },
+  ])
+  assert.equal(calls.find(([name]) => name === 'responseDone')[1].awaitsToolFollowUp, true)
+})
+
+for (const status of ['failed', 'cancelled', 'incomplete']) {
+  test(`suppresses even an inline result summary when the source response is ${status}`, () => {
+    const { runtime, calls } = harness({ resultSummaryResponses: ['response-1'] })
+    deliver(runtime, {
+      type: 'response.created',
+      response: { id: 'response-1' },
+      __voiceContext: { turnId: 'turn-1', turnGeneration: 1 },
+    })
+    runtime.markFunctionCall('response-1')
+    deliver(runtime, { type: 'response.done', response: { id: 'response-1', status } })
+    assert.deepEqual(calls.find(([name]) => name === 'finishToolResponse'), [
+      'finishToolResponse', 'response-1', { suppressResponse: true, sourceHasSpeech: false },
+    ])
+    assert.equal(calls.find(([name]) => name === 'responseDone')[1].awaitsToolFollowUp, false)
+  })
+}
 
 test('user interruption confirms an announcement and suppresses late output', () => {
   const { runtime, events, calls } = harness()

--- a/server/test/realtime-provider.test.mjs
+++ b/server/test/realtime-provider.test.mjs
@@ -1138,6 +1138,60 @@ test('restores recent conversation through the shared GA session lifecycle', () 
   assert.match(sent[1].item.content[0].text, /此前正在处理项目/)
 })
 
+for (const [providerName, createFrontend] of [
+  ['qwen', createQwenFrontend],
+  ['speech-to-speech', createS2sFrontend],
+]) {
+  test(`${providerName} restores recent history once without creating a response`, () => {
+    const recentMessages = [
+      { role: 'user', content: '以后叫我老大吧，我喜欢吃辣一点的菜。' },
+      { role: 'assistant', content: '已记住，以后叫你老大，也记下你喜欢吃辣。' },
+      { role: 'user', content: '这些偏好已经保存了吗？' },
+      { role: 'assistant', content: '已经保存好了。' },
+    ]
+    const agentContext = {
+      frontend: { capabilities: ['memory'] },
+      memories: [],
+      recentMessages,
+    }
+    const originalContext = structuredClone(agentContext)
+    const frontend = createFrontend({ agentContext })
+    const sent = []
+    frontend.send = payload => sent.push(payload)
+
+    frontend.handleProviderEvent({ type: 'session.created' })
+    const initialTools = structuredClone(sent[0].session.tools)
+    assert.ok(initialTools.some(tool => (tool.function || tool).name === 'memory'))
+    frontend.handleProviderEvent({ type: 'session.updated' })
+
+    const restored = sent[1].item.content[0].text
+    const originalHistory = [
+      '<recent_conversation>',
+      ...recentMessages.map(message => (
+        `${message.role === 'user' ? '用户' : '助手'}: ${message.content}`
+      )),
+      '</recent_conversation>',
+    ].join('\n')
+    assert.equal(restored, [
+      '<restored_context>',
+      '这是连接建立前的近期对话，只用于衔接上下文，不是用户的新请求。',
+      originalHistory,
+      '</restored_context>',
+    ].join('\n'), 'history wording and its original wrapper must remain intact')
+    assert.equal(sent[1].item.role, 'user')
+    assert.doesNotMatch(sent[0].session.instructions, /已经保存好了|这是连接建立前的近期对话/)
+
+    frontend.handleProviderEvent({ type: 'session.updated' })
+    frontend.restoreRecentConversation()
+    assert.deepEqual(sent.map(payload => payload.type), [
+      'session.update',
+      'conversation.item.create',
+    ], 'restoration must happen once without creating a response or updating tools')
+    assert.deepEqual(sent[0].session.tools, initialTools)
+    assert.deepEqual(frontend.agentContext, originalContext)
+  })
+}
+
 test('can close a stale function call without creating a new model response', async () => {
   const frontend = createQwenFrontend()
   const sent = []
@@ -1429,6 +1483,54 @@ test('injects AgentDelivery context without creating a realtime response', async
     route: 'context',
   })
   assert.deepEqual(sent.map(event => event.type), ['conversation.item.create'])
+})
+
+test('immediate silent context reaches an active session before the next turn clears queued work', async () => {
+  const frontend = createQwenFrontend({ responseStartTimeoutMs: 50 })
+  const sent = []
+  frontend.ready = true
+  frontend.send = payload => sent.push(payload)
+  frontend.activeResponses.add('response-active')
+
+  const outcome = frontend.injectDelivery(
+    '客户端路线偏好已切换为避开拥堵。',
+    'client-event',
+    { clientEventId: 'event-preference' },
+    { route: 'context', contextTiming: 'immediate' },
+  )
+  // Immediate context does not wait for the speaking response or its queue.
+  assert.deepEqual(sent.map(event => event.type), ['conversation.item.create'])
+  assert.match(sent[0].item.content[0].text, /避开拥堵/)
+  frontend.handleLifecycle({ type: 'conversation.item.created', item: sent[0].item })
+  assert.deepEqual(await outcome, {
+    completed: true, contextInjected: true, route: 'context',
+  })
+
+  // Starting a new user turn discards old queued responses, not the context
+  // already accepted by the provider. It must not trigger its own speech.
+  frontend.cancel()
+  assert.equal(sent.filter(event => event.type === 'conversation.item.create').length, 1)
+  assert.equal(sent.some(event => event.type === 'response.create'), false)
+  assert.equal(frontend.conversationItemWaiters.size, 0)
+})
+
+test('silent context keeps the default response-timed delivery behind active responses', async () => {
+  const frontend = createQwenFrontend({ responseStartTimeoutMs: 50 })
+  const sent = []
+  frontend.ready = true
+  frontend.send = payload => sent.push(payload)
+  frontend.activeResponses.add('response-active')
+  const outcome = frontend.injectDelivery('环境信息。', 'client-event', {}, { route: 'context' })
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(sent, [])
+  frontend.handleLifecycle({
+    type: 'response.done', response: { id: 'response-active', status: 'completed' },
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(sent.map(event => event.type), ['conversation.item.create'])
+  frontend.handleLifecycle({ type: 'conversation.item.created', item: sent[0].item })
+  assert.equal((await outcome).contextInjected, true)
+  assert.equal(sent.some(event => event.type === 'response.create'), false)
 })
 
 test('can expose permission context before its response queue becomes idle', async () => {

--- a/server/test/tool-call-handler.test.mjs
+++ b/server/test/tool-call-handler.test.mjs
@@ -5,6 +5,7 @@ import { ToolCallHandler } from '../src/frontend/tools/tool-call-handler.mjs'
 import { FrontendNotesStore } from '../src/conversation/frontend-notes.mjs'
 import { PermissionPolicy } from '../src/task/permission-policy.mjs'
 import { TurnTranscripts } from '../src/frontend/tools/turn-transcripts.mjs'
+import { REALTIME_PROVIDERS, RealtimeFrontend } from '../src/voice/realtime-provider.mjs'
 
 function harness({
   coordinator,
@@ -27,6 +28,7 @@ function harness({
   frontendToolSources,
   disabledTools,
   getTurnId = () => 'turn-one',
+  getTurnGeneration = () => 1,
 } = {}) {
   const outputs = []
   const toolResultsReady = []
@@ -43,7 +45,7 @@ function harness({
     transcripts,
     getFrontend: () => frontend,
     getTurnId,
-    getTurnGeneration: () => 1,
+    getTurnGeneration,
     backendRuntime: coordinator || {
       run: async () => ({ content: '完成', metadata: {} }),
       cancel: async taskId => ({ taskId, state: 'cancelled' }),
@@ -205,6 +207,304 @@ test('executes an explicitly enabled state-changing external tool inline', async
     turnId: 'turn-one',
     toolName: 'mcp__cockpit__vehicle_window_control',
   }])
+})
+
+function responseToolSource(names, execute) {
+  return {
+    tools: () => names.map(name => ({
+      name,
+      definition: {
+        type: 'function',
+        function: { name, parameters: { type: 'object', properties: {} } },
+      },
+      policy: { maxCallsPerTurn: 4, maxResultBytes: 2_048 },
+    })),
+    execute,
+  }
+}
+
+function responseToolCall(handler, callId, name, responseId = 'response-tools', args = {}) {
+  return handler.handle({
+    call_id: callId,
+    name,
+    response_id: responseId,
+    arguments: JSON.stringify(args),
+  }, { turnId: 'turn-one', turnGeneration: 1, responseId })
+}
+
+test('waits for all external results and response.done before one follow-up', async () => {
+  const slow = Promise.withResolvers()
+  const names = ['mcp__car__climate', 'mcp__car__window', 'mcp__car__light']
+  const completed = []
+  const kit = harness({ frontendToolSources: [responseToolSource(names, async name => {
+    if (name === names[0]) await slow.promise
+    completed.push(name)
+    if (name === names[2]) throw new Error('device unavailable')
+    return { status: 'ok', name }
+  })] })
+
+  const first = responseToolCall(kit.handler, 'slow', names[0])
+  await Promise.all([
+    responseToolCall(kit.handler, 'fast', names[1]),
+    responseToolCall(kit.handler, 'failed', names[2]),
+  ])
+  await kit.handler.finishToolResponse('response-tools')
+  assert.deepEqual(completed, [names[1], names[2]])
+  assert.equal(kit.outputs.length, 2)
+  assert.equal(kit.outputs[1][1].error_code, 'external_tool_unavailable')
+  assert.equal(kit.ensuredResponses.length, 0)
+
+  slow.resolve()
+  await first
+  assert.deepEqual(kit.outputs.map(output => output[0]), ['fast', 'failed', 'slow'])
+  assert.ok(kit.outputs.every(output => output[3].createResponse === false))
+  assert.equal(kit.ensuredResponses.length, 1)
+  assert.equal(kit.handler.deferredToolResponses.size, 0)
+  await kit.handler.finishToolResponse('response-tools')
+  assert.equal(kit.ensuredResponses.length, 1)
+})
+
+test('a single external result waits for source completion without changing uncorrelated calls', async () => {
+  const name = 'mcp__car__window'
+  const kit = harness({ frontendToolSources: [responseToolSource([name], async () => ({ status: 'ok' }))] })
+  await responseToolCall(kit.handler, 'single', name)
+  assert.equal(kit.outputs[0][3].createResponse, false)
+  assert.equal(kit.ensuredResponses.length, 0)
+  await kit.handler.finishToolResponse('response-tools')
+  assert.equal(kit.ensuredResponses.length, 1)
+
+  await responseToolCall(kit.handler, 'legacy', name, '', { action: 'close' })
+  assert.equal(kit.outputs[1][3].createResponse, undefined)
+  assert.equal(kit.ensuredResponses.length, 1)
+})
+
+test('batches normal built-ins, deferred memory tools and MCP in the same response', async () => {
+  const slow = Promise.withResolvers()
+  const name = 'mcp__car__window'
+  const kit = harness({
+    frontendToolSources: [responseToolSource([name], () => slow.promise)],
+    memoryStore: { apply: () => ({ changed: 1, documents: [] }) },
+  })
+  // A normal built-in can arrive first, before MCP or an existing deferred tool.
+  await responseToolCall(kit.handler, 'time', 'get_current_time')
+  const external = responseToolCall(kit.handler, 'window', name)
+  await responseToolCall(kit.handler, 'memory', 'memory', 'response-tools', {
+    action: 'append', document: 'memory', content: '- 喜欢安静',
+  })
+  await kit.handler.finishToolResponse('response-tools')
+  assert.equal(kit.ensuredResponses.length, 0)
+  slow.resolve({ status: 'ok' })
+  await external
+  assert.equal(kit.outputs.length, 3)
+  assert.ok(kit.outputs.every(output => output[3].createResponse === false))
+  assert.equal(kit.ensuredResponses.length, 1)
+})
+
+test('an early spoken acknowledgement does not swallow pending external results', async () => {
+  const slow = Promise.withResolvers()
+  const name = 'mcp__car__window'
+  const kit = harness({ frontendToolSources: [responseToolSource([name], () => slow.promise)] })
+  const pending = responseToolCall(kit.handler, 'window', name)
+  assert.equal(kit.handler.requiresToolResultSummary('response-tools'), true)
+  await kit.handler.finishToolResponse('response-tools', { sourceHasSpeech: true })
+  slow.resolve({ status: 'ok' })
+  await pending
+  assert.equal(kit.ensuredResponses.length, 1)
+})
+
+test('slow built-in searches are marked as result-bearing before response.done', async () => {
+  const result = Promise.withResolvers()
+  const kit = harness({ frontendRetrieval: {
+    capabilities: () => ['web-search'],
+    search: () => result.promise,
+  } })
+  const pending = responseToolCall(kit.handler, 'search', 'web_search', 'response-tools', { query: '天气' })
+  assert.equal(kit.handler.requiresToolResultSummary('response-tools'), true)
+  await kit.handler.finishToolResponse('response-tools', { sourceHasSpeech: true })
+  assert.equal(kit.ensuredResponses.length, 0)
+  result.resolve({ status: 'ok', text: '晴天' })
+  await pending
+  assert.equal(kit.ensuredResponses.length, 1)
+})
+
+test('memory reads need their results even after speech, but automatic writes stay quiet', async () => {
+  const result = Promise.withResolvers()
+  const kit = harness({ memoryStore: {
+    query: () => result.promise,
+    apply: () => ({ changed: 1, documents: [] }),
+  } })
+  const pending = responseToolCall(kit.handler, 'read', 'memory', 'response-read', {
+    action: 'read', query: '我的偏好',
+  })
+  assert.equal(kit.handler.requiresToolResultSummary('response-read'), true)
+  await kit.handler.finishToolResponse('response-read', { sourceHasSpeech: true })
+  result.resolve({ memories: [], context: '用户喜欢安静' })
+  await pending
+  assert.equal(kit.ensuredResponses.length, 1)
+
+  await responseToolCall(kit.handler, 'write', 'memory', 'response-write', {
+    action: 'append', document: 'memory', content: '- 喜欢安静',
+  })
+  assert.equal(kit.handler.requiresToolResultSummary('response-write'), false)
+  await kit.handler.finishToolResponse('response-write', { sourceHasSpeech: true })
+  assert.equal(kit.ensuredResponses.length, 1)
+})
+
+test('mixed cancellation receipts retain their constraints without hiding other tool results', async () => {
+  const name = 'mcp__car__window'
+  const kit = harness({ frontendToolSources: [responseToolSource([name], async () => ({ status: 'ok' }))] })
+  await Promise.all([
+    responseToolCall(kit.handler, 'cancel', 'cancel_agent_task'),
+    responseToolCall(kit.handler, 'window', name),
+  ])
+  await kit.handler.finishToolResponse('response-tools', { sourceHasSpeech: true })
+  assert.equal(kit.ensuredResponses.length, 1)
+  const instructions = kit.ensuredResponses[0][1].response.instructions
+  assert.match(instructions, /不要再次查询或取消/)
+  assert.match(instructions, /单项工具的回执说明仅约束该工具/)
+  assert.match(instructions, /全部工具的实际结果合并回复/)
+})
+
+test('explicitly silent tools remain silent after their source response completes', async () => {
+  const kit = harness({ presenceController: {
+    supportsSleep: () => true,
+    requestSleep: async () => {},
+  } })
+  await responseToolCall(kit.handler, 'sleep', 'enter_sleep')
+  await kit.handler.finishToolResponse('response-tools')
+  assert.equal(kit.outputs[0][1].status, 'sleeping')
+  assert.equal(kit.outputs[0][3].createResponse, false)
+  assert.equal(kit.ensuredResponses.length, 0)
+  assert.equal(kit.handler.deferredToolResponses.size, 0)
+})
+
+test('cancelled source responses backfill results but never start a follow-up', async () => {
+  const slow = Promise.withResolvers()
+  const name = 'mcp__car__window'
+  const kit = harness({ frontendToolSources: [responseToolSource([name], () => slow.promise)] })
+  const pending = responseToolCall(kit.handler, 'window', name)
+  await kit.handler.finishToolResponse('response-tools', { suppressResponse: true })
+  slow.resolve({ status: 'ok' })
+  await pending
+  assert.equal(kit.outputs.length, 1)
+  assert.equal(kit.ensuredResponses.length, 0)
+  assert.equal(kit.handler.deferredToolResponses.size, 0)
+})
+
+test('old-turn results cannot start or retain a queued follow-up after interruption', async () => {
+  let generation = 1
+  const slow = Promise.withResolvers()
+  const name = 'mcp__car__window'
+  const kit = harness({
+    getTurnGeneration: () => generation,
+    frontendToolSources: [responseToolSource([name], (_name, args) => (
+      args.slow ? slow.promise : { status: 'ok' }
+    ))],
+  })
+  await responseToolCall(kit.handler, 'first', name)
+  await kit.handler.finishToolResponse('response-tools')
+  const queuedGuard = kit.ensuredResponses[0][1].shouldCreate
+  assert.equal(queuedGuard(), true)
+  const pending = responseToolCall(kit.handler, 'slow', name, 'response-later', { slow: true })
+  await kit.handler.finishToolResponse('response-later')
+  generation = 2
+  slow.resolve({ status: 'ok' })
+  await pending
+  assert.equal(queuedGuard(), false)
+  assert.equal(kit.ensuredResponses.length, 1)
+})
+
+test('failed result delivery closes the batch instead of replying with missing results', async () => {
+  const name = 'mcp__car__window'
+  const kit = harness({ frontendToolSources: [responseToolSource([name], async () => ({ status: 'ok' }))] })
+  kit.handler.getFrontend = () => ({
+    sendFunctionOutput: async () => { throw new Error('connection closed') },
+    ensureResponse: async () => { assert.fail('must not request a response') },
+  })
+  await assert.rejects(responseToolCall(kit.handler, 'window', name), /connection closed/)
+  await kit.handler.finishToolResponse('response-tools')
+  assert.equal(kit.handler.deferredToolResponses.size, 0)
+})
+
+test('later model responses get their own result batch while duplicate call IDs remain ignored', async () => {
+  const executed = []
+  const name = 'mcp__car__window'
+  const kit = harness({ frontendToolSources: [responseToolSource([name], async (_name, args) => {
+    executed.push(args.action)
+    return { status: 'ok' }
+  })] })
+  await responseToolCall(kit.handler, 'open', name, 'response-open', { action: 'open' })
+  await kit.handler.finishToolResponse('response-open')
+  await responseToolCall(kit.handler, 'close', name, 'response-close', { action: 'close' })
+  await responseToolCall(kit.handler, 'close', name, 'response-close', { action: 'close' })
+  await kit.handler.finishToolResponse('response-close')
+  assert.deepEqual(executed, ['open', 'close'])
+  assert.equal(kit.outputs.length, 2)
+  assert.equal(kit.ensuredResponses.length, 2)
+})
+
+test('the provider sends every function output before the single result response', async () => {
+  const slow = Promise.withResolvers()
+  const names = ['mcp__car__climate', 'mcp__car__window']
+  const kit = harness({ frontendToolSources: [responseToolSource(names, async name => {
+    if (name === names[0]) await slow.promise
+    return { status: 'ok', name }
+  })] })
+  const frontend = new RealtimeFrontend({ provider: REALTIME_PROVIDERS.qwen })
+  const sent = []
+  frontend.ready = true
+  // A local wire-level peer acknowledges items and the final response; no
+  // socket, cloud service or paid model is involved.
+  frontend.send = payload => {
+    sent.push(payload)
+    queueMicrotask(() => {
+      if (payload.type === 'conversation.item.create') {
+        frontend.handleLifecycle({ type: 'conversation.item.created', item: payload.item })
+      } else if (payload.type === 'response.create') {
+        frontend.handleLifecycle({ type: 'response.created', response: { id: 'summary' } })
+        frontend.handleLifecycle({ type: 'response.done', response: { id: 'summary', status: 'completed' } })
+      }
+    })
+  }
+  kit.handler.getFrontend = () => frontend
+  frontend.handleLifecycle({ type: 'response.created', response: { id: 'response-tools' } })
+  const pending = [
+    responseToolCall(kit.handler, 'slow', names[0]),
+    responseToolCall(kit.handler, 'fast', names[1]),
+  ]
+  await kit.handler.finishToolResponse('response-tools')
+  frontend.handleLifecycle({ type: 'response.done', response: { id: 'response-tools', status: 'completed' } })
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(sent.map(event => event.type), ['conversation.item.create'])
+  assert.equal(sent[0].item.call_id, 'fast')
+  slow.resolve()
+  await Promise.all(pending)
+  assert.deepEqual(sent.map(event => event.type), [
+    'conversation.item.create', 'conversation.item.create', 'response.create',
+  ])
+  assert.equal(sent[1].item.call_id, 'slow')
+  assert.equal(frontend.conversationItemWaiters.size, 0)
+  assert.equal(frontend.pendingResponses.length, 0)
+})
+
+test('batched status results retain task-notification acknowledgement context', async () => {
+  const name = 'mcp__car__window'
+  const kit = harness({ frontendToolSources: [responseToolSource([name], async () => ({ status: 'ok' }))] })
+  const task = kit.manager.create({
+    objective: '查询内存', ownerId: 'owner', sessionId: 'voice',
+    runner: async () => ({ content: '24 GB' }),
+  })
+  await kit.manager.wait(task.id)
+  await Promise.all([
+    responseToolCall(kit.handler, 'status', 'get_agent_task_status'),
+    responseToolCall(kit.handler, 'window', name),
+  ])
+  await kit.handler.finishToolResponse('response-tools')
+  assert.equal(kit.ensuredResponses.length, 1)
+  assert.deepEqual(kit.ensuredResponses[0][0], {
+    turnId: 'turn-one', turnGeneration: 1,
+    taskId: task.id, taskIds: [task.id], consumesTaskNotification: true,
+  })
 })
 
 function taskForId(manager, taskId) {
@@ -588,7 +888,7 @@ test('suppresses the receipt reply when the original response already spoke', as
     responseId: 'response-spoken-before-tool',
   })
   await kit.handler.finishToolResponse('response-spoken-before-tool', {
-    suppressResponse: true,
+    sourceHasSpeech: true,
   })
 
   assert.equal(kit.outputs[0][1].status, 'accepted')
@@ -629,7 +929,8 @@ test('accepts distinct spawn_thinking calls from one realtime response', async (
     output[1].message === '工作已受理，请自然确认一次，不要再次调用工具。'
   )))
   assert.equal(kit.ensuredResponses.length, 1)
-  assert.equal(kit.ensuredResponses[0][1], undefined)
+  assert.equal(kit.ensuredResponses[0][1].response, undefined)
+  assert.equal(kit.ensuredResponses[0][1].shouldCreate(), true)
   await Promise.all(kit.manager.list({ ownerId: 'owner' }).map(task => (
     kit.manager.wait(task.id)
   )))
@@ -907,6 +1208,29 @@ test('does not execute a disabled tool even if the model still sends its call', 
   })
   assert.equal(calls, 0)
   assert.equal(kit.outputs[0][1].error_code, 'tool_unavailable')
+})
+
+test('rejects unavailable memory with null arguments and clears call tracking', async () => {
+  const kit = harness()
+  const responseId = 'response-unavailable-memory'
+  const execution = await kit.handler.handle({
+    call_id: 'memory-null-arguments',
+    response_id: responseId,
+    name: 'memory',
+    arguments: 'null',
+  })
+
+  assert.equal(execution.executed, false)
+  assert.equal(execution.limit.reason, 'tool_unavailable')
+  assert.equal(kit.outputs.length, 1)
+  assert.equal(kit.outputs[0][1].error_code, 'tool_unavailable')
+  assert.equal(kit.outputs[0][1].retryable, false)
+  assert.equal(kit.handler.activeToolEntries.size, 0)
+  assert.equal(kit.handler.activeToolDebugEntries.size, 0)
+
+  await kit.handler.finishToolResponse(responseId)
+  assert.equal(kit.handler.deferredToolResponses.size, 0)
+  assert.equal(kit.ensuredResponses.length, 1)
 })
 
 test('search and page reading compose inline without a backend or created work', async () => {

--- a/shared/protocol/gateway-events.mjs
+++ b/shared/protocol/gateway-events.mjs
@@ -289,6 +289,7 @@ const GatewayVoicePayloadSchemas = Object.freeze({
     turnId: z.string().optional(),
     taskId: z.string().optional(),
   }).passthrough(),
+  [GatewayServerEvent.MEMORY_CHANGED]: z.object({}).passthrough(),
   [GatewayServerEvent.AGENT_ACTIVITY]: z.object({
     activity: z.string().min(1),
   }).passthrough(),

--- a/shared/protocol/realtime-events.mjs
+++ b/shared/protocol/realtime-events.mjs
@@ -46,6 +46,8 @@ export const GatewayServerEvent = Object.freeze({
   TRANSCRIPT_FINAL: 'transcript.final',
   TRANSCRIPT_DISCARD: 'transcript.discard',
   TOOL_CALL: 'tool.call',
+  // Owner-scoped invalidation only; clients reload GET /api/memory.
+  MEMORY_CHANGED: 'memory.changed',
   AGENT_ACTIVITY: 'agent.activity',
   CLIENT_STATE: 'client.state',
   ERROR: 'error',

--- a/shared/web-search-configuration.mjs
+++ b/shared/web-search-configuration.mjs
@@ -1,0 +1,24 @@
+// Pure configuration projection: safe to use from a standalone Agent without
+// loading Gateway configuration files or preparing its runtime directories.
+export function resolveWebSearchConfiguration(env = process.env) {
+  const bailianMcpUrl = 'https://dashscope.aliyuncs.com/api/v1/mcps/WebSearch/mcp'
+  const explicitMcpUrl = String(env.QWEN_AUDIO_WEB_SEARCH_MCP_URL || '').trim()
+  const dashscopeApiKey = String(env.DASHSCOPE_API_KEY || '').trim()
+  const requestedProvider = String(env.QWEN_AUDIO_WEB_SEARCH_PROVIDER || '').trim().toLowerCase()
+  const provider = requestedProvider || (explicitMcpUrl ? 'mcp' : 'so360')
+  if (!['bailian', 'bing', 'mcp', 'none', 'so360'].includes(provider)) {
+    throw new Error(
+      '不支持的 Web Search Provider：'
+      + `${provider}（可选 bailian、bing、mcp、none、so360）`,
+    )
+  }
+  const usesBailianMcp = provider === 'bailian'
+  return {
+    provider,
+    mcpUrl: usesBailianMcp ? bailianMcpUrl : explicitMcpUrl,
+    mcpToken: String(env.QWEN_AUDIO_WEB_SEARCH_MCP_TOKEN
+      || (usesBailianMcp ? dashscopeApiKey : '')).trim(),
+    mcpTool: String(env.QWEN_AUDIO_WEB_SEARCH_MCP_TOOL || '').trim()
+      || (usesBailianMcp ? 'bailian_web_search' : 'web_search'),
+  }
+}

--- a/test/gateway-client-protocol.test.mjs
+++ b/test/gateway-client-protocol.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { GatewayServerEvent } from '../shared/protocol/realtime-events.mjs'
 import {
   GATEWAY_CLIENT_IMPLEMENTED_CAPABILITIES,
   GATEWAY_CLIENT_KNOWN_CAPABILITIES,
@@ -87,6 +88,18 @@ test('validates correlated application heartbeat messages', () => {
     type: GatewayClientProtocolEvent.SESSION_PONG,
     event_id: 'evt_client_pong',
   }))
+})
+
+test('transports a memory invalidation using the existing server envelope', () => {
+  const protocol = new GatewayClientProtocolSession({ sessionId: 'memory-view', createEventId: ids() })
+  protocol.receive(createGatewaySessionHello({
+    clientInstanceId: 'memory-view-client', capabilities: [],
+  }))
+  const encoded = protocol.encode({ type: GatewayServerEvent.MEMORY_CHANGED })
+  assert.deepEqual(parseGatewayServerProtocolMessage(encoded), {
+    type: 'memory.changed', event_id: 'evt_gateway_2',
+  })
+  assert.deepEqual(protocol.capabilities, [])
 })
 
 test('publishes image input capability', () => {

--- a/test/gateway-client-sdk.test.mjs
+++ b/test/gateway-client-sdk.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { GatewayClient } from '../shared/gateway/client-sdk.mjs'
+import { GatewayServerEvent } from '../shared/protocol/realtime-events.mjs'
 import {
   GATEWAY_CLIENT_OCCUPIED_CLOSE_CODE,
   GATEWAY_CLIENT_PROTOCOL_VERSION,
@@ -74,6 +75,27 @@ function completeHandshake(socket) {
     capabilities: [],
   })
 }
+
+test('reference Client forwards payload-free memory changes without tool events or a new capability', t => {
+  const received = []
+  const { client, sockets } = createTimedClient(t, {
+    capabilities: [],
+    onEvent: event => received.push(event),
+  })
+  const socket = sockets[0]
+  socket.open()
+  completeHandshake(socket)
+  const notification = {
+    type: GatewayServerEvent.MEMORY_CHANGED,
+    event_id: 'evt_gateway_memory_changed',
+  }
+  socket.receive(notification)
+  assert.deepEqual(received, [notification])
+  assert.deepEqual(client.negotiatedCapabilities, [])
+  assert.equal(client.ready, true)
+  assert.equal(sockets.length, 1)
+  assert.deepEqual(socket.sent.map(event => event.type), ['session.hello'])
+})
 
 test('passes remote credentials below GCP and requests takeover explicitly', () => {
   const socket = new FakeSocket()

--- a/test/gateway-event-schema.test.mjs
+++ b/test/gateway-event-schema.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { GatewayServerEvent } from '../shared/protocol/realtime-events.mjs'
 import {
   AguiEventType,
   parseAguiGatewayEvent,
@@ -135,6 +136,13 @@ test('validates voice and task messages in the server direction', () => {
     content: 'Answer',
     citations: [{ ...citation, url: 'https://user:secret@example.com/' }],
   }).success, false)
+})
+
+test('memory changes are payload-free server invalidations, not client commands', () => {
+  assert.equal(GatewayServerEvent.MEMORY_CHANGED, 'memory.changed')
+  const notification = { type: GatewayServerEvent.MEMORY_CHANGED }
+  assert.deepEqual(parseGatewayServerMessage(notification), notification)
+  assert.equal(GatewayClientMessageSchema.safeParse(notification).success, false)
 })
 
 test('preserves protocol-neutral backend observations and safe permission details', () => {

--- a/test/web-retrieval-api.test.mjs
+++ b/test/web-retrieval-api.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createWebRetrieval } from 'qwen-audio-agent/web-retrieval'
+import { resolveWebSearchConfiguration } from '../shared/web-search-configuration.mjs'
+
+test('public retrieval factory shares the default provider without starting Gateway state', () => {
+  const runtime = createWebRetrieval({ env: {} })
+  assert.deepEqual(runtime.capabilities(), ['web-search', 'url-fetch'])
+  assert.equal(runtime.describe().searchProvider.key, 'so360')
+  assert.deepEqual(createWebRetrieval({ env: { QWEN_AUDIO_WEB_SEARCH_PROVIDER: 'none' }, urlFetcher: null }).capabilities(), [])
+})
+
+test('pure search configuration preserves existing provider and credential selection', () => {
+  assert.equal(resolveWebSearchConfiguration({}).provider, 'so360')
+  const preset = resolveWebSearchConfiguration({ QWEN_AUDIO_WEB_SEARCH_PROVIDER: 'bailian', DASHSCOPE_API_KEY: 'test-only-key' })
+  assert.equal(preset.mcpToken, 'test-only-key')
+  assert.equal(preset.mcpTool, 'bailian_web_search')
+  const custom = resolveWebSearchConfiguration({ QWEN_AUDIO_WEB_SEARCH_MCP_URL: 'https://example.com/mcp', DASHSCOPE_API_KEY: 'test-only-key' })
+  assert.equal(custom.provider, 'mcp')
+  assert.equal(custom.mcpToken, '')
+  assert.throws(() => resolveWebSearchConfiguration({ QWEN_AUDIO_WEB_SEARCH_PROVIDER: 'unknown' }), /不支持/)
+})
+
+test('public retrieval uses existing normalization and cancellation contracts', async () => {
+  const controller = new AbortController()
+  let providerSignal
+  const runtime = createWebRetrieval({
+    env: {},
+    searchProvider: {
+      describe: () => ({ key: 'mock', label: 'Mock' }),
+      isConfigured: () => true,
+      search: async (_query, { limit, signal }) => {
+        providerSignal = signal
+        assert.equal(limit, 8)
+        return { results: [{ title: 'Original release', url: 'https://example.com/news#title', publishedAt: '2026-09-11', snippet: 'Verified fixture' }] }
+      },
+    },
+    urlFetcher: null,
+  })
+  const result = await runtime.search('latest releases', { limit: 99, signal: controller.signal })
+  assert.equal(result.citations[0].url, 'https://example.com/news')
+  assert.equal(result.citations[0].published_at, '2026-09-11')
+  assert.match(result.notice, /不可信/)
+  controller.abort()
+  assert.equal(providerSignal.aborted, true)
+})
+
+test('public URL retrieval retains private-network, protocol and credential protections', async () => {
+  const runtime = createWebRetrieval({ env: { QWEN_AUDIO_WEB_SEARCH_PROVIDER: 'none' } })
+  for (const [url, code] of [
+    ['http://127.0.0.1/private', 'private_network_forbidden'],
+    ['http://[::ffff:127.0.0.1]/private', 'private_network_forbidden'],
+    ['file:///etc/passwd', 'unsupported_protocol'],
+    ['https://user:password@example.com/', 'url_credentials_forbidden'],
+  ]) {
+    await assert.rejects(runtime.fetchUrl(url), error => error.code === code)
+  }
+})


### PR DESCRIPTION
## 范围

本 PR 只包含通用前台/网关框架、公共导出、协议、测试和对应参考文档。座舱场景代码会通过后续独立 PR 提交；不包含宣传文章或素材。

## 改动

- 收集同一模型响应中的内置/MCP 工具结果，在调用结束后统一请求一次结果回复；区分实际结果与受理回执，保留取消及过期回合保护。
- 前台 MCP 未显式配置时的默认超时由 8 秒调整为 10 秒。
- 修复即时、静默上下文注入被回复队列阻塞或清除的问题，不因此主动发起播报。
- 导出无启动副作用的 `qwen-audio-agent/web-retrieval`，供独立 Agent 复用搜索、URL 抓取、引用及现有安全边界；纯配置抽取保持原有行为和导出兼容。
- 记忆实际持久化后发送 owner 隔离、无正文的 `memory.changed` 事件；更新当前会话记忆快照，客户端可重新读取现有 API。MemoryProvider、ACP、A2A 接口不变。
- 模型记忆投影过滤模板/编辑注释，保留原有推断优先级和截断说明；不修改文档原文、API 返回或 revision。
- 修复未启用记忆时收到 `null` 工具参数的错误路径，确保正常拒绝并清理调用跟踪。

## Prompt 边界

- 全局系统 Prompt、记忆 Prompt、记忆工具描述和历史恢复包装保持原样，没有加入本轮记忆调试时的强化提示。
- 多工具混合回执仅保留一条轮级 `response.instructions`，说明合并本次全部结果、区分后台受理与任务完成，不增加场景业务规则。

## 兼容与测试

- `memory.changed` 是 GCP 的新增服务端事件；现有 SDK 透传，不要求新的 capability。客户端应在收到通知与重新 ready 时读取记忆。
- 事件不携带记忆正文，失败/无变化写入不通知，注销连接后取消订阅。
- 新增和更新批次收集、空参数、静默上下文、记忆持久化/通知/隔离、SDK 透传、公开检索及文档投影回归测试。
- 未重新进行付费真实模型测试；实时模型相关回归使用本机模拟服务。
- 基于含 PR #414 的最新 main，在隔离工作区完成 `npm test`：2159 通过、1 个按默认条件跳过的消费者安装探针、0 失败；另通过 `npm run lint`、`npm run build`、`node scripts/verify-package.mjs` 和 `git diff --check`。消费者探针仍由 GitHub CI 基线任务实际运行。
