### PR TITLE
ci: retry Windows suite on silent test-process exits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,32 @@ jobs:
       - if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22.2' }}
         run: node --test .gitlab/sync-github.test.mjs
       - run: npm ci
-      - run: npm test
+      # windows-latest occasionally kills a whole test file's child process: the
+      # runner reports the file as `✖ <file> ... 'test failed'` with a non-zero
+      # exit and no diagnostics, and it lands on a different heavyweight example
+      # suite each time (smart-cockpit gateway composition, AI Passport relay).
+      # It fails the same way on main, never reproduced in ~120 targeted reruns
+      # on windows-latest, and is unrelated to the change under test, so retry
+      # the Windows suite once before failing the job. The retry is announced as
+      # a warning annotation so a flaky pass stays visible instead of silently
+      # swallowing a real regression.
+      - if: ${{ runner.os != 'Windows' }}
+        run: npm test
+      - name: Run the test suite (Windows, one retry on silent process exits)
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        run: |
+          for attempt in 1 2; do
+            if npm test; then
+              if [ "$attempt" -gt 1 ]; then
+                echo "::warning::npm test only passed on attempt $attempt; the first attempt hit the known Windows test-process exit."
+              fi
+              exit 0
+            fi
+            echo "::warning::npm test failed on attempt $attempt on Windows; retrying once."
+          done
+          echo "::error::npm test failed on both attempts on Windows."
+          exit 1
       - run: npm run build
       # Smart Cockpit has its own Vite/ESLint toolchain outside the root
       # workspace graph. Exercise it once on the baseline Linux job instead of


### PR DESCRIPTION
## Summary

- isolate the flaky Windows `npm test` behavior behind a Windows-only single retry
- keep non-Windows jobs on the existing single-run path
- emit warning annotations when the first attempt fails or only the retry passes
- keep the job red when both attempts fail

This addresses the CI mitigation requested in #413. It does not claim to fix the underlying Windows child-process failure; it keeps the failure visible while avoiding unrelated intermittent red jobs.

## Verification

- `git diff --check origin/main...HEAD`
- branch contains only `.github/workflows/ci.yml` changes
- Windows CI remains the authoritative full validation

Fixes #413