### PR TITLE
feat(smart-cockpit): sync navigation route animations

### DIFF
--- a/examples/smart-cockpit/client/src/App.css
+++ b/examples/smart-cockpit/client/src/App.css
@@ -743,6 +743,17 @@ button {
   font-size: 14px;
 }
 
+.route-waypoints {
+  max-width: 250px;
+  margin-top: 4px;
+  color: #7a6a2e;
+  font-size: 13px;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .route-destination-title {
   max-width: 230px;
   color: #202a31;
@@ -923,6 +934,29 @@ button {
   animation: poiLabelIn 420ms cubic-bezier(0.2, 0.9, 0.2, 1) 180ms both;
 }
 
+.waypoint-pin {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 6px;
+}
+
+.waypoint-pin > span {
+  max-width: 112px;
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.82);
+  box-shadow: 0 6px 14px rgba(109, 98, 47, 0.13);
+  color: #67591f;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  animation: poiLabelIn 380ms cubic-bezier(0.2, 0.9, 0.2, 1) calc(var(--marker-delay, 0ms) + 140ms) both;
+}
+
 .camera-tracking .destination-pin > span {
   opacity: 0.42;
   transform: scale(0.94);
@@ -959,6 +993,7 @@ button {
 
 .marker-pop {
   animation: markerPop 0.52s cubic-bezier(0.2, 1.2, 0.2, 1) both;
+  animation-delay: var(--marker-delay, 0ms);
 }
 
 @keyframes markerPop {

--- a/examples/smart-cockpit/client/src/components/MapPanel.jsx
+++ b/examples/smart-cockpit/client/src/components/MapPanel.jsx
@@ -1,6 +1,11 @@
 import { useRef, useEffect, useMemo, useCallback, useState } from 'react'
 import AMapLoader from '@amap/amap-jsapi-loader'
-import { navigationRouteKey, navigationRouteView } from '../projections/navigation-route'
+import {
+  navigationProgressMarker,
+  navigationRouteCompletionViewMode,
+  navigationRouteKey,
+  navigationRouteView,
+} from '../projections/navigation-route'
 import { routeFlowFrame } from '../projections/route-flow'
 
 window._AMapSecurityConfig = {
@@ -60,6 +65,7 @@ export default function MapPanel({
   const markersRef = useRef([])
   const previewPolylinesRef = useRef([])
   const previewMarkersRef = useRef([])
+  const progressMarkerKeysRef = useRef(new Set())
   const queueRef = useRef([])
   const processingRef = useRef(false)
   const processedCountRef = useRef(0)
@@ -68,7 +74,6 @@ export default function MapPanel({
   const flowRafRef = useRef(null)
   const cameraRafRef = useRef(null)
   const cameraTimersRef = useRef([])
-  const currentViewModeRef = useRef(navState?.viewMode || 'follow')
   const lastAppliedViewModeRef = useRef(navState?.viewMode || 'follow')
   const [cameraStage, setCameraStage] = useState('idle')
   const [mapReady, setMapReady] = useState(false)
@@ -439,14 +444,15 @@ export default function MapPanel({
     if (cameraStage === 'focus' || cameraStage === 'expand') return '查找目的地'
     if (cameraStage === 'destination') return '目的地已锁定'
     if (cameraStage === 'draw') return '路线生成中'
-    if (cameraStage === 'settle') return '准备进入导航'
+    if (cameraStage === 'settle') return '路线全览'
     if (cameraStage === 'tracking') return '导航中'
     return '路线规划'
   }, [cameraStage])
 
   const progressStageLabel = useMemo(() => {
     if (activeNavProgress?.stage === 'searching_destination' || activeNavProgress?.stage === 'searching_waypoint') return '查找目的地'
-    if (activeNavProgress?.stage === 'destination_locked' || activeNavProgress?.stage === 'waypoint_locked') return '目的地已锁定'
+    if (activeNavProgress?.stage === 'waypoint_locked') return '途经点已锁定'
+    if (activeNavProgress?.stage === 'destination_locked') return '目的地已锁定'
     if (activeNavProgress?.stage === 'planning_route') return '路线生成中'
     if (activeNavProgress?.stage === 'route_ready' || activeNavProgress?.stage === 'navigation_started') return '准备进入导航'
     return '路线规划'
@@ -461,8 +467,12 @@ export default function MapPanel({
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;'), [])
 
-  const getDestinationMarkerContent = useCallback((name) => (
-    `<div class="destination-pin"><div class="dest-marker target-lock marker-pop"></div><span>${escapeHtml(name)}</span></div>`
+  const getDestinationMarkerContent = useCallback((name, delayMs = 0) => (
+    `<div class="destination-pin" style="--marker-delay:${delayMs}ms"><div class="dest-marker target-lock marker-pop"></div><span>${escapeHtml(name)}</span></div>`
+  ), [escapeHtml])
+
+  const getWaypointMarkerContent = useCallback((name, index, delayMs = 0) => (
+    `<div class="waypoint-pin" style="--marker-delay:${delayMs}ms"><div class="waypoint-marker marker-pop"></div><span>${escapeHtml(name || `途经点${index + 1}`)}</span></div>`
   ), [escapeHtml])
 
   const applyRouteViewMode = useCallback((viewMode) => {
@@ -504,6 +514,7 @@ export default function MapPanel({
     previewPolylinesRef.current = []
     previewMarkersRef.current.forEach(m => map.remove(m))
     previewMarkersRef.current = []
+    progressMarkerKeysRef.current = new Set()
     queueRef.current = []
     processingRef.current = false
     processedCountRef.current = 0
@@ -531,12 +542,14 @@ export default function MapPanel({
 
       if (next.action === 'add_marker') {
         const [lng, lat] = next.location.split(',').map(Number)
-        const cls = next.role === 'waypoint' ? 'waypoint-marker' : 'dest-marker'
-        const offset = next.role === 'waypoint' ? new AMap.Pixel(-8, -8) : new AMap.Pixel(-10, -10)
+        const content = next.role === 'waypoint'
+          ? getWaypointMarkerContent(next.name, Number(next.index) || 0)
+          : getDestinationMarkerContent(next.name)
+        const offset = next.role === 'waypoint' ? new AMap.Pixel(-24, -28) : new AMap.Pixel(-18, -36)
         const marker = new AMap.Marker({
           position: new AMap.LngLat(lng, lat),
           map,
-          content: `<div class="${cls} marker-pop"></div>`,
+          content,
           offset,
         })
         previewMarkersRef.current.push(marker)
@@ -642,24 +655,25 @@ export default function MapPanel({
           }, CAMERA_FOCUS_DURATION)
 
           scheduleCameraStep(() => {
-            const endMarker = new AMap.Marker({
-              position: points[points.length - 1],
-              map,
-              content: getDestinationMarkerContent(route.destination),
-              offset: new AMap.Pixel(-18, -36),
-            })
-            markersRef.current.push(endMarker)
-
-            for (const location of route.waypointLocations || []) {
+            for (const [index, location] of (route.waypointLocations || []).entries()) {
               const [vLng, vLat] = location.split(',').map(Number)
               const waypointMarker = new AMap.Marker({
                 position: new AMap.LngLat(vLng, vLat),
                 map,
-                content: '<div class="waypoint-marker marker-pop"></div>',
-                offset: new AMap.Pixel(-8, -8),
+                content: getWaypointMarkerContent(route.waypoints?.[index], index, index * 180),
+                offset: new AMap.Pixel(-24, -28),
               })
               markersRef.current.push(waypointMarker)
             }
+
+            const destinationDelayMs = (route.waypointLocations || []).length * 180 + 140
+            const endMarker = new AMap.Marker({
+              position: points[points.length - 1],
+              map,
+              content: getDestinationMarkerContent(route.destination, destinationDelayMs),
+              offset: new AMap.Pixel(-18, -36),
+            })
+            markersRef.current.push(endMarker)
 
             tweenCamera({
               center: points[points.length - 1],
@@ -681,25 +695,16 @@ export default function MapPanel({
                 animateRoute(routeLayers.animated, points, () => {
                   startRouteFlow(points)
                   setCameraStage('settle')
-                  const viewMode = currentViewModeRef.current
-                  if (viewMode === 'overview') {
+                  if (navigationRouteCompletionViewMode(route) === 'overview') {
                     tweenCamera(getFullRouteCamera(points), CAMERA_SETTLE_DURATION)
-                    return
                   }
-                  if (route.status !== 'navigating') return
-                  const followCamera = getFollowCamera(points)
-                  rotateVehiclePuck(followCamera.rotation)
-                  tweenCamera({
-                    ...followCamera,
-                    rotation: viewMode === 'north_up' ? 0 : followCamera.rotation,
-                  }, CAMERA_SETTLE_DURATION, () => setCameraStage('tracking'))
                 })
               }
             }, CAMERA_EXPAND_DURATION + CAMERA_DESTINATION_HOLD)
           }, CAMERA_FOCUS_DURATION + CAMERA_MASK_LEAD)
         }
-      } else if (route.destLocation) {
-        const [lng, lat] = route.destLocation.split(',').map(Number)
+      } else if (route.destinationLocation) {
+        const [lng, lat] = route.destinationLocation.split(',').map(Number)
         const destPos = new AMap.LngLat(lng, lat)
 
         scheduleCameraStep(() => {
@@ -733,10 +738,9 @@ export default function MapPanel({
       scheduleCameraStep(() => setCameraStage('idle'), 0)
       tweenCamera({ center: DEFAULT_CENTER, zoom: 14, pitch: 42, rotation: 0 }, 520)
     }
-  }, [navState?.status, routeInfo, mapReady, clearPreview, clearRouteLayers, createRouteLayers, animateRoute, parsePolyline, clearCameraTimeline, stopRouteFlow, scheduleCameraStep, tweenCamera, calculateBearing, getRouteCamera, getFollowCamera, getFullRouteCamera, getDestinationMarkerContent, startRouteFlow, rotateVehiclePuck])
+  }, [navState?.status, routeInfo, mapReady, clearPreview, clearRouteLayers, createRouteLayers, animateRoute, parsePolyline, clearCameraTimeline, stopRouteFlow, scheduleCameraStep, tweenCamera, calculateBearing, getRouteCamera, getFollowCamera, getFullRouteCamera, getDestinationMarkerContent, getWaypointMarkerContent, startRouteFlow, rotateVehiclePuck])
 
   useEffect(() => {
-    currentViewModeRef.current = navigationViewMode
     if (lastAppliedViewModeRef.current === navigationViewMode) return
     lastAppliedViewModeRef.current = navigationViewMode
     applyRouteViewMode(navigationViewMode)
@@ -746,6 +750,27 @@ export default function MapPanel({
     if (!mapReady || routeInfo || !activeNavProgress) return undefined
 
     const frame = requestAnimationFrame(() => {
+      const marker = navigationProgressMarker(activeNavProgress)
+      if (marker) {
+        const markerKey = `${marker.role}:${marker.index ?? 'destination'}:${marker.location}`
+        if (!progressMarkerKeysRef.current.has(markerKey)) {
+          progressMarkerKeysRef.current.add(markerKey)
+          const [lng, lat] = marker.location.split(',').map(Number)
+          const map = mapInstance.current
+          const AMap = amapRef.current
+          if (Number.isFinite(lng) && Number.isFinite(lat) && map && AMap) {
+            const previewMarker = new AMap.Marker({
+              position: new AMap.LngLat(lng, lat),
+              map,
+              content: marker.role === 'waypoint'
+                ? getWaypointMarkerContent(marker.name, marker.index)
+                : getDestinationMarkerContent(marker.name),
+              offset: marker.role === 'waypoint' ? new AMap.Pixel(-24, -28) : new AMap.Pixel(-18, -36),
+            })
+            previewMarkersRef.current.push(previewMarker)
+          }
+        }
+      }
       if (activeNavProgress.stage === 'searching_destination' || activeNavProgress.stage === 'searching_waypoint') {
         clearCameraTimeline()
         setCameraStage('focus')
@@ -760,7 +785,7 @@ export default function MapPanel({
     })
 
     return () => cancelAnimationFrame(frame)
-  }, [activeNavProgress, clearCameraTimeline, mapReady, routeInfo, tweenCamera])
+  }, [activeNavProgress, clearCameraTimeline, getDestinationMarkerContent, getWaypointMarkerContent, mapReady, routeInfo, tweenCamera])
 
   useEffect(() => {
     if (!mapReady) return
@@ -812,6 +837,9 @@ export default function MapPanel({
                 <div className="route-destination-title">{routeInfo.destination}</div>
               )}
               {showRouteMetrics && <div className="route-road">{routeInfo.destination}</div>}
+              {routeInfo.waypoints?.length > 0 && (
+                <div className="route-waypoints">途经：{routeInfo.waypoints.join('、')}</div>
+              )}
             </div>
           </div>
           <div className="route-progress"><span></span></div>

--- a/examples/smart-cockpit/client/src/projections/cockpit-activity.js
+++ b/examples/smart-cockpit/client/src/projections/cockpit-activity.js
@@ -30,12 +30,19 @@ export function cockpitProgressFromActivity(activity) {
   const stage = String(activity?.status || '').trim()
   const message = String(activity?.message || '').trim()
   if (!SUPPORTED_DOMAINS.has(domain) || !stage || !message) return null
-  return {
+  const progress = {
     domain,
     stage,
     message,
     source: 'cockpit-service',
   }
+  if (activity.item && typeof activity.item === 'object') {
+    progress.item = { ...activity.item }
+  }
+  if (activity.route && typeof activity.route === 'object') {
+    progress.route = { ...activity.route }
+  }
+  return progress
 }
 
 export function isTerminalCockpitProgress(progress) {

--- a/examples/smart-cockpit/client/src/projections/navigation-route.js
+++ b/examples/smart-cockpit/client/src/projections/navigation-route.js
@@ -3,6 +3,7 @@ export function navigationRouteView(navigation) {
   const route = navigation.route
   if (!route) return null
   const legs = Array.isArray(route.legs) ? route.legs : []
+  const markers = navigation.map?.markers || []
   const polylines = legs
     .map(leg => leg?.polyline)
     .filter(Boolean)
@@ -10,14 +11,23 @@ export function navigationRouteView(navigation) {
       index === 0 ? polyline : polyline.split(';').slice(1).join(';')
     ))
     .filter(Boolean)
-  const waypointLocations = (navigation.map?.markers || [])
+  const waypointMarkers = markers
     .filter(marker => marker?.role === 'waypoint')
     .sort((left, right) => Number(left.index) - Number(right.index))
+  const waypointLocations = waypointMarkers
     .map(marker => marker.location)
     .filter(Boolean)
+  const waypointNames = waypointMarkers
+    .map(marker => marker.name || navigation.waypoints?.[Number(marker.index)])
+    .filter(Boolean)
+  const destinationMarker = markers.find(marker => marker?.role === 'destination')
   return {
     status: navigation.status,
     destination: navigation.destination || '',
+    destinationLocation: navigation.destinationLocation || destinationMarker?.location || '',
+    waypoints: waypointNames.length
+      ? waypointNames
+      : (Array.isArray(navigation.waypoints) ? navigation.waypoints.filter(Boolean) : []),
     distKm: route.distKm,
     durationMin: route.durationMin,
     arrivalStr: route.arrival,
@@ -33,13 +43,38 @@ export function navigationRouteKey(navigation) {
   return JSON.stringify({
     status: navigation?.status || 'idle',
     destination: navigation?.destination || '',
+    destinationLocation: navigation?.destinationLocation || '',
+    waypoints: navigation?.waypoints || [],
     route: navigation?.route || null,
     map: {
       markers: (navigation?.map?.markers || []).map(marker => ({
         role: marker?.role,
         index: marker?.index,
+        name: marker?.name,
         location: marker?.location,
       })),
     },
   })
+}
+
+export function navigationProgressMarker(progress) {
+  const item = progress?.item
+  if (
+    progress?.domain !== 'navigation'
+    || !['destination_locked', 'waypoint_locked'].includes(progress?.stage)
+    || !item
+    || typeof item !== 'object'
+    || !item.location
+  ) return null
+  const role = item.role === 'waypoint' ? 'waypoint' : 'destination'
+  return {
+    role,
+    index: role === 'waypoint' ? Number(item.index) || 0 : null,
+    name: String(item.name || '').trim(),
+    location: item.location,
+  }
+}
+
+export function navigationRouteCompletionViewMode(route) {
+  return route?.polyline ? 'overview' : 'destination'
 }

--- a/examples/smart-cockpit/client/test/cockpit-activity.test.mjs
+++ b/examples/smart-cockpit/client/test/cockpit-activity.test.mjs
@@ -39,6 +39,39 @@ test('projects supported scenario activity into UI progress', () => {
   }), null)
 })
 
+test('preserves navigation semantic anchors for synchronized map feedback', () => {
+  assert.deepEqual(cockpitProgressFromActivity({
+    category: 'navigation',
+    status: 'waypoint_locked',
+    message: '途经点已锁定：黄龙体育中心',
+    item: {
+      role: 'waypoint',
+      index: 0,
+      name: '黄龙体育中心',
+      location: '120.2,30.3',
+    },
+    route: {
+      destination: '西湖',
+      waypoints: ['黄龙体育中心'],
+    },
+  }), {
+    domain: 'navigation',
+    stage: 'waypoint_locked',
+    message: '途经点已锁定：黄龙体育中心',
+    source: 'cockpit-service',
+    item: {
+      role: 'waypoint',
+      index: 0,
+      name: '黄龙体育中心',
+      location: '120.2,30.3',
+    },
+    route: {
+      destination: '西湖',
+      waypoints: ['黄龙体育中心'],
+    },
+  })
+})
+
 test('recognizes terminal scenario progress stages', () => {
   assert.equal(isTerminalCockpitProgress({ stage: 'planning_route' }), false)
   assert.equal(isTerminalCockpitProgress({ stage: 'navigation_started' }), true)

--- a/examples/smart-cockpit/client/test/navigation-route.test.mjs
+++ b/examples/smart-cockpit/client/test/navigation-route.test.mjs
@@ -1,11 +1,18 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { navigationRouteKey, navigationRouteView } from '../src/projections/navigation-route.js'
+import {
+  navigationProgressMarker,
+  navigationRouteCompletionViewMode,
+  navigationRouteKey,
+  navigationRouteView,
+} from '../src/projections/navigation-route.js'
 
 test('projects authoritative navigation state into the map view contract', () => {
   assert.deepEqual(navigationRouteView({
     status: 'navigating',
     destination: '西湖',
+    destinationLocation: '120.3,30.3',
+    waypoints: ['黄龙体育中心', '城西银泰'],
     route: {
       distKm: '12.3',
       durationMin: 25,
@@ -27,13 +34,16 @@ test('projects authoritative navigation state into the map view contract', () =>
     },
     map: {
       markers: [
-        { role: 'waypoint', index: 1, location: '120.2,30.2' },
-        { role: 'waypoint', index: 0, location: '120.1,30.1' },
+        { role: 'destination', name: '西湖', location: '120.3,30.3' },
+        { role: 'waypoint', index: 1, name: '城西银泰', location: '120.2,30.2' },
+        { role: 'waypoint', index: 0, name: '黄龙体育中心', location: '120.1,30.1' },
       ],
     },
   }), {
     status: 'navigating',
     destination: '西湖',
+    destinationLocation: '120.3,30.3',
+    waypoints: ['黄龙体育中心', '城西银泰'],
     distKm: '12.3',
     durationMin: 25,
     arrivalStr: '15:10',
@@ -73,4 +83,53 @@ test('keeps route key stable for voice and view changes', () => {
     viewMode: 'overview',
     voice: { muted: true, broadcastMode: 'brief' },
   }))
+})
+
+test('projects navigation progress semantic anchors into preview markers', () => {
+  assert.deepEqual(navigationProgressMarker({
+    domain: 'navigation',
+    stage: 'waypoint_locked',
+    item: {
+      role: 'waypoint',
+      index: 1,
+      name: '城西银泰',
+      location: '120.2,30.2',
+    },
+  }), {
+    role: 'waypoint',
+    index: 1,
+    name: '城西银泰',
+    location: '120.2,30.2',
+  })
+
+  assert.deepEqual(navigationProgressMarker({
+    domain: 'navigation',
+    stage: 'destination_locked',
+    item: {
+      role: 'destination',
+      name: '西湖',
+      location: '120.3,30.3',
+    },
+  }), {
+    role: 'destination',
+    index: null,
+    name: '西湖',
+    location: '120.3,30.3',
+  })
+
+  assert.equal(navigationProgressMarker({
+    domain: 'navigation',
+    stage: 'searching_waypoint',
+    item: { role: 'waypoint', location: '120.1,30.1' },
+  }), null)
+})
+
+test('settles completed route animation on the full route overview', () => {
+  assert.equal(navigationRouteCompletionViewMode({
+    polyline: '120.0,30.0;120.1,30.1;120.2,30.2',
+  }), 'overview')
+
+  assert.equal(navigationRouteCompletionViewMode({
+    destinationLocation: '120.2,30.2',
+  }), 'destination')
 })

--- a/examples/smart-cockpit/docs/navigation-voice-ui-sync-plan.md
+++ b/examples/smart-cockpit/docs/navigation-voice-ui-sync-plan.md
@@ -1,0 +1,109 @@
+# Navigation Voice/UI Sync Goals and Test Plan
+
+## Goals
+
+The navigation experience should make voice narration the primary timeline and
+map/UI animation the visual reflection of that timeline.
+
+Concrete goals:
+
+- Show waypoints in the navigation status panel when a route contains
+  waypoints.
+- Emit structured navigation activity anchors for destination and waypoint
+  resolution, so the UI can react to the same semantic points that narration
+  mentions.
+- Animate waypoint markers before the destination marker on waypoint routes,
+  matching natural narration such as "pass Huanglong Sports Center, then go to
+  West Lake".
+- Keep chitchat and other low-risk foreground interactions independent from the
+  navigation semantic timeline.
+- Leave a future extension point for phrase-level TTS timestamps: the current
+  `item`/`route` anchors can later be aligned to real narration timings without
+  changing the UI contract.
+
+## Implementation Scope
+
+This pass implements semantic soft-sync rather than audio timestamp sync:
+
+- The cockpit service attaches `item` anchors to `destination_locked` and
+  `waypoint_locked` activity events.
+- Final route activity includes a `route` summary with destination and waypoint
+  locations.
+- The client activity projection preserves these anchors.
+- The navigation route projection exposes waypoint names, waypoint locations,
+  and destination location.
+- The map panel uses active navigation progress to create preview markers for
+  the currently resolved destination or waypoint.
+- The committed route animation displays waypoint pins first, then the
+  destination pin, then route drawing.
+
+## Test Plan
+
+Unit and integration-style checks:
+
+- Service: starting navigation with two waypoints should emit ordered activity
+  events with destination and waypoint `item` anchors, followed by a route
+  summary.
+- Client activity projection: cockpit activity should preserve `item` and
+  `route` objects for downstream UI sync.
+- Navigation route projection: authoritative navigation state should project
+  waypoint names, waypoint locations, destination location, route polyline, and
+  traffic segments.
+- Navigation progress projection: `destination_locked` and `waypoint_locked`
+  should become map preview marker contracts; searching states should not.
+- Smart cockpit suite: service, agent, benchmark, bootstrap, client, gateway,
+  and scenario tests should all pass.
+- Client lint/build: JSX, CSS, and production bundling should pass.
+
+## Review Passes
+
+Review 1: Event Contract
+
+- `reportActivity` now supports structured metadata without changing existing
+  status/message fields.
+- Destination and waypoint resolution events carry role, index, name, and
+  location when available.
+- Final route events carry the resolved route anchor list.
+
+Review 2: UI Timeline
+
+- During active progress, resolved waypoints and destinations can appear before
+  the final route is committed.
+- During committed route animation, waypoint pins are created first and
+  destination pins use a delayed marker animation.
+- The status card distinguishes `waypoint_locked` from `destination_locked`.
+
+Review 3: Verification Coverage
+
+- Projection tests cover the exact marker contract used by the UI.
+- Service tests cover ordered activity and structured metadata.
+- Full smart-cockpit tests, lint, and build pass after the change.
+
+## Test Report
+
+Latest local verification:
+
+- `node --test examples/smart-cockpit/client/test/navigation-route.test.mjs examples/smart-cockpit/client/test/cockpit-activity.test.mjs examples/smart-cockpit/service/test/cockpit-service.test.mjs`
+  - 25 passed, 0 failed.
+- `npm run test:smart-cockpit`
+  - service: 29 passed, 0 failed.
+  - agent: 5 passed, 0 failed.
+  - combined example suites: 65 passed, 0 failed.
+- `npm run example:smart-cockpit:lint`
+  - passed.
+- `npm run example:smart-cockpit:build`
+  - passed; Vite reported a chunk-size warning only.
+
+## Reasonableness Analysis
+
+The result is a reasonable first step because it synchronizes UI animation to
+navigation semantics, which is the same level at which the assistant response is
+planned. It does not yet guarantee exact word-level audio synchronization,
+because no TTS timestamp stream is consumed here. That is acceptable for this
+stage: the UI contract now has stable anchors, and a future realtime/TTS layer
+can map phrase timings onto the same anchors.
+
+For benchmark interpretation, this supports the hybrid-harness thesis: the
+foreground can react quickly to low-risk semantic events, while the backend
+harness remains responsible for route planning and longer-horizon navigation
+state.

--- a/examples/smart-cockpit/service/test/cockpit-service.test.mjs
+++ b/examples/smart-cockpit/service/test/cockpit-service.test.mjs
@@ -227,6 +227,29 @@ test('projects navigation progress and route state separately', async () => {
     'planning_route',
     'navigation_started',
   ])
+  assert.deepEqual(activities[1].item, {
+    role: 'destination',
+    name: '西湖',
+    location: '120.1,30.2',
+  })
+  assert.deepEqual(activities[3].item, {
+    role: 'waypoint',
+    index: 0,
+    name: '黄龙体育中心',
+    location: '120.2,30.3',
+  })
+  assert.deepEqual(activities[5].item, {
+    role: 'waypoint',
+    index: 1,
+    name: '城西银泰',
+    location: '120.2,30.3',
+  })
+  assert.deepEqual(activities[7].route, {
+    destination: '西湖',
+    destinationLocation: '120.1,30.2',
+    waypoints: ['黄龙体育中心', '城西银泰'],
+    waypointLocations: ['120.2,30.3', '120.2,30.3'],
+  })
 })
 
 test('persists a route preference before a destination is selected', async () => {

--- a/examples/smart-cockpit/service/tools/navigation/execute.mjs
+++ b/examples/smart-cockpit/service/tools/navigation/execute.mjs
@@ -160,23 +160,35 @@ async function createRoutePlan({
 }) {
   const { cockpitId, onActivity, services, snapshot, store } = context
   const origin = currentOrigin(snapshot())
-  reportActivity(onActivity, 'navigation', 'searching_destination', '正在查找目的地')
+  reportActivity(onActivity, 'navigation', 'searching_destination', '正在查找目的地', {
+    item: { role: 'destination', name: destination },
+  })
   const destinationLocation = await resolvePlace(destination, DEFAULT_ORIGIN.city, services)
   if (!destinationLocation) {
-    reportActivity(onActivity, 'navigation', 'destination_not_found', `没有找到${destination}`)
+    reportActivity(onActivity, 'navigation', 'destination_not_found', `没有找到${destination}`, {
+      item: { role: 'destination', name: destination },
+    })
     return toolResult(`无法找到“${destination}”的位置信息`, snapshot(), [])
   }
-  reportActivity(onActivity, 'navigation', 'destination_locked', `已找到${destination}`)
+  reportActivity(onActivity, 'navigation', 'destination_locked', `已找到${destination}`, {
+    item: { role: 'destination', name: destination, location: destinationLocation },
+  })
   const waypointLocations = []
-  for (const waypoint of waypoints) {
-    reportActivity(onActivity, 'navigation', 'searching_waypoint', `正在查找途经点${waypoint}`)
+  for (const [index, waypoint] of waypoints.entries()) {
+    reportActivity(onActivity, 'navigation', 'searching_waypoint', `正在查找途经点${waypoint}`, {
+      item: { role: 'waypoint', index, name: waypoint },
+    })
     const location = await resolvePlace(waypoint, DEFAULT_ORIGIN.city, services)
     if (!location) {
-      reportActivity(onActivity, 'navigation', 'waypoint_not_found', `没有找到${waypoint}`)
+      reportActivity(onActivity, 'navigation', 'waypoint_not_found', `没有找到${waypoint}`, {
+        item: { role: 'waypoint', index, name: waypoint },
+      })
       return toolResult(`无法找到途经点“${waypoint}”的位置信息`, snapshot(), [])
     }
     waypointLocations.push(location)
-    reportActivity(onActivity, 'navigation', 'waypoint_locked', `已找到途经点${waypoint}`)
+    reportActivity(onActivity, 'navigation', 'waypoint_locked', `已找到途经点${waypoint}`, {
+      item: { role: 'waypoint', index, name: waypoint, location },
+    })
   }
   reportActivity(onActivity, 'navigation', 'planning_route', '正在规划路线')
   const route = await planRoute(origin, destinationLocation, waypointLocations, strategy, context)
@@ -194,7 +206,14 @@ async function createRoutePlan({
     route,
   })
   const activityStatus = name === 'navigation_start' ? 'navigation_started' : 'route_ready'
-  reportActivity(onActivity, 'navigation', activityStatus, name === 'navigation_start' ? '开始导航' : '路线规划好了')
+  reportActivity(onActivity, 'navigation', activityStatus, name === 'navigation_start' ? '开始导航' : '路线规划好了', {
+    route: {
+      destination,
+      destinationLocation,
+      waypoints,
+      waypointLocations,
+    },
+  })
   const prefix = name === 'navigation_start' ? '已开始导航到' : '已规划到'
   return toolResult(
     routeContent(prefix, destination, waypoints, route),
@@ -230,7 +249,14 @@ async function replanExistingRoute({
     strategy,
     route,
   })
-  reportActivity(onActivity, 'navigation', 'route_ready', '路线已更新')
+  reportActivity(onActivity, 'navigation', 'route_ready', '路线已更新', {
+    route: {
+      destination,
+      destinationLocation,
+      waypoints,
+      waypointLocations,
+    },
+  })
   return { state, route }
 }
 
@@ -247,14 +273,20 @@ async function addWaypoint(args, context) {
   const existing = await resolveExistingRouteLocations(state.navigation, services)
   if (!existing) return toolResult('当前路线信息不完整，请重新发起导航', state, [], { navigation: state.navigation })
 
-  reportActivity(onActivity, 'navigation', 'searching_waypoint', `正在查找途经点${waypoint}`)
+  const insertIndex = args.insertPosition === 'before_destination' ? state.navigation.waypoints.length : 0
+  reportActivity(onActivity, 'navigation', 'searching_waypoint', `正在查找途经点${waypoint}`, {
+    item: { role: 'waypoint', index: insertIndex, name: waypoint },
+  })
   const waypointLocation = await resolvePlace(waypoint, DEFAULT_ORIGIN.city, services)
   if (!waypointLocation) {
-    reportActivity(onActivity, 'navigation', 'waypoint_not_found', `没有找到${waypoint}`)
+    reportActivity(onActivity, 'navigation', 'waypoint_not_found', `没有找到${waypoint}`, {
+      item: { role: 'waypoint', index: insertIndex, name: waypoint },
+    })
     return toolResult(`无法找到途经点“${waypoint}”的位置信息`, snapshot(), [])
   }
-  reportActivity(onActivity, 'navigation', 'waypoint_locked', `已找到途经点${waypoint}`)
-  const insertIndex = args.insertPosition === 'before_destination' ? state.navigation.waypoints.length : 0
+  reportActivity(onActivity, 'navigation', 'waypoint_locked', `已找到途经点${waypoint}`, {
+    item: { role: 'waypoint', index: insertIndex, name: waypoint, location: waypointLocation },
+  })
   const waypoints = [...state.navigation.waypoints]
   const waypointLocations = [...existing.waypointLocations]
   waypoints.splice(insertIndex, 0, waypoint)
@@ -332,13 +364,19 @@ async function changeDestination(args, context) {
   const destination = clean(args.destination)
   if (!destination) return toolResult('请告诉我要把目的地改成哪里', state, [], { navigation: state.navigation })
 
-  reportActivity(onActivity, 'navigation', 'searching_destination', '正在查找目的地')
+  reportActivity(onActivity, 'navigation', 'searching_destination', '正在查找目的地', {
+    item: { role: 'destination', name: destination },
+  })
   const destinationLocation = await resolvePlace(destination, DEFAULT_ORIGIN.city, services)
   if (!destinationLocation) {
-    reportActivity(onActivity, 'navigation', 'destination_not_found', `没有找到${destination}`)
+    reportActivity(onActivity, 'navigation', 'destination_not_found', `没有找到${destination}`, {
+      item: { role: 'destination', name: destination },
+    })
     return toolResult(`无法找到“${destination}”的位置信息`, snapshot(), [])
   }
-  reportActivity(onActivity, 'navigation', 'destination_locked', `已找到${destination}`)
+  reportActivity(onActivity, 'navigation', 'destination_locked', `已找到${destination}`, {
+    item: { role: 'destination', name: destination, location: destinationLocation },
+  })
   const existing = await resolveExistingRouteLocations(state.navigation, services)
   if (!existing) return toolResult('当前路线信息不完整，请重新发起导航', state, [], { navigation: state.navigation })
   const strategy = normalizeStrategy(args.strategy, state.navigation.strategy)

--- a/examples/smart-cockpit/service/tools/shared.mjs
+++ b/examples/smart-cockpit/service/tools/shared.mjs
@@ -2,12 +2,13 @@ export function clean(value) {
   return String(value || '').trim()
 }
 
-export function reportActivity(callback, category, status, message) {
+export function reportActivity(callback, category, status, message, extra = {}) {
   callback?.({
     kind: 'status',
     category,
     status,
     message,
+    ...extra,
   })
 }
 


### PR DESCRIPTION
## Summary
- Add semantic navigation activity metadata for destination and waypoint search/lock/not-found events so voice progress can drive the map UI.
- Show waypoint markers and route waypoints in the smart-cockpit navigation panel, and settle completed route animations on the full route overview.
- Add a navigation voice/UI synchronization plan plus focused service/client tests for waypoint anchoring and full-route completion behavior.

## Scope
- Includes only navigation-related smart-cockpit files.
- Excludes benchmark, companion, system-name/profile, and other unrelated workspace changes.

## Tests
- `npm run example:smart-cockpit:lint`
- `npm run example:smart-cockpit:build`
- `node --test examples/smart-cockpit/client/test/navigation-route.test.mjs examples/smart-cockpit/client/test/cockpit-activity.test.mjs examples/smart-cockpit/service/test/cockpit-service.test.mjs`
- `npm run test:smart-cockpit`